### PR TITLE
Fixes gradient stepping in training script

### DIFF
--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -73,16 +73,16 @@ def update_policy(
         train_config.loss_weighting["MSE"] * losses["MSE"] + train_config.loss_weighting["CE"] * losses["CE"]
     )
 
-    # accelerator.backward(loss)
-    # accelerator.unscale_gradients(optimizer=optimizer)
+    accelerator.backward(loss)
+    accelerator.unscale_gradients(optimizer=optimizer)
 
-    # if accelerator.sync_gradients:
-    #     grad_norm = accelerator.clip_grad_norm_(policy.parameters(), grad_clip_norm)
-    #     if accelerator.is_main_process:
-    #         train_metrics.grad_norm = grad_norm
+    if accelerator.sync_gradients:
+        grad_norm = accelerator.clip_grad_norm_(policy.parameters(), grad_clip_norm)
+        if accelerator.is_main_process:
+            train_metrics.grad_norm = grad_norm
 
-    # optimizer.step()
-    # optimizer.zero_grad()
+    optimizer.step()
+    optimizer.zero_grad()
 
     # Step through pytorch scheduler at every batch instead of epoch
     if lr_scheduler is not None:


### PR DESCRIPTION
## What this does
This fixes an issue where gradient steps are skipped. 

Examples:
|  Title               | Label               |
|----------------------|---------------------|
| Fixes #[issue]       | (🐛 Bug)            |
| Adds new Feature     | (🗃️ Feature)        |
| Optimizes something  | (⚡️ Performance)    |
| Updates docs         | (📝 Documentation)  |

## How it was tested
Ran with the example training config for pi05 
```bash
accelerate launch src/opentau/scripts/train.py --config_path=configs/examples/pi05_training_config.json 
```
## How to checkout & try? (for the reviewer)
Checkout this branch and run
```bash
accelerate launch src/opentau/scripts/train.py --config_path=configs/examples/pi05_training_config.json 
```

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
