### PR TITLE
Move GPU pytests from AWS us-west-1 to us-west-2

### DIFF
--- a/.github/workflows/gpu_test.yml
+++ b/.github/workflows/gpu_test.yml
@@ -18,7 +18,6 @@ on:
     # Run at 2:00 AM PST every day (10:00 AM UTC)
     - cron: '0 10 * * *'
   workflow_dispatch:
-  pull_request:
 
 permissions:
   contents: read  # Required for actions/checkout


### PR DESCRIPTION
## What this does

Moves GPU pytests from AWS us-west-1 to us-west-2 since the g6 gpu clusters are not in us-west-1

## How it was tested

Launched github action and the test passed
see: https://github.com/TensorAuto/OpenTau/actions/runs/21231830961/job/61092901141

## How to checkout & try? (for the reviewer)

dispatch github action

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
