### PR TITLE
Fix Docker build by update uv sync command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ COPY . .
 # We explicitly use the system python 3.10 for the venv
 RUN uv venv .venv --python /usr/bin/python3.10 && \
     . .venv/bin/activate && \
-    uv sync --all-extras
+    uv sync --extra libero --extra dev --extra openai
 
 # Set environment variables
 ENV PATH=".venv/bin:$PATH"


### PR DESCRIPTION
## What this does

Fixes a broken Docker build (https://github.com/TensorAuto/OpenTau/actions/runs/21272925251) due to PR #67, making `uv sync --all-extras` fail due to a conflict between the libero and urdf extras. This PR avoids installing all extras to fix the issue.

## How it was tested

I ran `docker run --rm -it opentau:test`

## How to checkout & try? (for the reviewer)

Please run `docker run --rm -it opentau:test`

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
