### PR TITLE
Remove response from dummy observations for pi0.5 inference

### DIFF
--- a/src/opentau/utils/utils.py
+++ b/src/opentau/utils/utils.py
@@ -386,7 +386,6 @@ def create_dummy_observation(cfg, device, dtype=torch.bfloat16) -> dict:
         **camera_observations,
         "state": torch.zeros((1, cfg.max_state_dim), dtype=dtype, device=device),
         "prompt": ["Pick up yellow lego block and put it in the bin"],
-        "response": ["Pick up yellow lego block"],
         "img_is_pad": torch.zeros((1, cfg.num_cams), dtype=torch.bool, device=device),
         "action_is_pad": torch.zeros((1, cfg.action_chunk), dtype=torch.bool, device=device),
     }


### PR DESCRIPTION
see issue #89 for details

## What this does
Remove the "response" key, which contains subtask instruction, from the pi0.5 dummy observation. 

## How it was tested

No test was performed. Need to see the CI passing before merging this change.

## How to checkout & try? (for the reviewer)
Observe CI passing


## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

