### PR TITLE
Freezing discrete lm head and embedding matrix

### DIFF
--- a/src/opentau/policies/pi05/paligemma_with_expert.py
+++ b/src/opentau/policies/pi05/paligemma_with_expert.py
@@ -255,10 +255,6 @@ class PaliGemmaWithExpertModel(PreTrainedModel):
             self.paligemma.vision_tower.eval()
             for params in self.paligemma.vision_tower.parameters():
                 params.requires_grad = False
-            for param in self.da_head.parameters():
-                param.requires_grad = False
-            for param in self.discrete_action_embedding.parameters():
-                param.requires_grad = False
 
         if self.config.train_expert_only:
             self.paligemma.eval()


### PR DESCRIPTION
## What this does
Fixes #88

## How it was tested
Trained with vlm backbone freezed.
Internal;ref: look at wandb run name bug_fix_vlm_freeze

## Checklist

- [X] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [X] My PR includes policy-related changes.
  - [X] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
