### PR TITLE
fix: properly implement`PatchedGemmaRMSNorm:extra_repr`

### DIFF
--- a/src/opentau/utils/transformers_patch.py
+++ b/src/opentau/utils/transformers_patch.py
@@ -167,7 +167,10 @@ class PatchedGemmaRMSNorm(nn.Module):
 
     def extra_repr(self) -> str:
         """Returns the extra representation of the module."""
-        repr_str = f"{tuple(self.weight.shape)}, eps={self.eps}"
+        if hasattr(self, "weight") and self.weight is not None:
+            repr_str = f"{tuple(self.weight.shape)}, eps={self.eps}"
+        else:
+            repr_str = f"dim={self.dim}, eps={self.eps}"
         if self.dense is not None:
             repr_str += f", adaptive=True, cond_dim={self.cond_dim}"
         return repr_str


### PR DESCRIPTION
## What this does

Ensure `PatchedGemmaRMSNorm.extra_repr` doesn't access non existent fields.

## How it was tested
Ran regression tests.

## How to checkout & try? (for the reviewer)
Run regression tests.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.
