### PR TITLE
Fix issue with AWS GPU runners not picking up jobs.

### DIFF
--- a/.github/workflows/gpu_test.yml
+++ b/.github/workflows/gpu_test.yml
@@ -30,6 +30,7 @@ jobs:
   start-runner:
     name: Start GPU Runner
     runs-on: ubuntu-latest
+    timeout-minutes: 15  # Fail fast if ASG/runner never becomes ready
     permissions:
       id-token: write # Required for requesting the JWT
       contents: read
@@ -42,8 +43,26 @@ jobs:
 
       - name: Start Instance
         run: |
-          aws autoscaling set-desired-capacity --auto-scaling-group-name github-runner-asg-g6-2xlarge --desired-capacity 1
-          echo "Waiting for instance to be ready..."
+          ASG_NAME="github-runner-asg-g6-2xlarge"
+          aws autoscaling set-desired-capacity --auto-scaling-group-name "$ASG_NAME" --desired-capacity 1
+          echo "Waiting for instance to be InService (max 10 min)..."
+          for i in $(seq 1 40); do
+            COUNT=$(aws autoscaling describe-auto-scaling-groups --auto-scaling-group-names "$ASG_NAME" \
+              --query 'AutoScalingGroups[0].Instances[?LifecycleState==`InService`].InstanceId' --output text | wc -w)
+            [ "$COUNT" -ge 1 ] && break
+            echo "Instance not ready yet ($i/40)..."
+            sleep 15
+          done
+          if [ "$COUNT" -lt 1 ]; then
+            echo "Timeout: instance did not become InService"
+            exit 1
+          fi
+          INSTANCE_ID=$(aws autoscaling describe-auto-scaling-groups --auto-scaling-group-names "$ASG_NAME" \
+            --query 'AutoScalingGroups[0].Instances[?LifecycleState==`InService`].InstanceId' --output text | awk '{print $1}')
+          echo "Waiting for EC2 status checks on $INSTANCE_ID..."
+          aws ec2 wait instance-status-ok --instance-ids "$INSTANCE_ID"
+          echo "Instance ready. Waiting 3 min for GitHub runner to register..."
+          sleep 180
 
   gpu-test:
     name: Run Pytest on GPU

--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -32,6 +32,7 @@ jobs:
   start-runner:
     name: Start GPU Runner
     runs-on: ubuntu-latest
+    timeout-minutes: 15  # Fail fast if ASG/runner never becomes ready
     permissions:
       id-token: write
       contents: read
@@ -44,8 +45,26 @@ jobs:
 
       - name: Start Instance
         run: |
-          aws autoscaling set-desired-capacity --auto-scaling-group-name github-runner-asg-g6-12xlarge --desired-capacity 1
-          echo "Waiting for instance to be ready..."
+          ASG_NAME="github-runner-asg-g6-12xlarge"
+          aws autoscaling set-desired-capacity --auto-scaling-group-name "$ASG_NAME" --desired-capacity 1
+          echo "Waiting for instance to be InService (max 10 min)..."
+          for i in $(seq 1 40); do
+            COUNT=$(aws autoscaling describe-auto-scaling-groups --auto-scaling-group-names "$ASG_NAME" \
+              --query 'AutoScalingGroups[0].Instances[?LifecycleState==`InService`].InstanceId' --output text | wc -w)
+            [ "$COUNT" -ge 1 ] && break
+            echo "Instance not ready yet ($i/40)..."
+            sleep 15
+          done
+          if [ "$COUNT" -lt 1 ]; then
+            echo "Timeout: instance did not become InService"
+            exit 1
+          fi
+          INSTANCE_ID=$(aws autoscaling describe-auto-scaling-groups --auto-scaling-group-names "$ASG_NAME" \
+            --query 'AutoScalingGroups[0].Instances[?LifecycleState==`InService`].InstanceId' --output text | awk '{print $1}')
+          echo "Waiting for EC2 status checks on $INSTANCE_ID..."
+          aws ec2 wait instance-status-ok --instance-ids "$INSTANCE_ID"
+          echo "Instance ready. Waiting 3 min for GitHub runner to register..."
+          sleep 180
 
   train-regression:
     name: Train with Model Parallelism


### PR DESCRIPTION
## What this does

Added checks to see if EC2 instances are online before the start GPU runner job succeeds. This will prevent the actual CI test from not being able to pick up the runner.

## How it was tested

Dispatched GPU workflows

## How to checkout & try? (for the reviewer)

Dispatch GPU workflows

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
