### PR TITLE
feat: support setting joint names for each state dim in URDF viz

### DIFF
--- a/src/opentau/scripts/visualize_dataset.py
+++ b/src/opentau/scripts/visualize_dataset.py
@@ -174,6 +174,21 @@ def visualize_dataset(
     urdf: Path | None = None,
     joint_names: list[str] | None = None,
 ) -> Path | None:
+    r"""
+    Visualize data of a given episode of a LeRobotDataset with rerun.
+
+    Args:
+        dataset: The dataset to visualize.
+        episode_index: The index of the episode to visualize.
+        batch_size: Batch size for loading data. Defaults to 32.
+        num_workers: Number of workers for data loading. Defaults to 0.
+        mode: Visualization mode, either "local" or "distant". Defaults to "local".
+        web_port: Web port for rerun when in "distant" mode. Defaults to 9090.
+        save: Whether to save the visualization as a .rrd file instead of spawning a viewer. Defaults to False.
+        output_dir: Directory to save the .rrd file if `save` is True. Required if `save` is True. Defaults to None.
+        urdf: Path to a URDF file to load and visualize alongside the dataset. Defaults to None.
+        joint_names: List of joint names for each state dimension, in order. Used for associating state dimensions with URDF joints. If not provided, state names from dataset metadata will be used. Defaults to None.
+    """
     if save:
         assert output_dir is not None, (
             "Set an output directory where to write .rrd files with `--output-dir path/to/directory`."


### PR DESCRIPTION
## What this does
This PR supports setting joint names for each state dim in URDF visualization. If unset, will default to the names in info.json of the dataset.

## How it was tested
Ran URDF visaulization script on a local dataset with and without --joint-names arg

## How to checkout & try? (for the reviewer)
Run URDF visaulization script on a local dataset with and without --joint-names arg

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
