### PR TITLE
Adding AWR algorithm for pi0

### DIFF
--- a/configs/examples/pi_config.json
+++ b/configs/examples/pi_config.json
@@ -38,6 +38,8 @@
         "train_state_proj": true,
         "tokenizer_max_length": 100,
         "optimizer_lr": 2.5e-05,
+        "use_awr": false,
+        "awr_max_weight": 10.0,
         "optimizer_betas": [
             0.9,
             0.95

--- a/src/opentau/policies/pi0/configuration_pi0.py
+++ b/src/opentau/policies/pi0/configuration_pi0.py
@@ -147,6 +147,10 @@ class PI0Config(PreTrainedConfig):
     scheduler_decay_steps: int = 30_000
     scheduler_decay_lr: float = 2.5e-6
 
+    # AWR settings
+    use_awr: bool = False
+    awr_max_weight: float = 10.0
+
     # TODO: Add EMA
 
     def __post_init__(self):

--- a/src/opentau/policies/pi0/modeling_pi0.py
+++ b/src/opentau/policies/pi0/modeling_pi0.py
@@ -460,7 +460,7 @@ class PI0Policy(PreTrainedPolicy):
             # weight loss based on exponent of advantage. Also clamp at awr_max_weight.
             losses = losses * rearrange(
                 torch.min(
-                    torch.exp(batch["advantage"]),
+                    torch.exp(batch["advantage"].to(dtype=torch.float32)),
                     torch.tensor(self.config.awr_max_weight, device=losses.device),
                 ),
                 "b -> b 1 1",


### PR DESCRIPTION
## What this does
Implements AWR (Advantage Weighted Regression) alogirthm for PI0.

## How it was tested
Ran training on local desktop.

Examples:
opentau-train --config_path=configs/examples/pi_config.json
set use_awr = true

## Checklist

- [X] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
