### PR TITLE
Switch torch compile to use max-autotune mode

### DIFF
--- a/src/opentau/scripts/inference.py
+++ b/src/opentau/scripts/inference.py
@@ -56,7 +56,10 @@ def inference_main(cfg: TrainPipelineConfig):
     print(observation.keys())
 
     with torch.inference_mode():
-        # One warmup call right after compiling
+        # two warmup calls are needed right after compiling
+        # the first warmup call is needed for compiling
+        # the second warmup call is needed for kernel autotuning
+        _ = policy.sample_actions(observation)
         _ = policy.sample_actions(observation)
 
         # Run 10 times and record inference times

--- a/src/opentau/utils/utils.py
+++ b/src/opentau/utils/utils.py
@@ -352,8 +352,7 @@ def attempt_torch_compile(fn: callable, device_hint=None) -> callable:
     if hasattr(torch, "compile"):
         logging.info("Attempting to compile the policy with torch.compile()...")
         try:
-            # Other options: "default", "max-autotune" (longer compile time)
-            fn = torch.compile(fn)
+            fn = torch.compile(fn, mode="max-autotune")
             logging.info("Policy compiled successfully.")
         except Exception as e:
             logging.warning(f"torch.compile failed with error: {e}. Proceeding without compilation.")


### PR DESCRIPTION
## What this does

Switch torch compile to use max-autotune mode. It speeds up PI05 inference from 150ms to 100ms on Nvidia 3090 GPUs.

## How it was tested

Ran inference.py

## How to checkout & try? (for the reviewer)

```bash
python src/opentau/scripts/inference.py --config_path=configs/examples/pi05_training_config.json
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
