### PR TITLE
fix(model): Compile policy.model.sample_actions instead of policy.sample_actions

### DIFF
--- a/src/opentau/scripts/inference.py
+++ b/src/opentau/scripts/inference.py
@@ -46,7 +46,7 @@ def inference_main(cfg: TrainPipelineConfig):
     policy = policy_class.from_pretrained(cfg.policy.pretrained_path, config=cfg.policy)
     policy.to(device=device, dtype=torch.bfloat16)
     policy.eval()
-    policy.sample_actions = attempt_torch_compile(policy.sample_actions, device_hint=device)
+    policy.model.sample_actions = attempt_torch_compile(policy.model.sample_actions, device_hint=device)
 
     # Always reset policy before episode to clear out action cache.
     policy.reset()


### PR DESCRIPTION
## What this does

The old torch compile script compiled policy.sample_actions which took non-tensor inputs (such as strings for prompts). This will cause torch to recompile when the non-tensor inputs change since torch compile treats them as constants when compiling. This is fixed by compiling policy.model.sample_actions which only takes tensors as inputs and allows the policy to turn the string into tokens before passing it to the compiled method.

There was no noticeable runtime difference after making this change.

## How it was tested

I ran inference with the newly compiled method and it worked.

## How to checkout & try? (for the reviewer)

```bash
python src/opentau/scripts/inference.py --config_path=/path/to/config
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
