### PR TITLE
Adding warning when discrete action is truncated and increased dicret…

### DIFF
--- a/configs/examples/pi05_training_config.json
+++ b/configs/examples/pi05_training_config.json
@@ -37,7 +37,7 @@
         "freeze_vision_encoder": true,
         "train_expert_only": true,
         "prompt_max_length": 256,
-        "discrete_action_max_length": 60,
+        "discrete_action_max_length": 100,
         "optimizer_lr": 2.5e-05,
         "optimizer_betas": [
             0.9,

--- a/src/opentau/policies/pi05/modeling_pi05.py
+++ b/src/opentau/policies/pi05/modeling_pi05.py
@@ -215,6 +215,9 @@ def pad_discrete_tokens(tokens: list[list[int]], max_length: int) -> tuple[np.nd
     discrete_action_masks = []
     for token in tokens:
         if len(token) > max_length:
+            logging.warning(
+                f"Discrete action token length {len(token)} is greater than max_length {max_length}, truncating"
+            )
             discrete_action_tokens.append(np.array(token[:max_length]))
             discrete_action_masks.append(np.ones(max_length, dtype=bool))
         else:


### PR DESCRIPTION
…e actiuon max length

## What this does
Updates discrete action max length and adds warnings if its truncated

## How it was tested
run on local desktop

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
