### PR TITLE
fix: guard type of states names in info.json

### DIFF
--- a/src/opentau/scripts/visualize_dataset.py
+++ b/src/opentau/scripts/visualize_dataset.py
@@ -222,8 +222,12 @@ def visualize_dataset(
     if joint_names is None:
         joint_names = dataset.meta.info.get("features", {}).get("observation.state", {}).get("names", [])
 
-    # In case the info.json lists the state names in a nested dictionary
+    # Guard against invalid state names from info.json (ensure it's a list of strings)
     if not (isinstance(joint_names, list) and all(isinstance(name, str) for name in joint_names)):
+        logging.warning(
+            "Invalid joint_names type in info.json: %s. Expected list of strings. Using numeric indices instead.",
+            type(joint_names),
+        )
         joint_names = []
 
     if urdf:


### PR DESCRIPTION
## What this does
When the states are not of type `list[str]` in `info.json`, joint names default to empty list in the dataset visualization script.

Fix #122 

## How it was tested
Ran `python3 src/opentau/scripts/visualize_dataset.py --repo-id lerobot/droid_100 --episode-index 0 `

## How to checkout & try? (for the reviewer)
Run `python3 src/opentau/scripts/visualize_dataset.py --repo-id lerobot/droid_100 --episode-index 0 `

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.
