### PR TITLE
Remove temporal grouping from dataset pipeline

### DIFF
--- a/src/opentau/configs/policies.py
+++ b/src/opentau/configs/policies.py
@@ -23,6 +23,7 @@ configurations from pretrained models or local paths.
 import abc
 import json
 import os
+import warnings
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Type, TypeVar
@@ -73,6 +74,33 @@ def strip_deprecated_fields_from_json(path: Path) -> None:
     if changed:
         with open(path, "w") as f:
             json.dump(data, f, indent=4)
+
+
+def warn_deprecated_latency_fields(config_path: str | Path) -> None:
+    """Emit a deprecation warning if a config JSON file contains latency fields.
+
+    Checks both top-level fields and fields nested under a ``"policy"`` key.
+    Should be called before loading a config so users are aware the fields
+    will be ignored.
+    """
+    with open(config_path) as f:
+        data = json.load(f)
+
+    found: list[str] = []
+    for key in _DEPRECATED_LATENCY_FIELDS:
+        if key in data:
+            found.append(key)
+        if isinstance(data.get("policy"), dict) and key in data["policy"]:
+            found.append(f"policy.{key}")
+
+    if found:
+        warnings.warn(
+            f"Config '{config_path}' contains deprecated latency fields that are no longer "
+            f"used and will be ignored: {', '.join(found)}. "
+            "Consider re-saving the config to remove them.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
 
 
 @dataclass
@@ -326,6 +354,9 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):
                 raise FileNotFoundError(
                     f"{CONFIG_NAME} not found on the HuggingFace Hub in {model_id}"
                 ) from e
+
+        if config_file is not None:
+            warn_deprecated_latency_fields(config_file)
 
         # HACK: this is very ugly, ideally we'd like to be able to do that natively with draccus
         # something like --policy.path (in addition to --policy.type)

--- a/src/opentau/configs/policies.py
+++ b/src/opentau/configs/policies.py
@@ -52,7 +52,7 @@ _DEPRECATED_LATENCY_FIELDS = (
 )
 
 
-def _strip_deprecated_fields_from_json(path: Path) -> None:
+def strip_deprecated_fields_from_json(path: Path) -> None:
     """Remove deprecated latency fields from a saved config JSON file in-place.
 
     Handles both top-level fields (policy configs) and fields nested under a
@@ -253,7 +253,7 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):
         config_path = save_directory / CONFIG_NAME
         with open(config_path, "w") as f, draccus.config_type("json"):
             draccus.dump(self, f, indent=4)
-        _strip_deprecated_fields_from_json(config_path)
+        strip_deprecated_fields_from_json(config_path)
 
     @classmethod
     def from_pretrained(

--- a/src/opentau/configs/policies.py
+++ b/src/opentau/configs/policies.py
@@ -21,6 +21,7 @@ configurations from pretrained models or local paths.
 """
 
 import abc
+import json
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -38,6 +39,40 @@ from opentau.utils.hub import HubMixin
 
 # Generic variable that is either PreTrainedConfig or a subclass thereof
 T = TypeVar("T", bound="PreTrainedConfig")
+
+_DEPRECATED_LATENCY_FIELDS = (
+    "cloud_vlm_latency_mean",
+    "cloud_vlm_latency_std",
+    "cloud_vlm_latency_lower",
+    "cloud_vlm_latency_upper",
+    "action_decoder_latency_mean",
+    "action_decoder_latency_std",
+    "action_decoder_latency_lower",
+    "action_decoder_latency_upper",
+)
+
+
+def _strip_deprecated_fields_from_json(path: Path) -> None:
+    """Remove deprecated latency fields from a saved config JSON file in-place.
+
+    Handles both top-level fields (policy configs) and fields nested under a
+    ``"policy"`` key (train configs).
+    """
+    with open(path) as f:
+        data = json.load(f)
+
+    changed = False
+    for key in _DEPRECATED_LATENCY_FIELDS:
+        if key in data:
+            del data[key]
+            changed = True
+        if isinstance(data.get("policy"), dict) and key in data["policy"]:
+            del data["policy"][key]
+            changed = True
+
+    if changed:
+        with open(path, "w") as f:
+            json.dump(data, f, indent=4)
 
 
 @dataclass
@@ -68,22 +103,15 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):
     use_amp: bool = False
     pretrained_path: str | None = None
 
-    # Mean latency of cloud VLM in seconds.
+    # Deprecated: latency fields are no longer used. Kept for backward-compatible
+    # loading of old JSON configs. Must remain 0.0; non-zero values will raise.
     cloud_vlm_latency_mean: float = 0.0
-    # Standard deviation of latency of cloud VLM in seconds.
     cloud_vlm_latency_std: float = 0.0
-    # Lower bound of latency of cloud VLM in seconds.
     cloud_vlm_latency_lower: float = 0.0
-    # Upper bound of latency of cloud VLM in seconds.
     cloud_vlm_latency_upper: float = 0.0
-
-    # Mean latency of action decoder in seconds.
     action_decoder_latency_mean: float = 0.0
-    # Standard deviation of latency of action decoder in seconds.
     action_decoder_latency_std: float = 0.0
-    # Lower bound of latency of action decoder in seconds.
     action_decoder_latency_lower: float = 0.0
-    # Upper bound of latency of action decoder in seconds.
     action_decoder_latency_upper: float = 0.0
 
     def __post_init__(self):
@@ -92,7 +120,13 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):
         This method can be overridden by subclasses to perform additional
         initialization after the dataclass is created.
         """
-        pass
+        for field_name in _DEPRECATED_LATENCY_FIELDS:
+            value = getattr(self, field_name)
+            if value != 0.0:
+                raise ValueError(
+                    f"Deprecated config field '{field_name}' must be 0.0, got {value}. "
+                    "Non-zero latency config fields are no longer supported."
+                )
 
     @property
     def type(self) -> str:
@@ -216,8 +250,10 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):
         Args:
             save_directory: Directory path where the configuration will be saved.
         """
-        with open(save_directory / CONFIG_NAME, "w") as f, draccus.config_type("json"):
+        config_path = save_directory / CONFIG_NAME
+        with open(config_path, "w") as f, draccus.config_type("json"):
             draccus.dump(self, f, indent=4)
+        _strip_deprecated_fields_from_json(config_path)
 
     @classmethod
     def from_pretrained(

--- a/src/opentau/configs/train.py
+++ b/src/opentau/configs/train.py
@@ -33,7 +33,11 @@ from huggingface_hub.errors import HfHubHTTPError
 from opentau.configs import parser
 from opentau.configs.default import DatasetMixtureConfig, EvalConfig, WandBConfig
 from opentau.configs.deployment import ServerConfig
-from opentau.configs.policies import PreTrainedConfig, strip_deprecated_fields_from_json
+from opentau.configs.policies import (
+    PreTrainedConfig,
+    strip_deprecated_fields_from_json,
+    warn_deprecated_latency_fields,
+)
 from opentau.envs.configs import EnvConfig
 from opentau.optim import OptimizerConfig
 from opentau.optim.schedulers import LRSchedulerConfig
@@ -370,6 +374,9 @@ class TrainPipelineConfig(HubMixin):
                 raise FileNotFoundError(
                     f"{TRAIN_CONFIG_NAME} not found on the HuggingFace Hub in {model_id}"
                 ) from e
+
+        if config_file is not None:
+            warn_deprecated_latency_fields(config_file)
 
         cli_args = kwargs.pop("cli_args", [])
         cfg = draccus.parse(cls, config_file, args=cli_args)

--- a/src/opentau/configs/train.py
+++ b/src/opentau/configs/train.py
@@ -33,7 +33,7 @@ from huggingface_hub.errors import HfHubHTTPError
 from opentau.configs import parser
 from opentau.configs.default import DatasetMixtureConfig, EvalConfig, WandBConfig
 from opentau.configs.deployment import ServerConfig
-from opentau.configs.policies import PreTrainedConfig
+from opentau.configs.policies import PreTrainedConfig, _strip_deprecated_fields_from_json
 from opentau.envs.configs import EnvConfig
 from opentau.optim import OptimizerConfig
 from opentau.optim.schedulers import LRSchedulerConfig
@@ -292,8 +292,10 @@ class TrainPipelineConfig(HubMixin):
         Args:
             save_directory: Directory path where the configuration will be saved.
         """
-        with open(save_directory / TRAIN_CONFIG_NAME, "w") as f, draccus.config_type("json"):
+        config_path = save_directory / TRAIN_CONFIG_NAME
+        with open(config_path, "w") as f, draccus.config_type("json"):
             draccus.dump(self, f, indent=4)
+        _strip_deprecated_fields_from_json(config_path)
 
     @classmethod
     def from_pretrained(

--- a/src/opentau/configs/train.py
+++ b/src/opentau/configs/train.py
@@ -33,7 +33,7 @@ from huggingface_hub.errors import HfHubHTTPError
 from opentau.configs import parser
 from opentau.configs.default import DatasetMixtureConfig, EvalConfig, WandBConfig
 from opentau.configs.deployment import ServerConfig
-from opentau.configs.policies import PreTrainedConfig, _strip_deprecated_fields_from_json
+from opentau.configs.policies import PreTrainedConfig, strip_deprecated_fields_from_json
 from opentau.envs.configs import EnvConfig
 from opentau.optim import OptimizerConfig
 from opentau.optim.schedulers import LRSchedulerConfig
@@ -295,7 +295,7 @@ class TrainPipelineConfig(HubMixin):
         config_path = save_directory / TRAIN_CONFIG_NAME
         with open(config_path, "w") as f, draccus.config_type("json"):
             draccus.dump(self, f, indent=4)
-        _strip_deprecated_fields_from_json(config_path)
+        strip_deprecated_fields_from_json(config_path)
 
     @classmethod
     def from_pretrained(

--- a/src/opentau/datasets/factory.py
+++ b/src/opentau/datasets/factory.py
@@ -30,8 +30,7 @@ The factory supports two types of datasets:
 
 Key Features:
     - Delta timestamp resolution: Automatically configures temporal offsets
-      for features based on policy latency settings (action decoder and
-      cloud VLM latencies).
+      for features.
     - Image transform support: Applies configurable image transformations
       during dataset creation.
     - Imagenet stats override: Optionally replaces dataset statistics with
@@ -97,33 +96,21 @@ IMAGENET_STATS = {
 def resolve_delta_timestamps(
     cfg: TrainPipelineConfig, dataset_cfg: DatasetConfig, ds_meta: LeRobotDatasetMetadata
 ) -> tuple:
-    """Resolves delta_timestamps by based on TrainPipelineConfig.
+    """Resolves per-feature delta_timestamps based on TrainPipelineConfig.
 
     Args:
         cfg (TrainPipelineConfig): The TrainPipelineConfig to read delta_indices from.
+        dataset_cfg (DatasetConfig): The dataset configuration.
         ds_meta (LeRobotDatasetMetadata): The dataset from which features and fps are used to build
             delta_timestamps against.
 
     Returns:
-        A 2-tuple containing:
-
-            - At index 0, a 4-tuple containing delta timestamps mean, std, lower, and upper bounds for each group.
-            - At index 1, a dictionary mapping feature names to their corresponding group and index.
-
-        The delta timestamps and group mapping should follow the structure expected by LeRobotDataset.
+        A 4-tuple ``(mean, std, lower, upper)`` of dicts mapping feature names
+        to lists of delta-timestamp values.  Keys that appear only in ``mean``
+        will be filled with sensible defaults by
+        ``LeRobotDataset.compute_delta_params``.
     """
-    group = "input_group"
-    feature2group = {}
-    # Delta timestamps are in seconds, and negative because they represent past timestamps.
-    # Hence, lower and upper bounds correspond to -upper and -lower.
-    delta_timestamps = {group: [-cfg.policy.action_decoder_latency_mean, -cfg.policy.cloud_vlm_latency_mean]}
-    delta_timestamps_std = {group: [cfg.policy.action_decoder_latency_std, cfg.policy.cloud_vlm_latency_std]}
-    delta_timestamps_lower = {
-        group: [-cfg.policy.action_decoder_latency_upper, -cfg.policy.cloud_vlm_latency_upper]
-    }
-    delta_timestamps_upper = {
-        group: [-cfg.policy.action_decoder_latency_lower, -cfg.policy.cloud_vlm_latency_lower]
-    }
+    delta_timestamps: dict[str, list[float]] = {}
     action_freq = cfg.dataset_mixture.action_freq
 
     name_map = DATA_FEATURES_NAME_MAPPING[dataset_cfg.repo_id]
@@ -135,21 +122,10 @@ def resolve_delta_timestamps(
         standard_key = reverse_name_map[key]
         if standard_key == "actions" and cfg.policy.action_delta_indices is not None:
             delta_timestamps[key] = [i / action_freq for i in cfg.policy.action_delta_indices]
-            feature2group[key] = (key, None)
-        if "camera" in standard_key:
-            # Index 0 corresponds to action decoder latency and index 1 to cloud VLM latency.
-            # Pick both indices. `_to_standard_data_format()` will separate the two.
-            feature2group[key] = (group, [0, 1])
-        elif standard_key == "state":
-            # Pick index 0, which corresponds to latency of action decoder, and squeeze it to a scalar.
-            feature2group[key] = (group, 0)
+        elif "camera" in standard_key or standard_key == "state":
+            delta_timestamps[key] = [0.0]
 
-    return (
-        delta_timestamps,
-        delta_timestamps_std,
-        delta_timestamps_lower,
-        delta_timestamps_upper,
-    ), feature2group
+    return delta_timestamps, {}, {}, {}
 
 
 def make_dataset(
@@ -191,7 +167,7 @@ def make_dataset(
         dataset = ds_cls(train_cfg)
     elif isinstance(cfg.repo_id, str):
         ds_meta = LeRobotDatasetMetadata(cfg.repo_id, root=cfg.root, revision=cfg.revision)
-        (dt_mean, dt_std, dt_lower, dt_upper), f2g = resolve_delta_timestamps(train_cfg, cfg, ds_meta)
+        dt_mean, dt_std, dt_lower, dt_upper = resolve_delta_timestamps(train_cfg, cfg, ds_meta)
         dataset = LeRobotDataset(
             train_cfg,
             cfg.repo_id,
@@ -201,7 +177,6 @@ def make_dataset(
             delta_timestamps_std=dt_std,
             delta_timestamps_lower=dt_lower,
             delta_timestamps_upper=dt_upper,
-            feature2group=f2g,
             image_transforms=image_transforms,
             revision=cfg.revision,
             video_backend=cfg.video_backend,

--- a/src/opentau/datasets/factory.py
+++ b/src/opentau/datasets/factory.py
@@ -113,6 +113,7 @@ def resolve_delta_timestamps(
     delta_timestamps: dict[str, list[float]] = {}
     action_freq = cfg.dataset_mixture.action_freq
 
+    assert dataset_cfg.repo_id is not None
     name_map = DATA_FEATURES_NAME_MAPPING[dataset_cfg.repo_id]
     reverse_name_map = {v: k for k, v in name_map.items()}
     for key in ds_meta.features:
@@ -120,7 +121,11 @@ def resolve_delta_timestamps(
             continue  # only process camera, state, and action features
 
         standard_key = reverse_name_map[key]
-        if standard_key == "actions" and cfg.policy.action_delta_indices is not None:
+        if (
+            standard_key == "actions"
+            and cfg.policy is not None
+            and cfg.policy.action_delta_indices is not None
+        ):
             delta_timestamps[key] = [i / action_freq for i in cfg.policy.action_delta_indices]
         elif "camera" in standard_key or standard_key == "state":
             delta_timestamps[key] = [0.0]
@@ -184,9 +189,18 @@ def make_dataset(
             vector_resample_strategy=train_cfg.dataset_mixture.vector_resample_strategy,
             return_advantage_input=return_advantage_input,
         )
+    else:
+        raise ValueError("Exactly one of `cfg.vqa` and `cfg.repo_id` should be provided.")
 
     # TODO vqa datasets implement stats in original feature names, but camera_keys are standardized names
-    if not isinstance(cfg.vqa, str) and "dummy" not in cfg.repo_id and cfg.use_imagenet_stats:
+    if (
+        not isinstance(cfg.vqa, str)
+        and isinstance(cfg.repo_id, str)
+        and "dummy" not in cfg.repo_id
+        and cfg.use_imagenet_stats
+    ):
+        if dataset.meta.stats is None:
+            dataset.meta.stats = {}
         for key in dataset.meta.camera_keys:
             for stats_type, stats in IMAGENET_STATS.items():
                 if key not in dataset.meta.stats:
@@ -197,9 +211,9 @@ def make_dataset(
         val_size = int(len(dataset) * cfg.val_split_ratio)
         train_size = len(dataset) - val_size
         train_dataset, val_dataset = torch.utils.data.random_split(dataset, [train_size, val_size])
-        train_dataset.meta = copy.deepcopy(dataset.meta)
-        val_dataset.meta = copy.deepcopy(dataset.meta)
-        return train_dataset, val_dataset
+        train_dataset.meta = copy.deepcopy(dataset.meta)  # type: ignore[assignment]
+        val_dataset.meta = copy.deepcopy(dataset.meta)  # type: ignore[assignment]
+        return train_dataset, val_dataset  # type: ignore[return-value]
 
     return dataset
 

--- a/src/opentau/datasets/factory.py
+++ b/src/opentau/datasets/factory.py
@@ -84,6 +84,7 @@ from opentau.datasets.lerobot_dataset import (
 )
 from opentau.datasets.standard_data_format_mapping import DATA_FEATURES_NAME_MAPPING
 from opentau.datasets.transforms import ImageTransforms
+from opentau.datasets.utils import DeltaTimestampInfo
 
 IMAGENET_STATS = {
     "min": [[[0.0]], [[0.0]], [[0.0]]],  # (c,1,1)
@@ -95,7 +96,7 @@ IMAGENET_STATS = {
 
 def resolve_delta_timestamps(
     cfg: TrainPipelineConfig, dataset_cfg: DatasetConfig, ds_meta: LeRobotDatasetMetadata
-) -> tuple:
+) -> DeltaTimestampInfo:
     """Resolves per-feature delta_timestamps based on TrainPipelineConfig.
 
     Args:
@@ -113,7 +114,8 @@ def resolve_delta_timestamps(
     delta_timestamps: dict[str, list[float]] = {}
     action_freq = cfg.dataset_mixture.action_freq
 
-    assert dataset_cfg.repo_id is not None
+    if dataset_cfg.repo_id is None:
+        raise ValueError("dataset_cfg.repo_id must not be None when resolving delta timestamps.")
     name_map = DATA_FEATURES_NAME_MAPPING[dataset_cfg.repo_id]
     reverse_name_map = {v: k for k, v in name_map.items()}
     for key in ds_meta.features:
@@ -130,7 +132,8 @@ def resolve_delta_timestamps(
         elif "camera" in standard_key or standard_key == "state":
             delta_timestamps[key] = [0.0]
 
-    return delta_timestamps, {}, {}, {}
+    dt_mean = {k: np.array(v) for k, v in delta_timestamps.items()}
+    return dt_mean, {}, {}, {}
 
 
 def make_dataset(

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -603,8 +603,6 @@ class BaseDataset(torch.utils.data.Dataset):
     Subclasses must implement:
         - `_get_feature_mapping_key()`: Returns the key used for feature name
           mapping (e.g., "lerobot/aloha_mobile_cabinet")
-        - `_separate_image_in_time()`: Separates temporal image sequences into
-          individual frames
 
     Attributes:
         resolution: Target image resolution (height, width).
@@ -618,8 +616,6 @@ class BaseDataset(torch.utils.data.Dataset):
             >>> class MyDataset(BaseDataset):
             ...     def _get_feature_mapping_key(self):
             ...         return "my-dataset"
-            ...     def _separate_image_in_time(self, item):
-            ...         pass  # No temporal separation needed
     """
 
     def __init__(self, cfg: TrainPipelineConfig):
@@ -636,21 +632,7 @@ class BaseDataset(torch.utils.data.Dataset):
         r"""Returns the key used for feature mapping"""
         pass
 
-    @abstractmethod
-    def _separate_image_in_time(self, item: dict):
-        r"""Some keys correspond to 2 images, where the first is image at current timestamp and the second is the image
-        from some time ago. We separate these 2 images into different keys by modifying the `item` dictionary.
-        For example, {"image_key": torch.zeros(2, 3, 224, 224), "image_key_is_pad": [False, True] } will become
-        {
-            "image_key": torch.zeros(3, 224, 224),
-            "image_key_local": torch.zeros(3, 224, 224),
-            "image_key_is_pad: False,
-            "image_key_local_is_pad": True,
-        }.
-        """
-        raise NotImplementedError
-
-    def _standardize_images(self, item, standard_item, n_cams, is_local) -> list[bool]:
+    def _standardize_images(self, item, standard_item, n_cams) -> list[bool]:
         """Standardize image features to a common format.
 
         Resizes images to the target resolution with padding, and tracks
@@ -660,7 +642,6 @@ class BaseDataset(torch.utils.data.Dataset):
             item: Input item dictionary with original image keys.
             standard_item: Output dictionary to populate with standardized images.
             n_cams: Number of cameras to process.
-            is_local: Whether processing local (past) images.
 
         Returns:
             List of boolean values indicating which images are padded.
@@ -710,13 +691,12 @@ class BaseDataset(torch.utils.data.Dataset):
             Dictionary with standardized feature names and formats.
         """
         name_map = DATA_FEATURES_NAME_MAPPING[self._get_feature_mapping_key()]
-        self._separate_image_in_time(item)
 
         standard_item = {}
-        img_is_pad = self._standardize_images(item, standard_item, self.num_cams, False)
+        img_is_pad = self._standardize_images(item, standard_item, self.num_cams)
 
         for new_key, key in name_map.items():
-            if new_key.startswith("camera"):
+            if "camera" in new_key:
                 continue
             standard_item[new_key] = item[key]
 
@@ -827,7 +807,6 @@ class LeRobotDataset(BaseDataset):
         episodes: Dictionary mapping episode_index to episode info.
         image_transforms: Optional image transforms to apply.
         delta_timestamps_params: Processed delta timestamp parameters.
-        feature2group: Mapping from features to temporal groups.
         video_backend: Backend used for video decoding.
         standardize: Whether to standardize data format.
 
@@ -863,7 +842,6 @@ class LeRobotDataset(BaseDataset):
         delta_timestamps_std: dict[str, np.ndarray | list[float]] | None = None,
         delta_timestamps_lower: dict[str, np.ndarray | list[float]] | None = None,
         delta_timestamps_upper: dict[str, np.ndarray | list[float]] | None = None,
-        feature2group: dict[str, tuple[str, (list[int] | int | None)]] | None = None,
         tolerance_s: float = 1e-4,
         revision: str | None = None,
         force_cache_sync: bool = False,
@@ -963,39 +941,18 @@ class LeRobotDataset(BaseDataset):
             image_transforms (Callable | None, optional): You can pass standard v2 image transforms from
                 torchvision.transforms.v2 here which will be applied to visual modalities (whether they come
                 from videos or images). Defaults to None.
-            delta_timestamps (dict[list[float]] | None, optional): Dictionary where each key is a group name and its
-                corresponding value is a list of delta timestamps in seconds. For example, {'group1': [0, 0.1]} means
-                features of group1 will be returned as a chunk of 2, with the first element being the value at current
-                time and the second element being the value at current time + 0.1 seconds. This will also add a key
-                named '{feature}_is_pad' to the returned item, with a boolean type and a length of 2, indicating whether
-                the feature is padded or not. Padding will happen when t + 0.1 is outside the episode time range.
+            delta_timestamps (dict[list[float]] | None, optional): Dictionary mapping feature
+                names to lists of delta timestamps in seconds. For example,
+                ``{'state': [0.0], 'action': [0, 0.5, 1.0]}`` means state is sampled at the current
+                time and action is sampled at three offsets. A ``{feature}_is_pad`` boolean mask of the
+                same length is added to the returned item. Defaults to None.
+            delta_timestamps_std: (dict[list[float]] | None, optional): Per-feature standard
+                deviation for the delta timestamps. Absent keys are treated as deterministic (std=0).
                 Defaults to None.
-            delta_timestamps_std: (dict[list[float]] | None, optional): Similar to delta_timestamps, but specifies an
-                optional standard deviation for the delta timestamps. If a key is absent, the delta timestamps for that
-                key will be deterministic. If a key is present without corresponding delta_timestamps, it will be
-                ignored. E.g., delta_timestamps={'group1': [0, 0.1]} and delta_timestamps_std={'group1': [0, 0.05]} will
-                result in a chunk of 2, with the first element being the feature at current time and the second
-                element at a time following a Gaussian distribution with N(t+0.1, 0.05^2). When it takes on a value
-                outside the episode, the corresponding element in `{feature}_is_mask` will be set to True.
-                Defaults to None.
-            delta_timestamps_lower: (dict[list[float]] | None, optional): Similar to delta_timestamps_std, but specifies
-                a minimum value for the delta timestamps. When specified, the delta timestamps will be lower-clipped
-                accordingly. Defaults to None.
-            delta_timestamps_upper: (dict[list[float]] | None, optional): Similar to delta_timestamps_std, but specifies
-                a maximum value for the delta timestamps. When specified, the delta timestamps will be upper-clipped
-                accordingly. Defaults to None.
-            feature2group: (dict[str, tuple[str, (list[int] | int | None)]] | None, optional): Dictionary mapping every
-                individual feature to a tuple of (group name, indices). Group names are keys passed to delta_timestamps.
-                If `indices` is None, will use all indices in the group. If indices is a list, will use only those
-                indices in the corresponding order, including duplicates if present. If indices is an int, will return
-                that index only, resulting in a reduction in ndim by 1.
-                For example, `feature2group={'action': ('group1', None), 'observation.state': ('group2', 0),
-                'observation.images.left_hand': ('group2', [0, 1])}` means the feature `action` will use resolved
-                `delta_timestamps` from `group1` and will return every index. Also, `observation.state` will pick the
-                first element (index-0) of `group2`. `observation.images.left_hand` will pick the first and second
-                elements (indices 0 and 1) of `group2` and return them as a chunk of 2 images. The first element of
-                `observation.images.left_hand` and the state vector will always be sampled at the same timestamp despite
-                having gaussian noise applied, because they are in the same group.
+            delta_timestamps_lower: (dict[list[float]] | None, optional): Per-feature lower bound
+                for the delta timestamps. Defaults to None.
+            delta_timestamps_upper: (dict[list[float]] | None, optional): Per-feature upper bound
+                for the delta timestamps. Defaults to None.
             tolerance_s (float, optional): Tolerance in seconds used to ensure data timestamps are actually in
                 sync with the fps value. It is used at the init of the dataset to make sure that each
                 timestamps is separated to the next by 1/fps +/- tolerance_s. This also applies to frames
@@ -1023,19 +980,12 @@ class LeRobotDataset(BaseDataset):
         self.repo_id = repo_id
         self.root = Path(root) if root else HF_OPENTAU_HOME / repo_id
         self.image_transforms = image_transforms
-        if bool(delta_timestamps) ^ bool(feature2group):
-            raise ValueError(
-                "Either both delta_timestamps and feature2group should be provided, or neither of them."
-            )
-        # delta_timestamps_params is a 4 tuple (mean, std, lower, upper)
         self.delta_timestamps_params = self.compute_delta_params(
             delta_timestamps,
             delta_timestamps_std,
             delta_timestamps_lower,
             delta_timestamps_upper,
         )
-        self.feature2group = feature2group or {}
-        self._check_feature_group_mapping()
         self.episodes = episodes
         self.tolerance_s = tolerance_s
         self.revision = revision if revision else CODEBASE_VERSION
@@ -1283,13 +1233,6 @@ class LeRobotDataset(BaseDataset):
 
         # Get the delta_indices by group
         delta_indices = get_delta_indices_soft(self.delta_timestamps_params, self.fps)
-        # Map from group to feature
-        delta_indices = {
-            feature: delta_indices[group][
-                slice(None) if indices is None else [indices] if isinstance(indices, int) else indices
-            ]
-            for feature, (group, indices) in self.feature2group.items()
-        }
         query_indices = {
             key: np.clip(idx + delta_idx, ep_start, ep_end - 1) for key, delta_idx in delta_indices.items()
         }
@@ -1485,9 +1428,9 @@ class LeRobotDataset(BaseDataset):
         task_idx = item["task_index"].item()
         item["task"] = self.meta.tasks[task_idx]
 
-        # If indices is an int, squeeze the feature
-        for feature, (_, indices) in self.feature2group.items():
-            if isinstance(indices, int):
+        # Squeeze the temporal dimension for features with a single delta timestamp
+        for feature, mean in self.delta_timestamps_params[0].items():
+            if len(mean) == 1 and feature in item:
                 item[feature] = item[feature].squeeze(0)
 
         # The conversion script of AGI BOT dataset uses a dataloader to enumerate data and compute stats.
@@ -1797,18 +1740,6 @@ class LeRobotDataset(BaseDataset):
 
         return video_paths
 
-    def _separate_image_in_time(self, item: dict):
-        name_map = DATA_FEATURES_NAME_MAPPING[self._get_feature_mapping_key()]
-        cam_keys = {v for k, v in name_map.items() if k.startswith("camera")}
-        for k in cam_keys:
-            images = item.pop(k)
-            if len(images) == 2:
-                item[k + "_local"], item[k] = images
-
-            pads = item.get(k + "_is_pad")
-            if hasattr(pads, "__len__") and len(pads) == 2:
-                item[k + "_local_is_pad"], item[k + "_is_pad"] = pads
-
     @staticmethod
     def compute_delta_params(
         mean: dict[str, np.ndarray | list[float]],
@@ -1817,22 +1748,21 @@ class LeRobotDataset(BaseDataset):
         upper: dict[str, np.ndarray | list[float]],
     ):
         r"""Process the parameters `mean`, `std`, `lower` and `upper` for delta timestamps.
-        Delta timestamps will be computed dynamically in `__getitem__` with `clip(dT, lower, upper)` where `dT` follows
-        the gaussian distribution N(mean, std^2). Each parameter is a dictionary mapping group names to sequences of
+
+        Delta timestamps are computed dynamically in ``__getitem__`` with
+        ``clip(dT, lower, upper)`` where ``dT ~ N(mean, std^2)``.  Each
+        parameter is a dictionary mapping **feature names** to sequences of
         floats.
 
-        For example, mean = {"group1": [-0.1, 0.0, 0.1], "group2": [0.0, 0.2]}. indicates that 3 delta timestamps for
-        features in group1 will be sampled: time t-0.1, t, and t+0.1; and 2 delta timestamps for features in group2 will
-        be sampled: time t and t+0.2, where t is the timestamp of the current data point.
+        For example, ``mean = {"state": [0.0], "action": [0.0, 0.5, 1.0]}``
+        means the ``state`` feature will be sampled at ``t + 0.0`` and the
+        ``action`` feature will be sampled at three offsets ``t``, ``t+0.5``
+        and ``t+1.0``.
 
-        It is assumed that the `std`, `lower`, and `upper` have the same keys as `mean`, and matching keys have values
-        of the same length. If a key absent from `std`, `lower`, or `upper`, it will be set to a default value.
-        Namely, `std` will be set to all 0, `lower` will be set to all `-inf`, and `upper` will be set to `+inf`, with
-        lengths equal to the length of sequences in `mean` for that key.
-        If a key is absent from `mean` but present in `std`, `lower`, or `upper`, it will be ignored.
-
-        After processing, the function returns four dictionaries: `mean`, `std`, `lower`, and `upper`, where each key
-        is a feature name and each value is a numpy array of floats, satisfying the above conditions.
+        Keys present in ``std`` / ``lower`` / ``upper`` but absent from
+        ``mean`` are ignored.  Keys absent from ``std`` / ``lower`` /
+        ``upper`` but present in ``mean`` receive sensible defaults (0 for
+        std, -inf / +inf for bounds).
         """
         inf = float("inf")
         mean = mean or {}
@@ -1855,18 +1785,6 @@ class LeRobotDataset(BaseDataset):
                 )
 
         return mean, std, lower, upper
-
-    def _check_feature_group_mapping(self):
-        for feature, (group, indices) in self.feature2group.items():
-            if group not in self.delta_timestamps_params[0]:
-                raise ValueError(
-                    f"Feature '{feature}' is mapped to group '{group}', which is not present in "
-                    "delta_timestamps_params. Please check the mapping."
-                )
-            if indices is not None and not isinstance(indices, (int, list)):
-                raise ValueError(
-                    f"Indices for feature '{feature}' in group '{group}' should be a list, an int, or None"
-                )
 
     @classmethod
     def create(
@@ -1912,7 +1830,6 @@ class LeRobotDataset(BaseDataset):
         obj.hf_dataset = obj.create_hf_dataset()
         obj.image_transforms = None
         obj.delta_timestamps_params = obj.compute_delta_params(None, None, None, None)
-        obj.feature2group = {}
         obj.episode_data_index = None
         obj.video_backend = video_backend if video_backend is not None else get_safe_default_codec()
         obj.image_resample_strategy = image_resample_strategy

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -114,6 +114,8 @@ from opentau.datasets.utils import (
     DEFAULT_IMAGE_PATH,
     INFO_PATH,
     TASKS_PATH,
+    DeltaTimestampInfo,
+    DeltaTimestampParam,
     append_jsonlines,
     backward_compatible_episodes_stats,
     check_timestamps_sync,
@@ -216,7 +218,7 @@ class DatasetMetadata:
         repo_id: Repository ID of the dataset (set by subclasses).
     """
 
-    def __init__(self, *, info: dict = None, stats: dict = None):
+    def __init__(self, *, info: dict | None = None, stats: dict | None = None):
         self.info = info or {"features": {}}
         self.stats = stats or {}
 
@@ -226,7 +228,7 @@ class DatasetMetadata:
                     self.stats[feature_name][metric] = np.array(self.stats[feature_name][metric])
                 # TODO: check stats[feature_name][metric].shape is broadcastable with features[feature_name]["shape"]
 
-        self.repo_id = None
+        self.repo_id: str | None = None
 
     @property
     def features(self) -> dict[str, dict]:
@@ -344,12 +346,14 @@ class LeRobotDatasetMetadata(DatasetMetadata):
         Loads info, tasks, episodes, statistics, and advantages from the
         dataset root directory. Handles version compatibility checks.
         """
+        assert self.repo_id is not None
         self.info = load_info(self.root)
         check_version_compatibility(self.repo_id, self._version, CODEBASE_VERSION)
         self.tasks, self.task_to_task_index = load_tasks(self.root)
         self.episodes = load_episodes(self.root)
         if self._version < packaging.version.parse("v2.1"):
             self.stats = load_stats(self.root)
+            assert self.stats is not None
             self.episodes_stats = backward_compatible_episodes_stats(self.stats, self.episodes)
         else:
             self.episodes_stats = load_episodes_stats(self.root)
@@ -362,6 +366,7 @@ class LeRobotDatasetMetadata(DatasetMetadata):
         allow_patterns: list[str] | str | None = None,
         ignore_patterns: list[str] | str | None = None,
     ) -> None:
+        assert self.repo_id is not None
         snapshot_download(
             self.repo_id,
             repo_type="dataset",
@@ -400,6 +405,7 @@ class LeRobotDatasetMetadata(DatasetMetadata):
             Path to the video file for the episode.
         """
         ep_chunk = self.get_episode_chunk(ep_index)
+        assert self.video_path is not None
         fpath = self.video_path.format(episode_chunk=ep_chunk, video_key=vid_key, episode_index=ep_index)
         return Path(fpath)
 
@@ -1013,6 +1019,7 @@ class LeRobotDataset(BaseDataset):
         # Unused attributes
         self.image_writer = None
         self.episode_buffer = None
+        self.skip_video_stats = False
 
         self.root.mkdir(exist_ok=True, parents=True)
 
@@ -1136,7 +1143,7 @@ class LeRobotDataset(BaseDataset):
 
         self.pull_from_repo(allow_patterns=files, ignore_patterns=ignore_patterns)
 
-    def get_episodes_file_paths(self) -> list[Path]:
+    def get_episodes_file_paths(self) -> list[str]:
         """Get file paths for all selected episodes.
 
         Returns paths for both parquet data files and video files (if applicable)
@@ -1178,7 +1185,7 @@ class LeRobotDataset(BaseDataset):
         """
         features = get_hf_features_from_features(self.features)
         ft_dict = {col: [] for col in features}
-        hf_dataset = datasets.Dataset.from_dict(ft_dict, features=features, split="train")
+        hf_dataset = datasets.Dataset.from_dict(ft_dict, features=features, split=datasets.Split.TRAIN)
 
         # TODO(aliberts): hf_dataset.set_format("torch")
         hf_dataset.set_transform(hf_transform_to_torch)
@@ -1213,7 +1220,7 @@ class LeRobotDataset(BaseDataset):
 
     def _get_query_indices_soft(
         self, idx: int, ep_idx: int
-    ) -> tuple[dict[str, np.ndarray], dict[str, np.ndarray]]:
+    ) -> tuple[dict[str, np.ndarray], dict[str, torch.Tensor]]:
         """Get soft (float) indices for querying features with delta timestamps.
 
         Computes indices for features based on delta timestamps, accounting for
@@ -1237,7 +1244,9 @@ class LeRobotDataset(BaseDataset):
             key: np.clip(idx + delta_idx, ep_start, ep_end - 1) for key, delta_idx in delta_indices.items()
         }
         padding = {  # Pad values outside of current episode range
-            f"{key}_is_pad": torch.BoolTensor((idx + delta_idx < ep_start) | (idx + delta_idx >= ep_end))
+            f"{key}_is_pad": torch.tensor(
+                (idx + delta_idx < ep_start) | (idx + delta_idx >= ep_end), dtype=torch.bool
+            )
             for key, delta_idx in delta_indices.items()
         }
         return query_indices, padding
@@ -1399,7 +1408,9 @@ class LeRobotDataset(BaseDataset):
         ep_idx = item["episode_index"].item()
 
         if self.episode_data_index is not None and self.epi2idx is not None:
-            ep_end = self.episode_data_index["to"][self.epi2idx[ep_idx]].item()
+            ep_end = int(self.episode_data_index["to"][self.epi2idx[ep_idx]].item())
+        else:
+            ep_end = 0
 
         episodes_info = self.meta.episodes[ep_idx]
 
@@ -1581,8 +1592,9 @@ class LeRobotDataset(BaseDataset):
                 save the current episode in self.episode_buffer, which is filled with 'add_frame'. Defaults to
                 None.
         """
-        if not episode_data:
-            episode_buffer = self.episode_buffer
+        episode_buffer = self.episode_buffer if episode_data is None else episode_data
+        if episode_buffer is None:
+            raise RuntimeError("No episode data provided and no episode buffer exists. Call add_frame first.")
 
         validate_episode_buffer(episode_buffer, self.meta.total_episodes, self.features)
 
@@ -1665,7 +1677,9 @@ class LeRobotDataset(BaseDataset):
 
     def _save_episode_table(self, episode_buffer: dict, episode_index: int) -> None:
         episode_dict = {key: episode_buffer[key] for key in self.hf_features}
-        ep_dataset = datasets.Dataset.from_dict(episode_dict, features=self.hf_features, split="train")
+        ep_dataset = datasets.Dataset.from_dict(
+            episode_dict, features=self.hf_features, split=datasets.Split.TRAIN
+        )
         ep_dataset = embed_images(ep_dataset)
         self.hf_dataset = concatenate_datasets([self.hf_dataset, ep_dataset])
         self.hf_dataset.set_transform(hf_transform_to_torch)
@@ -1674,6 +1688,8 @@ class LeRobotDataset(BaseDataset):
         ep_dataset.to_parquet(ep_data_path)
 
     def clear_episode_buffer(self) -> None:
+        if self.episode_buffer is None:
+            return
         episode_index = self.episode_buffer["episode_index"]
         if self.image_writer is not None:
             for cam_key in self.meta.camera_keys:
@@ -1742,11 +1758,11 @@ class LeRobotDataset(BaseDataset):
 
     @staticmethod
     def compute_delta_params(
-        mean: dict[str, np.ndarray | list[float]],
-        std: dict[str, np.ndarray | list[float]],
-        lower: dict[str, np.ndarray | list[float]],
-        upper: dict[str, np.ndarray | list[float]],
-    ):
+        mean: dict[str, np.ndarray | list[float]] | None,
+        std: dict[str, np.ndarray | list[float]] | None,
+        lower: dict[str, np.ndarray | list[float]] | None,
+        upper: dict[str, np.ndarray | list[float]] | None,
+    ) -> DeltaTimestampInfo:
         r"""Process the parameters `mean`, `std`, `lower` and `upper` for delta timestamps.
 
         Delta timestamps are computed dynamically in ``__getitem__`` with
@@ -1765,26 +1781,32 @@ class LeRobotDataset(BaseDataset):
         std, -inf / +inf for bounds).
         """
         inf = float("inf")
-        mean = mean or {}
-        mean = {k: np.array(v) for k, v in mean.items()}
+        mean_np: DeltaTimestampParam = {k: np.array(v) for k, v in (mean or {}).items()}
 
-        std = std or {}
-        std = {k: np.array(std.get(k) or np.zeros_like(v)) for k, v in mean.items()}
+        std_raw = std or {}
+        std_np: DeltaTimestampParam = {
+            k: np.array(std_raw.get(k) or np.zeros_like(v)) for k, v in mean_np.items()
+        }
 
-        lower = lower or {}
-        lower = {k: np.array(lower.get(k) or (np.zeros_like(v) - inf)) for k, v in mean.items()}
+        lower_raw = lower or {}
+        lower_np: DeltaTimestampParam = {
+            k: np.array(lower_raw.get(k) or (np.zeros_like(v) - inf)) for k, v in mean_np.items()
+        }
 
-        upper = upper or {}
-        upper = {k: np.array(upper.get(k) or (np.zeros_like(v) + inf)) for k, v in mean.items()}
+        upper_raw = upper or {}
+        upper_np: DeltaTimestampParam = {
+            k: np.array(upper_raw.get(k) or (np.zeros_like(v) + inf)) for k, v in mean_np.items()
+        }
 
-        for k in mean:
-            if not (mean[k].shape == std[k].shape == lower[k].shape == upper[k].shape):
+        for k in mean_np:
+            if not (mean_np[k].shape == std_np[k].shape == lower_np[k].shape == upper_np[k].shape):
                 raise ValueError(
                     f"Delta timestamps parameters for {k} have inconsistent shapes: "
-                    f"mean={mean[k].shape}, std={std[k].shape}, lower={lower[k].shape}, upper={upper[k].shape}"
+                    f"mean={mean_np[k].shape}, std={std_np[k].shape}, "
+                    f"lower={lower_np[k].shape}, upper={upper_np[k].shape}"
                 )
 
-        return mean, std, lower, upper
+        return mean_np, std_np, lower_np, upper_np
 
     @classmethod
     def create(

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -1407,10 +1407,12 @@ class LeRobotDataset(BaseDataset):
         item = self.hf_dataset[idx]
         ep_idx = item["episode_index"].item()
 
-        if self.episode_data_index is not None and self.epi2idx is not None:
-            ep_end = int(self.episode_data_index["to"][self.epi2idx[ep_idx]].item())
-        else:
-            ep_end = 0
+        if self.episode_data_index is None or self.epi2idx is None:
+            raise RuntimeError(
+                "episode_data_index and epi2idx must be set before calling __getitem__. "
+                "This usually means the dataset was not properly initialized."
+            )
+        ep_end = int(self.episode_data_index["to"][self.epi2idx[ep_idx]].item())
 
         episodes_info = self.meta.episodes[ep_idx]
 

--- a/src/opentau/datasets/standard_data_format_mapping.py
+++ b/src/opentau/datasets/standard_data_format_mapping.py
@@ -132,9 +132,6 @@ DATA_FEATURES_NAME_MAPPING = {
         "camera0": "observation.images.top",
         "camera1": "observation.images.main",
         "camera2": "observation.images.cv",
-        "local_camera0": "observation.images.top",
-        "local_camera1": "observation.images.main",
-        "local_camera2": "observation.images.cv",
         "state": "observation.state",
         "actions": "action",
         "prompt": "task",
@@ -170,8 +167,6 @@ DATA_FEATURES_NAME_MAPPING = {
     "lerobot/svla_so101_pickplace": {
         "camera0": "observation.images.up",
         "camera1": "observation.images.side",
-        "local_camera0": "observation.images.up",
-        "local_camera1": "observation.images.side",
         "state": "observation.state",
         "actions": "action",
         "prompt": "task",

--- a/src/opentau/datasets/utils.py
+++ b/src/opentau/datasets/utils.py
@@ -77,7 +77,7 @@ import contextlib
 import importlib.resources
 import json
 import logging
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from itertools import accumulate
 from pathlib import Path
 from pprint import pformat
@@ -404,7 +404,7 @@ def cast_stats_to_numpy(stats) -> dict[str, dict[str, np.ndarray]]:
     return unflatten_dict(stats)
 
 
-def load_stats(local_dir: Path) -> dict[str, dict[str, np.ndarray]]:
+def load_stats(local_dir: Path) -> dict[str, dict[str, np.ndarray]] | None:
     """Load dataset statistics from the standard stats.json file.
 
     Args:
@@ -419,7 +419,7 @@ def load_stats(local_dir: Path) -> dict[str, dict[str, np.ndarray]]:
     return cast_stats_to_numpy(stats)
 
 
-def load_advantages(local_dir: Path) -> dict:
+def load_advantages(local_dir: Path) -> dict | None:
     """Load advantage values from the advantages.json file.
 
     Advantages are keyed by (episode_index, timestamp) tuples in the JSON file
@@ -480,7 +480,7 @@ def write_episode(episode: dict, local_dir: Path) -> None:
     append_jsonlines(episode, local_dir / EPISODES_PATH)
 
 
-def load_episodes(local_dir: Path) -> dict:
+def load_episodes(local_dir: Path) -> dict[int, dict]:
     """Load episodes from the episodes.jsonl file.
 
     Args:
@@ -509,7 +509,7 @@ def write_episode_stats(episode_index: int, episode_stats: dict, local_dir: Path
     append_jsonlines(episode_stats, local_dir / EPISODES_STATS_PATH)
 
 
-def load_episodes_stats(local_dir: Path) -> dict:
+def load_episodes_stats(local_dir: Path) -> dict[int, dict[str, dict[str, np.ndarray]]]:
     """Load episode statistics from the episodes_stats.jsonl file.
 
     Args:
@@ -526,8 +526,8 @@ def load_episodes_stats(local_dir: Path) -> dict:
 
 
 def backward_compatible_episodes_stats(
-    stats: dict[str, dict[str, np.ndarray]], episodes: list[int]
-) -> dict[str, dict[str, np.ndarray]]:
+    stats: dict[str, dict[str, np.ndarray]], episodes: Iterable[int]
+) -> dict[int, dict[str, dict[str, np.ndarray]]]:
     """Create episode-level statistics from global statistics for backward compatibility.
 
     In older dataset versions, statistics were stored globally rather than per-episode.
@@ -545,7 +545,7 @@ def backward_compatible_episodes_stats(
 
 
 def load_image_as_numpy(
-    fpath: str | Path, dtype: np.dtype = np.float32, channel_first: bool = True
+    fpath: str | Path, dtype: np.typing.DTypeLike = np.float32, channel_first: bool = True
 ) -> np.ndarray:
     """Load an image file as a numpy array.
 
@@ -568,7 +568,7 @@ def load_image_as_numpy(
     return img_array
 
 
-def hf_transform_to_torch(items_dict: dict[torch.Tensor | None]):
+def hf_transform_to_torch(items_dict: dict[str, list]):
     """Get a transform function that convert items from Hugging Face dataset (pyarrow)
     to torch tensors. Importantly, images are converted from PIL, which corresponds to
     a channel last representation (h w c) of uint8 type, to a torch image representation
@@ -778,7 +778,7 @@ def dataset_to_policy_features(features: dict[str, dict]) -> dict[str, PolicyFea
 def create_empty_dataset_info(
     codebase_version: str,
     fps: int,
-    robot_type: str,
+    robot_type: str | None,
     features: dict,
     use_videos: bool,
 ) -> dict:
@@ -812,7 +812,7 @@ def create_empty_dataset_info(
 
 
 def get_episode_data_index(
-    episode_dicts: dict[dict], episodes: list[int] | None = None
+    episode_dicts: dict[int, dict], episodes: list[int] | None = None
 ) -> tuple[dict[str, torch.Tensor], dict[int, int]]:
     """Compute data indices for episodes in a flattened dataset.
 
@@ -1033,7 +1033,7 @@ class IterableNamespace(SimpleNamespace):
         details: IterableNamespace(age=25)
     """
 
-    def __init__(self, dictionary: dict[str, Any] = None, **kwargs):
+    def __init__(self, dictionary: dict[str, Any] | None = None, **kwargs):
         super().__init__(**kwargs)
         if dictionary is not None:
             for key, value in dictionary.items():
@@ -1136,10 +1136,18 @@ def validate_feature_dtype_and_shape(
     expected_dtype = feature["dtype"]
     expected_shape = feature["shape"]
     if is_valid_numpy_dtype_string(expected_dtype):
+        if not isinstance(value, np.ndarray):
+            return (
+                f"The feature '{name}' is expected to be a numpy array, but got '{type(value).__name__}'.\n"
+            )
         return validate_feature_numpy_array(name, expected_dtype, expected_shape, value)
     elif expected_dtype in ["image", "video"]:
+        if not isinstance(value, (np.ndarray, PILImage.Image)):
+            return f"The feature '{name}' is expected to be an image, but got '{type(value).__name__}'.\n"
         return validate_feature_image_or_video(name, expected_shape, value)
     elif expected_dtype == "string":
+        if not isinstance(value, str):
+            return f"The feature '{name}' is expected to be a string, but got '{type(value).__name__}'.\n"
         return validate_feature_string(name, value)
     else:
         raise NotImplementedError(f"The feature dtype '{expected_dtype}' is not implemented yet.")

--- a/src/opentau/datasets/vqa/base.py
+++ b/src/opentau/datasets/vqa/base.py
@@ -115,6 +115,9 @@ class VQADataset(BaseDataset):
         metadata.repo_id = self._get_feature_mapping_key()
         return metadata
 
+    def __len__(self) -> int:
+        return self.num_frames
+
     @abstractmethod
     def __getitem_helper__(self, item) -> dict:
         """Helper method to get a dataset item (to be implemented by subclasses).

--- a/src/opentau/datasets/vqa/base.py
+++ b/src/opentau/datasets/vqa/base.py
@@ -141,14 +141,3 @@ class VQADataset(BaseDataset):
         item["return_continuous"] = torch.tensor(0, dtype=torch.float32)
         item["advantage"] = torch.tensor(0, dtype=torch.bfloat16)
         return item
-
-    def _separate_image_in_time(self, item: dict) -> None:
-        """Separate images in time (no-op for vqa datasets).
-
-        VQA datasets don't have temporal image sequences, so this is a no-op.
-
-        Args:
-            item: Item dictionary (unmodified).
-        """
-        # VQA datasets have nothing to separate.
-        pass

--- a/tests/configs/test_utils_policies.py
+++ b/tests/configs/test_utils_policies.py
@@ -93,7 +93,7 @@ def test_save_pretrained(tmp_path, get_inherited_pretrainedconfig):
     with (
         patch("draccus.dump") as mock_dump,
         patch("builtins.open", mock_open()),
-        patch("opentau.configs.policies._strip_deprecated_fields_from_json"),
+        patch("opentau.configs.policies.strip_deprecated_fields_from_json"),
     ):
         config = get_inherited_pretrainedconfig()
 

--- a/tests/configs/test_utils_policies.py
+++ b/tests/configs/test_utils_policies.py
@@ -90,7 +90,11 @@ def test_save_pretrained(tmp_path, get_inherited_pretrainedconfig):
     Tests that _save_pretrained writes a file using draccus.dump.
     """
     # Setup: Mock the file system and draccus dependencies
-    with patch("draccus.dump") as mock_dump, patch("builtins.open", mock_open()):
+    with (
+        patch("draccus.dump") as mock_dump,
+        patch("builtins.open", mock_open()),
+        patch("opentau.configs.policies._strip_deprecated_fields_from_json"),
+    ):
         config = get_inherited_pretrainedconfig()
 
         # Act

--- a/tests/datasets/test_dataset_mixture.py
+++ b/tests/datasets/test_dataset_mixture.py
@@ -348,10 +348,8 @@ class TestWeightedDatasetMixtureIntegration:
         assert dataloader.num_workers == train_pipeline_config.num_workers
 
     @pytest.mark.slow  # ~3.5 min
-    def test_integration_basic_functionality_with_no_latency_and_same_fps_as_dataset(
-        self, train_pipeline_config
-    ):
-        """Test that the mixture with no latency and same fps as datasets actually uses the samples from the datasets."""
+    def test_integration_basic_functionality_with_same_fps_as_dataset(self, train_pipeline_config):
+        """Test that the mixture with same fps as datasets actually uses the samples from the datasets."""
         # Create dataset
         dataset_config = DatasetConfig(repo_id="lerobot/droid_100", episodes=[0, 1])
 
@@ -359,16 +357,6 @@ class TestWeightedDatasetMixtureIntegration:
         train_pipeline_config.dataset_mixture.action_freq = 15.0  # same fps as droid_100 dataset
         train_pipeline_config.dataset_mixture.image_resample_strategy = "nearest"
         train_pipeline_config.dataset_mixture.vector_resample_strategy = "nearest"
-
-        # set latency to 0
-        train_pipeline_config.policy.cloud_vlm_latency_mean = 0.0
-        train_pipeline_config.policy.cloud_vlm_latency_std = 0.0
-        train_pipeline_config.policy.cloud_vlm_latency_lower = 0.0
-        train_pipeline_config.policy.cloud_vlm_latency_upper = 0.0
-        train_pipeline_config.policy.action_decoder_latency_mean = 0.0
-        train_pipeline_config.policy.action_decoder_latency_std = 0.0
-        train_pipeline_config.policy.action_decoder_latency_lower = 0.0
-        train_pipeline_config.policy.action_decoder_latency_upper = 0.0
 
         train_pipeline_config.batch_size = 1
         train_pipeline_config.dataloader_batch_size = 1

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -121,9 +121,7 @@ def test_add_frame_wrong_shape_python_float(tmp_path, empty_lerobot_dataset_fact
     dataset = empty_lerobot_dataset_factory(root=tmp_path / "test", features=features)
     with pytest.raises(
         ValueError,
-        match=re.escape(
-            "The feature 'state' is not a 'np.ndarray'. Expected type is 'float32', but type '<class 'float'>' provided instead.\n"
-        ),
+        match=re.escape("The feature 'state' is expected to be a numpy array, but got 'float'.\n"),
     ):
         dataset.add_frame({"state": 1.0, "task": "Dummy task"})
 
@@ -143,9 +141,7 @@ def test_add_frame_wrong_shape_numpy_ndim_0(tmp_path, empty_lerobot_dataset_fact
     dataset = empty_lerobot_dataset_factory(root=tmp_path / "test", features=features)
     with pytest.raises(
         ValueError,
-        match=re.escape(
-            "The feature 'state' is not a 'np.ndarray'. Expected type is 'float32', but type '<class 'numpy.float32'>' provided instead.\n"
-        ),
+        match=re.escape("The feature 'state' is expected to be a numpy array, but got 'float32'.\n"),
     ):
         dataset.add_frame({"state": np.float32(1.0), "task": "Dummy task"})
 

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -334,10 +334,13 @@ def check_standard_data_format(item, delta_timestamps_params, dataset, train_pip
             assert item[key].shape == shape, f"{key}"
             assert isinstance(item[key], torch.BoolTensor), f"{key}"
 
-    # test delta_timestamps
-    for timestamp_param in delta_timestamps_params:
-        assert timestamp_param["input_group"].shape == (2,)
-        assert (timestamp_param["action"].shape[0],) == (train_pipeline_config.action_chunk,)
+    # test delta_timestamps — per-feature keys
+    dt_mean = delta_timestamps_params[0]
+    for key, val in dt_mean.items():
+        if key == "action":
+            assert val.shape == (train_pipeline_config.action_chunk,)
+        else:
+            assert val.shape == (1,), f"{key} has unexpected shape {val.shape}"
 
 
 @pytest.mark.slow  # 3 sec

--- a/tests/datasets/test_delta_timestamps.py
+++ b/tests/datasets/test_delta_timestamps.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from collections import defaultdict
 from itertools import accumulate
 from unittest.mock import MagicMock, patch
 
@@ -215,63 +214,47 @@ def test_resolve_delta_timestamps_basic_structure(
     """Test that resolve_delta_timestamps returns the correct basic structure."""
     result = resolve_delta_timestamps(train_pipeline_config, dataset_config, lerobot_dataset_metadata)
 
-    # Check that result is a tuple with 2 elements
     assert isinstance(result, tuple)
-    assert len(result) == 2
+    assert len(result) == 4
 
-    # First element should be a 4-tuple
-    delta_params, feature2group = result
-    assert isinstance(delta_params, tuple)
-    assert len(delta_params) == 4
-
-    # Second element should be a dict
-    assert isinstance(feature2group, dict)
+    dt_mean, dt_std, dt_lower, dt_upper = result
+    assert isinstance(dt_mean, dict)
+    assert isinstance(dt_std, dict)
+    assert isinstance(dt_lower, dict)
+    assert isinstance(dt_upper, dict)
 
 
-def test_resolve_delta_timestamps_input_group_calculation(
+def test_resolve_delta_timestamps_per_feature(
     train_pipeline_config, dataset_config, lerobot_dataset_metadata
 ):
-    """Test that input_group delta timestamps are calculated correctly."""
-    delta_params, _ = resolve_delta_timestamps(
+    """Test that per-feature delta timestamps are calculated correctly."""
+    dt_mean, dt_std, dt_lower, dt_upper = resolve_delta_timestamps(
         train_pipeline_config, dataset_config, lerobot_dataset_metadata
     )
 
-    delta_timestamps, delta_timestamps_std, delta_timestamps_lower, delta_timestamps_upper = delta_params
+    # camera0 and state should have per-feature entries with [0.0]
+    assert "camera0" in dt_mean
+    assert "state" in dt_mean
+    assert dt_mean["camera0"] == [0.0]
+    assert dt_mean["state"] == [0.0]
 
-    # Check input_group exists
-    assert "input_group" in delta_timestamps
-    assert "input_group" in delta_timestamps_std
-    assert "input_group" in delta_timestamps_lower
-    assert "input_group" in delta_timestamps_upper
-
-    # Check values are correct (negative because they represent past timestamps)
-    # Using default PI0Config values
-    expected_mean = [0.0, 0.0]  # action_decoder_latency_mean, cloud_vlm_latency_mean
-    expected_std = [0.0, 0.0]  # action_decoder_latency_std, cloud_vlm_latency_std
-    expected_lower = [0.0, 0.0]  # action_decoder_latency_upper, cloud_vlm_latency_upper (note: -upper)
-    expected_upper = [0.0, 0.0]  # action_decoder_latency_lower, cloud_vlm_latency_lower (note: -lower)
-
-    assert delta_timestamps["input_group"] == expected_mean
-    assert delta_timestamps_std["input_group"] == expected_std
-    assert delta_timestamps_lower["input_group"] == expected_lower
-    assert delta_timestamps_upper["input_group"] == expected_upper
+    # std, lower, upper default to empty dicts (filled by compute_delta_params)
+    assert dt_std == {}
+    assert dt_lower == {}
+    assert dt_upper == {}
 
 
 def test_resolve_delta_timestamps_no_reward_action_features(
     train_pipeline_config, dataset_config, lerobot_dataset_metadata
 ):
     """Test that reward and action features are not included when not present in dataset."""
-    delta_params, feature2group = resolve_delta_timestamps(
+    dt_mean, _, _, _ = resolve_delta_timestamps(
         train_pipeline_config, dataset_config, lerobot_dataset_metadata
     )
-    delta_timestamps, _, _, _ = delta_params
 
     # The lerobot_dataset_metadata fixture doesn't have "next.reward" or "action" features
-    # So they should not be in delta_timestamps or feature2group
-    assert "next.reward" not in delta_timestamps
-    assert "action" not in delta_timestamps
-    assert "next.reward" not in feature2group
-    assert "action" not in feature2group
+    assert "next.reward" not in dt_mean
+    assert "action" not in dt_mean
 
 
 def test_resolve_delta_timestamps_with_reward_action_features(
@@ -286,18 +269,15 @@ def test_resolve_delta_timestamps_with_reward_action_features(
         }
     )
 
-    delta_params, feature2group = resolve_delta_timestamps(
+    dt_mean, _, _, _ = resolve_delta_timestamps(
         train_pipeline_config, dataset_config, lerobot_dataset_metadata
     )
-    delta_timestamps, _, _, _ = delta_params
 
     # Check reward feature (PI0Config has reward_delta_indices = None by default)
-    assert "next.reward" not in delta_timestamps
-    assert "next.reward" not in feature2group
+    assert "next.reward" not in dt_mean
 
     # Check action feature (PI0Config has action_delta_indices = None by default)
-    assert "action" not in delta_timestamps
-    assert "action" not in feature2group
+    assert "action" not in dt_mean
 
 
 def test_resolve_delta_timestamps_empty_features(train_pipeline_config, dataset_config):
@@ -305,14 +285,9 @@ def test_resolve_delta_timestamps_empty_features(train_pipeline_config, dataset_
     metadata = MagicMock()
     metadata.features = {}
 
-    delta_params, feature2group = resolve_delta_timestamps(train_pipeline_config, dataset_config, metadata)
+    dt_mean, _, _, _ = resolve_delta_timestamps(train_pipeline_config, dataset_config, metadata)
 
-    # Should still have input_group in delta_timestamps
-    delta_timestamps, _, _, _ = delta_params
-    assert "input_group" in delta_timestamps
-
-    # But feature2group should be empty
-    assert len(feature2group) == 0
+    assert len(dt_mean) == 0
 
 
 def test_resolve_delta_timestamps_only_image_features(train_pipeline_config, dataset_config):
@@ -323,18 +298,11 @@ def test_resolve_delta_timestamps_only_image_features(train_pipeline_config, dat
         "camera1": {"dtype": "video", "shape": [3, 224, 224]},
     }
 
-    delta_params, feature2group = resolve_delta_timestamps(train_pipeline_config, dataset_config, metadata)
+    dt_mean, _, _, _ = resolve_delta_timestamps(train_pipeline_config, dataset_config, metadata)
 
-    # Should have input_group in delta_timestamps
-    delta_timestamps, _, _, _ = delta_params
-    assert "input_group" in delta_timestamps
-
-    # Should have image features in feature2group
-    assert len(feature2group) == 2
-    assert "camera0" in feature2group
-    assert "camera1" in feature2group
-    assert feature2group["camera0"] == ("input_group", [0, 1])
-    assert feature2group["camera1"] == ("input_group", [0, 1])
+    assert len(dt_mean) == 2
+    assert dt_mean["camera0"] == [0.0]
+    assert dt_mean["camera1"] == [0.0]
 
 
 def test_resolve_delta_timestamps_only_state_feature(train_pipeline_config, dataset_config):
@@ -344,50 +312,16 @@ def test_resolve_delta_timestamps_only_state_feature(train_pipeline_config, data
         "state": {"dtype": "float32", "shape": [7]},
     }
 
-    delta_params, feature2group = resolve_delta_timestamps(train_pipeline_config, dataset_config, metadata)
+    dt_mean, _, _, _ = resolve_delta_timestamps(train_pipeline_config, dataset_config, metadata)
 
-    # Should have input_group in delta_timestamps
-    delta_timestamps, _, _, _ = delta_params
-    assert "input_group" in delta_timestamps
-
-    # Should have state feature in feature2group
-    assert len(feature2group) == 1
-    assert "state" in feature2group
-    assert feature2group["state"] == ("input_group", 0)
-
-
-def test_resolve_delta_timestamps_zero_latency_values(
-    train_pipeline_config, dataset_config, lerobot_dataset_metadata
-):
-    """Test behavior with zero latency values."""
-    # Set all latency values to 0
-    train_pipeline_config.policy.action_decoder_latency_mean = 0.0
-    train_pipeline_config.policy.action_decoder_latency_std = 0.0
-    train_pipeline_config.policy.action_decoder_latency_lower = 0.0
-    train_pipeline_config.policy.action_decoder_latency_upper = 0.0
-    train_pipeline_config.policy.cloud_vlm_latency_mean = 0.0
-    train_pipeline_config.policy.cloud_vlm_latency_std = 0.0
-    train_pipeline_config.policy.cloud_vlm_latency_lower = 0.0
-    train_pipeline_config.policy.cloud_vlm_latency_upper = 0.0
-
-    delta_params, _ = resolve_delta_timestamps(
-        train_pipeline_config, dataset_config, lerobot_dataset_metadata
-    )
-    delta_timestamps, delta_timestamps_std, delta_timestamps_lower, delta_timestamps_upper = delta_params
-
-    # Check that all values are 0
-    expected_zero = [0.0, 0.0]
-    assert delta_timestamps["input_group"] == expected_zero
-    assert delta_timestamps_std["input_group"] == expected_zero
-    assert delta_timestamps_lower["input_group"] == expected_zero
-    assert delta_timestamps_upper["input_group"] == expected_zero
+    assert len(dt_mean) == 1
+    assert dt_mean["state"] == [0.0]
 
 
 def test_resolve_delta_timestamps_other_features_ignored(
     train_pipeline_config, dataset_config, lerobot_dataset_metadata
 ):
-    """Test that other features are not included in feature2group."""
-    # Add some other features to the metadata
+    """Test that non-camera/state/action features are not included in delta timestamps."""
     lerobot_dataset_metadata.features.update(
         {
             "timestamp": {"dtype": "float32", "shape": []},
@@ -396,64 +330,13 @@ def test_resolve_delta_timestamps_other_features_ignored(
         }
     )
 
-    _, feature2group = resolve_delta_timestamps(
+    dt_mean, _, _, _ = resolve_delta_timestamps(
         train_pipeline_config, dataset_config, lerobot_dataset_metadata
     )
 
-    # These features should not be in feature2group
-    assert "timestamp" not in feature2group
-    assert "episode_index" not in feature2group
-    assert "some_other_feature" not in feature2group
-
-
-def test_check_feature_group_mapping_valid():
-    """Test that valid feature-group mappings pass validation."""
-    # Create a minimal dataset instance with the required attributes
-    dataset = LeRobotDataset.__new__(LeRobotDataset)
-
-    # Set up valid delta_timestamps_params (4-tuple: mean, std, lower, upper)
-    dataset.delta_timestamps_params = (
-        {"input_group": [-0.1, 0.0, 0.1]},  # mean
-        {"input_group": [0.01, 0.0, 0.01]},  # std
-        {"input_group": [-0.2, -0.05, 0.05]},  # lower
-        {"input_group": [0.0, 0.05, 0.2]},  # upper
-    )
-
-    # Set up valid feature2group mapping
-    dataset.feature2group = {
-        "observation.state": ("input_group", 0),
-        "observation.images.camera0": ("input_group", [0, 1]),
-        "action": ("input_group", None),
-    }
-
-    # Should not raise any exception
-    dataset._check_feature_group_mapping()
-
-
-def test_check_feature_group_mapping_invalid_group():
-    """Test that missing group in delta_timestamps_params raises ValueError."""
-    # Create a minimal dataset instance with the required attributes
-    dataset = LeRobotDataset.__new__(LeRobotDataset)
-
-    # Set up delta_timestamps_params with only one group
-    dataset.delta_timestamps_params = (
-        {"input_group": [-0.1, 0.0, 0.1]},  # mean
-        {"input_group": [0.01, 0.0, 0.01]},  # std
-        {"input_group": [-0.2, -0.05, 0.05]},  # lower
-        {"input_group": [0.0, 0.05, 0.2]},  # upper
-    )
-
-    # Set up feature2group with a group that doesn't exist in delta_timestamps_params
-    dataset.feature2group = {
-        "observation.images.camera0": ("missing_group", [0, 1]),  # invalid
-    }
-
-    # Should raise ValueError
-    with pytest.raises(
-        ValueError,
-        match="Feature 'observation.images.camera0' is mapped to group 'missing_group', which is not present in delta_timestamps_params",
-    ):
-        dataset._check_feature_group_mapping()
+    assert "timestamp" not in dt_mean
+    assert "episode_index" not in dt_mean
+    assert "some_other_feature" not in dt_mean
 
 
 def test_compute_delta_params_basic():
@@ -666,154 +549,27 @@ def test_get_delta_indices_soft_different_fps():
 # Tests for _get_query_indices_soft method
 def test_get_query_indices_soft_basic():
     """Test basic functionality of _get_query_indices_soft."""
-    # Create a minimal dataset instance
     dataset = LeRobotDataset.__new__(LeRobotDataset)
 
-    # Set up episode_data_index
     dataset.episode_data_index = {
         "from": np.array([0, 100, 200], dtype=np.int64),
         "to": np.array([100, 200, 300], dtype=np.int64),
     }
 
-    # Set up delta_timestamps_params
     dataset.delta_timestamps_params = (
-        {"input_group": np.array([-0.1, 0.0, 0.1])},  # mean
-        {"input_group": np.array([0.01, 0.02, 0.03])},  # std
-        {"input_group": np.array([-0.2, -0.1, 0.0])},  # lower
-        {"input_group": np.array([0.0, 0.1, 0.2])},  # upper
+        {"observation.state": np.array([0.0]), "action": np.array([-0.1, 0.0, 0.1])},
+        {"observation.state": np.array([0.0]), "action": np.array([0.01, 0.02, 0.03])},
+        {"observation.state": np.array([0.0]), "action": np.array([-0.2, -0.1, 0.0])},
+        {"observation.state": np.array([0.0]), "action": np.array([0.0, 0.1, 0.2])},
     )
 
-    # Set up feature2group mapping
-    dataset.feature2group = {
-        "observation.state": ("input_group", 0),
-        "observation.images.camera0": ("input_group", [0, 1]),
-        "action": ("input_group", None),
-    }
-
-    # Mock the fps property to return 30
     type(dataset).fps = property(lambda self: 30)
 
-    # Mock get_delta_indices_soft to return predictable values
     with patch("opentau.datasets.lerobot_dataset.get_delta_indices_soft") as mock_get_delta:
         mock_get_delta.return_value = {
-            "input_group": np.array([-3.0, 0.0, 3.0])  # -0.1s, 0s, 0.1s * 30fps
+            "observation.state": np.array([0.0]),
+            "action": np.array([-3.0, 0.0, 3.0]),
         }
-
-        idx = 50  # Current index
-        ep_idx = 1  # Episode 1 (starts at 100, ends at 200)
-        dataset.epi2idx = {1: 1}
-
-        query_indices, padding = dataset._get_query_indices_soft(idx, ep_idx)
-
-        # Check query_indices
-        assert "observation.state" in query_indices
-        assert "observation.images.camera0" in query_indices
-        assert "action" in query_indices
-
-        # observation.state should use index 0 from input_group
-        expected_state_idx = np.clip(50 + (-3.0), 100, 199)  # 47 clipped to 100
-        assert query_indices["observation.state"] == expected_state_idx
-
-        # observation.images.camera0 should use indices [0, 1] from input_group
-        expected_camera_indices = np.clip(50 + np.array([-3.0, 0.0]), 100, 199)
-        assert np.allclose(query_indices["observation.images.camera0"], expected_camera_indices)
-
-        # action should use all indices from input_group
-        expected_action_indices = np.clip(50 + np.array([-3.0, 0.0, 3.0]), 100, 199)
-        assert np.allclose(query_indices["action"], expected_action_indices)
-
-        # Check padding masks
-        assert "observation.state_is_pad" in padding
-        assert "observation.images.camera0_is_pad" in padding
-        assert "action_is_pad" in padding
-
-        # observation.state should be padded (47 < 100)
-        assert padding["observation.state_is_pad"].item() is True
-
-        # observation.images.camera0 should have mixed padding
-        expected_camera_padding = torch.BoolTensor([True, True])  # 47 < 100
-        assert torch.all(padding["observation.images.camera0_is_pad"] == expected_camera_padding)
-
-        # action should have mixed padding
-        expected_action_padding = torch.BoolTensor([True, True, True])  # 47 < 100
-        assert torch.all(padding["action_is_pad"] == expected_action_padding)
-
-
-def test_get_query_indices_soft_no_padding():
-    """Test _get_query_indices_soft when no indices are outside episode bounds."""
-    # Create a minimal dataset instance
-    dataset = LeRobotDataset.__new__(LeRobotDataset)
-
-    # Set up episode_data_index
-    dataset.episode_data_index = {
-        "from": np.array([0, 100, 200], dtype=np.int64),
-        "to": np.array([100, 200, 300], dtype=np.int64),
-    }
-
-    # Set up delta_timestamps_params
-    dataset.delta_timestamps_params = (
-        {"input_group": np.array([-0.1, 0.0, 0.1])},  # mean
-        {"input_group": np.array([0.01, 0.02, 0.03])},  # std
-        {"input_group": np.array([-0.2, -0.1, 0.0])},  # lower
-        {"input_group": np.array([0.0, 0.1, 0.2])},  # upper
-    )
-
-    # Set up feature2group mapping
-    dataset.feature2group = {
-        "observation.state": ("input_group", 0),
-    }
-
-    # Mock the fps property to return 30
-    type(dataset).fps = property(lambda self: 30)
-
-    # Mock get_delta_indices_soft to return small values
-    with patch("opentau.datasets.lerobot_dataset.get_delta_indices_soft") as mock_get_delta:
-        mock_get_delta.return_value = {
-            "input_group": np.array([-1.0])  # Small offset
-        }
-
-        idx = 150  # Current index (well within episode 1 bounds)
-        ep_idx = 1  # Episode 1 (starts at 100, ends at 200)
-        dataset.epi2idx = {1: 1}
-
-        query_indices, padding = dataset._get_query_indices_soft(idx, ep_idx)
-
-        # Check query_indices
-        expected_state_idx = np.clip(150 + (-1.0), 100, 199)  # 149
-        assert query_indices["observation.state"] == expected_state_idx
-
-        # Check padding mask (should be False since 149 >= 100)
-        assert padding["observation.state_is_pad"].item() is False
-
-
-def test_get_query_indices_soft_empty_feature2group():
-    """Test _get_query_indices_soft with empty feature2group."""
-    # Create a minimal dataset instance
-    dataset = LeRobotDataset.__new__(LeRobotDataset)
-
-    # Set up episode_data_index
-    dataset.episode_data_index = {
-        "from": np.array([0, 100, 200], dtype=np.int64),
-        "to": np.array([100, 200, 300], dtype=np.int64),
-    }
-
-    # Set up delta_timestamps_params
-    dataset.delta_timestamps_params = (
-        {"input_group": np.array([-0.1, 0.0, 0.1])},  # mean
-        {"input_group": np.array([0.01, 0.02, 0.03])},  # std
-        {"input_group": np.array([-0.2, -0.1, 0.0])},  # lower
-        {"input_group": np.array([0.0, 0.1, 0.2])},  # upper
-    )
-
-    # Set up empty feature2group
-    dataset.feature2group = {}
-
-    # Mock the fps property to return 30
-    type(dataset).fps = property(lambda self: 30)
-
-    # Mock get_delta_indices_soft
-    with patch("opentau.datasets.lerobot_dataset.get_delta_indices_soft") as mock_get_delta:
-        mock_get_delta.return_value = {"input_group": np.array([-3.0, 0.0, 3.0])}
 
         idx = 50
         ep_idx = 1
@@ -821,66 +577,118 @@ def test_get_query_indices_soft_empty_feature2group():
 
         query_indices, padding = dataset._get_query_indices_soft(idx, ep_idx)
 
-        # Should return empty dictionaries
-        assert query_indices == {}
-        assert padding == {}
+        assert "observation.state" in query_indices
+        assert "action" in query_indices
+
+        expected_state_idx = np.clip(50 + 0.0, 100, 199)
+        assert query_indices["observation.state"] == expected_state_idx
+
+        expected_action_indices = np.clip(50 + np.array([-3.0, 0.0, 3.0]), 100, 199)
+        assert np.allclose(query_indices["action"], expected_action_indices)
+
+        assert padding["observation.state_is_pad"].item() is True
+        assert torch.all(padding["action_is_pad"] == torch.BoolTensor([True, True, True]))
 
 
-def test_get_query_indices_soft_edge_cases():
-    """Test _get_query_indices_soft with edge cases."""
-    # Create a minimal dataset instance
+def test_get_query_indices_soft_no_padding():
+    """Test _get_query_indices_soft when no indices are outside episode bounds."""
     dataset = LeRobotDataset.__new__(LeRobotDataset)
 
-    # Set up episode_data_index
     dataset.episode_data_index = {
         "from": np.array([0, 100, 200], dtype=np.int64),
         "to": np.array([100, 200, 300], dtype=np.int64),
     }
 
-    # Set up delta_timestamps_params
     dataset.delta_timestamps_params = (
-        {"input_group": np.array([-0.1, 0.0, 0.1])},  # mean
-        {"input_group": np.array([0.01, 0.02, 0.03])},  # std
-        {"input_group": np.array([-0.2, -0.1, 0.0])},  # lower
-        {"input_group": np.array([0.0, 0.1, 0.2])},  # upper
+        {"observation.state": np.array([0.0])},
+        {"observation.state": np.array([0.0])},
+        {"observation.state": np.array([0.0])},
+        {"observation.state": np.array([0.0])},
     )
 
-    # Set up feature2group mapping
-    dataset.feature2group = {
-        "feature1": ("input_group", 0),  # single index
-        "feature2": ("input_group", [1, 2]),  # list of indices
-        "feature3": ("input_group", None),  # all indices
-    }
-
-    # Mock the fps property to return 30
     type(dataset).fps = property(lambda self: 30)
 
-    # Mock get_delta_indices_soft
     with patch("opentau.datasets.lerobot_dataset.get_delta_indices_soft") as mock_get_delta:
-        mock_get_delta.return_value = {"input_group": np.array([-5.0, 0.0, 5.0])}
+        mock_get_delta.return_value = {
+            "observation.state": np.array([-1.0]),
+        }
 
-        # Test at episode start
-        idx = 100  # Episode 1 start
+        idx = 150
         ep_idx = 1
         dataset.epi2idx = {1: 1}
 
         query_indices, padding = dataset._get_query_indices_soft(idx, ep_idx)
 
-        # feature1 should be clipped to episode start
+        expected_state_idx = np.clip(150 + (-1.0), 100, 199)
+        assert query_indices["observation.state"] == expected_state_idx
+        assert padding["observation.state_is_pad"].item() is False
+
+
+def test_get_query_indices_soft_empty_delta_timestamps():
+    """Test _get_query_indices_soft with empty delta_timestamps."""
+    dataset = LeRobotDataset.__new__(LeRobotDataset)
+
+    dataset.episode_data_index = {
+        "from": np.array([0, 100, 200], dtype=np.int64),
+        "to": np.array([100, 200, 300], dtype=np.int64),
+    }
+
+    dataset.delta_timestamps_params = ({}, {}, {}, {})
+
+    type(dataset).fps = property(lambda self: 30)
+
+    with patch("opentau.datasets.lerobot_dataset.get_delta_indices_soft") as mock_get_delta:
+        mock_get_delta.return_value = {}
+
+        idx = 50
+        ep_idx = 1
+        dataset.epi2idx = {1: 1}
+
+        query_indices, padding = dataset._get_query_indices_soft(idx, ep_idx)
+
+        assert query_indices == {}
+        assert padding == {}
+
+
+def test_get_query_indices_soft_edge_cases():
+    """Test _get_query_indices_soft at episode boundaries."""
+    dataset = LeRobotDataset.__new__(LeRobotDataset)
+
+    dataset.episode_data_index = {
+        "from": np.array([0, 100, 200], dtype=np.int64),
+        "to": np.array([100, 200, 300], dtype=np.int64),
+    }
+
+    dataset.delta_timestamps_params = (
+        {"feature1": np.array([0.0]), "feature2": np.array([-0.1, 0.0, 0.1])},
+        {"feature1": np.array([0.0]), "feature2": np.array([0.01, 0.02, 0.03])},
+        {"feature1": np.array([0.0]), "feature2": np.array([-0.2, -0.1, 0.0])},
+        {"feature1": np.array([0.0]), "feature2": np.array([0.0, 0.1, 0.2])},
+    )
+
+    type(dataset).fps = property(lambda self: 30)
+
+    with patch("opentau.datasets.lerobot_dataset.get_delta_indices_soft") as mock_get_delta:
+        mock_get_delta.return_value = {
+            "feature1": np.array([-5.0]),
+            "feature2": np.array([-5.0, 0.0, 5.0]),
+        }
+
+        idx = 100
+        ep_idx = 1
+        dataset.epi2idx = {1: 1}
+
+        query_indices, padding = dataset._get_query_indices_soft(idx, ep_idx)
+
+        # feature1 clipped to episode start
         assert query_indices["feature1"] == 100  # 100 + (-5) clipped to 100
 
-        # feature2 should use indices [1, 2]
-        expected_feature2 = np.clip(100 + np.array([0.0, 5.0]), 100, 199)
+        # feature2 should be clipped per-element
+        expected_feature2 = np.clip(100 + np.array([-5.0, 0.0, 5.0]), 100, 199)
         assert np.allclose(query_indices["feature2"], expected_feature2)
 
-        # feature3 should use all indices
-        expected_feature3 = np.clip(100 + np.array([-5.0, 0.0, 5.0]), 100, 199)
-        assert np.allclose(query_indices["feature3"], expected_feature3)
-
-        # Check padding masks
         assert padding["feature1_is_pad"].item() is True
-        assert torch.all(padding["feature2_is_pad"] == torch.BoolTensor([False, False]))
-        assert torch.all(padding["feature3_is_pad"] == torch.BoolTensor([True, False, False]))
+        assert torch.all(padding["feature2_is_pad"] == torch.BoolTensor([True, False, False]))
 
 
 # Tests for _query_hf_dataset_soft method
@@ -1044,105 +852,3 @@ def test_query_hf_dataset_soft_invalid_strategy():
 
     with pytest.raises(ValueError, match="Unsupported vector_resample_strategy"):
         dataset._query_hf_dataset_soft(soft_indices)
-
-
-@pytest.mark.parametrize(
-    ("feature2group", "delta_indices"),
-    [
-        (
-            {
-                "observation.images.exterior_image_1_left": ("input_group", [0, 1]),
-                "observation.images.exterior_image_2_left": ("input_group", [0, 1]),
-                "observation.images.wrist_image_left": ("input_group", [0, 1]),
-                "observation.state": ("input_group", 0),
-                "action": ("action", None),
-            },
-            {
-                "input_group": np.array([-0.5902292, -3.7006334]),
-                "action": np.array([0.5 * i for i in range(50)]),
-            },
-        ),
-        (
-            {
-                "observation.images.exterior_image_1_left": ("input_group", [0, 1]),
-                "observation.images.exterior_image_2_left": ("input_group", [0, 1]),
-                "observation.images.wrist_image_left": ("input_group", [1, 1]),
-                "observation.state": ("input_group", 1),
-                "action": ("action", None),
-            },
-            {
-                "input_group": np.array([-0.5902292, -3.7006334]),
-                "action": np.array([0.5 * i for i in range(50)]),
-            },
-        ),
-        (
-            {
-                "observation.images.exterior_image_1_left": ("input_group", [1, 0]),
-                "observation.images.exterior_image_2_left": ("input_group", [1, 0]),
-                "observation.images.wrist_image_left": ("input_group", [0, 0]),
-                "observation.state": ("input_group", 0),
-                "action": ("action", None),
-            },
-            {
-                "input_group": np.array([-0.5902292, -3.7006334]),
-                "action": np.array([0.5 * i for i in range(50)]),
-            },
-        ),
-        (
-            {
-                "observation.images.exterior_image_1_left": ("input_group", [1, 0]),
-                "observation.images.exterior_image_2_left": ("input_group", [1, 0]),
-                "observation.images.wrist_image_left": ("control_group", [0, 0]),
-                "observation.state": ("input_group", 0),
-                "action": ("action", None),
-            },
-            {
-                "input_group": np.array([-0.5902292, -3.7006334]),
-                "control_group": np.array([-0.7802292, -2.7465334]),
-                "action": np.array([0.5 * i for i in range(50)]),
-            },
-        ),
-    ],
-)
-def test_feature2group(lerobot_dataset, feature2group, delta_indices):
-    """
-    Test if the function get_query_indices_soft returns same timesteps for same group features. The group inside features group are changed
-    """
-
-    # setting the feature2group attribute in lerobot dataset
-    lerobot_dataset.feature2group = feature2group
-
-    # mocking start id  and end id of episode and setting delta_indices to predefined value
-    with (
-        patch.object(
-            lerobot_dataset, "episode_data_index", new_callable=MagicMock
-        ) as mock_episode_data_index,
-        patch("opentau.datasets.lerobot_dataset.get_delta_indices_soft", return_value=delta_indices),
-    ):
-        # Configure the mocks just like before
-        mock_from_item = MagicMock()
-        mock_from_item.item.return_value = 700
-
-        mock_to_item = MagicMock()
-        mock_to_item.item.return_value = 799
-
-        mock_episode_data_index.__getitem__.side_effect = lambda key: {
-            "from": [mock_from_item],
-            "to": [mock_to_item],
-        }[key]
-
-        query_indices, _ = lerobot_dataset._get_query_indices_soft(idx=710, ep_idx=0)
-
-        # grouping all the query indices with same group into dictionary
-        dict1 = defaultdict(list)
-        for key, (group, indices) in feature2group.items():
-            if type(indices) is int:
-                dict1[(str(indices) + "_" + str(group))].append(float(query_indices[key]))
-            elif indices:
-                for i, idx in enumerate(indices):
-                    dict1[(str(idx) + "_" + str(group))].append(float(query_indices[key][i]))
-
-        # checking if all the values are same in the list of same group
-
-        for _, values in dict1.items():
-            assert len(list(set(values))) == 1

--- a/tests/fixtures/dataset_factories.py
+++ b/tests/fixtures/dataset_factories.py
@@ -377,6 +377,7 @@ def lerobot_dataset_metadata():
         1: {"episode_index": 1, "stats": mock_metadata.stats},
         2: {"episode_index": 2, "stats": mock_metadata.stats},
     }
+    mock_metadata.features = mock_metadata.info["features"]
     mock_metadata.tasks = {0: {"task_index": 0, "task": "Perform action 0."}}
     mock_metadata.episodes = {
         0: {"episode_index": 0, "tasks": ["Perform action 0."], "length": 50},


### PR DESCRIPTION
## What this does
The feature2group mechanism mapped features to shared temporal groups with index selection, originally to support different latency offsets between cloud VLM and action decoder. 

Each feature now owns its own key in delta_timestamps directly. Camera and state features get [0.0] individually rather than indexing into a shared "input_group" of [0.0, 0.0]. This also removes _separate_image_in_time (cameras now get 1 frame instead of 2 identical frames), _check_feature_group_mapping, the is_local parameter from _standardize_images, and local_camera* entries from the data format mappings.

## How it was tested
Explain/show how you tested your changes.

Ran all CPU tests. 

## How to checkout & try? (for the reviewer)
Run all CPU tests.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
