### PR TITLE
Feat/pi05 mem

### DIFF
--- a/configs/examples/pi05_mem_training_config.json
+++ b/configs/examples/pi05_mem_training_config.json
@@ -13,6 +13,7 @@
             1.0
         ],
         "action_freq": 10.0,
+        "n_obs_history": 8,
         "image_resample_strategy": "nearest",
         "vector_resample_strategy": "nearest"
     },
@@ -104,5 +105,26 @@
         "mode": null,
         "allow_resume": true,
         "disable_artifact": false
-    }
+    },
+    "env": {
+        "type": "libero",
+        "task": "libero_10",
+        "fps": 10,
+        "max_parallel_tasks": 1,
+        "task_ids": [0],
+        "episode_length": 100,
+        "obs_type": "pixels_agent_pos",
+        "render_mode": "rgb_array",
+        "camera_name": "agentview_image,robot0_eye_in_hand_image",
+        "init_states": true,
+        "camera_name_mapping": null
+    },
+    "eval": {
+        "n_episodes": 1,
+        "batch_size": 1,
+        "use_async_envs": true,
+        "max_episodes_rendered": 11,
+        "grid_size": null
+    },
+    "eval_freq": 10
 }

--- a/configs/examples/pi05_mem_training_config.json
+++ b/configs/examples/pi05_mem_training_config.json
@@ -1,0 +1,108 @@
+{
+    "dataset_mixture": {
+        "datasets": [
+            {
+                "repo_id": "physical-intelligence/libero",
+                "episodes": [
+                    0,1,2,3,4,5,6,7,8,9
+                ]
+            }
+
+        ],
+        "weights": [
+            1.0
+        ],
+        "action_freq": 10.0,
+        "image_resample_strategy": "nearest",
+        "vector_resample_strategy": "nearest"
+    },
+    "policy": {
+        "type": "pi05_mem",
+        "pretrained_path": null,
+        "n_obs_steps": 8,
+        "normalization_mapping": {
+            "VISUAL": "IDENTITY",
+            "STATE": "MEAN_STD",
+            "ACTION": "MEAN_STD"
+        },
+        "chunk_size": 10,
+        "n_action_steps": 10,
+        "max_state_dim": 32,
+        "max_action_dim": 32,
+        "proj_width": 1024,
+        "dropout": 0.1,
+        "num_steps": 10,
+        "init_strategy": "full_he_init",
+        "attention_implementation": "eager",
+        "freeze_vision_encoder": true,
+        "train_expert_only": false,
+        "prompt_max_length": 50,
+        "discrete_action_max_length": 100,
+        "vjepa2_model_name": "facebook/vjepa2-vitl-fpc64-256",
+        "vjepa2_crop_size": 224,
+        "vjepa2_num_video_tokens": 256,
+        "vjepa2_perceiver_heads": 8,
+        "optimizer_lr": 2.5e-05,
+        "optimizer_betas": [
+            0.9,
+            0.95
+        ],
+        "optimizer_eps": 1e-08,
+        "optimizer_weight_decay": 1e-10,
+        "scheduler_warmup_steps": 1000,
+        "scheduler_decay_steps": 30000,
+        "scheduler_decay_lr": 2.5e-06
+    },
+    "resume": false,
+    "seed": 1000,
+    "resolution": [224, 224],
+    "num_cams": 2,
+    "max_state_dim": 32,
+    "max_action_dim": 32,
+    "action_chunk": 10,
+    "loss_weighting": {"MSE": 1, "CE": 1},
+    "num_workers": 4,
+    "batch_size": 2,
+    "gradient_accumulation_steps": 1,
+    "dataloader_batch_size": 2,
+    "prefetch_factor": 8,
+    "steps": 40,
+    "log_freq": 5,
+    "save_checkpoint": true,
+    "save_freq": 40,
+    "val_freq": 10,
+    "use_policy_training_preset": false,
+    "trace_nans": false,
+    "optimizer": {
+        "type": "adamw",
+        "lr": 2.5e-05,
+        "weight_decay": 1e-10,
+        "grad_clip_norm": 10.0,
+        "betas": [
+            0.9,
+            0.95
+        ],
+        "eps": 1e-08
+    },
+    "scheduler": {
+        "type": "cosine_decay_with_warmup",
+        "num_warmup_steps": 1000,
+        "num_decay_steps": 30000,
+        "peak_lr": 2.5e-05,
+        "decay_lr": 2.5e-06
+    },
+    "wandb": {
+        "enable": true,
+        "entity": "wyautox-autox",
+        "project": "pi05_mem",
+        "run_id": null,
+        "name": null,
+        "notes": "PI05 Mem training run with V-JEPA2 video encoder",
+        "tags": [],
+        "group": null,
+        "job_type": null,
+        "mode": null,
+        "allow_resume": true,
+        "disable_artifact": false
+    }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,8 +139,7 @@ urdf = [
     "rerun-sdk>=0.28.2",
 ]
 trt = [
-    "tensorrt>=10.15.1.29",
-    "tensorrt>=10.9.0 ; (sys_platform == 'linux' and platform_machine == 'x86_64') or (sys_platform == 'win32' and (platform_machine == 'AMD64' or platform_machine == 'x86_64'))",
+    "tensorrt>=10.15.1.29 ; (sys_platform == 'linux' and platform_machine == 'x86_64') or (sys_platform == 'win32' and (platform_machine == 'AMD64' or platform_machine == 'x86_64'))",
 ]
 
 [tool.uv.sources]

--- a/src/opentau/__init__.py
+++ b/src/opentau/__init__.py
@@ -149,7 +149,7 @@ available_datasets = sorted(
 )
 
 # lists all available policies from `src/opentau/policies`
-available_policies = ["pi0", "pi05", "value"]
+available_policies = ["pi0", "pi05", "pi05_mem", "value"]
 
 # keys and values refer to yaml files
 available_policies_per_env = {}

--- a/src/opentau/__init__.py
+++ b/src/opentau/__init__.py
@@ -149,7 +149,7 @@ available_datasets = sorted(
 )
 
 # lists all available policies from `src/opentau/policies`
-available_policies = ["pi0", "pi05", "pi05_mem", "value"]
+available_policies = ["pi0", "pi05", "value"]
 
 # keys and values refer to yaml files
 available_policies_per_env = {}

--- a/src/opentau/configs/train.py
+++ b/src/opentau/configs/train.py
@@ -270,6 +270,25 @@ class TrainPipelineConfig(HubMixin):
             self.policy.max_action_state = self.max_action_dim
             self.policy.chunk_size = self.action_chunk
 
+            # Sync observation history settings from dataset mixture to policy.
+            if hasattr(self.policy, "n_obs_history") and self.dataset_mixture is not None:
+                dm = self.dataset_mixture
+                if dm.n_obs_history is not None:
+                    if self.policy.n_obs_history is None:
+                        self.policy.n_obs_history = dm.n_obs_history
+                        self.policy.history_interval = dm.history_interval
+                    else:
+                        if self.policy.n_obs_history != dm.n_obs_history:
+                            raise ValueError(
+                                f"policy.n_obs_history ({self.policy.n_obs_history}) != "
+                                f"dataset_mixture.n_obs_history ({dm.n_obs_history})"
+                            )
+                        if (self.policy.history_interval or 1) != dm.history_interval:
+                            raise ValueError(
+                                f"policy.history_interval ({self.policy.history_interval}) != "
+                                f"dataset_mixture.history_interval ({dm.history_interval})"
+                            )
+
     @classmethod
     def __get_path_fields__(cls) -> list[str]:
         """Get list of field names that support path-based loading.

--- a/src/opentau/policies/__init__.py
+++ b/src/opentau/policies/__init__.py
@@ -22,4 +22,5 @@ such as PI0, PI05, and Value policy.
 from .pi0.configuration_pi0 import PI0Config as PI0Config
 from .pi05.configuration_pi05 import PI05Config as PI05Config
 from .pi05_continuous_state.configuration_pi05 import PI05ContinuousStateConfig as PI05ContinuousStateConfig
+from .pi05_mem.configuration_pi05 import PI05MemConfig as PI05MemConfig
 from .value.configuration_value import ValueConfig as ValueConfig

--- a/src/opentau/policies/factory.py
+++ b/src/opentau/policies/factory.py
@@ -35,6 +35,7 @@ from opentau.datasets.utils import dataset_to_policy_features
 from opentau.policies.pi0.configuration_pi0 import PI0Config
 from opentau.policies.pi05.configuration_pi05 import PI05Config
 from opentau.policies.pi05_continuous_state.configuration_pi05 import PI05ContinuousStateConfig
+from opentau.policies.pi05_mem.configuration_pi05 import PI05MemConfig
 from opentau.policies.pretrained import PreTrainedPolicy
 from opentau.policies.value.configuration_value import ValueConfig
 
@@ -64,6 +65,10 @@ def get_policy_class(name: str) -> type[PreTrainedPolicy]:
         from opentau.policies.pi05_continuous_state.modeling_pi05 import PI05ContinuousStatePolicy
 
         return PI05ContinuousStatePolicy
+    elif name == "pi05_mem":
+        from opentau.policies.pi05_mem.modeling_pi05 import PI05MemPolicy
+
+        return PI05MemPolicy
     elif name == "value":
         from opentau.policies.value.modeling_value import ValueFunction
 
@@ -91,6 +96,8 @@ def make_policy_config(policy_type: str, **kwargs) -> PreTrainedConfig:
         return PI05Config(**kwargs)
     elif policy_type == "pi05_continuous_state":
         return PI05ContinuousStateConfig(**kwargs)
+    elif policy_type == "pi05_mem":
+        return PI05MemConfig(**kwargs)
     elif policy_type == "value":
         return ValueConfig(**kwargs)
     else:

--- a/src/opentau/policies/pi05_mem/__init__.py
+++ b/src/opentau/policies/pi05_mem/__init__.py
@@ -1,0 +1,20 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+PI05 Mem Policy Module.
+
+This module implements a variant of the π05 (Pi05) Vision-Language-Action Flow Model
+that uses V-JEPA2 as a video encoder (replacing SigLIP) and processes temporal state
+sequences, passing one continuous state token per timestep to the Gemma backbone.
+"""

--- a/src/opentau/policies/pi05_mem/configuration_pi05.py
+++ b/src/opentau/policies/pi05_mem/configuration_pi05.py
@@ -44,7 +44,11 @@ class PI05MemConfig(PreTrainedConfig):
     embedding space.
 
     Args:
-        n_obs_steps: Number of observation steps (temporal frames). Defaults to 8.
+        n_obs_steps: Number of temporal video frames passed to V-JEPA2 per forward call.
+            During training each sample has this many frames; during inference the
+            observation-history buffer (controlled by ``n_obs_history`` and
+            ``history_interval``) is stacked to produce exactly this many frames.
+            Must equal ``n_obs_history`` when the latter is set.
         chunk_size: Size of the action chunk. The upper bound for n_action_steps. Defaults to 50.
         n_action_steps: Number of action steps to predict. Defaults to 50.
         normalization_mapping: Mapping of feature names to normalization modes.
@@ -66,6 +70,8 @@ class PI05MemConfig(PreTrainedConfig):
         vjepa2_crop_size: Spatial resolution fed to V-JEPA2. Defaults to 224.
         vjepa2_num_video_tokens: Number of output tokens after reduction (must match SigLIP's 256). Defaults to 256.
         vjepa2_perceiver_heads: Number of attention heads in the Perceiver reducer. Defaults to 8.
+        vjepa2_dtype: Torch dtype string for V-JEPA2 weights (e.g. "bfloat16", "float32").
+            Defaults to None, which uses bfloat16 on CUDA and float32 on CPU.
     """
 
     # Input / output structure.
@@ -74,6 +80,12 @@ class PI05MemConfig(PreTrainedConfig):
     n_action_steps: int = 50
 
     # Observation history for inference buffering.
+    # ``n_obs_history`` controls how many evenly-spaced historical frames the
+    # inference buffer keeps.  ``history_interval`` is the stride between those
+    # frames.  Together they determine ``obs_buffer_size = (n_obs_history-1) *
+    # history_interval + 1``.  Typically ``n_obs_history`` should equal
+    # ``n_obs_steps`` so the V-JEPA2 encoder sees the same number of frames at
+    # training and inference time.
     # Populated from DatasetMixtureConfig during training if unset.
     n_obs_history: int | None = None
     history_interval: int | None = None
@@ -127,6 +139,7 @@ class PI05MemConfig(PreTrainedConfig):
     vjepa2_crop_size: int = 224
     vjepa2_num_video_tokens: int = 256
     vjepa2_perceiver_heads: int = 8
+    vjepa2_dtype: str | None = None
 
     # Training presets
     optimizer_lr: float = 2.5e-5

--- a/src/opentau/policies/pi05_mem/configuration_pi05.py
+++ b/src/opentau/policies/pi05_mem/configuration_pi05.py
@@ -1,0 +1,202 @@
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Configuration module for the PI05 Mem Policy.
+
+This module defines the ``PI05MemConfig`` class, which handles configuration
+parameters for the PI05 Mem variant. This variant replaces the SigLIP image
+encoder with a V-JEPA2 video encoder and processes temporal state sequences
+(one continuous token per timestep).
+"""
+
+import logging
+from dataclasses import dataclass, field
+from typing import Literal
+
+from opentau.configs.policies import PreTrainedConfig
+from opentau.configs.types import FeatureType, NormalizationMode, PolicyFeature
+from opentau.optim.optimizers import AdamWConfig
+from opentau.optim.schedulers import (
+    CosineDecayWithWarmupSchedulerConfig,
+    LRSchedulerConfig,
+)
+
+
+@PreTrainedConfig.register_subclass("pi05_mem")
+@dataclass
+class PI05MemConfig(PreTrainedConfig):
+    """Configuration class for the PI05 Mem Policy.
+
+    This variant uses V-JEPA2 as a video encoder (replacing SigLIP) and projects
+    temporal state sequences into per-timestep continuous tokens in the VLM
+    embedding space.
+
+    Args:
+        n_obs_steps: Number of observation steps (temporal frames). Defaults to 8.
+        chunk_size: Size of the action chunk. The upper bound for n_action_steps. Defaults to 50.
+        n_action_steps: Number of action steps to predict. Defaults to 50.
+        normalization_mapping: Mapping of feature names to normalization modes.
+        max_state_dim: Maximum dimension for state vectors. Shorter vectors are padded. Defaults to 32.
+        max_action_dim: Maximum dimension for action vectors. Shorter vectors are padded. Defaults to 32.
+        resize_imgs_with_padding: Target size (height, width) for video frame resizing with padding.
+            Defaults to (224, 224).
+        empty_cameras: Number of empty camera inputs to add. Defaults to 0.
+        prompt_max_length: Maximum length for tokenizer. Defaults to 256.
+        discrete_action_max_length: Maximum length for discrete action tokens. Defaults to 32.
+        proj_width: Width of the projection layer. Defaults to 1024.
+        dropout: Dropout rate. Defaults to 0.1.
+        num_steps: Number of flow matching steps for decoding. Defaults to 10.
+        init_strategy: Initialization strategy. Defaults to "full_he_init".
+        attention_implementation: Attention implementation ("eager" or "fa2"). Defaults to "eager".
+        freeze_vision_encoder: Whether to freeze the V-JEPA2 encoder. Defaults to True.
+        train_expert_only: Whether to train only the expert module. Defaults to False.
+        vjepa2_model_name: HuggingFace repo for V-JEPA2 weights. Defaults to "facebook/vjepa2-vitl-fpc64-256".
+        vjepa2_crop_size: Spatial resolution fed to V-JEPA2. Defaults to 224.
+        vjepa2_num_video_tokens: Number of output tokens after reduction (must match SigLIP's 256). Defaults to 256.
+        vjepa2_perceiver_heads: Number of attention heads in the Perceiver reducer. Defaults to 8.
+    """
+
+    # Input / output structure.
+    n_obs_steps: int = 8
+    chunk_size: int = 50
+    n_action_steps: int = 50
+
+    normalization_mapping: dict[str, NormalizationMode] = field(
+        default_factory=lambda: {
+            "VISUAL": NormalizationMode.IDENTITY,
+            "STATE": NormalizationMode.MEAN_STD,
+            "ACTION": NormalizationMode.MEAN_STD,
+        }
+    )
+
+    max_state_dim: int = 32
+    max_action_dim: int = 32
+
+    # Video frame preprocessing
+    resize_imgs_with_padding: tuple[int, int] = (224, 224)
+
+    empty_cameras: int = 0
+
+    # Language Tokenizer
+    prompt_max_length: int = 256
+
+    # Maximum length of the action tokens
+    discrete_action_max_length: int = 32
+
+    # Projector
+    proj_width: int = 1024
+
+    # Dropout
+    dropout: float = 0.1
+
+    # Decoding
+    num_steps: int = 10
+
+    # Real Time Inference
+    max_delay: int = 0
+
+    # Initialization strategy
+    init_strategy: Literal["no_init", "full_he_init", "expert_only_he_init"] = "full_he_init"
+
+    # Attention utils
+    attention_implementation: str = "eager"
+
+    # Finetuning settings
+    freeze_vision_encoder: bool = True
+    train_expert_only: bool = False
+
+    # V-JEPA2 settings
+    vjepa2_model_name: str = "facebook/vjepa2-vitl-fpc64-256"
+    vjepa2_crop_size: int = 224
+    vjepa2_num_video_tokens: int = 256
+    vjepa2_perceiver_heads: int = 8
+
+    # Training presets
+    optimizer_lr: float = 2.5e-5
+    optimizer_betas: tuple[float, float] = (0.9, 0.95)
+    optimizer_eps: float = 1e-8
+    optimizer_weight_decay: float = 1e-10
+
+    scheduler_warmup_steps: int = 1_000
+    scheduler_decay_steps: int = 30_000
+    scheduler_decay_lr: float = 2.5e-6
+
+    def __post_init__(self):
+        """Post-initialization validation."""
+        super().__post_init__()
+
+        if self.n_action_steps > self.chunk_size:
+            raise ValueError(
+                f"The chunk size is the upper bound for the number of action steps per model invocation. Got "
+                f"{self.n_action_steps} for `n_action_steps` and {self.chunk_size} for `chunk_size`."
+            )
+
+        assert self.init_strategy in ["no_init", "full_he_init", "expert_only_he_init"], (
+            f"Invalid init strategy: {self.init_strategy} must be one of ['no_init', 'full_he_init', 'expert_only_he_init']"
+        )
+
+        if self.init_strategy == "expert_only_he_init" and self.pretrained_path == "lerobot/pi05":
+            raise ValueError(
+                "You cannot load pretrained PI0 model when init_strategy is 'expert_only_he_init' due to differences in PaliGemma tokenizer vocab sizes."
+            )
+
+        if self.pretrained_path is not None and self.pretrained_path != "lerobot/pi05":
+            logging.info("Setting init_strategy to 'no_init' because we are resuming from a checkpoint.")
+            self.init_strategy = "no_init"
+
+        if self.max_delay > self.chunk_size:
+            raise ValueError(
+                f"The max delay must be less than or equal to the chunk size. Got {self.max_delay} for `max_delay` and {self.chunk_size} for `chunk_size`."
+            )
+
+    def validate_features(self) -> None:
+        """Validates the features and adds empty cameras if configured."""
+        for i in range(self.empty_cameras):
+            key = f"observation.images.empty_camera_{i}"
+            empty_camera = PolicyFeature(
+                type=FeatureType.VISUAL,
+                shape=(3, 480, 640),
+            )
+            self.input_features[key] = empty_camera
+
+    def get_optimizer_preset(self) -> AdamWConfig:
+        """Returns the default optimizer configuration."""
+        return AdamWConfig(
+            lr=self.optimizer_lr,
+            betas=self.optimizer_betas,
+            eps=self.optimizer_eps,
+            weight_decay=self.optimizer_weight_decay,
+        )
+
+    def get_scheduler_preset(self) -> LRSchedulerConfig:
+        """Returns the default scheduler configuration."""
+        return CosineDecayWithWarmupSchedulerConfig(
+            peak_lr=self.optimizer_lr,
+            decay_lr=self.scheduler_decay_lr,
+            num_warmup_steps=self.scheduler_warmup_steps,
+            num_decay_steps=self.scheduler_decay_steps,
+        )
+
+    @property
+    def observation_delta_indices(self) -> None:
+        return None
+
+    @property
+    def action_delta_indices(self) -> list[int]:
+        return list(range(self.chunk_size))
+
+    @property
+    def reward_delta_indices(self) -> None:
+        return None

--- a/src/opentau/policies/pi05_mem/configuration_pi05.py
+++ b/src/opentau/policies/pi05_mem/configuration_pi05.py
@@ -149,7 +149,7 @@ class PI05MemConfig(PreTrainedConfig):
 
         if self.init_strategy == "expert_only_he_init" and self.pretrained_path == "lerobot/pi05":
             raise ValueError(
-                "You cannot load pretrained PI0 model when init_strategy is 'expert_only_he_init' due to differences in PaliGemma tokenizer vocab sizes."
+                "You cannot load pretrained PI05 model when init_strategy is 'expert_only_he_init' due to differences in PaliGemma tokenizer vocab sizes."
             )
 
         if self.pretrained_path is not None and self.pretrained_path != "lerobot/pi05":

--- a/src/opentau/policies/pi05_mem/configuration_pi05.py
+++ b/src/opentau/policies/pi05_mem/configuration_pi05.py
@@ -73,6 +73,11 @@ class PI05MemConfig(PreTrainedConfig):
     chunk_size: int = 50
     n_action_steps: int = 50
 
+    # Observation history for inference buffering.
+    # Populated from DatasetMixtureConfig during training if unset.
+    n_obs_history: int | None = None
+    history_interval: int | None = None
+
     normalization_mapping: dict[str, NormalizationMode] = field(
         default_factory=lambda: {
             "VISUAL": NormalizationMode.IDENTITY,
@@ -133,9 +138,35 @@ class PI05MemConfig(PreTrainedConfig):
     scheduler_decay_steps: int = 30_000
     scheduler_decay_lr: float = 2.5e-6
 
+    @property
+    def obs_buffer_size(self) -> int:
+        """Total raw frames the observation buffer must keep.
+
+        With ``n_obs_history=T`` and ``history_interval=k``, the buffer stores
+        the most recent ``(T-1)*k + 1`` frames so that ``T`` evenly-spaced
+        frames can be selected.
+        """
+        if self.n_obs_history is None or self.n_obs_history <= 1:
+            return 1
+        return (self.n_obs_history - 1) * (self.history_interval or 1) + 1
+
     def __post_init__(self):
         """Post-initialization validation."""
         super().__post_init__()
+
+        if self.n_obs_history is not None:
+            if not isinstance(self.n_obs_history, int) or self.n_obs_history < 1:
+                raise ValueError(
+                    f"`n_obs_history` must be None or a positive integer, got {self.n_obs_history}."
+                )
+            if self.history_interval is None:
+                self.history_interval = 1
+        if self.history_interval is not None and (
+            not isinstance(self.history_interval, int) or self.history_interval < 1
+        ):
+            raise ValueError(
+                f"`history_interval` must be None or a positive integer, got {self.history_interval}."
+            )
 
         if self.n_action_steps > self.chunk_size:
             raise ValueError(

--- a/src/opentau/policies/pi05_mem/modeling_pi05.py
+++ b/src/opentau/policies/pi05_mem/modeling_pi05.py
@@ -249,6 +249,9 @@ class PI05MemPolicy(PreTrainedPolicy):
     def reset(self) -> None:
         """This should be called whenever the environment is reset."""
         self._action_queue = deque([], maxlen=self.config.n_action_steps)
+        # Observation history buffers for inference.
+        self._obs_buffers: dict[str, deque] = {}
+        self._state_buffer: deque | None = None
 
     @classmethod
     def from_pretrained(
@@ -406,10 +409,70 @@ class PI05MemPolicy(PreTrainedPolicy):
     def predict_action_chunk(self, batch: dict[str, Tensor]) -> Tensor:
         raise NotImplementedError("Currently not implemented for PI05 Mem")
 
+    def _build_history_batch(self, batch: dict[str, Tensor]) -> dict[str, Tensor]:
+        """Buffer the current observation and construct a temporal batch.
+
+        Appends the single-frame observation from ``batch`` to internal deque
+        buffers, then assembles a batch with ``n_obs_history`` evenly-spaced
+        frames (interval = ``history_interval``).  Early in an episode, missing
+        history slots are zero-padded.
+        """
+        n_hist = self.config.n_obs_history
+        k = self.config.history_interval or 1
+        buf_maxlen = self.config.obs_buffer_size
+
+        # --- initialise buffers on first call after reset() ---
+        if self._state_buffer is None:
+            self._state_buffer = deque(maxlen=buf_maxlen)
+            self._obs_buffers = {}
+
+        img_keys = [key for key in self.config.image_features if key in batch]
+        for key in img_keys:
+            if key not in self._obs_buffers:
+                self._obs_buffers[key] = deque(maxlen=buf_maxlen)
+
+        # --- append current observation ---
+        self._state_buffer.append(batch["state"])  # (B, D)
+        for key in img_keys:
+            self._obs_buffers[key].append(batch[key])  # (B, C, H, W)
+
+        # --- sample n_hist frames at interval k ---
+        buf_len = len(self._state_buffer)
+        missing = buf_maxlen - buf_len  # how many slots are still empty
+
+        temporal_batch = {k_: v for k_, v in batch.items() if k_ not in img_keys and k_ != "state"}
+
+        # Build state tensor (B, T, D)
+        state_frames = []
+        for i in range(n_hist):
+            idx = i * k - missing  # index into current buffer
+            if idx < 0:
+                state_frames.append(torch.zeros_like(self._state_buffer[0]))
+            else:
+                state_frames.append(self._state_buffer[idx])
+        temporal_batch["state"] = torch.stack(state_frames, dim=1)  # (B, T, D)
+
+        # Build camera tensors (B, T, C, H, W)
+        for key in img_keys:
+            cam_frames = []
+            for i in range(n_hist):
+                idx = i * k - missing
+                if idx < 0:
+                    cam_frames.append(torch.zeros_like(self._obs_buffers[key][0]))
+                else:
+                    cam_frames.append(self._obs_buffers[key][idx])
+            temporal_batch[key] = torch.stack(cam_frames, dim=1)  # (B, T, C, H, W)
+
+        return temporal_batch
+
     @torch.no_grad()
     def select_action(self, batch: dict[str, Tensor], noise: Tensor | None = None) -> Tensor:
         """Select a single action given environment observations."""
         self.eval()
+
+        # Build temporal observation history if configured.
+        if self.config.n_obs_history is not None and self.config.n_obs_history > 1:
+            batch = self._build_history_batch(batch)
 
         if len(self._action_queue) == 0 or len(self._action_queue) <= self.config.max_delay:
             action_prefix = None
@@ -450,6 +513,20 @@ class PI05MemPolicy(PreTrainedPolicy):
         videos, vid_masks = self.prepare_videos(batch)
         lang_tokens, lang_masks = self.prepare_language(batch)
         state = self.prepare_state(batch)
+
+        # Shape checks: videos must be 5D (B, T, C, H, W), state must be 3D (B, T, D).
+        for vid in videos:
+            assert vid.ndim == 5, f"Expected 5D video tensor (B, T, C, H, W), got {vid.shape}"
+        assert state.ndim == 3, f"Expected 3D state tensor (B, T, D), got {state.shape}"
+
+        if self.config.n_obs_history is not None and self.config.n_obs_history > 1:
+            t_dim = state.shape[1]
+            if t_dim == 1:
+                logging.warning(
+                    "Temporal dimension T=1: no historical frames included. "
+                    "This should only happen at most %d time(s) at the start of an episode.",
+                    self.config.history_interval or 1,
+                )
 
         if delay is None:
             delay = torch.tensor(0, dtype=torch.long, device=lang_tokens.device)
@@ -535,6 +612,11 @@ class PI05MemPolicy(PreTrainedPolicy):
         """
         state = batch["state"]  # (B, T, D) or (B, D) during inference
         if state.ndim == 2:
+            if self.config.n_obs_history is not None and self.config.n_obs_history > 1:
+                raise ValueError(
+                    f"Expected 3D state tensor (B, T, D) when n_obs_history > 1, "
+                    f"got shape {state.shape}. Ensure select_action() is being used."
+                )
             state = state.unsqueeze(1)  # (B, D) -> (B, 1, D)
         state_dim = state.shape[-1]
         if state_dim > self.config.max_state_dim:
@@ -591,6 +673,11 @@ class PI05MemPolicy(PreTrainedPolicy):
         for key in present_img_keys:
             vid = batch[key]  # (B, T, C, H, W) or (B, C, H, W) during inference
             if vid.ndim == 4:
+                if self.config.n_obs_history is not None and self.config.n_obs_history > 1:
+                    raise ValueError(
+                        f"Expected 5D video tensor (B, T, C, H, W) when n_obs_history > 1, "
+                        f"got shape {vid.shape}. Ensure select_action() is being used."
+                    )
                 vid = vid.unsqueeze(1)  # (B, C, H, W) -> (B, 1, C, H, W)
 
             if obs_history_is_pad is not None:

--- a/src/opentau/policies/pi05_mem/modeling_pi05.py
+++ b/src/opentau/policies/pi05_mem/modeling_pi05.py
@@ -416,9 +416,18 @@ class PI05MemPolicy(PreTrainedPolicy):
         buffers, then assembles a batch with ``n_obs_history`` evenly-spaced
         frames (interval = ``history_interval``).  Early in an episode, missing
         history slots are zero-padded.
+
+        Expected batch keys:
+            - ``"state"``: (B, D) current proprioceptive state.
+            - image keys matching ``config.image_features``: (B, C, H, W) camera frames.
+            - ``"prompt"``: list[str] language instructions (passed through unchanged).
+            - Any other metadata keys are forwarded unchanged.
+
+        Returns a new dict with ``"state"`` expanded to (B, T, D) and image keys
+        expanded to (B, T, C, H, W), where T = ``n_obs_history``.
         """
         n_hist = self.config.n_obs_history
-        k = self.config.history_interval or 1
+        interval = self.config.history_interval or 1
         buf_maxlen = self.config.obs_buffer_size
 
         # --- initialise buffers on first call after reset() ---
@@ -436,16 +445,17 @@ class PI05MemPolicy(PreTrainedPolicy):
         for key in img_keys:
             self._obs_buffers[key].append(batch[key])  # (B, C, H, W)
 
-        # --- sample n_hist frames at interval k ---
+        # --- sample n_hist frames at the configured interval ---
         buf_len = len(self._state_buffer)
         missing = buf_maxlen - buf_len  # how many slots are still empty
 
-        temporal_batch = {k_: v for k_, v in batch.items() if k_ not in img_keys and k_ != "state"}
+        # Pass through all non-image, non-state keys (e.g. "prompt" and other metadata).
+        temporal_batch = {key: v for key, v in batch.items() if key not in img_keys and key != "state"}
 
         # Build state tensor (B, T, D)
         state_frames = []
         for i in range(n_hist):
-            idx = i * k - missing  # index into current buffer
+            idx = i * interval - missing  # index into current buffer
             if idx < 0:
                 state_frames.append(torch.zeros_like(self._state_buffer[0]))
             else:
@@ -456,7 +466,7 @@ class PI05MemPolicy(PreTrainedPolicy):
         for key in img_keys:
             cam_frames = []
             for i in range(n_hist):
-                idx = i * k - missing
+                idx = i * interval - missing
                 if idx < 0:
                     cam_frames.append(torch.zeros_like(self._obs_buffers[key][0]))
                 else:
@@ -696,13 +706,10 @@ class PI05MemPolicy(PreTrainedPolicy):
             videos.append(vid)
             vid_masks.append(mask)
 
-        for num_empty_cameras in range(len(missing_img_keys)):
-            if num_empty_cameras >= self.config.empty_cameras:
-                break
-            vid = torch.zeros_like(vid)
-            mask = torch.zeros_like(mask)
-            videos.append(vid)
-            vid_masks.append(mask)
+        n_empty = min(len(missing_img_keys), self.config.empty_cameras)
+        for _ in range(n_empty):
+            videos.append(torch.zeros_like(vid))
+            vid_masks.append(torch.zeros_like(mask))
 
         return videos, vid_masks
 
@@ -773,6 +780,7 @@ class PI05MemFlowMatching(nn.Module):
         vlm_hidden_size = self.paligemma_with_expert.config.paligemma_config.text_config.hidden_size
 
         # V-JEPA2 video encoder (replaces SigLIP)
+        encoder_dtype = getattr(torch, config.vjepa2_dtype) if config.vjepa2_dtype else None
         self.video_encoder = VJEPA2VideoEncoder(
             vjepa2_model_name=config.vjepa2_model_name,
             num_frames=config.n_obs_steps,
@@ -781,6 +789,7 @@ class PI05MemFlowMatching(nn.Module):
             vlm_hidden_size=vlm_hidden_size,
             perceiver_heads=config.vjepa2_perceiver_heads,
             freeze_encoder=config.freeze_vision_encoder,
+            encoder_dtype=encoder_dtype,
         )
 
         # Per-timestep state projection: each of the T state vectors becomes one token
@@ -791,8 +800,6 @@ class PI05MemFlowMatching(nn.Module):
 
         self.time_mlp_in = nn.Linear(self.config.proj_width, self.config.proj_width)
         self.time_mlp_out = nn.Linear(self.config.proj_width, self.config.proj_width)
-
-        self.language_tokenizer = AutoTokenizer.from_pretrained("google/paligemma-3b-pt-224")
 
         self._init_model()
 

--- a/src/opentau/policies/pi05_mem/modeling_pi05.py
+++ b/src/opentau/policies/pi05_mem/modeling_pi05.py
@@ -1,0 +1,1065 @@
+#!/usr/bin/env python
+
+# Copyright 2025 Physical Intelligence and The HuggingFace Inc. team. All rights reserved.
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""π05 Mem: A Vision-Language-Action Flow Model with V-JEPA2 video encoding
+and temporal state sequences.
+
+Based on π05, this variant:
+  1. Replaces the SigLIP image encoder with a frozen V-JEPA2 video encoder
+     followed by a Perceiver cross-attention reducer that compresses the video
+     into 256 tokens (matching the original SigLIP token count).
+  2. Accepts temporal state sequences (B, T, D) and projects each timestep
+     into a separate continuous token for the Gemma backbone.
+"""
+
+import builtins
+import logging
+import math
+from collections import deque
+from pathlib import Path
+
+import numpy as np
+import torch
+import torch.nn.functional as F  # noqa: N812
+from einops import rearrange, repeat
+from torch import Tensor, nn
+from transformers import AutoProcessor, AutoTokenizer
+
+from opentau.configs.policies import PreTrainedConfig
+from opentau.configs.types import NormalizationMode
+from opentau.policies.normalize import Normalize, Unnormalize
+from opentau.policies.pi05.paligemma_with_expert import (
+    PaliGemmaWithExpertConfig,
+    PaliGemmaWithExpertModel,
+)
+from opentau.policies.pi05_mem.configuration_pi05 import PI05MemConfig
+from opentau.policies.pi05_mem.video_encoder import VJEPA2VideoEncoder
+from opentau.policies.pretrained import PreTrainedPolicy, T
+from opentau.utils.accelerate_utils import get_proc_accelerator
+from opentau.utils.utils import get_safe_dtype
+
+
+def _preferred_dtype():
+    return torch.float32 if torch.onnx.is_in_onnx_export() else torch.bfloat16
+
+
+def create_sinusoidal_pos_embedding(
+    time: Tensor, dimension: int, min_period: float, max_period: float, device: torch.device | str = "cpu"
+) -> Tensor:
+    """Computes sine-cosine positional embedding vectors for scalar positions.
+
+    Args:
+        time: A 2-D tensor of shape (batch_size, action_chunk_length).
+        dimension: The dimension of the embedding vectors. Must be divisible by 2.
+        min_period: The minimum period of the sinusoidal functions.
+        max_period: The maximum period of the sinusoidal functions.
+        device: The device to create the tensors on. Defaults to "cpu".
+
+    Returns:
+        A tensor of shape (batch_size, action_chunk_length, dimension).
+    """
+    if dimension % 2 != 0:
+        raise ValueError(f"dimension ({dimension}) must be divisible by 2")
+
+    if time.ndim != 2:
+        raise ValueError("The time tensor is expected to be of shape `(batch_size, action_chunk_length)`.")
+
+    dtype = (
+        get_safe_dtype(torch.float64, device.type)
+        if isinstance(device, torch.device)
+        else get_safe_dtype(torch.float64, device)
+    )
+    fraction = torch.linspace(0.0, 1.0, dimension // 2, dtype=dtype, device=device)
+    period = min_period * (max_period / min_period) ** fraction
+
+    scaling_factor = 1.0 / period * 2 * math.pi
+    sin_input = rearrange(scaling_factor, "d -> 1 1 d") * rearrange(time, "b c -> b c 1")
+    pos_emb = torch.cat([torch.sin(sin_input), torch.cos(sin_input)], dim=2)
+    return pos_emb
+
+
+def make_att_2d_masks(
+    pad_masks: Tensor,
+    att_masks: Tensor,
+    n_cross_att_tokens: int | None = None,
+    cross_att_pad_masks: Tensor | None = None,
+) -> Tensor:
+    """Creates a 2-D attention mask given padding and 1-D attention masks.
+
+    Args:
+        pad_masks: bool[B, N] true if its part of the input, false if padding.
+        att_masks: int32[B, N] mask that's 1 where previous tokens cannot depend on
+            it and 0 where it shares the same attention mask as the previous token.
+        n_cross_att_tokens: Add attention mask for cross-attention tokens if provided.
+        cross_att_pad_masks: Padding masks for cross attention tokens.
+
+    Returns:
+        A 2D attention mask tensor.
+    """
+    if att_masks.ndim != 2:
+        raise ValueError(att_masks.ndim)
+    if pad_masks.ndim != 2:
+        raise ValueError(pad_masks.ndim)
+
+    cumsum = torch.cumsum(att_masks, dim=1)
+    att_2d_masks = cumsum[:, None, :] <= cumsum[:, :, None]
+    pad_2d_masks = pad_masks[:, None, :] * pad_masks[:, :, None]
+    att_2d_masks = att_2d_masks & pad_2d_masks
+
+    if n_cross_att_tokens is not None:
+        assert cross_att_pad_masks is not None, (
+            "cross_att_pad_masks must be provided if n_cross_att_tokens is provided"
+        )
+        assert cross_att_pad_masks.shape == (att_masks.size(0), n_cross_att_tokens), (
+            "cross_att_pad_masks must have shape (batch_size, n_cross_att_tokens)"
+        )
+
+        cross_att_mask = torch.full(
+            (att_masks.size(0), att_masks.size(1), n_cross_att_tokens),
+            True,
+            dtype=torch.bool,
+            device=att_masks.device,
+        )
+
+        cross_att_mask = cross_att_mask & pad_masks[:, :, None] & cross_att_pad_masks[:, None, :]
+        att_2d_masks = torch.cat((cross_att_mask, att_2d_masks), dim=2)
+
+    return att_2d_masks
+
+
+def resize_with_pad(img: Tensor, width: int, height: int, pad_value: int = -1) -> Tensor:
+    """Resizes an image to fit within the specified dimensions while maintaining aspect ratio,
+    and pads the remaining area.
+
+    Args:
+        img: Input image tensor of shape (batch_size, channels, current_height, current_width).
+        width: Target width.
+        height: Target height.
+        pad_value: Value to use for padding. Defaults to -1.
+
+    Returns:
+        The resized and padded image tensor of shape (batch_size, channels, height, width).
+    """
+    if img.ndim != 4:
+        raise ValueError(f"(b,c,h,w) expected, but {img.shape}")
+
+    cur_height, cur_width = img.shape[2:]
+
+    ratio = max(cur_width / width, cur_height / height)
+    resized_height = int(cur_height / ratio)
+    resized_width = int(cur_width / ratio)
+    resized_img = F.interpolate(
+        img, size=(resized_height, resized_width), mode="bilinear", align_corners=False
+    )
+
+    pad_height = max(0, int(height - resized_height))
+    pad_width = max(0, int(width - resized_width))
+
+    padded_img = F.pad(resized_img, (pad_width, 0, pad_height, 0), value=pad_value)
+    return padded_img
+
+
+def pad_discrete_tokens(tokens: list[list[int]], max_length: int) -> tuple[np.ndarray, np.ndarray]:
+    """Pads or truncates a list of discrete action token sequences to a fixed length.
+
+    Args:
+        tokens: A list of discrete action token sequences.
+        max_length: The target length.
+
+    Returns:
+        A tuple of (discrete_action_tokens, discrete_action_masks) numpy arrays.
+    """
+    discrete_action_tokens = []
+    discrete_action_masks = []
+    for token in tokens:
+        if len(token) > max_length:
+            logging.warning(
+                f"Discrete action token length {len(token)} is greater than max_length {max_length}, truncating"
+            )
+            discrete_action_tokens.append(np.array(token[:max_length]))
+            discrete_action_masks.append(np.ones(max_length, dtype=bool))
+        else:
+            discrete_action_masks.append(
+                np.concatenate(
+                    [np.ones(len(token), dtype=bool), np.zeros(max_length - len(token), dtype=bool)]
+                )
+            )
+            discrete_action_tokens.append(np.pad(token, (0, max_length - len(token)), constant_values=0))
+    return np.array(discrete_action_tokens), np.array(discrete_action_masks)
+
+
+# ---------------------------------------------------------------------------
+# Policy wrapper
+# ---------------------------------------------------------------------------
+
+
+class PI05MemPolicy(PreTrainedPolicy):
+    """Wrapper class around PI05MemFlowMatching model.
+
+    Uses V-JEPA2 as a video encoder and temporal state sequences projected
+    into per-timestep continuous tokens in the VLM embedding space.
+    """
+
+    config_class = PI05MemConfig
+    name = "pi05_mem"
+
+    def __init__(
+        self,
+        config: PI05MemConfig,
+        dataset_stats: dict[str, dict[str, Tensor]] | None = None,
+    ):
+        super().__init__(config)
+        config.validate_features()
+        self.config = config
+        self.normalize_inputs = Normalize(config.input_features, config.normalization_mapping, dataset_stats)
+        self.normalize_targets = Normalize(
+            config.output_features, config.normalization_mapping, dataset_stats
+        )
+        self.normalize_discrete_actions = Normalize(
+            config.output_features, {"ACTION": NormalizationMode.MIN_MAX}, dataset_stats
+        )
+        self.unnormalize_outputs = Unnormalize(
+            config.output_features, config.normalization_mapping, dataset_stats
+        )
+
+        self.language_tokenizer = AutoTokenizer.from_pretrained("google/paligemma-3b-pt-224")
+
+        self.discrete_action_processor = AutoProcessor.from_pretrained(
+            "physical-intelligence/fast", trust_remote_code=True
+        )
+        discrete_action_vocab_size = getattr(self.discrete_action_processor, "vocab_size", None)
+        self.model = PI05MemFlowMatching(config, discrete_action_vocab_size=discrete_action_vocab_size)
+
+        self.reset()
+
+    def reset(self) -> None:
+        """This should be called whenever the environment is reset."""
+        self._action_queue = deque([], maxlen=self.config.n_action_steps)
+
+    @classmethod
+    def from_pretrained(
+        cls: builtins.type[T],
+        pretrained_name_or_path: str | Path,
+        *,
+        config: PreTrainedConfig | None = None,
+        force_download: bool = False,
+        resume_download: bool | None = None,
+        proxies: dict | None = None,
+        token: str | bool | None = None,
+        cache_dir: str | Path | None = None,
+        local_files_only: bool = False,
+        revision: str | None = None,
+        strict: bool = True,
+        **kwargs,
+    ) -> T:
+        """Override the from_pretrained method to handle key remapping."""
+        if pretrained_name_or_path is None:
+            raise ValueError("pretrained_name_or_path is required")
+
+        if config is None:
+            config = PreTrainedConfig.from_pretrained(
+                pretrained_name_or_path=pretrained_name_or_path,
+                force_download=force_download,
+                resume_download=resume_download,
+                proxies=proxies,
+                token=token,
+                cache_dir=cache_dir,
+                local_files_only=local_files_only,
+                revision=revision,
+                **kwargs,
+            )
+
+        model = cls(config, **kwargs)
+
+        acc = get_proc_accelerator()
+        is_main_process = acc.is_main_process if acc else True
+        try:
+            if is_main_process:
+                logging.info("Loading model from: %s", pretrained_name_or_path)
+            try:
+                from transformers.utils import cached_file
+
+                resolved_file = cached_file(
+                    pretrained_name_or_path,
+                    "model.safetensors",
+                    cache_dir=cache_dir,
+                    force_download=force_download,
+                    resume_download=resume_download,
+                    proxies=proxies,
+                    token=token,
+                    revision=revision,
+                    local_files_only=local_files_only,
+                )
+                from safetensors.torch import load_file
+
+                original_state_dict = load_file(resolved_file)
+                if is_main_process:
+                    logging.info("Loaded state dict from model.safetensors")
+            except Exception as e:
+                if is_main_process:
+                    logging.warning("Could not load state dict from remote files: %s", e)
+                    logging.info("Returning model without loading pretrained weights")
+                return model
+
+            fixed_state_dict = model._fix_pytorch_state_dict_keys(original_state_dict, model.config)
+
+            remapped_state_dict = {}
+            remap_count = 0
+
+            for key, value in fixed_state_dict.items():
+                if not key.startswith("model.") and "normalize" not in key:
+                    new_key = f"model.{key}"
+                    remapped_state_dict[new_key] = value
+                    remap_count += 1
+                    if remap_count <= 10 and is_main_process:
+                        logging.debug("Remapped: %s -> %s", key, new_key)
+                else:
+                    remapped_state_dict[key] = value
+
+            if remap_count > 0 and is_main_process:
+                logging.info("Remapped %d state dict keys", remap_count)
+
+            missing_keys, unexpected_keys = model.load_state_dict(remapped_state_dict, strict=False)
+
+            if missing_keys and is_main_process:
+                logging.warning("Missing keys when loading state dict: %d keys", len(missing_keys))
+                for key in missing_keys[:20]:
+                    logging.warning("  - %s", key)
+                if len(missing_keys) > 20:
+                    logging.warning("  ... and %d more", len(missing_keys) - 20)
+
+            if unexpected_keys and is_main_process:
+                logging.warning("Unexpected keys when loading state dict: %d keys", len(unexpected_keys))
+                for key in unexpected_keys[:20]:
+                    logging.warning("  - %s", key)
+                if len(unexpected_keys) > 20:
+                    logging.warning("  ... and %d more", len(unexpected_keys) - 20)
+
+            if not missing_keys and not unexpected_keys and is_main_process:
+                logging.info("All keys loaded successfully!")
+
+        except Exception as e:
+            if is_main_process:
+                logging.warning("Could not remap state dict keys: %s", e)
+
+        return model
+
+    def _fix_pytorch_state_dict_keys(
+        self, state_dict: dict[str, Tensor], model_config: PreTrainedConfig
+    ) -> dict[str, Tensor]:
+        """Fix state dict keys to match current model architecture."""
+        import re
+
+        fixed_state_dict = {}
+
+        for key, value in state_dict.items():
+            new_key = key
+
+            if re.match(
+                r"paligemma_with_expert\.gemma_expert\.model\.layers\.\d+\.(input_layernorm|post_attention_layernorm)\.weight",
+                key,
+            ):
+                expert_uses_adarms = getattr(
+                    self.model.paligemma_with_expert.gemma_expert.config, "use_adarms", False
+                )
+                if expert_uses_adarms:
+                    logging.warning(f"Skipping layer norm key (adaRMS mismatch): {key}")
+                    continue
+
+            if re.match(r"paligemma_with_expert\.gemma_expert\.model\.norm\.weight", key):
+                expert_uses_adarms = getattr(
+                    self.model.paligemma_with_expert.gemma_expert.config, "use_adarms", False
+                )
+                if expert_uses_adarms:
+                    logging.warning(f"Skipping norm key (adaRMS mismatch): {key}")
+                    continue
+
+            if key.startswith("action_time_mlp_in."):
+                new_key = key.replace("action_time_mlp_in.", "time_mlp_in.")
+            elif key.startswith("action_time_mlp_out."):
+                new_key = key.replace("action_time_mlp_out.", "time_mlp_out.")
+            if "patch_embedding" in key:
+                logging.warning(f"Vision embedding key might need handling: {key}")
+
+            fixed_state_dict[new_key] = value
+
+        return fixed_state_dict
+
+    def get_optim_params(self) -> dict:
+        return self.parameters()
+
+    @torch.no_grad()
+    def predict_action_chunk(self, batch: dict[str, Tensor]) -> Tensor:
+        raise NotImplementedError("Currently not implemented for PI05 Mem")
+
+    @torch.no_grad()
+    def select_action(self, batch: dict[str, Tensor], noise: Tensor | None = None) -> Tensor:
+        """Select a single action given environment observations."""
+        self.eval()
+
+        if len(self._action_queue) == 0 or len(self._action_queue) <= self.config.max_delay:
+            action_prefix = None
+            delay = 0
+            if len(self._action_queue) > 0:
+                prefix_actions = list(self._action_queue)
+                delay = min(len(prefix_actions), self.config.max_delay)
+                assert delay == self.config.max_delay, f"Delay must be equal to {self.config.max_delay}"
+                prefix_actions = prefix_actions[-delay:]
+                action_prefix = torch.stack(prefix_actions, dim=1)
+            delay = torch.tensor(delay, dtype=torch.long, device=batch["state"].device)
+            actions = self.sample_actions(batch, noise=noise, action_prefix=action_prefix, delay=delay)
+            actions = rearrange(actions, "b c d -> c b d")
+            self._action_queue.extend(actions[delay:])
+            assert len(self._action_queue) == self.config.n_action_steps, (
+                f"Action queue must have {self.config.n_action_steps} actions"
+            )
+
+        action = self._action_queue.popleft()
+        return action
+
+    @torch.no_grad()
+    def sample_actions(
+        self,
+        batch: dict[str, Tensor],
+        action_prefix: Tensor | None = None,
+        delay: Tensor | None = None,
+        noise: Tensor | None = None,
+    ) -> Tensor:
+        """Sample actions from the policy given environment observations."""
+        if not (torch.compiler.is_compiling() or torch.onnx.is_in_onnx_export()):
+            assert delay is None or 0 <= delay.item() <= self.config.max_delay, (
+                f"Delay must be None or between 0 and {self.config.max_delay}"
+            )
+
+        batch = self.normalize_inputs(batch)
+
+        videos, vid_masks = self.prepare_videos(batch)
+        lang_tokens, lang_masks = self.prepare_language(batch)
+        state = self.prepare_state(batch)
+
+        if delay is None:
+            delay = torch.tensor(0, dtype=torch.long, device=lang_tokens.device)
+
+        if action_prefix is None:
+            bsize = lang_tokens.shape[0]
+            actions_shape = (bsize, self.config.chunk_size, self.config.max_action_dim)
+            action_prefix = torch.zeros(actions_shape, dtype=lang_tokens.dtype, device=lang_tokens.device)
+        else:
+            action_prefix = self.normalize_targets({"actions": action_prefix})["actions"]
+            action_prefix = F.pad(
+                action_prefix,
+                (0, 0, 0, self.config.chunk_size - action_prefix.shape[1]),
+            )
+
+        actions = self.model.sample_actions(
+            videos,
+            vid_masks,
+            lang_tokens,
+            lang_masks,
+            state,
+            action_prefix,
+            delay,
+            noise=noise,
+        )
+
+        original_action_dim = self.config.action_feature.shape[0]
+        actions = actions[:, :, :original_action_dim]
+
+        actions = self.unnormalize_outputs({"actions": actions})["actions"]
+
+        return actions
+
+    def forward(
+        self, batch: dict[str, Tensor], noise: Tensor | None = None, time: Tensor | None = None
+    ) -> dict[str, Tensor]:
+        """Do a full training forward pass to compute the loss."""
+        batch = self.normalize_inputs(batch)
+        batch["discrete_actions"] = self.normalize_discrete_actions(dict(batch))["actions"]
+        batch = self.normalize_targets(batch)
+
+        videos, vid_masks = self.prepare_videos(batch)
+        lang_tokens, lang_masks = self.prepare_language(batch)
+        state = self.prepare_state(batch)
+        discrete_actions, discrete_action_masks = self.prepare_discrete_actions(batch)
+        actions = batch["actions"]
+        actions_is_pad = batch.get("action_is_pad")
+
+        losses = self.model.forward(
+            videos,
+            vid_masks,
+            lang_tokens,
+            lang_masks,
+            state,
+            actions,
+            actions_is_pad,
+            noise,
+            time,
+            discrete_actions,
+            discrete_action_masks,
+        )
+
+        mse_loss = losses["MSE"]
+        ce_loss = losses["CE"]
+
+        return {"MSE": mse_loss, "CE": ce_loss}
+
+    def prepare_state(self, batch: dict[str, Tensor]) -> Tensor:
+        """Prepares the temporal state tensor, padding or truncating to max_state_dim.
+
+        Args:
+            batch: Batch of data containing "state" tensor of shape (B, T, D).
+
+        Returns:
+            A tensor of shape (B, T, max_state_dim).
+        """
+        state = batch["state"]  # (B, T, D)
+        state_dim = state.shape[-1]
+        if state_dim > self.config.max_state_dim:
+            raise ValueError(
+                f"State dimension ({state_dim}) exceeds max_state_dim ({self.config.max_state_dim}). "
+                f"Increase max_state_dim in the config to accommodate the state vector."
+            )
+        if state_dim < self.config.max_state_dim:
+            state = F.pad(state, (0, self.config.max_state_dim - state_dim))
+        return state
+
+    def prepare_discrete_actions(self, batch: dict[str, Tensor]) -> tuple[Tensor, Tensor]:
+        """Prepares discrete actions for the model by tokenizing and padding them."""
+        device = batch["discrete_actions"].device
+        discrete_actions = batch["discrete_actions"].to(device="cpu", dtype=torch.float32)
+        tokens = self.discrete_action_processor.__call__(discrete_actions)
+        discrete_action_tokens, discrete_action_masks = pad_discrete_tokens(
+            tokens, self.config.discrete_action_max_length
+        )
+        return torch.from_numpy(discrete_action_tokens).to(device=device, dtype=torch.long), torch.from_numpy(
+            discrete_action_masks
+        ).to(device=device, dtype=torch.bool)
+
+    def prepare_videos(self, batch: dict[str, Tensor]) -> tuple[list[Tensor], list[Tensor]]:
+        """Apply preprocessing to the video inputs.
+
+        Each camera key now contains a video tensor of shape (B, T, C, H, W).
+        Frames are resized to 224x224 with padding. ImageNet normalization is
+        assumed to be already applied by the dataset loader.
+
+        Args:
+            batch: Batch of data containing video tensors.
+
+        Returns:
+            A tuple of (videos, vid_masks) lists.
+        """
+        videos = []
+        vid_masks = []
+
+        present_img_keys = [key for key in self.config.image_features if key in batch]
+        missing_img_keys = [key for key in self.config.image_features if key not in batch]
+
+        if len(present_img_keys) == 0:
+            raise ValueError(
+                f"All image features are missing from the batch. At least one expected. "
+                f"(batch: {batch.keys()}) (image_features:{self.config.image_features})"
+            )
+
+        for key in present_img_keys:
+            vid = batch[key]  # (B, T, C, H, W)
+
+            if self.config.resize_imgs_with_padding is not None:
+                b, t_frames = vid.shape[:2]
+                flat = rearrange(vid, "B T C H W -> (B T) C H W")
+                flat = resize_with_pad(flat, *self.config.resize_imgs_with_padding, pad_value=0)
+                vid = rearrange(flat, "(B T) C H W -> B T C H W", B=b, T=t_frames)
+
+            bsize = vid.shape[0]
+            device = vid.device
+            mask = torch.ones(bsize, dtype=torch.bool, device=device)
+            videos.append(vid)
+            vid_masks.append(mask)
+
+        for num_empty_cameras in range(len(missing_img_keys)):
+            if num_empty_cameras >= self.config.empty_cameras:
+                break
+            vid = torch.zeros_like(vid)
+            mask = torch.zeros_like(mask)
+            videos.append(vid)
+            vid_masks.append(mask)
+
+        return videos, vid_masks
+
+    def prepare_language(self, batch: dict[str, Tensor]) -> tuple[Tensor, Tensor]:
+        """Tokenize the text input."""
+        device = batch["state"].device
+        tasks = batch["prompt"]
+
+        prompt = [f"Task: {task}<eos>Actions:" for task in tasks]
+
+        tokenized_prompt = self.language_tokenizer.__call__(
+            prompt,
+            padding="max_length",
+            padding_side="right",
+            max_length=self.config.prompt_max_length,
+            return_tensors="pt",
+            truncation=True,
+        )
+        lang_tokens = tokenized_prompt["input_ids"].to(device=device)
+        lang_masks = tokenized_prompt["attention_mask"].to(device=device, dtype=torch.bool)
+
+        return lang_tokens, lang_masks
+
+
+# ---------------------------------------------------------------------------
+# Flow-matching model
+# ---------------------------------------------------------------------------
+
+
+class PI05MemFlowMatching(nn.Module):
+    """π05 Mem: A Vision-Language-Action Flow Model with V-JEPA2 video encoding
+    and temporal state sequences.
+
+    ┌──────────────────────────────────────────┐
+    │                   actions                │
+    │                   ▲                      │
+    │                  ┌┴─────┐                │
+    │      kv cache    │Gemma │                │
+    │      ┌──────────►│Expert│                │
+    │      │           │      │                │
+    │     ┌┴─────────┐ │x 10  │                │
+    │     │          │ └▲─────┘                │
+    │     │PaliGemma │  │                      │
+    │     │          │  noise                  │
+    │     └▲──▲──▲──▲                          │
+    │      │  │  │  └── discrete actions       │
+    │      │  │  └───── state (T tokens)       │
+    │      │  └──────── language tokens        │
+    │      └─────────── video (V-JEPA2)        │
+    └──────────────────────────────────────────┘
+    """
+
+    def __init__(self, config: PI05MemConfig, discrete_action_vocab_size: int | None = None):
+        super().__init__()
+        self.config = config
+
+        load_pretrained_paligemma = self.config.init_strategy == "expert_only_he_init"
+        paligemma_with_expert_config = PaliGemmaWithExpertConfig(
+            freeze_vision_encoder=self.config.freeze_vision_encoder,
+            train_expert_only=self.config.train_expert_only,
+            attention_implementation=self.config.attention_implementation,
+            load_pretrained_paligemma=load_pretrained_paligemma,
+            discrete_action_vocab_size=discrete_action_vocab_size,
+            dropout=self.config.dropout,
+        )
+        self.paligemma_with_expert = PaliGemmaWithExpertModel(paligemma_with_expert_config)
+
+        vlm_hidden_size = self.paligemma_with_expert.config.paligemma_config.text_config.hidden_size
+
+        # V-JEPA2 video encoder (replaces SigLIP)
+        self.video_encoder = VJEPA2VideoEncoder(
+            vjepa2_model_name=config.vjepa2_model_name,
+            num_frames=config.n_obs_steps,
+            crop_size=config.vjepa2_crop_size,
+            num_video_tokens=config.vjepa2_num_video_tokens,
+            vlm_hidden_size=vlm_hidden_size,
+            perceiver_heads=config.vjepa2_perceiver_heads,
+            freeze_encoder=config.freeze_vision_encoder,
+        )
+
+        # Per-timestep state projection: each of the T state vectors becomes one token
+        self.state_proj = nn.Linear(self.config.max_state_dim, vlm_hidden_size)
+
+        self.action_in_proj = nn.Linear(self.config.max_action_dim, self.config.proj_width)
+        self.action_out_proj = nn.Linear(self.config.proj_width, self.config.max_action_dim)
+
+        self.time_mlp_in = nn.Linear(self.config.proj_width, self.config.proj_width)
+        self.time_mlp_out = nn.Linear(self.config.proj_width, self.config.proj_width)
+
+        self.language_tokenizer = AutoTokenizer.from_pretrained("google/paligemma-3b-pt-224")
+
+        self._init_model()
+
+    def _init_weights(self, module: nn.Module) -> None:
+        if isinstance(module, nn.Linear):
+            nn.init.kaiming_normal_(module.weight, mode="fan_out", nonlinearity="relu")
+            if module.bias is not None:
+                nn.init.zeros_(module.bias)
+        elif isinstance(module, nn.LayerNorm):
+            nn.init.ones_(module.weight)
+            nn.init.zeros_(module.bias)
+
+    def _init_model(self) -> None:
+        if self.config.init_strategy == "no_init":
+            return
+        elif self.config.init_strategy == "full_he_init":
+            for m in self.modules():
+                self._init_weights(m)
+        elif self.config.init_strategy == "expert_only_he_init":
+            for m in self.paligemma_with_expert.gemma_expert.modules():
+                self._init_weights(m)
+        else:
+            raise ValueError(f"Invalid init strategy: {self.config.init_strategy}")
+
+    def sample_noise(self, shape: tuple[int, ...], device: torch.device | str) -> Tensor:
+        return torch.normal(mean=0.0, std=1.0, size=shape, dtype=torch.float32, device=device)
+
+    def sample_time(self, bsize: int, device: torch.device | str) -> Tensor:
+        beta_dist = torch.distributions.Beta(concentration1=1.5, concentration0=1.0)
+        time_beta = beta_dist.sample((bsize,)).to(device=device, dtype=torch.float32)
+        time = time_beta * 0.999 + 0.001
+        return time
+
+    def embed_video(self, video: Tensor) -> Tensor:
+        """Encode a video through V-JEPA2 + Perceiver reducer + projection.
+
+        Args:
+            video: (B, T, C, H, W)
+
+        Returns:
+            (B, num_video_tokens, vlm_hidden_size)
+        """
+        return self.video_encoder(video)
+
+    def embed_prefix(
+        self,
+        videos: list[Tensor],
+        vid_masks: list[Tensor],
+        lang_tokens: Tensor,
+        lang_masks: Tensor,
+        state: Tensor,
+        discrete_actions: Tensor | None = None,
+        discrete_action_masks: Tensor | None = None,
+    ) -> tuple[Tensor, Tensor, Tensor]:
+        """Embed videos with V-JEPA2, language tokens with embedding layer, and
+        temporal state via per-timestep learned projection.
+
+        Args:
+            videos: List of video tensors, each (B, T, C, H, W).
+            vid_masks: List of video mask tensors, each (B,).
+            lang_tokens: Language token tensor.
+            lang_masks: Language mask tensor.
+            state: Temporal state tensor of shape (B, T, max_state_dim).
+            discrete_actions: Optional discrete action tensor.
+            discrete_action_masks: Optional discrete action mask tensor.
+
+        Returns:
+            (embs, pad_masks, att_masks) tuple.
+        """
+        embs = []
+        pad_masks = []
+        att_masks = []
+
+        for vid, vid_mask in zip(videos, vid_masks, strict=False):
+            vid_emb = self.embed_video(vid)  # (B, num_video_tokens, vlm_hidden)
+            vid_emb = vid_emb.to(dtype=_preferred_dtype())
+
+            bsize, num_vid_embs = vid_emb.shape[:2]
+            vid_mask_expanded = vid_mask[:, None].expand(bsize, num_vid_embs)
+
+            embs.append(vid_emb)
+            pad_masks.append(vid_mask_expanded)
+
+            att_masks += [0] * num_vid_embs
+
+        lang_emb = self.paligemma_with_expert.embed_language_tokens(lang_tokens)
+        lang_emb_dim = lang_emb.shape[-1]
+        lang_emb = lang_emb * math.sqrt(lang_emb_dim)
+
+        embs.append(lang_emb)
+        pad_masks.append(lang_masks)
+
+        num_lang_embs = lang_emb.shape[1]
+        att_masks += [0] * num_lang_embs
+
+        # Project each timestep's state into a separate VLM token
+        # state: (B, T, max_state_dim) -> state_emb: (B, T, vlm_hidden_size)
+        state_emb = self.state_proj(state.to(dtype=_preferred_dtype()))
+        num_state_tokens = state_emb.shape[1]  # T
+        state_mask = torch.ones(bsize, num_state_tokens, dtype=torch.bool, device=state.device)
+
+        embs.append(state_emb)
+        pad_masks.append(state_mask)
+        att_masks += [0] * num_state_tokens  # full attention with video and language
+
+        if discrete_actions is not None:
+            discrete_action_emb = self.paligemma_with_expert.embed_discrete_actions(discrete_actions)
+            embs.append(discrete_action_emb.to(dtype=_preferred_dtype()))
+            pad_masks.append(discrete_action_masks)
+            att_masks += [1] * discrete_action_emb.shape[1]
+
+        embs = torch.cat(embs, dim=1)
+        pad_masks = torch.cat(pad_masks, dim=1)
+        att_masks = torch.tensor(att_masks, dtype=torch.bool, device=pad_masks.device)
+        att_masks = att_masks[None, :].expand(bsize, len(att_masks))
+
+        return embs, pad_masks, att_masks
+
+    def embed_suffix(self, noisy_actions: Tensor, timestep: Tensor) -> tuple[Tensor, Tensor, Tensor, Tensor]:
+        """Embed noisy_actions, timestep to prepare for Expert Gemma processing."""
+        embs = []
+        pad_masks = []
+        att_masks = []
+
+        bsize = noisy_actions.shape[0]
+        dtype = _preferred_dtype()
+        device = noisy_actions.device
+
+        time_emb = create_sinusoidal_pos_embedding(
+            timestep, self.config.proj_width, min_period=4e-3, max_period=4.0, device=device
+        )
+
+        noisy_actions = noisy_actions.to(dtype=dtype)
+        action_emb = self.action_in_proj(noisy_actions)
+
+        def time_mlp_func(time_emb):
+            x = self.time_mlp_in(time_emb)
+            x = F.silu(x)
+            x = self.time_mlp_out(x)
+            return F.silu(x)
+
+        time_emb = time_emb.to(dtype=dtype)
+        adarms_cond = time_mlp_func(time_emb)
+
+        embs.append(action_emb)
+
+        bsize, action_dim = action_emb.shape[:2]
+        action_mask = torch.ones(bsize, action_dim, dtype=torch.bool, device=device)
+        pad_masks.append(action_mask)
+
+        att_masks += [1] + ([0] * (self.config.n_action_steps - 1))
+
+        embs = torch.cat(embs, dim=1)
+        pad_masks = torch.cat(pad_masks, dim=1)
+        att_masks = torch.tensor(att_masks, dtype=embs.dtype, device=embs.device)
+        att_masks = att_masks[None, :].expand(bsize, len(att_masks))
+
+        return embs, pad_masks, att_masks, adarms_cond
+
+    def forward(
+        self,
+        videos: list[Tensor],
+        vid_masks: list[Tensor],
+        lang_tokens: Tensor,
+        lang_masks: Tensor,
+        state: Tensor,
+        actions: Tensor,
+        actions_is_pad: Tensor | None = None,
+        noise: Tensor | None = None,
+        time: Tensor | None = None,
+        discrete_actions: Tensor | None = None,
+        discrete_action_masks: Tensor | None = None,
+    ) -> dict[str, Tensor]:
+        """Do a full training forward pass and compute the loss."""
+        prefix_embs, prefix_pad_masks, prefix_att_masks = self.embed_prefix(
+            videos,
+            vid_masks,
+            lang_tokens,
+            lang_masks,
+            state,
+            discrete_actions,
+            discrete_action_masks,
+        )
+
+        vlm_2d_attention_mask = make_att_2d_masks(prefix_pad_masks, prefix_att_masks)
+        vlm_position_ids = torch.cumsum(prefix_pad_masks, dim=1) - 1
+
+        num_cross_att_tokens = prefix_embs.shape[1] - self.config.discrete_action_max_length
+
+        (prefix_out, _), past_key_values = self.paligemma_with_expert.forward(
+            attention_mask=vlm_2d_attention_mask,
+            position_ids=vlm_position_ids,
+            past_key_values=None,
+            inputs_embeds=[prefix_embs, None],
+            n_cross_att_tokens=num_cross_att_tokens,
+            use_cache=False,
+            fill_kv_cache=True,
+        )
+
+        batch_size = actions.shape[0]
+        if noise is None:
+            noise = self.sample_noise(actions.shape, actions.device)
+
+        if time is None:
+            time = self.sample_time(batch_size, actions.device)
+
+        delay = torch.randint(0, self.config.max_delay + 1, (batch_size,))
+        prefix_mask = rearrange(torch.arange(self.config.chunk_size), "c -> 1 c") < rearrange(
+            delay, "b -> b 1"
+        )
+        prefix_mask = prefix_mask.to(device=actions.device)
+        time = torch.where(prefix_mask, 0, rearrange(time, "b -> b 1"))
+
+        time_expanded = rearrange(time, "b c -> b c 1")
+        x_t = time_expanded * noise + (1 - time_expanded) * actions
+        u_t = noise - actions
+
+        suffix_embs, suffix_pad_masks, suffix_att_masks, adarms_cond = self.embed_suffix(x_t, time)
+
+        action_expert_2d_attention_mask = make_att_2d_masks(
+            suffix_pad_masks,
+            suffix_att_masks,
+            n_cross_att_tokens=num_cross_att_tokens,
+            cross_att_pad_masks=prefix_pad_masks[:, :num_cross_att_tokens],
+        )
+        prefix_offsets = torch.sum(prefix_pad_masks[:, : -self.config.discrete_action_max_length], dim=-1)[
+            :, None
+        ]
+        action_expert_position_ids = prefix_offsets + torch.cumsum(suffix_pad_masks, dim=1) - 1
+
+        for layer_idx in past_key_values:
+            past_key_values[layer_idx]["key_states"] = past_key_values[layer_idx]["key_states"].detach()
+            past_key_values[layer_idx]["value_states"] = past_key_values[layer_idx]["value_states"].detach()
+
+        (_, suffix_out), _ = self.paligemma_with_expert.forward(
+            attention_mask=action_expert_2d_attention_mask,
+            position_ids=action_expert_position_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=[None, suffix_embs],
+            use_cache=True,
+            fill_kv_cache=False,
+            adarms_cond=[None, adarms_cond],
+        )
+
+        suffix_out = suffix_out[:, -self.config.n_action_steps :]
+        v_t = self.action_out_proj(suffix_out)
+        v_t = v_t.to(dtype=torch.float32)
+
+        mse_loss = F.mse_loss(u_t, v_t, reduction="none")
+
+        postfix_mask = rearrange(torch.logical_not(prefix_mask), "b c -> b c 1")
+
+        if actions_is_pad is not None:
+            in_episode_bound = ~actions_is_pad
+            in_episode_bound = rearrange(in_episode_bound, "b c -> b c 1")
+            postfix_mask = torch.logical_and(postfix_mask, in_episode_bound)
+
+        mse_loss = mse_loss * postfix_mask
+
+        mse_loss = mse_loss[:, :, : self.config.max_action_dim]
+
+        postfix_mask_expanded = repeat(postfix_mask, "b c 1 -> b c d", d=mse_loss.shape[-1])
+        mse_loss = mse_loss.sum() / (postfix_mask_expanded.sum() + 1e-8)
+
+        batch_size, seq_len = discrete_actions.shape
+        discrete_token_start = -self.config.discrete_action_max_length
+        discrete_action_slice_object = slice(discrete_token_start - 1, -1)
+        discrete_action_out = prefix_out[:, discrete_action_slice_object]
+        logits = self.paligemma_with_expert.da_head(discrete_action_out)
+
+        logits = logits.to(dtype=torch.float32)
+        logits = rearrange(logits, "b s d -> (b s) d")
+        labels = rearrange(discrete_actions, "b s -> (b s)")
+        discrete_action_ce_loss = F.cross_entropy(logits, labels, reduction="none")
+
+        discrete_action_ce_loss = rearrange(discrete_action_ce_loss, "(b s) -> b s", b=batch_size, s=seq_len)
+
+        discrete_action_is_pad = ~discrete_action_masks
+        discrete_action_ce_loss = discrete_action_ce_loss * ~discrete_action_is_pad
+
+        discrete_action_ce_loss = discrete_action_ce_loss.mean()
+
+        return {"MSE": mse_loss, "CE": discrete_action_ce_loss}
+
+    def sample_actions(
+        self,
+        videos: list[Tensor],
+        vid_masks: list[Tensor],
+        lang_tokens: Tensor,
+        lang_masks: Tensor,
+        state: Tensor,
+        action_prefix: Tensor,
+        delay: Tensor,
+        noise: Tensor | None = None,
+    ) -> Tensor:
+        """Do a full inference forward and compute the action."""
+        bsize = lang_tokens.shape[0]
+        device = lang_tokens.device
+
+        if noise is None:
+            actions_shape = (bsize, self.config.chunk_size, self.config.max_action_dim)
+            noise = self.sample_noise(actions_shape, device)
+
+        prefix_embs, prefix_pad_masks, prefix_att_masks = self.embed_prefix(
+            videos, vid_masks, lang_tokens, lang_masks, state
+        )
+        prefix_att_2d_masks = make_att_2d_masks(prefix_pad_masks, prefix_att_masks)
+        prefix_position_ids = torch.cumsum(prefix_pad_masks, dim=1) - 1
+
+        num_cross_att_tokens = prefix_embs.shape[1]
+
+        (prefix_out, _), past_key_values = self.paligemma_with_expert.forward(
+            attention_mask=prefix_att_2d_masks,
+            position_ids=prefix_position_ids,
+            past_key_values=None,
+            inputs_embeds=[prefix_embs, None],
+            n_cross_att_tokens=num_cross_att_tokens,
+            use_cache=False,
+            fill_kv_cache=True,
+        )
+
+        dt = -1.0 / self.config.num_steps
+        dt = torch.tensor(dt, dtype=torch.float32, device=device)
+
+        x_t = noise
+        time = torch.tensor(1.0, dtype=torch.float32, device=device)
+        prefix_mask = rearrange(torch.arange(self.config.chunk_size, device=device), "c -> 1 c") < delay
+        while time >= -dt / 2:
+            x_t = torch.where(rearrange(prefix_mask, "b c -> b c 1"), action_prefix, x_t)
+            masked_time = torch.where(prefix_mask, 0, time)
+            v_t = self.denoise_step(
+                prefix_pad_masks,
+                past_key_values,
+                x_t,
+                masked_time,
+            )
+
+            x_t += dt * v_t
+            time += dt
+
+        x_t = torch.where(rearrange(prefix_mask, "b c -> b c 1"), action_prefix, x_t)
+        return x_t
+
+    def denoise_step(
+        self,
+        prefix_pad_masks: Tensor,
+        past_key_values: list[dict[str, Tensor]],
+        x_t: Tensor,
+        time: Tensor,
+    ) -> Tensor:
+        """Apply one denoising step."""
+        suffix_embs, suffix_pad_masks, suffix_att_masks, adarms_cond = self.embed_suffix(x_t, time)
+
+        num_cross_att_tokens = prefix_pad_masks.shape[1]
+        action_expert_2d_attention_mask = make_att_2d_masks(
+            suffix_pad_masks,
+            suffix_att_masks,
+            n_cross_att_tokens=num_cross_att_tokens,
+            cross_att_pad_masks=prefix_pad_masks[:, :num_cross_att_tokens],
+        )
+        prefix_offsets = torch.sum(prefix_pad_masks, dim=-1)[:, None]
+        action_expert_position_ids = prefix_offsets + torch.cumsum(suffix_pad_masks, dim=1) - 1
+
+        outputs_embeds, _ = self.paligemma_with_expert.forward(
+            attention_mask=action_expert_2d_attention_mask,
+            position_ids=action_expert_position_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=[None, suffix_embs],
+            use_cache=True,
+            fill_kv_cache=False,
+            adarms_cond=[None, adarms_cond],
+        )
+        suffix_out = outputs_embeds[1]
+        suffix_out = suffix_out[:, -self.config.n_action_steps :]
+        v_t = self.action_out_proj(suffix_out)
+        v_t = v_t.to(dtype=torch.float32)
+        return v_t

--- a/src/opentau/policies/pi05_mem/modeling_pi05.py
+++ b/src/opentau/policies/pi05_mem/modeling_pi05.py
@@ -533,7 +533,9 @@ class PI05MemPolicy(PreTrainedPolicy):
         Returns:
             A tensor of shape (B, T, max_state_dim).
         """
-        state = batch["state"]  # (B, T, D)
+        state = batch["state"]  # (B, T, D) or (B, D) during inference
+        if state.ndim == 2:
+            state = state.unsqueeze(1)  # (B, D) -> (B, 1, D)
         state_dim = state.shape[-1]
         if state_dim > self.config.max_state_dim:
             raise ValueError(
@@ -587,7 +589,9 @@ class PI05MemPolicy(PreTrainedPolicy):
             )
 
         for key in present_img_keys:
-            vid = batch[key]  # (B, T, C, H, W)
+            vid = batch[key]  # (B, T, C, H, W) or (B, C, H, W) during inference
+            if vid.ndim == 4:
+                vid = vid.unsqueeze(1)  # (B, C, H, W) -> (B, 1, C, H, W)
 
             if obs_history_is_pad is not None:
                 frame_mask = (~obs_history_is_pad)[:, :, None, None, None]  # (B, T, 1, 1, 1)

--- a/src/opentau/policies/pi05_mem/modeling_pi05.py
+++ b/src/opentau/policies/pi05_mem/modeling_pi05.py
@@ -491,7 +491,13 @@ class PI05MemPolicy(PreTrainedPolicy):
         batch["discrete_actions"] = self.normalize_discrete_actions(dict(batch))["actions"]
         batch = self.normalize_targets(batch)
 
-        videos, vid_masks = self.prepare_videos(batch)
+        obs_history_is_pad = batch.get("obs_history_is_pad")
+        if obs_history_is_pad is None:
+            logging.warning(
+                "obs_history_is_pad is missing from the training batch. "
+                "Padded observation-history timesteps will not be masked."
+            )
+        videos, vid_masks = self.prepare_videos(batch, obs_history_is_pad=obs_history_is_pad)
         lang_tokens, lang_masks = self.prepare_language(batch)
         state = self.prepare_state(batch)
         discrete_actions, discrete_action_masks = self.prepare_discrete_actions(batch)
@@ -510,6 +516,7 @@ class PI05MemPolicy(PreTrainedPolicy):
             time,
             discrete_actions,
             discrete_action_masks,
+            obs_history_is_pad=obs_history_is_pad,
         )
 
         mse_loss = losses["MSE"]
@@ -549,7 +556,9 @@ class PI05MemPolicy(PreTrainedPolicy):
             discrete_action_masks
         ).to(device=device, dtype=torch.bool)
 
-    def prepare_videos(self, batch: dict[str, Tensor]) -> tuple[list[Tensor], list[Tensor]]:
+    def prepare_videos(
+        self, batch: dict[str, Tensor], obs_history_is_pad: Tensor | None = None
+    ) -> tuple[list[Tensor], list[Tensor]]:
         """Apply preprocessing to the video inputs.
 
         Each camera key now contains a video tensor of shape (B, T, C, H, W).
@@ -558,6 +567,9 @@ class PI05MemPolicy(PreTrainedPolicy):
 
         Args:
             batch: Batch of data containing video tensors.
+            obs_history_is_pad: Optional bool tensor (B, T) indicating which
+                temporal frames are padded. Padded frames are zeroed out before
+                encoding so V-JEPA2 does not process clamped/repeated content.
 
         Returns:
             A tuple of (videos, vid_masks) lists.
@@ -576,6 +588,10 @@ class PI05MemPolicy(PreTrainedPolicy):
 
         for key in present_img_keys:
             vid = batch[key]  # (B, T, C, H, W)
+
+            if obs_history_is_pad is not None:
+                frame_mask = (~obs_history_is_pad)[:, :, None, None, None]  # (B, T, 1, 1, 1)
+                vid = vid * frame_mask
 
             if self.config.resize_imgs_with_padding is not None:
                 b, t_frames = vid.shape[:2]
@@ -739,6 +755,7 @@ class PI05MemFlowMatching(nn.Module):
         state: Tensor,
         discrete_actions: Tensor | None = None,
         discrete_action_masks: Tensor | None = None,
+        obs_history_is_pad: Tensor | None = None,
     ) -> tuple[Tensor, Tensor, Tensor]:
         """Embed videos with V-JEPA2, language tokens with embedding layer, and
         temporal state via per-timestep learned projection.
@@ -751,6 +768,9 @@ class PI05MemFlowMatching(nn.Module):
             state: Temporal state tensor of shape (B, T, max_state_dim).
             discrete_actions: Optional discrete action tensor.
             discrete_action_masks: Optional discrete action mask tensor.
+            obs_history_is_pad: Optional bool tensor (B, T) from the dataloader.
+                True for padded (clamped) timesteps, False for real ones.
+                Used to mask state tokens during training; None during inference.
 
         Returns:
             (embs, pad_masks, att_masks) tuple.
@@ -786,7 +806,10 @@ class PI05MemFlowMatching(nn.Module):
         # state: (B, T, max_state_dim) -> state_emb: (B, T, vlm_hidden_size)
         state_emb = self.state_proj(state.to(dtype=_preferred_dtype()))
         num_state_tokens = state_emb.shape[1]  # T
-        state_mask = torch.ones(bsize, num_state_tokens, dtype=torch.bool, device=state.device)
+        if obs_history_is_pad is not None:
+            state_mask = ~obs_history_is_pad  # True = real, False = padded
+        else:
+            state_mask = torch.ones(bsize, num_state_tokens, dtype=torch.bool, device=state.device)
 
         embs.append(state_emb)
         pad_masks.append(state_mask)
@@ -859,6 +882,7 @@ class PI05MemFlowMatching(nn.Module):
         time: Tensor | None = None,
         discrete_actions: Tensor | None = None,
         discrete_action_masks: Tensor | None = None,
+        obs_history_is_pad: Tensor | None = None,
     ) -> dict[str, Tensor]:
         """Do a full training forward pass and compute the loss."""
         prefix_embs, prefix_pad_masks, prefix_att_masks = self.embed_prefix(
@@ -869,6 +893,7 @@ class PI05MemFlowMatching(nn.Module):
             state,
             discrete_actions,
             discrete_action_masks,
+            obs_history_is_pad=obs_history_is_pad,
         )
 
         vlm_2d_attention_mask = make_att_2d_masks(prefix_pad_masks, prefix_att_masks)

--- a/src/opentau/policies/pi05_mem/modeling_pi05.py
+++ b/src/opentau/policies/pi05_mem/modeling_pi05.py
@@ -758,12 +758,13 @@ class PI05MemFlowMatching(nn.Module):
         embs = []
         pad_masks = []
         att_masks = []
+        bsize = lang_tokens.shape[0]
 
         for vid, vid_mask in zip(videos, vid_masks, strict=False):
             vid_emb = self.embed_video(vid)  # (B, num_video_tokens, vlm_hidden)
             vid_emb = vid_emb.to(dtype=_preferred_dtype())
 
-            bsize, num_vid_embs = vid_emb.shape[:2]
+            num_vid_embs = vid_emb.shape[1]
             vid_mask_expanded = vid_mask[:, None].expand(bsize, num_vid_embs)
 
             embs.append(vid_emb)
@@ -836,7 +837,7 @@ class PI05MemFlowMatching(nn.Module):
         action_mask = torch.ones(bsize, action_dim, dtype=torch.bool, device=device)
         pad_masks.append(action_mask)
 
-        att_masks += [1] + ([0] * (self.config.n_action_steps - 1))
+        att_masks += [1] + ([0] * (self.config.chunk_size - 1))
 
         embs = torch.cat(embs, dim=1)
         pad_masks = torch.cat(pad_masks, dim=1)

--- a/src/opentau/policies/pi05_mem/modeling_pi05.py
+++ b/src/opentau/policies/pi05_mem/modeling_pi05.py
@@ -202,11 +202,7 @@ def pad_discrete_tokens(tokens: list[list[int]], max_length: int) -> tuple[np.nd
     return np.array(discrete_action_tokens), np.array(discrete_action_masks)
 
 
-# ---------------------------------------------------------------------------
 # Policy wrapper
-# ---------------------------------------------------------------------------
-
-
 class PI05MemPolicy(PreTrainedPolicy):
     """Wrapper class around PI05MemFlowMatching model.
 
@@ -277,7 +273,7 @@ class PI05MemPolicy(PreTrainedPolicy):
             config = PreTrainedConfig.from_pretrained(
                 pretrained_name_or_path=pretrained_name_or_path,
                 force_download=force_download,
-                resume_download=resume_download,
+                resume_download=resume_download if resume_download is not None else False,
                 proxies=proxies,
                 token=token,
                 cache_dir=cache_dir,
@@ -294,7 +290,7 @@ class PI05MemPolicy(PreTrainedPolicy):
             if is_main_process:
                 logging.info("Loading model from: %s", pretrained_name_or_path)
             try:
-                from transformers.utils import cached_file
+                from transformers.utils.hub import cached_file
 
                 resolved_file = cached_file(
                     pretrained_name_or_path,
@@ -307,6 +303,7 @@ class PI05MemPolicy(PreTrainedPolicy):
                     revision=revision,
                     local_files_only=local_files_only,
                 )
+                assert resolved_file is not None, "cached_file returned None"
                 from safetensors.torch import load_file
 
                 original_state_dict = load_file(resolved_file)
@@ -426,11 +423,12 @@ class PI05MemPolicy(PreTrainedPolicy):
         Returns a new dict with ``"state"`` expanded to (B, T, D) and image keys
         expanded to (B, T, C, H, W), where T = ``n_obs_history``.
         """
-        n_hist = self.config.n_obs_history
+        assert self.config.n_obs_history is not None
+        n_hist: int = self.config.n_obs_history
         interval = self.config.history_interval or 1
         buf_maxlen = self.config.obs_buffer_size
 
-        # --- initialise buffers on first call after reset() ---
+        # initialise buffers on first call after reset()
         if self._state_buffer is None:
             self._state_buffer = deque(maxlen=buf_maxlen)
             self._obs_buffers = {}
@@ -440,12 +438,12 @@ class PI05MemPolicy(PreTrainedPolicy):
             if key not in self._obs_buffers:
                 self._obs_buffers[key] = deque(maxlen=buf_maxlen)
 
-        # --- append current observation ---
+        # append current observation
         self._state_buffer.append(batch["state"])  # (B, D)
         for key in img_keys:
             self._obs_buffers[key].append(batch[key])  # (B, C, H, W)
 
-        # --- sample n_hist frames at the configured interval ---
+        # sample n_hist frames at the configured interval
         buf_len = len(self._state_buffer)
         missing = buf_maxlen - buf_len  # how many slots are still empty
 
@@ -546,10 +544,10 @@ class PI05MemPolicy(PreTrainedPolicy):
             actions_shape = (bsize, self.config.chunk_size, self.config.max_action_dim)
             action_prefix = torch.zeros(actions_shape, dtype=lang_tokens.dtype, device=lang_tokens.device)
         else:
-            action_prefix = self.normalize_targets({"actions": action_prefix})["actions"]
+            normalized = self.normalize_targets({"actions": action_prefix})["actions"]
             action_prefix = F.pad(
-                action_prefix,
-                (0, 0, 0, self.config.chunk_size - action_prefix.shape[1]),
+                normalized,
+                (0, 0, 0, self.config.chunk_size - normalized.shape[1]),
             )
 
         actions = self.model.sample_actions(
@@ -563,7 +561,9 @@ class PI05MemPolicy(PreTrainedPolicy):
             noise=noise,
         )
 
-        original_action_dim = self.config.action_feature.shape[0]
+        action_feature = self.config.action_feature
+        assert action_feature is not None, "action_feature must be set in output_features"
+        original_action_dim = action_feature.shape[0]
         actions = actions[:, :, :original_action_dim]
 
         actions = self.unnormalize_outputs({"actions": actions})["actions"]
@@ -668,8 +668,8 @@ class PI05MemPolicy(PreTrainedPolicy):
         Returns:
             A tuple of (videos, vid_masks) lists.
         """
-        videos = []
-        vid_masks = []
+        videos: list[Tensor] = []
+        vid_masks: list[Tensor] = []
 
         present_img_keys = [key for key in self.config.image_features if key in batch]
         missing_img_keys = [key for key in self.config.image_features if key not in batch]
@@ -679,6 +679,9 @@ class PI05MemPolicy(PreTrainedPolicy):
                 f"All image features are missing from the batch. At least one expected. "
                 f"(batch: {batch.keys()}) (image_features:{self.config.image_features})"
             )
+
+        last_vid: Tensor | None = None
+        last_mask: Tensor | None = None
 
         for key in present_img_keys:
             vid = batch[key]  # (B, T, C, H, W) or (B, C, H, W) during inference
@@ -705,11 +708,15 @@ class PI05MemPolicy(PreTrainedPolicy):
             mask = torch.ones(bsize, dtype=torch.bool, device=device)
             videos.append(vid)
             vid_masks.append(mask)
+            last_vid = vid
+            last_mask = mask
 
         n_empty = min(len(missing_img_keys), self.config.empty_cameras)
-        for _ in range(n_empty):
-            videos.append(torch.zeros_like(vid))
-            vid_masks.append(torch.zeros_like(mask))
+        if n_empty > 0:
+            assert last_vid is not None and last_mask is not None
+            for _ in range(n_empty):
+                videos.append(torch.zeros_like(last_vid))
+                vid_masks.append(torch.zeros_like(last_mask))
 
         return videos, vid_masks
 
@@ -734,11 +741,7 @@ class PI05MemPolicy(PreTrainedPolicy):
         return lang_tokens, lang_masks
 
 
-# ---------------------------------------------------------------------------
 # Flow-matching model
-# ---------------------------------------------------------------------------
-
-
 class PI05MemFlowMatching(nn.Module):
     """π05 Mem: A Vision-Language-Action Flow Model with V-JEPA2 video encoding
     and temporal state sequences.
@@ -1040,20 +1043,23 @@ class PI05MemFlowMatching(nn.Module):
         ]
         action_expert_position_ids = prefix_offsets + torch.cumsum(suffix_pad_masks, dim=1) - 1
 
-        for layer_idx in past_key_values:
-            past_key_values[layer_idx]["key_states"] = past_key_values[layer_idx]["key_states"].detach()
-            past_key_values[layer_idx]["value_states"] = past_key_values[layer_idx]["value_states"].detach()
+        assert past_key_values is not None
+        kv_cache: dict = past_key_values
+        for layer_idx in kv_cache:
+            kv_cache[layer_idx]["key_states"] = kv_cache[layer_idx]["key_states"].detach()
+            kv_cache[layer_idx]["value_states"] = kv_cache[layer_idx]["value_states"].detach()
 
         (_, suffix_out), _ = self.paligemma_with_expert.forward(
             attention_mask=action_expert_2d_attention_mask,
             position_ids=action_expert_position_ids,
-            past_key_values=past_key_values,
+            past_key_values=kv_cache,
             inputs_embeds=[None, suffix_embs],
             use_cache=True,
             fill_kv_cache=False,
             adarms_cond=[None, adarms_cond],
         )
 
+        assert suffix_out is not None
         suffix_out = suffix_out[:, -self.config.n_action_steps :]
         v_t = self.action_out_proj(suffix_out)
         v_t = v_t.to(dtype=torch.float32)
@@ -1074,6 +1080,9 @@ class PI05MemFlowMatching(nn.Module):
         postfix_mask_expanded = repeat(postfix_mask, "b c 1 -> b c d", d=mse_loss.shape[-1])
         mse_loss = mse_loss.sum() / (postfix_mask_expanded.sum() + 1e-8)
 
+        assert discrete_actions is not None
+        assert discrete_action_masks is not None
+        assert prefix_out is not None
         batch_size, seq_len = discrete_actions.shape
         discrete_token_start = -self.config.discrete_action_max_length
         discrete_action_slice_object = slice(discrete_token_start - 1, -1)
@@ -1121,7 +1130,7 @@ class PI05MemFlowMatching(nn.Module):
 
         num_cross_att_tokens = prefix_embs.shape[1]
 
-        (prefix_out, _), past_key_values = self.paligemma_with_expert.forward(
+        (prefix_out, _), past_kv = self.paligemma_with_expert.forward(
             attention_mask=prefix_att_2d_masks,
             position_ids=prefix_position_ids,
             past_key_values=None,
@@ -1130,6 +1139,7 @@ class PI05MemFlowMatching(nn.Module):
             use_cache=False,
             fill_kv_cache=True,
         )
+        past_key_values: list[dict[str, Tensor]] = past_kv
 
         dt = -1.0 / self.config.num_steps
         dt = torch.tensor(dt, dtype=torch.float32, device=device)
@@ -1183,6 +1193,7 @@ class PI05MemFlowMatching(nn.Module):
             adarms_cond=[None, adarms_cond],
         )
         suffix_out = outputs_embeds[1]
+        assert suffix_out is not None
         suffix_out = suffix_out[:, -self.config.n_action_steps :]
         v_t = self.action_out_proj(suffix_out)
         v_t = v_t.to(dtype=torch.float32)

--- a/src/opentau/policies/pi05_mem/video_encoder.py
+++ b/src/opentau/policies/pi05_mem/video_encoder.py
@@ -1,0 +1,102 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""V-JEPA2 video encoder with Perceiver token reduction.
+
+Wraps a frozen V-JEPA2 ViT encoder with a learnable Perceiver cross-attention
+reducer and a linear projection to the VLM embedding dimension.
+"""
+
+import torch
+from torch import Tensor, nn
+from transformers import VJEPA2Config, VJEPA2Model
+
+
+class PerceiverReducer(nn.Module):
+    """Learned cross-attention bottleneck that compresses V-JEPA2 encoder tokens
+    into a fixed number of output tokens."""
+
+    def __init__(self, hidden_size: int, num_queries: int = 256, num_heads: int = 8):
+        super().__init__()
+        self.queries = nn.Parameter(torch.randn(1, num_queries, hidden_size) * 0.02)
+        self.cross_attn = nn.MultiheadAttention(hidden_size, num_heads, batch_first=True)
+        self.norm_q = nn.LayerNorm(hidden_size)
+        self.norm_kv = nn.LayerNorm(hidden_size)
+
+    def forward(self, tokens: Tensor) -> Tensor:
+        """tokens: (B, N, D) -> (B, num_queries, D)."""
+        b = tokens.shape[0]
+        q = self.norm_q(self.queries.expand(b, -1, -1))
+        kv = self.norm_kv(tokens)
+        out, _ = self.cross_attn(q, kv, kv)
+        return out
+
+
+class VJEPA2VideoEncoder(nn.Module):
+    """Frozen V-JEPA2 encoder + learnable Perceiver reducer + projection to VLM dim.
+
+    Takes video tensors (B, T, C, H, W) and produces (B, num_video_tokens, vlm_hidden_size).
+    """
+
+    def __init__(
+        self,
+        vjepa2_model_name: str,
+        num_frames: int,
+        crop_size: int,
+        num_video_tokens: int,
+        vlm_hidden_size: int,
+        perceiver_heads: int = 8,
+        freeze_encoder: bool = True,
+    ):
+        super().__init__()
+
+        vjepa2_config = VJEPA2Config.from_pretrained(vjepa2_model_name)
+        vjepa2_config.crop_size = crop_size
+        vjepa2_config.frames_per_clip = num_frames
+
+        self.encoder = VJEPA2Model.from_pretrained(
+            vjepa2_model_name,
+            config=vjepa2_config,
+            torch_dtype=torch.bfloat16,
+            attn_implementation="sdpa",
+        )
+
+        if freeze_encoder:
+            self.encoder.eval()
+            for p in self.encoder.parameters():
+                p.requires_grad = False
+
+        vjepa2_hidden = vjepa2_config.hidden_size  # 1024 for ViT-L
+        self.reducer = PerceiverReducer(
+            vjepa2_hidden,
+            num_queries=num_video_tokens,
+            num_heads=perceiver_heads,  # gitleaks:allow
+        )
+        self.proj = nn.Linear(vjepa2_hidden, vlm_hidden_size)
+
+    def forward(self, video: Tensor) -> Tensor:
+        """Encode a video clip into a fixed-length token sequence.
+
+        Args:
+            video: (B, T, C, H, W) pixel values, ImageNet-normalized.
+
+        Returns:
+            (B, num_video_tokens, vlm_hidden_size)
+        """
+        with torch.no_grad():
+            encoder_out = self.encoder(video, skip_predictor=True)
+        tokens = encoder_out.last_hidden_state  # (B, N_patches, vjepa2_hidden)
+        tokens = self.reducer(tokens)  # (B, num_video_tokens, vjepa2_hidden)
+        tokens = self.proj(tokens)  # (B, num_video_tokens, vlm_hidden_size)
+        return tokens

--- a/src/opentau/policies/pi05_mem/video_encoder.py
+++ b/src/opentau/policies/pi05_mem/video_encoder.py
@@ -60,8 +60,12 @@ class VJEPA2VideoEncoder(nn.Module):
         vlm_hidden_size: int,
         perceiver_heads: int = 8,
         freeze_encoder: bool = True,
+        encoder_dtype: torch.dtype | None = None,
     ):
         super().__init__()
+
+        if encoder_dtype is None:
+            encoder_dtype = torch.bfloat16 if torch.cuda.is_available() else torch.float32
 
         vjepa2_config = VJEPA2Config.from_pretrained(vjepa2_model_name)
         vjepa2_config.crop_size = crop_size
@@ -70,7 +74,7 @@ class VJEPA2VideoEncoder(nn.Module):
         self.encoder = VJEPA2Model.from_pretrained(
             vjepa2_model_name,
             config=vjepa2_config,
-            torch_dtype=torch.bfloat16,
+            torch_dtype=encoder_dtype,
             attn_implementation="sdpa",
         )
 

--- a/src/opentau/policies/pi05_mem/video_encoder.py
+++ b/src/opentau/policies/pi05_mem/video_encoder.py
@@ -18,6 +18,8 @@ Wraps a frozen V-JEPA2 ViT encoder with a learnable Perceiver cross-attention
 reducer and a linear projection to the VLM embedding dimension.
 """
 
+from contextlib import nullcontext
+
 import torch
 from torch import Tensor, nn
 from transformers import VJEPA2Config, VJEPA2Model
@@ -72,6 +74,7 @@ class VJEPA2VideoEncoder(nn.Module):
             attn_implementation="sdpa",
         )
 
+        self.freeze_encoder = freeze_encoder
         if freeze_encoder:
             self.encoder.eval()
             for p in self.encoder.parameters():
@@ -94,7 +97,8 @@ class VJEPA2VideoEncoder(nn.Module):
         Returns:
             (B, num_video_tokens, vlm_hidden_size)
         """
-        with torch.no_grad():
+        ctx = torch.no_grad() if self.freeze_encoder else nullcontext()
+        with ctx:
             encoder_out = self.encoder(video, skip_predictor=True)
         tokens = encoder_out.last_hidden_state  # (B, N_patches, vjepa2_hidden)
         tokens = self.reducer(tokens)  # (B, num_video_tokens, vjepa2_hidden)

--- a/tests/policies/test_pi05_mem.py
+++ b/tests/policies/test_pi05_mem.py
@@ -1,0 +1,324 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+import torch
+
+from opentau.policies.pi05_mem.configuration_pi05 import PI05MemConfig
+from opentau.policies.pi05_mem.modeling_pi05 import (
+    create_sinusoidal_pos_embedding,
+    make_att_2d_masks,
+    pad_discrete_tokens,
+    resize_with_pad,
+)
+
+
+class TestPI05MemConfig:
+    """Unit tests for PI05MemConfig validation and properties."""
+
+    def test_default_config(self):
+        config = PI05MemConfig()
+        assert config.n_obs_steps == 8
+        assert config.chunk_size == 50
+        assert config.n_action_steps == 50
+        assert config.n_obs_history is None
+        assert config.history_interval is None
+        assert config.max_state_dim == 32
+        assert config.max_action_dim == 32
+        assert config.vjepa2_dtype is None
+
+    def test_obs_buffer_size_no_history(self):
+        config = PI05MemConfig()
+        assert config.obs_buffer_size == 1
+
+    def test_obs_buffer_size_with_history(self):
+        config = PI05MemConfig(n_obs_history=4, history_interval=2)
+        assert config.obs_buffer_size == (4 - 1) * 2 + 1  # 7
+
+    def test_obs_buffer_size_interval_defaults_to_1(self):
+        config = PI05MemConfig(n_obs_history=8)
+        assert config.history_interval == 1
+        assert config.obs_buffer_size == 8
+
+    def test_invalid_n_obs_history(self):
+        with pytest.raises(ValueError, match="n_obs_history"):
+            PI05MemConfig(n_obs_history=0)
+
+    def test_invalid_history_interval(self):
+        with pytest.raises(ValueError, match="history_interval"):
+            PI05MemConfig(n_obs_history=4, history_interval=-1)
+
+    def test_n_action_steps_exceeds_chunk_size(self):
+        with pytest.raises(ValueError, match="chunk size"):
+            PI05MemConfig(chunk_size=10, n_action_steps=20)
+
+    def test_max_delay_exceeds_chunk_size(self):
+        with pytest.raises(ValueError, match="max delay"):
+            PI05MemConfig(chunk_size=10, n_action_steps=10, max_delay=20)
+
+    def test_validate_features_adds_empty_cameras(self):
+        config = PI05MemConfig(empty_cameras=2)
+        config.input_features = {}
+        config.validate_features()
+        assert "observation.images.empty_camera_0" in config.input_features
+        assert "observation.images.empty_camera_1" in config.input_features
+
+    def test_action_delta_indices(self):
+        config = PI05MemConfig(chunk_size=10, n_action_steps=10)
+        assert config.action_delta_indices == list(range(10))
+
+
+class TestHelperFunctions:
+    """Unit tests for standalone helper functions in modeling_pi05."""
+
+    def test_sinusoidal_embedding_shape(self):
+        time = torch.rand(2, 10)
+        emb = create_sinusoidal_pos_embedding(time, dimension=64, min_period=4e-3, max_period=4.0)
+        assert emb.shape == (2, 10, 64)
+
+    def test_sinusoidal_embedding_odd_dimension_raises(self):
+        time = torch.rand(2, 10)
+        with pytest.raises(ValueError, match="divisible by 2"):
+            create_sinusoidal_pos_embedding(time, dimension=63, min_period=4e-3, max_period=4.0)
+
+    def test_sinusoidal_embedding_wrong_ndim_raises(self):
+        time = torch.rand(10)
+        with pytest.raises(ValueError, match="batch_size"):
+            create_sinusoidal_pos_embedding(time, dimension=64, min_period=4e-3, max_period=4.0)
+
+    def test_resize_with_pad_maintains_shape(self):
+        img = torch.randn(2, 3, 480, 640)
+        result = resize_with_pad(img, width=224, height=224)
+        assert result.shape == (2, 3, 224, 224)
+
+    def test_resize_with_pad_wrong_ndim(self):
+        img = torch.randn(3, 480, 640)
+        with pytest.raises(ValueError, match="expected"):
+            resize_with_pad(img, width=224, height=224)
+
+    def test_pad_discrete_tokens_padding(self):
+        tokens = [[1, 2, 3], [4, 5]]
+        result_tokens, result_masks = pad_discrete_tokens(tokens, max_length=5)
+        assert result_tokens.shape == (2, 5)
+        assert result_masks.shape == (2, 5)
+        np.testing.assert_array_equal(result_tokens[0], [1, 2, 3, 0, 0])
+        np.testing.assert_array_equal(result_masks[0], [True, True, True, False, False])
+        np.testing.assert_array_equal(result_tokens[1], [4, 5, 0, 0, 0])
+        np.testing.assert_array_equal(result_masks[1], [True, True, False, False, False])
+
+    def test_pad_discrete_tokens_truncation(self):
+        tokens = [[1, 2, 3, 4, 5]]
+        result_tokens, result_masks = pad_discrete_tokens(tokens, max_length=3)
+        assert result_tokens.shape == (1, 3)
+        np.testing.assert_array_equal(result_tokens[0], [1, 2, 3])
+        np.testing.assert_array_equal(result_masks[0], [True, True, True])
+
+    def test_make_att_2d_masks_basic(self):
+        pad_masks = torch.ones(1, 4, dtype=torch.bool)
+        att_masks = torch.tensor([[1, 0, 0, 1]], dtype=torch.int32)
+        result = make_att_2d_masks(pad_masks, att_masks)
+        assert result.shape == (1, 4, 4)
+        assert result.dtype == torch.bool
+        assert result[0, 0, 0].item() is True
+        assert result[0, 0, 3].item() is False
+
+    def test_make_att_2d_masks_with_padding(self):
+        pad_masks = torch.tensor([[True, True, False]], dtype=torch.bool)
+        att_masks = torch.tensor([[1, 0, 0]], dtype=torch.int32)
+        result = make_att_2d_masks(pad_masks, att_masks)
+        assert result[0, 2, 0].item() is False
+        assert result[0, 0, 2].item() is False
+
+
+class TestBuildHistoryBatch:
+    """Test _build_history_batch logic using a lightweight mock policy."""
+
+    @pytest.fixture
+    def mock_policy(self):
+        """Create a minimal mock that simulates PI05MemPolicy for history testing."""
+        from opentau.configs.types import FeatureType, PolicyFeature
+
+        policy = MagicMock()
+        policy.config = PI05MemConfig(n_obs_history=4, history_interval=1)
+        policy.config.input_features = {
+            "camera0": PolicyFeature(type=FeatureType.VISUAL, shape=(3, 224, 224)),
+        }
+        policy._state_buffer = None
+        policy._obs_buffers = {}
+
+        from opentau.policies.pi05_mem.modeling_pi05 import PI05MemPolicy
+
+        policy._build_history_batch = PI05MemPolicy._build_history_batch.__get__(policy)
+        return policy
+
+    def test_first_call_zero_pads(self, mock_policy):
+        batch = {
+            "state": torch.ones(1, 8),
+            "camera0": torch.ones(1, 3, 4, 4),
+            "prompt": ["test"],
+        }
+        result = mock_policy._build_history_batch(batch)
+
+        assert result["state"].shape == (1, 4, 8)
+        assert result["camera0"].shape == (1, 4, 3, 4, 4)
+        assert result["prompt"] == ["test"]
+
+        # First 3 frames should be zero-padded, last should be the actual observation
+        assert torch.all(result["state"][:, :3, :] == 0)
+        assert torch.all(result["state"][:, 3, :] == 1)
+
+    def test_history_fills_up(self, mock_policy):
+        batch_template = {
+            "state": torch.zeros(1, 8),
+            "camera0": torch.zeros(1, 3, 4, 4),
+            "prompt": ["test"],
+        }
+
+        for i in range(4):
+            batch = {k: v.clone() if isinstance(v, torch.Tensor) else v for k, v in batch_template.items()}
+            batch["state"] = torch.full((1, 8), float(i + 1))
+            batch["camera0"] = torch.full((1, 3, 4, 4), float(i + 1))
+            result = mock_policy._build_history_batch(batch)
+
+        assert result["state"].shape == (1, 4, 8)
+        for t in range(4):
+            assert result["state"][0, t, 0].item() == float(t + 1)
+
+    def test_metadata_keys_passed_through(self, mock_policy):
+        batch = {
+            "state": torch.ones(1, 8),
+            "camera0": torch.ones(1, 3, 4, 4),
+            "prompt": ["pick up the block"],
+            "extra_metadata": "should_pass_through",
+        }
+        result = mock_policy._build_history_batch(batch)
+        assert result["prompt"] == ["pick up the block"]
+        assert result["extra_metadata"] == "should_pass_through"
+
+
+class TestPrepareState:
+    """Test prepare_state in isolation."""
+
+    def test_2d_state_unsqueezes(self):
+        from opentau.policies.pi05_mem.modeling_pi05 import PI05MemPolicy
+
+        policy = MagicMock(spec=PI05MemPolicy)
+        policy.config = PI05MemConfig(max_state_dim=8)
+        policy.prepare_state = PI05MemPolicy.prepare_state.__get__(policy)
+
+        batch = {"state": torch.randn(2, 6)}
+        result = policy.prepare_state(batch)
+        assert result.shape == (2, 1, 8)
+
+    def test_3d_state_pads(self):
+        from opentau.policies.pi05_mem.modeling_pi05 import PI05MemPolicy
+
+        policy = MagicMock(spec=PI05MemPolicy)
+        policy.config = PI05MemConfig(max_state_dim=16)
+        policy.prepare_state = PI05MemPolicy.prepare_state.__get__(policy)
+
+        batch = {"state": torch.randn(2, 4, 10)}
+        result = policy.prepare_state(batch)
+        assert result.shape == (2, 4, 16)
+
+    def test_state_exceeding_max_dim_raises(self):
+        from opentau.policies.pi05_mem.modeling_pi05 import PI05MemPolicy
+
+        policy = MagicMock(spec=PI05MemPolicy)
+        policy.config = PI05MemConfig(max_state_dim=8)
+        policy.prepare_state = PI05MemPolicy.prepare_state.__get__(policy)
+
+        batch = {"state": torch.randn(2, 1, 16)}
+        with pytest.raises(ValueError, match="exceeds max_state_dim"):
+            policy.prepare_state(batch)
+
+    def test_2d_state_with_history_raises(self):
+        from opentau.policies.pi05_mem.modeling_pi05 import PI05MemPolicy
+
+        policy = MagicMock(spec=PI05MemPolicy)
+        policy.config = PI05MemConfig(max_state_dim=8, n_obs_history=4)
+        policy.prepare_state = PI05MemPolicy.prepare_state.__get__(policy)
+
+        batch = {"state": torch.randn(2, 6)}
+        with pytest.raises(ValueError, match="Expected 3D"):
+            policy.prepare_state(batch)
+
+
+class TestPrepareVideos:
+    """Test prepare_videos preprocessing logic."""
+
+    @pytest.fixture
+    def mock_policy(self):
+        from opentau.configs.types import FeatureType, PolicyFeature
+        from opentau.policies.pi05_mem.modeling_pi05 import PI05MemPolicy
+
+        policy = MagicMock(spec=PI05MemPolicy)
+        policy.config = PI05MemConfig(
+            resize_imgs_with_padding=(224, 224),
+            empty_cameras=0,
+        )
+        policy.config.input_features = {
+            "camera0": PolicyFeature(type=FeatureType.VISUAL, shape=(3, 224, 224)),
+        }
+        policy.prepare_videos = PI05MemPolicy.prepare_videos.__get__(policy)
+        return policy
+
+    def test_4d_input_unsqueezes(self, mock_policy):
+        batch = {"camera0": torch.randn(2, 3, 224, 224)}
+        videos, masks = mock_policy.prepare_videos(batch)
+        assert len(videos) == 1
+        assert videos[0].shape == (2, 1, 3, 224, 224)
+        assert masks[0].shape == (2,)
+        assert torch.all(masks[0])
+
+    def test_5d_input_passes_through(self, mock_policy):
+        batch = {"camera0": torch.randn(2, 4, 3, 224, 224)}
+        videos, masks = mock_policy.prepare_videos(batch)
+        assert videos[0].shape == (2, 4, 3, 224, 224)
+
+    def test_all_images_missing_raises(self, mock_policy):
+        batch = {"state": torch.randn(2, 8)}
+        with pytest.raises(ValueError, match="All image features are missing"):
+            mock_policy.prepare_videos(batch)
+
+    def test_obs_history_is_pad_masks_frames(self, mock_policy):
+        vid = torch.ones(1, 4, 3, 224, 224)
+        obs_pad = torch.tensor([[True, False, False, False]])
+        batch = {"camera0": vid}
+        videos, masks = mock_policy.prepare_videos(batch, obs_history_is_pad=obs_pad)
+        assert torch.all(videos[0][:, 0, :, :, :] == 0)
+        assert torch.all(videos[0][:, 1, :, :, :] == 1)
+
+    def test_empty_cameras_appended(self, mock_policy):
+        from opentau.configs.types import FeatureType, PolicyFeature
+
+        mock_policy.config.empty_cameras = 1
+        mock_policy.config.input_features["empty_cam"] = PolicyFeature(
+            type=FeatureType.VISUAL, shape=(3, 224, 224)
+        )
+
+        batch = {"camera0": torch.randn(2, 3, 224, 224)}
+        videos, masks = mock_policy.prepare_videos(batch)
+        assert len(videos) == 2
+        assert torch.all(videos[1] == 0)
+        assert torch.all(masks[1] == 0)
+
+    def test_4d_with_history_raises(self, mock_policy):
+        mock_policy.config.n_obs_history = 4
+        batch = {"camera0": torch.randn(2, 3, 224, 224)}
+        with pytest.raises(ValueError, match="Expected 5D"):
+            mock_policy.prepare_videos(batch)

--- a/tests/test_available.py
+++ b/tests/test_available.py
@@ -19,6 +19,7 @@
 import opentau
 from opentau.policies.pi0.modeling_pi0 import PI0Policy
 from opentau.policies.pi05.modeling_pi05 import PI05Policy
+from opentau.policies.pi05_mem.modeling_pi05 import PI05MemPolicy
 from opentau.policies.value.modeling_value import ValueFunction
 
 
@@ -31,6 +32,7 @@ def test_available_policies():
         PI0Policy,
         ValueFunction,
         PI05Policy,
+        PI05MemPolicy,
     ]
     policies = [pol_cls.name for pol_cls in policy_classes]
     assert set(policies) == set(opentau.available_policies), policies

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.10.*"
 resolution-markers = [
     "platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf'",
@@ -462,7 +462,7 @@ name = "cuda-bindings"
 version = "12.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "cuda-pathfinder", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf') or (sys_platform != 'linux' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/37/31/bfcc870f69c6a017c4ad5c42316207fc7551940db6f3639aa4466ec5faf3/cuda_bindings-12.9.4-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a022c96b8bd847e8dc0675523431149a4c3e872f440e3002213dbb9e08f0331a", size = 11800959, upload-time = "2025-10-21T14:51:26.458Z" },
@@ -889,6 +889,14 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/3f/efeb7c6801c46e11bd666a5180f0d615f74f72264212f74f39586c6fda9d/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.py39.py310.py311.py312.py313.py314-none-manylinux_2_28_x86_64.whl", hash = "sha256:ce6724bb7cb3d0543dcba17206dce909f94176e68220b8eafee72e9f92bcf542", size = 243522, upload-time = "2026-01-28T05:58:03.517Z" },
     { url = "https://files.pythonhosted.org/packages/cf/b9/b04c3aa0aad2870cfe799f32f8b59789c98e1816bbce9e83f4823c5b840b/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.py39.py310.py311.py312.py313.py314-none-win32.whl", hash = "sha256:fca724a21a372731edb290841edd28a9fb1ee490f833392752844ac807c0086a", size = 552682, upload-time = "2026-01-28T05:58:05.649Z" },
     { url = "https://files.pythonhosted.org/packages/bd/e1/6d6816b296a529ac9b897ad228b1e084eb1f92319e96371880eebdc874a6/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.py39.py310.py311.py312.py313.py314-none-win_amd64.whl", hash = "sha256:823c0bd7770977d4b10e0ed0aef2f3682276b7c88b8b65cfc540afce5951392f", size = 559464, upload-time = "2026-01-28T05:58:07.261Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/a8/d4dab8a58fc2e6981fc7a58c4e56ba9d777fb24931cec6a22152edbb3540/glfw-2.10.0-py2.py3-none-macosx_10_6_intel.whl", hash = "sha256:a0d1f29f206219cc291edfb6cace663a86da2470632551c998e3db82d48ea177", size = 105288, upload-time = "2026-03-10T17:21:19.929Z" },
+    { url = "https://files.pythonhosted.org/packages/14/61/68d35e001872a7705112418da236fa2418d4f2e5419f8b2837f9b81bb3da/glfw-2.10.0-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:d28d6f3ef217e64e35dc6fd0a7acb4cec9bfe7cd14dd9b35a7228a87002de154", size = 102139, upload-time = "2026-03-10T17:21:21.645Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/e1/ca5984081aaae07c9d371cb11dc4e4ff603510678ed9b73e58b6c351fe63/glfw-2.10.0-py2.py3-none-manylinux2014_aarch64.whl", hash = "sha256:f968b522bb6a0e04aaf4dcac30a476d7229308bb2bac406a60587debb5a61e29", size = 229998, upload-time = "2026-03-10T17:21:23.549Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c4/82ac75fdcfba2896da7a573c0fc7f8ceb8f77ead6866d500d06c32f1c464/glfw-2.10.0-py2.py3-none-manylinux2014_x86_64.whl", hash = "sha256:68cf3752bdadb6f4bc0a876247c28c88c7251ac39f8af076ed938fdfd71e72dd", size = 241944, upload-time = "2026-03-10T17:21:26.102Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/96/9f691823cca5eb6a08f346bd0ff03b78032db9370b509a1e9c8976fb20a5/glfw-2.10.0-py2.py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:44d98de5dbf8f727e0cb29f9b29d29528ea7570f2e6f42f8430a69df05f12b48", size = 231009, upload-time = "2026-03-10T17:21:28.481Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/93/977b9e679e356871d428ae7a1139ec767dd5177bed58a6344b4d2199e00f/glfw-2.10.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:cca5158d62189e08792b1ae54f92307a282921a0e7783315b467e21b0a381c88", size = 243480, upload-time = "2026-03-10T17:21:30.538Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/bd/cea9569c8f2188b0a104472951420434a3e1f5cf26f5836ef9d7227a1a30/glfw-2.10.0-py2.py3-none-win32.whl", hash = "sha256:5e024509989740e8e7b86cc4aab508195495f79879072b0e1f68bd036a2916ad", size = 552641, upload-time = "2026-03-10T17:21:32.653Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/9b/4366ad3e1c0688146c70aa6143584d6a8d88583b9390f106250e25a3d5cd/glfw-2.10.0-py2.py3-none-win_amd64.whl", hash = "sha256:7f787ee8645781f10e8800438ce4357ab38c573ffb191aba380c1e72eba6311c", size = 559423, upload-time = "2026-03-10T17:21:34.766Z" },
 ]
 
 [[package]]
@@ -1877,7 +1885,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cublas-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf') or (sys_platform != 'linux' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/41/e79269ce215c857c935fd86bcfe91a451a584dfc27f1e068f568b9ad1ab7/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:c9132cc3f8958447b4910a1720036d9eff5928cc3179b0a51fb6d167c6cc87d8", size = 705026878, upload-time = "2025-06-06T21:52:51.348Z" },
@@ -1890,7 +1898,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf') or (sys_platform != 'linux' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/60/bc/7771846d3a0272026c416fbb7e5f4c1f146d6d80704534d0b187dd6f4800/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:848ef7224d6305cdb2a4df928759dca7b1201874787083b6e7550dd6765ce69a", size = 193109211, upload-time = "2025-03-07T01:44:56.873Z" },
@@ -1922,9 +1930,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cublas-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf') or (sys_platform != 'linux' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf')" },
+    { name = "nvidia-cusparse-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf') or (sys_platform != 'linux' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf') or (sys_platform != 'linux' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/32/f7cd6ce8a7690544d084ea21c26e910a97e077c9b7f07bf5de623ee19981/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:db9ed69dbef9715071232caa9b69c52ac7de3a95773c2db65bdba85916e4e5c0", size = 267229841, upload-time = "2025-03-07T01:46:54.356Z" },
@@ -1937,7 +1945,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf') or (sys_platform != 'linux' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/f7/cd777c4109681367721b00a106f491e0d0d15cfa1fd59672ce580ce42a97/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9b6c161cb130be1a07a27ea6923df8141f3c295852f4b260c65f18f3e0a091dc", size = 288117129, upload-time = "2025-03-07T01:47:40.407Z" },
@@ -2279,7 +2287,7 @@ wheels = [
 
 [[package]]
 name = "opentau"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },
@@ -2370,7 +2378,7 @@ libero = [
     { name = "thop" },
 ]
 trt = [
-    { name = "tensorrt" },
+    { name = "tensorrt", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'x86_64' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf') or (sys_platform == 'linux' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf') or (sys_platform == 'win32' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf')" },
 ]
 urdf = [
     { name = "rerun-sdk", version = "0.29.0", source = { registry = "https://pypi.org/simple" } },
@@ -2399,7 +2407,7 @@ requires-dist = [
     { name = "gym", marker = "extra == 'libero'", specifier = ">=0.25,<0.27" },
     { name = "gymnasium", extras = ["other"], specifier = ">=0.29" },
     { name = "h5py", specifier = ">=3.10.0" },
-    { name = "huggingface-hub", extras = ["hf-transfer", "cli"], marker = "python_full_version < '4.0'", specifier = ">=0.27.1" },
+    { name = "huggingface-hub", extras = ["hf-transfer", "cli"], marker = "python_full_version < '4'", specifier = ">=0.27.1" },
     { name = "imageio", extras = ["ffmpeg"], specifier = ">=2.34.0" },
     { name = "jsonlines", specifier = ">=4.0.0" },
     { name = "libero", marker = "extra == 'libero'", git = "https://github.com/shuheng-liu/LIBERO?branch=master" },
@@ -2451,8 +2459,7 @@ requires-dist = [
     { name = "sphinx-copybutton", marker = "extra == 'dev'", specifier = ">=0.5.2" },
     { name = "sphinx-design", marker = "extra == 'dev'", specifier = ">=0.6.1" },
     { name = "sphinx-rtd-theme", marker = "extra == 'dev'", specifier = ">=3.0.1" },
-    { name = "tensorrt", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'trt') or (platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'trt') or (platform_machine == 'x86_64' and sys_platform == 'win32' and extra == 'trt')", specifier = ">=10.9.0" },
-    { name = "tensorrt", marker = "extra == 'trt'", specifier = ">=10.15.1.29" },
+    { name = "tensorrt", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'trt') or (platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'trt') or (platform_machine == 'x86_64' and sys_platform == 'win32' and extra == 'trt')", specifier = ">=10.15.1.29" },
     { name = "termcolor", specifier = ">=2.4.0" },
     { name = "thop", marker = "extra == 'libero'", specifier = "==0.1.1.post2209072238" },
     { name = "torch", specifier = ">=2.7.1" },
@@ -2903,7 +2910,7 @@ name = "pytest"
 version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf')" },
     { name = "exceptiongroup" },
     { name = "iniconfig" },
     { name = "packaging" },
@@ -3149,11 +3156,11 @@ resolution-markers = [
     "sys_platform == 'emscripten'",
 ]
 dependencies = [
-    { name = "attrs" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "pillow" },
-    { name = "pyarrow" },
-    { name = "typing-extensions" },
+    { name = "attrs", marker = "extra == 'extra-7-opentau-urdf' or extra != 'extra-7-opentau-libero'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-7-opentau-urdf' or extra != 'extra-7-opentau-libero'" },
+    { name = "pillow", marker = "extra == 'extra-7-opentau-urdf' or extra != 'extra-7-opentau-libero'" },
+    { name = "pyarrow", marker = "extra == 'extra-7-opentau-urdf' or extra != 'extra-7-opentau-libero'" },
+    { name = "typing-extensions", marker = "extra == 'extra-7-opentau-urdf' or extra != 'extra-7-opentau-libero'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/b9/cbde1f19a2b2b148cc0335d27e26b0aa1cbd886b619658c8659bc35f83bd/rerun_sdk-0.29.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:8e52f466a21e2a4fa71755e48fb767dcff6d6854561dcc12a9c1cd1b8fc58a7e", size = 112354388, upload-time = "2026-01-30T10:04:42.093Z" },
@@ -3629,7 +3636,7 @@ name = "tensorrt"
 version = "10.15.1.29"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "tensorrt-cu13" },
+    { name = "tensorrt-cu13", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'x86_64' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf') or (sys_platform == 'linux' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf') or (sys_platform == 'win32' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/29/8d/1b3ea6493ee07d221fdf655a936f6b9d7c4bebfad7c0fdb879440a4172ad/tensorrt-10.15.1.29.tar.gz", hash = "sha256:a78fb34aee9695b81a7485ac0648859b802ff1faaac4bde743d9c51d7493204b", size = 16701, upload-time = "2026-01-30T07:40:25.93Z" }
 
@@ -3638,8 +3645,8 @@ name = "tensorrt-cu13"
 version = "10.15.1.29"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "tensorrt-cu13-bindings" },
-    { name = "tensorrt-cu13-libs" },
+    { name = "tensorrt-cu13-bindings", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'x86_64' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf') or (sys_platform == 'linux' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf') or (sys_platform == 'win32' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf')" },
+    { name = "tensorrt-cu13-libs", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'x86_64' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf') or (sys_platform == 'linux' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf') or (sys_platform == 'win32' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1b/0b/ff3683ddf1960227fb2c6210e92ab83c26eda92091046c123d8dfc1adc93/tensorrt_cu13-10.15.1.29.tar.gz", hash = "sha256:60edcdf1a68526732ea613c309283af036f418f6ebcbc8e18d24566b74d776e0", size = 19084, upload-time = "2026-01-30T07:42:55.055Z" }
 
@@ -3749,32 +3756,33 @@ name = "torch"
 version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-bindings", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "cuda-bindings", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf') or (sys_platform != 'linux' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf')" },
     { name = "filelock" },
     { name = "fsspec" },
     { name = "jinja2" },
     { name = "networkx" },
-    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cudnn-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufft-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufile-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-curand-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusolver-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparselt-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvshmem-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cublas-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf') or (sys_platform != 'linux' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf')" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf') or (sys_platform != 'linux' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf')" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf') or (sys_platform != 'linux' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf')" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf') or (sys_platform != 'linux' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf')" },
+    { name = "nvidia-cudnn-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf') or (sys_platform != 'linux' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf')" },
+    { name = "nvidia-cufft-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf') or (sys_platform != 'linux' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf')" },
+    { name = "nvidia-cufile-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf') or (sys_platform != 'linux' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf')" },
+    { name = "nvidia-curand-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf') or (sys_platform != 'linux' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf')" },
+    { name = "nvidia-cusolver-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf') or (sys_platform != 'linux' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf')" },
+    { name = "nvidia-cusparse-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf') or (sys_platform != 'linux' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf')" },
+    { name = "nvidia-cusparselt-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf') or (sys_platform != 'linux' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf')" },
+    { name = "nvidia-nccl-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf') or (sys_platform != 'linux' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf') or (sys_platform != 'linux' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf')" },
+    { name = "nvidia-nvshmem-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf') or (sys_platform != 'linux' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf')" },
+    { name = "nvidia-nvtx-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf') or (sys_platform != 'linux' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf')" },
     { name = "sympy" },
-    { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "triton", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf') or (sys_platform != 'linux' and extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf')" },
     { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/30/bfebdd8ec77db9a79775121789992d6b3b75ee5494971294d7b4b7c999bc/torch-2.10.0-2-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:2b980edd8d7c0a68c4e951ee1856334a43193f98730d97408fbd148c1a933313", size = 79411457, upload-time = "2026-02-10T21:44:59.189Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ee/efbd56687be60ef9af0c9c0ebe106964c07400eade5b0af8902a1d8cd58c/torch-2.10.0-3-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:a1ff626b884f8c4e897c4c33782bdacdff842a165fee79817b1dd549fdda1321", size = 915510070, upload-time = "2026-03-11T14:16:39.386Z" },
     { url = "https://files.pythonhosted.org/packages/0c/1a/c61f36cfd446170ec27b3a4984f072fd06dab6b5d7ce27e11adb35d6c838/torch-2.10.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:5276fa790a666ee8becaffff8acb711922252521b28fbce5db7db5cf9cb2026d", size = 145992962, upload-time = "2026-01-21T16:24:14.04Z" },
     { url = "https://files.pythonhosted.org/packages/b5/60/6662535354191e2d1555296045b63e4279e5a9dbad49acf55a5d38655a39/torch-2.10.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:aaf663927bcd490ae971469a624c322202a2a1e68936eb952535ca4cd3b90444", size = 915599237, upload-time = "2026-01-21T16:23:25.497Z" },
     { url = "https://files.pythonhosted.org/packages/40/b8/66bbe96f0d79be2b5c697b2e0b187ed792a15c6c4b8904613454651db848/torch-2.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:a4be6a2a190b32ff5c8002a0977a25ea60e64f7ba46b1be37093c141d9c49aeb", size = 113720931, upload-time = "2026-01-21T16:24:23.743Z" },
@@ -3812,7 +3820,7 @@ name = "tqdm"
 version = "4.67.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [


### PR DESCRIPTION
## What this does
Implements PI05_mem. Short term memory is implemented with a pretrained V-JEPA2 video encoder.

Examples:
|  Title               | Label               |
|----------------------|---------------------|
| Fixes #[issue]       | (🐛 Bug)            |
| Adds new Feature     | (🗃️ Feature)        |
| Optimizes something  | (⚡️ Performance)    |
| Updates docs         | (📝 Documentation)  |

## How it was tested
Explain/show how you tested your changes.

Examples:
- Added `test_something` in `tests/test_stuff.py`.
- Added `new_feature` and checked that training converges with policy X on dataset/environment Y.
- Optimized `some_function`, it now runs X times faster than previously.

## How to checkout & try? (for the reviewer)

```bash
opentau-train --config_path=configs/examples/pi05_mem_training_config.json
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
