### PR TITLE
feat: support observation history in standard data format

### DIFF
--- a/docs/source/concepts.rst
+++ b/docs/source/concepts.rst
@@ -43,7 +43,9 @@ Metadata is stored in JSON files (``info.json``, ``stats.json``) and JSONL files
 Standard Data Format
 --------------------
 To ensure compatibility across different datasets and policies, OpenTau introduces the **Standard Data Format**.
-The Standard Data Format is the expected data format returned by ``torch.utils.data.Dataset``'s ``__getitem__`` and the expected input to ``torch.nn.Module``'s ``forward`` method. Any new datasets, VLMs, or VLAs that get added to this repository need to adhere to this format. Data being passed to the model during inference should also adhere to this format. The format is as follows:
+The Standard Data Format is the expected data format returned by ``torch.utils.data.Dataset``'s ``__getitem__`` and the expected input to ``torch.nn.Module``'s ``forward`` method. Any new datasets, VLMs, or VLAs that get added to this repository need to adhere to this format. Data being passed to the model during inference should also adhere to this format.
+
+Default format (``n_obs_history=None``):
 
 .. code-block:: python
 
@@ -53,7 +55,7 @@ The Standard Data Format is the expected data format returned by ``torch.utils.d
         # ...
         "camera{num_cams-1}": torch.Tensor,  # shape (C, H, W) with values from [0, 1] and with the H, W resized to the config's specifications.
 
-        "state": torch.Tensor,    # shape (max_state_dim)
+        "state": torch.Tensor,    # shape (max_state_dim,)
         "actions": torch.Tensor,  # shape (action_chunk, max_action_dim)
         "prompt": str,            # the task prompt, e.g. "Pick up the object and place it on the table."
         "response": str,          # the response from the VLM for vision QA tasks. For LeRobotDataset, this will be an empty string.
@@ -61,7 +63,32 @@ The Standard Data Format is the expected data format returned by ``torch.utils.d
 
         "img_is_pad": torch.BoolTensor,  # shape (num_cams,) with values 0 or 1, where 1 indicates that the camera image is a padded image.
         "action_is_pad": torch.BoolTensor,  # shape (action_chunk,) with values 0 or 1, where 1 indicates that the action is a padded action.
+        "obs_is_pad": torch.BoolTensor,  # shape (1,) — always False when n_obs_history is None.
     }
+
+With observation history (``n_obs_history=T``):
+
+.. code-block:: python
+
+    {
+        "camera0": torch.Tensor,  # shape (T, C, H, W) — T historical steps for camera 0.
+        # ...
+        "camera{num_cams-1}": torch.Tensor,  # shape (T, C, H, W)
+
+        "state": torch.Tensor,    # shape (T, max_state_dim)
+        "actions": torch.Tensor,  # shape (action_chunk, max_action_dim)
+        # ... (prompt, response, loss_type unchanged)
+
+        "img_is_pad": torch.BoolTensor,  # shape (num_cams,) — camera slot availability.
+        "action_is_pad": torch.BoolTensor,  # shape (action_chunk,)
+        "obs_is_pad": torch.BoolTensor,  # shape (T,) — True for timesteps outside the episode boundary.
+    }
+
+When ``n_obs_history=T`` and ``history_interval=k``, observations are sampled at timesteps
+:math:`t - (T-1)k,\; t - (T-2)k,\; \ldots,\; t` relative to the current timestep :math:`t`, where
+the interval is measured in dataset steps (at the configured ``action_freq``). For timesteps that
+fall before the start of the current episode, the observation is clamped to the first step of the
+episode and the corresponding entry in ``obs_is_pad`` is set to ``True``.
 
 The config file will have to provide the following information in TrainPipelineConfig:
 
@@ -70,6 +97,11 @@ The config file will have to provide the following information in TrainPipelineC
 *   ``max_state_dim``: The maximum dimension of the state vector.
 *   ``max_action_dim``: The maximum dimension of the action vector.
 *   ``action_chunk``: The number of actions in the action vector. This is usually 1 for single action tasks, but can be more for multi-action tasks.
+
+The following fields are set in ``DatasetMixtureConfig``:
+
+*   ``n_obs_history``: Number of historical observation steps to include. When ``None`` (default), the single-step format is used. When set to an integer ``T``, cameras and state gain a leading temporal dimension of size ``T``.
+*   ``history_interval``: Step interval between historical observation steps. Defaults to ``1``. Only relevant when ``n_obs_history`` is set.
 
 Cameras should be labeled in order of importance (e.g. camera0 is the most important camera, camera1 is the second most important camera, etc.). The model dataset will select the most important cameras to use if num_cams is less than the number of cameras in the dataset.
 

--- a/docs/source/concepts.rst
+++ b/docs/source/concepts.rst
@@ -63,7 +63,7 @@ Default format (``n_obs_history=None``):
 
         "img_is_pad": torch.BoolTensor,  # shape (num_cams,) with values 0 or 1, where 1 indicates that the camera image is a padded image.
         "action_is_pad": torch.BoolTensor,  # shape (action_chunk,) with values 0 or 1, where 1 indicates that the action is a padded action.
-        "obs_is_pad": torch.BoolTensor,  # shape (1,) — always False when n_obs_history is None.
+        "obs_history_is_pad": torch.BoolTensor,  # shape (1,) — always False when n_obs_history is None.
     }
 
 With observation history (``n_obs_history=T``):
@@ -81,14 +81,14 @@ With observation history (``n_obs_history=T``):
 
         "img_is_pad": torch.BoolTensor,  # shape (num_cams,) — camera slot availability.
         "action_is_pad": torch.BoolTensor,  # shape (action_chunk,)
-        "obs_is_pad": torch.BoolTensor,  # shape (T,) — True for timesteps outside the episode boundary.
+        "obs_history_is_pad": torch.BoolTensor,  # shape (T,) — True for timesteps outside the episode boundary.
     }
 
 When ``n_obs_history=T`` and ``history_interval=k``, observations are sampled at timesteps
 :math:`t - (T-1)k,\; t - (T-2)k,\; \ldots,\; t` relative to the current timestep :math:`t`, where
 the interval is measured in dataset steps (at the configured ``action_freq``). For timesteps that
 fall before the start of the current episode, the observation is clamped to the first step of the
-episode and the corresponding entry in ``obs_is_pad`` is set to ``True``.
+episode and the corresponding entry in ``obs_history_is_pad`` is set to ``True``.
 
 The config file will have to provide the following information in TrainPipelineConfig:
 

--- a/src/opentau/configs/default.py
+++ b/src/opentau/configs/default.py
@@ -131,7 +131,11 @@ class DatasetMixtureConfig:
         n_obs_history: Number of historical observation steps to include. When
             set to ``T``, each camera returns shape ``(T, C, H, W)`` and state
             returns shape ``(T, max_state_dim)``. When ``None``, the default
-            single-step behavior is preserved. Defaults to ``None``.
+            single-step behavior is preserved with rank-3 camera tensors
+            ``(C, H, W)`` and rank-1 state tensors ``(max_state_dim,)``.
+            Note that ``n_obs_history=1`` produces rank-4/rank-2 tensors with
+            a leading singleton dimension, so downstream consumers must handle
+            both rank conventions. Defaults to ``None``.
         history_interval: Step interval between historical observation steps.
             Must be a positive integer. When ``n_obs_history=T`` and
             ``history_interval=k``, observations are sampled at timesteps

--- a/src/opentau/configs/default.py
+++ b/src/opentau/configs/default.py
@@ -110,7 +110,7 @@ class DatasetConfig:
 
 @dataclass
 class DatasetMixtureConfig:
-    """Configuration for a mixture of multiple datasets.
+    r"""Configuration for a mixture of multiple datasets.
 
     This configuration allows combining multiple datasets with specified weights
     for training. The datasets are sampled according to their weights during
@@ -128,6 +128,14 @@ class DatasetMixtureConfig:
         vector_resample_strategy: Resample strategy for non-image features, such
             as action or state. Must be one of 'linear' or 'nearest'.
             Defaults to 'nearest'.
+        n_obs_history: Number of historical observation steps to include. When
+            set to ``T``, each camera returns shape ``(T, C, H, W)`` and state
+            returns shape ``(T, max_state_dim)``. When ``None``, the default
+            single-step behavior is preserved. Defaults to ``None``.
+        history_interval: Step interval between historical observation steps.
+            Must be a positive integer. When ``n_obs_history=T`` and
+            ``history_interval=k``, observations are sampled at timesteps
+            :math:`t - (T-1)k,\; t - (T-2)k,\; \ldots,\; t`. Defaults to 1.
 
     Raises:
         ValueError: If `weights` is provided and its length doesn't match
@@ -151,6 +159,10 @@ class DatasetMixtureConfig:
     # This value is applied to all datasets in the mixture.
     # Defaults to 0.05.
     val_split_ratio: float = 0.05
+    # Number of historical observation steps. None preserves default single-step behavior.
+    n_obs_history: int | None = None
+    # Step interval between historical observation steps. Must be a positive integer.
+    history_interval: int = 1
 
     def __post_init__(self):
         """Validate dataset mixture configuration."""
@@ -168,6 +180,12 @@ class DatasetMixtureConfig:
             )
         if self.val_split_ratio < 0 or self.val_split_ratio > 1:
             raise ValueError(f"`val_split_ratio` must be between 0 and 1, got {self.val_split_ratio}.")
+        if self.n_obs_history is not None and (
+            not isinstance(self.n_obs_history, int) or self.n_obs_history < 1
+        ):
+            raise ValueError(f"`n_obs_history` must be None or a positive integer, got {self.n_obs_history}.")
+        if not isinstance(self.history_interval, int) or self.history_interval < 1:
+            raise ValueError(f"`history_interval` must be a positive integer, got {self.history_interval}.")
 
         # set the val_split_ratio for all datasets in the mixture
         for dataset_cfg in self.datasets:

--- a/src/opentau/datasets/factory.py
+++ b/src/opentau/datasets/factory.py
@@ -130,7 +130,12 @@ def resolve_delta_timestamps(
         ):
             delta_timestamps[key] = [i / action_freq for i in cfg.policy.action_delta_indices]
         elif "camera" in standard_key or standard_key == "state":
-            delta_timestamps[key] = [0.0]
+            n_obs = cfg.dataset_mixture.n_obs_history
+            if n_obs is not None:
+                k = cfg.dataset_mixture.history_interval
+                delta_timestamps[key] = [-(n_obs - 1 - i) * k / action_freq for i in range(n_obs)]
+            else:
+                delta_timestamps[key] = [0.0]
 
     dt_mean = {k: np.array(v) for k, v in delta_timestamps.items()}
     return dt_mean, {}, {}, {}

--- a/src/opentau/datasets/factory.py
+++ b/src/opentau/datasets/factory.py
@@ -132,8 +132,8 @@ def resolve_delta_timestamps(
         elif "camera" in standard_key or standard_key == "state":
             n_obs = cfg.dataset_mixture.n_obs_history
             if n_obs is not None:
-                k = cfg.dataset_mixture.history_interval
-                delta_timestamps[key] = [-(n_obs - 1 - i) * k / action_freq for i in range(n_obs)]
+                interval = cfg.dataset_mixture.history_interval
+                delta_timestamps[key] = [-(n_obs - 1 - i) * interval / action_freq for i in range(n_obs)]
             else:
                 delta_timestamps[key] = [0.0]
 

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -740,6 +740,8 @@ class BaseDataset(torch.utils.data.Dataset):
         state_pad_key = f"{state_raw_key}_is_pad" if state_raw_key else None
         if state_pad_key and state_pad_key in item:
             standard_item["obs_history_is_pad"] = item[state_pad_key]
+        elif self.n_obs_history is not None:
+            standard_item["obs_history_is_pad"] = torch.zeros(self.n_obs_history, dtype=torch.bool)
         else:
             standard_item["obs_history_is_pad"] = torch.tensor([False], dtype=torch.bool)
 

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -713,6 +713,13 @@ class BaseDataset(torch.utils.data.Dataset):
         standard_item["img_is_pad"] = torch.tensor(img_is_pad, dtype=torch.bool)
         standard_item["action_is_pad"] = item[name_map["actions"] + "_is_pad"]
 
+        state_raw_key = name_map.get("state")
+        state_pad_key = f"{state_raw_key}_is_pad" if state_raw_key else None
+        if state_pad_key and state_pad_key in item:
+            standard_item["obs_is_pad"] = item[state_pad_key]
+        else:
+            standard_item["obs_is_pad"] = torch.tensor([False], dtype=torch.bool)
+
         # cast all tensors in standard_item to bfloat16
         for key, value in standard_item.items():
             if isinstance(value, torch.Tensor) and value.dtype.is_floating_point:

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -669,11 +669,13 @@ class BaseDataset(torch.utils.data.Dataset):
                     standard_item[std_key] = torch.zeros((3, *self.resolution))
                 image_is_pad.append(True)
             elif self.n_obs_history is not None:
-                frames = [
-                    self.resize_with_pad(item[key][t], self.resolution[1], self.resolution[0], pad_value=0)
-                    for t in range(item[key].shape[0])
-                ]
-                standard_item[std_key] = torch.stack(frames, dim=0)
+                standard_item[std_key] = self.resize_with_pad(
+                    item[key], self.resolution[1], self.resolution[0], pad_value=0
+                )
+                # Per-frame temporal padding info (from clamped episode boundaries) is
+                # tracked by obs_history_is_pad on the state side. Camera _is_pad only
+                # indicates whether the entire camera slot is absent, so we always mark
+                # a present camera as not padded regardless of frame-level clamping.
                 image_is_pad.append(False)
             else:
                 standard_item[std_key] = self.resize_with_pad(
@@ -759,21 +761,23 @@ class BaseDataset(torch.utils.data.Dataset):
         then pads on the left and top to reach exact target size.
 
         Args:
-            img: Input image tensor of shape (C, H, W).
+            img: Input image tensor of shape (C, H, W) or (T, C, H, W).
             width: Target width.
             height: Target height.
             pad_value: Value to use for padding. Defaults to 0.
 
         Returns:
-            Resized and padded image tensor of shape (C, height, width).
+            Resized and padded image tensor of shape (C, height, width) or
+            (T, C, height, width), matching the input rank.
 
         Raises:
-            ValueError: If input image doesn't have 4 dimensions when reshaped.
+            ValueError: If input is not 3D or 4D.
         """
-        # assume no-op when width height fits already
-        img = rearrange(img, "c h w -> 1 c h w")
+        batched = img.ndim == 4
+        if not batched:
+            img = img.unsqueeze(0)
         if img.ndim != 4:
-            raise ValueError(f"(b,c,h,w) expected, but {img.shape}")
+            raise ValueError(f"Expected (C,H,W) or (T,C,H,W), got shape {img.shape}")
 
         cur_height, cur_width = img.shape[2:]
 
@@ -787,11 +791,10 @@ class BaseDataset(torch.utils.data.Dataset):
         pad_height = max(0, int(height - resized_height))
         pad_width = max(0, int(width - resized_width))
 
-        # pad on left and top of image
         padded_img = F.pad(resized_img, (pad_width, 0, pad_height, 0), value=pad_value)
 
-        # rearrange back to (c, h, w)
-        padded_img = rearrange(padded_img, "1 c h w -> c h w")
+        if not batched:
+            padded_img = padded_img.squeeze(0)
         return padded_img
 
     @staticmethod

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -632,6 +632,7 @@ class BaseDataset(torch.utils.data.Dataset):
         self.max_state_dim = cfg.max_state_dim  # maximum dimension of the state vector
         self.max_action_dim = cfg.max_action_dim  # maximum dimension of the action vector
         self.action_chunk = cfg.action_chunk  # number of actions to be processed in a chunk
+        self.n_obs_history = cfg.dataset_mixture.n_obs_history if cfg.dataset_mixture else None
 
     @abstractmethod
     def _get_feature_mapping_key(self) -> str:
@@ -642,7 +643,10 @@ class BaseDataset(torch.utils.data.Dataset):
         """Standardize image features to a common format.
 
         Resizes images to the target resolution with padding, and tracks
-        which images are padded.
+        which camera slots are padded (absent cameras).
+
+        When ``self.n_obs_history`` is set, camera tensors have shape
+        ``(T, C, H, W)`` and each frame is resized individually.
 
         Args:
             item: Input item dictionary with original image keys.
@@ -650,7 +654,7 @@ class BaseDataset(torch.utils.data.Dataset):
             n_cams: Number of cameras to process.
 
         Returns:
-            List of boolean values indicating which images are padded.
+            List of boolean values indicating which camera slots are padded.
         """
         name_map = DATA_FEATURES_NAME_MAPPING[self._get_feature_mapping_key()]
         image_is_pad = []
@@ -659,8 +663,18 @@ class BaseDataset(torch.utils.data.Dataset):
             key = name_map.get(std_key)
 
             if key is None:
-                standard_item[std_key] = torch.zeros((3, *self.resolution))
+                if self.n_obs_history is not None:
+                    standard_item[std_key] = torch.zeros((self.n_obs_history, 3, *self.resolution))
+                else:
+                    standard_item[std_key] = torch.zeros((3, *self.resolution))
                 image_is_pad.append(True)
+            elif self.n_obs_history is not None:
+                frames = [
+                    self.resize_with_pad(item[key][t], self.resolution[1], self.resolution[0], pad_value=0)
+                    for t in range(item[key].shape[0])
+                ]
+                standard_item[std_key] = torch.stack(frames, dim=0)
+                image_is_pad.append(False)
             else:
                 standard_item[std_key] = self.resize_with_pad(
                     item[key],
@@ -669,16 +683,25 @@ class BaseDataset(torch.utils.data.Dataset):
                     pad_value=0,
                 )
                 image_is_pad.append(item.get(key + "_is_pad", torch.tensor(False)).item())
+
+            img = standard_item[std_key]
+            if self.n_obs_history is not None:
+                expected_ndim = 4
+                expected_c_dim = 1
+                shape_desc = "(T, 3, H, W)"
+            else:
+                expected_ndim = 3
+                expected_c_dim = 0
+                shape_desc = "(3, H, W)"
             assert (
-                len(standard_item[std_key].shape) == 3
-                and standard_item[std_key].shape[0] == 3
-                and standard_item[std_key].min() >= 0.0 - 1e-6  # bfloat16 results in precision loss
-                and standard_item[std_key].max() <= 1.0 + 1e-6  # bfloat16 results in precision loss
+                len(img.shape) == expected_ndim
+                and img.shape[expected_c_dim] == 3
+                and img.min() >= 0.0 - 1e-6
+                and img.max() <= 1.0 + 1e-6
             ), (
-                f"Expected image {std_key} to have shape (3, H, W) with values in [0, 1], "
-                f"Got shape {standard_item[std_key].shape}, "
-                f"min={standard_item[std_key].min()}, "
-                f"max={standard_item[std_key].max()}, "
+                f"Expected image {std_key} to have shape {shape_desc} with values in [0, 1], "
+                f"Got shape {img.shape}, "
+                f"min={img.min()}, max={img.max()}, "
                 f"self={self._get_feature_mapping_key()}."
             )
 
@@ -716,9 +739,9 @@ class BaseDataset(torch.utils.data.Dataset):
         state_raw_key = name_map.get("state")
         state_pad_key = f"{state_raw_key}_is_pad" if state_raw_key else None
         if state_pad_key and state_pad_key in item:
-            standard_item["obs_is_pad"] = item[state_pad_key]
+            standard_item["obs_history_is_pad"] = item[state_pad_key]
         else:
-            standard_item["obs_is_pad"] = torch.tensor([False], dtype=torch.bool)
+            standard_item["obs_history_is_pad"] = torch.tensor([False], dtype=torch.bool)
 
         # cast all tensors in standard_item to bfloat16
         for key, value in standard_item.items():

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -300,17 +300,28 @@ def test_image_array_to_pil_image_wrong_range_float_0_255():
 
 
 def check_standard_data_format(item, delta_timestamps_params, dataset, train_pipeline_config):
+    n_obs = getattr(train_pipeline_config.dataset_mixture, "n_obs_history", None)
     # the keys in standard data format + tensor shape
+    if n_obs is not None:
+        state_shape = (n_obs, train_pipeline_config.max_state_dim)
+        cam_shape_fn = lambda res: (n_obs, 3, *res)  # noqa: E731
+        obs_pad_shape = (n_obs,)
+    else:
+        state_shape = (train_pipeline_config.max_state_dim,)
+        cam_shape_fn = lambda res: (3, *res)  # noqa: E731
+        obs_pad_shape = (1,)
+
     keys_shape_required = [
-        ("state", (train_pipeline_config.max_state_dim,)),
+        ("state", state_shape),
         ("actions", (train_pipeline_config.action_chunk, train_pipeline_config.max_action_dim)),
         ("prompt", None),
         ("response", None),
         ("img_is_pad", (train_pipeline_config.num_cams,)),
         ("action_is_pad", (train_pipeline_config.action_chunk,)),
+        ("obs_is_pad", obs_pad_shape),
     ]
     for i in range(train_pipeline_config.num_cams):
-        keys_shape_required.append((f"camera{i}", (3, *train_pipeline_config.resolution)))
+        keys_shape_required.append((f"camera{i}", cam_shape_fn(train_pipeline_config.resolution)))
 
     # enforce standard data format
     for key, shape in keys_shape_required:
@@ -326,17 +337,18 @@ def check_standard_data_format(item, delta_timestamps_params, dataset, train_pip
             assert item[key].shape == shape, f"{key}"
         elif key == "prompt" or key == "response":
             assert type(item[key]) is str, f"{key}"
-        elif key == "img_is_pad" or key == "action_is_pad":
+        elif key in ("img_is_pad", "action_is_pad", "obs_is_pad"):
             assert item[key].shape == shape, f"{key}"
             assert isinstance(item[key], torch.BoolTensor), f"{key}"
 
     # test delta_timestamps — per-feature keys
     dt_mean = delta_timestamps_params[0]
+    expected_obs_len = n_obs if n_obs is not None else 1
     for key, val in dt_mean.items():
         if key == "action":
             assert val.shape == (train_pipeline_config.action_chunk,)
         else:
-            assert val.shape == (1,), f"{key} has unexpected shape {val.shape}"
+            assert val.shape == (expected_obs_len,), f"{key} has unexpected shape {val.shape}"
 
 
 @pytest.mark.slow  # 3 sec

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -304,11 +304,17 @@ def check_standard_data_format(item, delta_timestamps_params, dataset, train_pip
     # the keys in standard data format + tensor shape
     if n_obs is not None:
         state_shape = (n_obs, train_pipeline_config.max_state_dim)
-        cam_shape_fn = lambda res: (n_obs, 3, *res)  # noqa: E731
+
+        def cam_shape_fn(res):
+            return (n_obs, 3, *res)
+
         obs_pad_shape = (n_obs,)
     else:
         state_shape = (train_pipeline_config.max_state_dim,)
-        cam_shape_fn = lambda res: (3, *res)  # noqa: E731
+
+        def cam_shape_fn(res):  # type: ignore[no-redef]
+            return (3, *res)
+
         obs_pad_shape = (1,)
 
     keys_shape_required = [

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -318,7 +318,7 @@ def check_standard_data_format(item, delta_timestamps_params, dataset, train_pip
         ("response", None),
         ("img_is_pad", (train_pipeline_config.num_cams,)),
         ("action_is_pad", (train_pipeline_config.action_chunk,)),
-        ("obs_is_pad", obs_pad_shape),
+        ("obs_history_is_pad", obs_pad_shape),
     ]
     for i in range(train_pipeline_config.num_cams):
         keys_shape_required.append((f"camera{i}", cam_shape_fn(train_pipeline_config.resolution)))
@@ -337,7 +337,7 @@ def check_standard_data_format(item, delta_timestamps_params, dataset, train_pip
             assert item[key].shape == shape, f"{key}"
         elif key == "prompt" or key == "response":
             assert type(item[key]) is str, f"{key}"
-        elif key in ("img_is_pad", "action_is_pad", "obs_is_pad"):
+        elif key in ("img_is_pad", "action_is_pad", "obs_history_is_pad"):
             assert item[key].shape == shape, f"{key}"
             assert isinstance(item[key], torch.BoolTensor), f"{key}"
 

--- a/tests/datasets/test_obs_history.py
+++ b/tests/datasets/test_obs_history.py
@@ -25,6 +25,7 @@ from opentau.configs.default import DatasetConfig, DatasetMixtureConfig
 from opentau.configs.policies import PreTrainedConfig
 from opentau.configs.train import TrainPipelineConfig
 from opentau.datasets.factory import resolve_delta_timestamps
+from opentau.datasets.lerobot_dataset import BaseDataset
 from opentau.datasets.standard_data_format_mapping import DATA_FEATURES_NAME_MAPPING
 from opentau.datasets.transforms import ImageTransformsConfig
 from tests.fixtures.constants import DUMMY_REPO_ID
@@ -334,3 +335,72 @@ def test_obs_history_is_pad_fallback_shape(lerobot_dataset_factory, info_factory
     )
     assert item["obs_history_is_pad"].dtype == torch.bool
     assert not item["obs_history_is_pad"].any()
+
+
+# ---------------------------------------------------------------------------
+# Batched resize_with_pad tests
+# ---------------------------------------------------------------------------
+
+
+class TestResizeWithPadBatch:
+    """Verify that batched (T,C,H,W) resize_with_pad matches per-frame results."""
+
+    @staticmethod
+    def _resize(img, width, height, pad_value=0):
+        return BaseDataset.resize_with_pad(None, img, width, height, pad_value)
+
+    @pytest.mark.parametrize(
+        "src_hw, target_hw",
+        [
+            ((64, 64), (48, 48)),  # square -> square
+            ((120, 80), (48, 64)),  # portrait -> landscape
+            ((80, 120), (64, 48)),  # landscape -> portrait
+            ((100, 200), (48, 48)),  # wide -> square
+            ((200, 100), (48, 48)),  # tall -> square
+        ],
+        ids=["square", "portrait-to-landscape", "landscape-to-portrait", "wide-to-square", "tall-to-square"],
+    )
+    @pytest.mark.parametrize("T", [1, 3, 7])
+    def test_batch_matches_per_frame(self, src_hw, target_hw, T):  # noqa: N803
+        C = 3  # noqa: N806
+        h, w = src_hw
+        target_h, target_w = target_hw
+        imgs = torch.rand(T, C, h, w)
+
+        batched_result = self._resize(imgs, target_w, target_h)
+
+        per_frame = torch.stack(
+            [self._resize(imgs[t], target_w, target_h) for t in range(T)],
+            dim=0,
+        )
+
+        assert batched_result.shape == (T, C, target_h, target_w)
+        assert per_frame.shape == (T, C, target_h, target_w)
+        assert torch.allclose(batched_result, per_frame), (
+            f"Max diff: {(batched_result - per_frame).abs().max().item()}"
+        )
+
+    def test_single_frame_output_is_3d(self):
+        img = torch.rand(3, 100, 80)
+        result = self._resize(img, 48, 64)
+        assert result.shape == (3, 64, 48)
+
+    def test_batched_output_is_4d(self):
+        imgs = torch.rand(5, 3, 100, 80)
+        result = self._resize(imgs, 48, 64)
+        assert result.shape == (5, 3, 64, 48)
+
+    def test_t1_batched_stays_4d(self):
+        imgs = torch.rand(1, 3, 100, 80)
+        result = self._resize(imgs, 48, 64)
+        assert result.ndim == 4
+        assert result.shape == (1, 3, 64, 48)
+
+    def test_invalid_ndim_raises(self):
+        with pytest.raises(ValueError, match="Expected"):
+            self._resize(torch.rand(100, 80), 48, 64)
+
+    def test_pad_value_propagated(self):
+        img = torch.zeros(3, 100, 200)
+        result = self._resize(img, 48, 48, pad_value=1.0)
+        assert result.max() == 1.0, "Padding region should contain pad_value"

--- a/tests/datasets/test_obs_history.py
+++ b/tests/datasets/test_obs_history.py
@@ -245,14 +245,14 @@ def _make_dataset_with_history(
 
 
 def test_default_no_history_shapes(lerobot_dataset_factory, info_factory, tmp_path):
-    """n_obs_history=None preserves single-frame shapes and adds obs_is_pad."""
+    """n_obs_history=None preserves single-step shapes and adds obs_history_is_pad."""
     dataset = _make_dataset_with_history(lerobot_dataset_factory, info_factory, tmp_path, n_obs_history=None)
     item = dataset[25]
     assert item["state"].shape == (dataset.cfg.max_state_dim,)
-    assert "obs_is_pad" in item
-    assert item["obs_is_pad"].shape == (1,)
-    assert item["obs_is_pad"].dtype == torch.bool
-    assert not item["obs_is_pad"].any()
+    assert "obs_history_is_pad" in item
+    assert item["obs_history_is_pad"].shape == (1,)
+    assert item["obs_history_is_pad"].dtype == torch.bool
+    assert not item["obs_history_is_pad"].any()
 
 
 def test_history_t3_state_shape(lerobot_dataset_factory, info_factory, tmp_path):
@@ -261,21 +261,21 @@ def test_history_t3_state_shape(lerobot_dataset_factory, info_factory, tmp_path)
     assert item["state"].shape == (3, dataset.cfg.max_state_dim)
 
 
-def test_history_t3_obs_is_pad_shape(lerobot_dataset_factory, info_factory, tmp_path):
+def test_history_t3_obs_history_is_pad_shape(lerobot_dataset_factory, info_factory, tmp_path):
     dataset = _make_dataset_with_history(lerobot_dataset_factory, info_factory, tmp_path, n_obs_history=3)
     item = dataset[25]
-    assert "obs_is_pad" in item
-    assert item["obs_is_pad"].shape == (3,)
-    assert item["obs_is_pad"].dtype == torch.bool
+    assert "obs_history_is_pad" in item
+    assert item["obs_history_is_pad"].shape == (3,)
+    assert item["obs_history_is_pad"].dtype == torch.bool
 
 
-def test_history_t3_obs_is_pad_mid_episode(lerobot_dataset_factory, info_factory, tmp_path):
+def test_history_t3_obs_history_is_pad_mid_episode(lerobot_dataset_factory, info_factory, tmp_path):
     """In the middle of an episode, no observation should be padded."""
     dataset = _make_dataset_with_history(lerobot_dataset_factory, info_factory, tmp_path, n_obs_history=3)
     ep_from = int(dataset.episode_data_index["from"][0].item())
     mid_idx = ep_from + 10
     item = dataset[mid_idx]
-    assert not item["obs_is_pad"].any(), "Mid-episode observations should not be padded"
+    assert not item["obs_history_is_pad"].any(), "Mid-episode observations should not be padded"
 
 
 def test_history_padding_at_episode_start(lerobot_dataset_factory, info_factory, tmp_path):
@@ -283,8 +283,8 @@ def test_history_padding_at_episode_start(lerobot_dataset_factory, info_factory,
     dataset = _make_dataset_with_history(lerobot_dataset_factory, info_factory, tmp_path, n_obs_history=5)
     ep_from = int(dataset.episode_data_index["from"][0].item())
     item = dataset[ep_from]
-    assert item["obs_is_pad"][0].item() is True, "Earliest history frame at ep start should be padded"
-    assert item["obs_is_pad"][-1].item() is False, "Current frame should never be padded"
+    assert item["obs_history_is_pad"][0].item() is True, "Earliest history frame at ep start should be padded"
+    assert item["obs_history_is_pad"][-1].item() is False, "Current frame should never be padded"
 
 
 def test_history_interval_k2_padding(lerobot_dataset_factory, info_factory, tmp_path):
@@ -294,9 +294,9 @@ def test_history_interval_k2_padding(lerobot_dataset_factory, info_factory, tmp_
     )
     ep_from = int(dataset.episode_data_index["from"][0].item())
     item = dataset[ep_from + 1]
-    assert item["obs_is_pad"][0].item() is True
-    assert item["obs_is_pad"][1].item() is True
-    assert item["obs_is_pad"][2].item() is False
+    assert item["obs_history_is_pad"][0].item() is True
+    assert item["obs_history_is_pad"][1].item() is True
+    assert item["obs_history_is_pad"][2].item() is False
 
 
 def test_history_actions_unchanged(lerobot_dataset_factory, info_factory, tmp_path):

--- a/tests/datasets/test_obs_history.py
+++ b/tests/datasets/test_obs_history.py
@@ -1,0 +1,314 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for observation history support (n_obs_history and history_interval)."""
+
+from dataclasses import dataclass
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+import torch
+
+from opentau.configs.default import DatasetConfig, DatasetMixtureConfig
+from opentau.configs.policies import PreTrainedConfig
+from opentau.configs.train import TrainPipelineConfig
+from opentau.datasets.factory import resolve_delta_timestamps
+from opentau.datasets.standard_data_format_mapping import DATA_FEATURES_NAME_MAPPING
+from opentau.datasets.transforms import ImageTransformsConfig
+from tests.fixtures.constants import DUMMY_REPO_ID
+
+
+@dataclass
+class DummyPolicyConfig(PreTrainedConfig):
+    chunk_size: int = 50
+
+    @property
+    def observation_delta_indices(self):
+        return None
+
+    @property
+    def action_delta_indices(self):
+        return list(range(self.chunk_size))
+
+    @property
+    def reward_delta_indices(self):
+        return None
+
+    def get_optimizer_preset(self):
+        return None
+
+    def get_scheduler_preset(self):
+        return None
+
+    def validate_features(self):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Config validation tests
+# ---------------------------------------------------------------------------
+
+
+class TestDatasetMixtureConfigValidation:
+    def test_n_obs_history_none_is_default(self):
+        cfg = DatasetMixtureConfig()
+        assert cfg.n_obs_history is None
+        assert cfg.history_interval == 1
+
+    def test_n_obs_history_positive_int_accepted(self):
+        cfg = DatasetMixtureConfig(n_obs_history=3)
+        assert cfg.n_obs_history == 3
+
+    def test_n_obs_history_one_accepted(self):
+        cfg = DatasetMixtureConfig(n_obs_history=1)
+        assert cfg.n_obs_history == 1
+
+    def test_n_obs_history_zero_rejected(self):
+        with pytest.raises(ValueError, match="n_obs_history"):
+            DatasetMixtureConfig(n_obs_history=0)
+
+    def test_n_obs_history_negative_rejected(self):
+        with pytest.raises(ValueError, match="n_obs_history"):
+            DatasetMixtureConfig(n_obs_history=-1)
+
+    def test_n_obs_history_float_rejected(self):
+        with pytest.raises(ValueError, match="n_obs_history"):
+            DatasetMixtureConfig(n_obs_history=2.5)
+
+    def test_history_interval_positive_int_accepted(self):
+        cfg = DatasetMixtureConfig(n_obs_history=3, history_interval=2)
+        assert cfg.history_interval == 2
+
+    def test_history_interval_zero_rejected(self):
+        with pytest.raises(ValueError, match="history_interval"):
+            DatasetMixtureConfig(history_interval=0)
+
+    def test_history_interval_negative_rejected(self):
+        with pytest.raises(ValueError, match="history_interval"):
+            DatasetMixtureConfig(history_interval=-1)
+
+
+# ---------------------------------------------------------------------------
+# resolve_delta_timestamps tests
+# ---------------------------------------------------------------------------
+
+
+def _make_train_cfg(n_obs_history=None, history_interval=1, action_freq=30.0):
+    transforms_cfg = ImageTransformsConfig(enable=False)
+    dataset_cfg = DatasetConfig(
+        repo_id="mock_dataset",
+        root="/tmp/mock",
+        image_transforms=transforms_cfg,
+        episodes=[0],
+        video_backend=None,
+    )
+    mixture_cfg = DatasetMixtureConfig(
+        datasets=[dataset_cfg],
+        weights=[1.0],
+        action_freq=action_freq,
+        n_obs_history=n_obs_history,
+        history_interval=history_interval,
+    )
+    policy_cfg = DummyPolicyConfig()
+    return TrainPipelineConfig(
+        dataset_mixture=mixture_cfg,
+        policy=policy_cfg,
+        batch_size=8,
+    ), dataset_cfg
+
+
+def _make_metadata(features):
+    meta = MagicMock()
+    meta.features = features
+    return meta
+
+
+class TestResolveDeltaTimestampsHistory:
+    def test_no_history_single_delta(self):
+        """Without n_obs_history, camera/state get [0.0]."""
+        cfg, ds_cfg = _make_train_cfg(n_obs_history=None)
+        meta = _make_metadata({"camera0": {}, "state": {}})
+        dt_mean, _, _, _ = resolve_delta_timestamps(cfg, ds_cfg, meta)
+        np.testing.assert_array_equal(dt_mean["camera0"], [0.0])
+        np.testing.assert_array_equal(dt_mean["state"], [0.0])
+
+    def test_history_t3_k1(self):
+        """n_obs_history=3, history_interval=1 at 30Hz."""
+        cfg, ds_cfg = _make_train_cfg(n_obs_history=3, history_interval=1, action_freq=30.0)
+        meta = _make_metadata({"camera0": {}, "state": {}})
+        dt_mean, _, _, _ = resolve_delta_timestamps(cfg, ds_cfg, meta)
+        expected = np.array([-2 / 30, -1 / 30, 0.0])
+        np.testing.assert_allclose(dt_mean["camera0"], expected)
+        np.testing.assert_allclose(dt_mean["state"], expected)
+
+    def test_history_t3_k2(self):
+        """n_obs_history=3, history_interval=2 at 30Hz."""
+        cfg, ds_cfg = _make_train_cfg(n_obs_history=3, history_interval=2, action_freq=30.0)
+        meta = _make_metadata({"camera0": {}, "state": {}})
+        dt_mean, _, _, _ = resolve_delta_timestamps(cfg, ds_cfg, meta)
+        expected = np.array([-4 / 30, -2 / 30, 0.0])
+        np.testing.assert_allclose(dt_mean["camera0"], expected)
+        np.testing.assert_allclose(dt_mean["state"], expected)
+
+    def test_history_t1_single_delta(self):
+        """n_obs_history=1 should produce [0.0] (same as no history)."""
+        cfg, ds_cfg = _make_train_cfg(n_obs_history=1, history_interval=1)
+        meta = _make_metadata({"state": {}})
+        dt_mean, _, _, _ = resolve_delta_timestamps(cfg, ds_cfg, meta)
+        np.testing.assert_array_equal(dt_mean["state"], [0.0])
+
+    def test_history_does_not_affect_actions(self):
+        """Action deltas come from policy config, not n_obs_history."""
+        cfg, ds_cfg = _make_train_cfg(n_obs_history=3, history_interval=1)
+        meta = _make_metadata({"camera0": {}, "state": {}, "actions": {}})
+        dt_mean, _, _, _ = resolve_delta_timestamps(cfg, ds_cfg, meta)
+        assert len(dt_mean["actions"]) == cfg.policy.chunk_size
+        assert len(dt_mean["camera0"]) == 3
+        assert len(dt_mean["state"]) == 3
+
+    def test_history_last_element_is_zero(self):
+        """The last delta timestamp should always be 0.0 (current time)."""
+        for t in [2, 5, 10]:
+            cfg, ds_cfg = _make_train_cfg(n_obs_history=t, history_interval=3)
+            meta = _make_metadata({"state": {}})
+            dt_mean, _, _, _ = resolve_delta_timestamps(cfg, ds_cfg, meta)
+            assert dt_mean["state"][-1] == 0.0
+            assert len(dt_mean["state"]) == t
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: __getitem__ with observation history
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _fix_dummy_mapping():
+    """Fix DUMMY_REPO_ID mapping so standardized __getitem__ works."""
+    original = DATA_FEATURES_NAME_MAPPING.get(DUMMY_REPO_ID, {}).copy()
+    DATA_FEATURES_NAME_MAPPING[DUMMY_REPO_ID] = {
+        "state": "state",
+        "actions": "action",
+        "prompt": "task",
+        "response": "response",
+    }
+    yield
+    DATA_FEATURES_NAME_MAPPING[DUMMY_REPO_ID] = original
+
+
+def _make_dataset_with_history(
+    lerobot_dataset_factory, info_factory, tmp_path, n_obs_history, history_interval=1, suffix=""
+):
+    """Create a LeRobotDataset with observation history configured.
+
+    Uses camera_features={} to avoid video decoding in tests.
+    """
+    from opentau.datasets.lerobot_dataset import LeRobotDataset
+
+    info = info_factory(
+        total_episodes=3,
+        total_frames=150,
+        total_tasks=1,
+        camera_features={},
+    )
+
+    dataset = lerobot_dataset_factory(
+        root=tmp_path / f"obs_hist_{n_obs_history}_{history_interval}{suffix}",
+        repo_id=DUMMY_REPO_ID,
+        total_episodes=3,
+        total_frames=150,
+        total_tasks=1,
+        info=info,
+    )
+
+    # Patch config with desired history settings and a policy with action_delta_indices
+    dataset.cfg.dataset_mixture.n_obs_history = n_obs_history
+    dataset.cfg.dataset_mixture.history_interval = history_interval
+    dataset.n_obs_history = n_obs_history
+    dataset.cfg.policy = DummyPolicyConfig(chunk_size=dataset.cfg.action_chunk)
+
+    dt_info = resolve_delta_timestamps(dataset.cfg, dataset.cfg.dataset_mixture.datasets[0], dataset.meta)
+    dataset.delta_timestamps_params = LeRobotDataset.compute_delta_params(*dt_info)
+
+    return dataset
+
+
+def test_default_no_history_shapes(lerobot_dataset_factory, info_factory, tmp_path):
+    """n_obs_history=None preserves single-frame shapes and adds obs_is_pad."""
+    dataset = _make_dataset_with_history(lerobot_dataset_factory, info_factory, tmp_path, n_obs_history=None)
+    item = dataset[25]
+    assert item["state"].shape == (dataset.cfg.max_state_dim,)
+    assert "obs_is_pad" in item
+    assert item["obs_is_pad"].shape == (1,)
+    assert item["obs_is_pad"].dtype == torch.bool
+    assert not item["obs_is_pad"].any()
+
+
+def test_history_t3_state_shape(lerobot_dataset_factory, info_factory, tmp_path):
+    dataset = _make_dataset_with_history(lerobot_dataset_factory, info_factory, tmp_path, n_obs_history=3)
+    item = dataset[25]
+    assert item["state"].shape == (3, dataset.cfg.max_state_dim)
+
+
+def test_history_t3_obs_is_pad_shape(lerobot_dataset_factory, info_factory, tmp_path):
+    dataset = _make_dataset_with_history(lerobot_dataset_factory, info_factory, tmp_path, n_obs_history=3)
+    item = dataset[25]
+    assert "obs_is_pad" in item
+    assert item["obs_is_pad"].shape == (3,)
+    assert item["obs_is_pad"].dtype == torch.bool
+
+
+def test_history_t3_obs_is_pad_mid_episode(lerobot_dataset_factory, info_factory, tmp_path):
+    """In the middle of an episode, no observation should be padded."""
+    dataset = _make_dataset_with_history(lerobot_dataset_factory, info_factory, tmp_path, n_obs_history=3)
+    ep_from = int(dataset.episode_data_index["from"][0].item())
+    mid_idx = ep_from + 10
+    item = dataset[mid_idx]
+    assert not item["obs_is_pad"].any(), "Mid-episode observations should not be padded"
+
+
+def test_history_padding_at_episode_start(lerobot_dataset_factory, info_factory, tmp_path):
+    """At the start of an episode, earlier history frames should be padded."""
+    dataset = _make_dataset_with_history(lerobot_dataset_factory, info_factory, tmp_path, n_obs_history=5)
+    ep_from = int(dataset.episode_data_index["from"][0].item())
+    item = dataset[ep_from]
+    assert item["obs_is_pad"][0].item() is True, "Earliest history frame at ep start should be padded"
+    assert item["obs_is_pad"][-1].item() is False, "Current frame should never be padded"
+
+
+def test_history_interval_k2_padding(lerobot_dataset_factory, info_factory, tmp_path):
+    """With history_interval=2, padding extends further at episode start."""
+    dataset = _make_dataset_with_history(
+        lerobot_dataset_factory, info_factory, tmp_path, n_obs_history=3, history_interval=2
+    )
+    ep_from = int(dataset.episode_data_index["from"][0].item())
+    item = dataset[ep_from + 1]
+    assert item["obs_is_pad"][0].item() is True
+    assert item["obs_is_pad"][1].item() is True
+    assert item["obs_is_pad"][2].item() is False
+
+
+def test_history_actions_unchanged(lerobot_dataset_factory, info_factory, tmp_path):
+    """Action shape should be unchanged regardless of n_obs_history."""
+    dataset = _make_dataset_with_history(lerobot_dataset_factory, info_factory, tmp_path, n_obs_history=3)
+    item = dataset[25]
+    assert item["actions"].shape == (dataset.cfg.action_chunk, dataset.cfg.max_action_dim)
+    assert item["action_is_pad"].shape == (dataset.cfg.action_chunk,)
+
+
+def test_history_img_is_pad_unchanged(lerobot_dataset_factory, info_factory, tmp_path):
+    """img_is_pad should remain (num_cams,) regardless of n_obs_history."""
+    dataset = _make_dataset_with_history(lerobot_dataset_factory, info_factory, tmp_path, n_obs_history=3)
+    item = dataset[25]
+    assert item["img_is_pad"].shape == (dataset.cfg.num_cams,)

--- a/tests/datasets/test_obs_history.py
+++ b/tests/datasets/test_obs_history.py
@@ -312,3 +312,25 @@ def test_history_img_is_pad_unchanged(lerobot_dataset_factory, info_factory, tmp
     dataset = _make_dataset_with_history(lerobot_dataset_factory, info_factory, tmp_path, n_obs_history=3)
     item = dataset[25]
     assert item["img_is_pad"].shape == (dataset.cfg.num_cams,)
+
+
+def test_obs_history_is_pad_fallback_shape(lerobot_dataset_factory, info_factory, tmp_path):
+    """When state_is_pad is absent from item, obs_history_is_pad fallback must match (T,) shape."""
+    dataset = _make_dataset_with_history(
+        lerobot_dataset_factory, info_factory, tmp_path, n_obs_history=4, suffix="_no_state"
+    )
+
+    dt_mean, dt_std, dt_lower, dt_upper = dataset.delta_timestamps_params
+    dt_mean = {k: v for k, v in dt_mean.items() if k != "state"}
+    dt_std = {k: v for k, v in dt_std.items() if k != "state"}
+    dt_lower = {k: v for k, v in dt_lower.items() if k != "state"}
+    dt_upper = {k: v for k, v in dt_upper.items() if k != "state"}
+    dataset.delta_timestamps_params = (dt_mean, dt_std, dt_lower, dt_upper)
+
+    item = dataset[25]
+    assert "obs_history_is_pad" in item
+    assert item["obs_history_is_pad"].shape == (4,), (
+        f"Expected fallback shape (4,), got {item['obs_history_is_pad'].shape}"
+    )
+    assert item["obs_history_is_pad"].dtype == torch.bool
+    assert not item["obs_history_is_pad"].any()


### PR DESCRIPTION
## What this does
Support observation history in standard data format.

By default `n_obs_history` is None and the default standard data format is unchanged. 

With `n_obs_history = T`, and `history_interval=k` observations are sampled at timesteps $t - (T-1)k$, $t-(T-2)k$, $\dots$, $t$ relative to the current timestep `t`, where the interval is measured in dataset steps (at the configured `action_freq`). For timesteps that
fall before the start of the current episode, the observation is clamped to the first step of the
episode and the corresponding entry in `obs_is_pad` is set to `True`

## How it was tested
Ran unit tests.

## How to checkout & try? (for the reviewer)
Run unit tests
## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.
