### PR TITLE
feat: support deferred video attachment in LeRobotDataset

### DIFF
--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -147,6 +147,7 @@ from opentau.datasets.video_utils import (
     encode_video_frames,
     get_safe_default_codec,
     get_video_info,
+    resample_and_trim_video,
 )
 from opentau.policies.value.configuration_value import ValueConfig
 from opentau.policies.value.reward import (
@@ -525,14 +526,24 @@ class LeRobotDatasetMetadata(DatasetMetadata):
         self.stats = aggregate_stats([self.stats, episode_stats]) if self.stats else episode_stats
         write_episode_stats(episode_index, episode_stats, self.root)
 
-    def update_video_info(self) -> None:
-        """
-        Warning: this function writes info from first episode videos, implicitly assuming that all videos have
-        been encoded the same way. Also, this means it assumes the first episode exists.
+    def update_video_info(self, skip_keys: set[str] | None = None) -> None:
+        """Update video metadata from the first episode's video files.
+
+        Warning: this function writes info from first episode videos, implicitly
+        assuming that all videos have been encoded the same way. Also, this means
+        it assumes the first episode exists.
+
+        Args:
+            skip_keys: Optional set of video keys to skip (e.g. deferred video
+                keys whose files don't exist yet).
         """
         for key in self.video_keys:
+            if skip_keys and key in skip_keys:
+                continue
             if not self.features[key].get("info", None):
                 video_path = self.root / self.get_video_file_path(ep_index=0, vid_key=key)
+                if not video_path.is_file():
+                    continue
                 self.info["features"][key]["info"] = get_video_info(video_path)
 
     def __repr__(self):
@@ -1551,11 +1562,14 @@ class LeRobotDataset(BaseDataset):
 
     def create_episode_buffer(self, episode_index: int | None = None) -> dict:
         current_ep_idx = self.meta.total_episodes if episode_index is None else episode_index
+        deferred = getattr(self, "deferred_video_keys", set())
         ep_buffer = {}
         # size and task are special cases that are not in self.features
         ep_buffer["size"] = 0
         ep_buffer["task"] = []
         for key in self.features:
+            if key in deferred:
+                continue
             ep_buffer[key] = current_ep_idx if key == "episode_index" else []
         return ep_buffer
 
@@ -1578,13 +1592,18 @@ class LeRobotDataset(BaseDataset):
         This function only adds the frame to the episode_buffer. Apart from images — which are written in a
         temporary directory — nothing is written to disk. To save those frames, the 'save_episode()' method
         then needs to be called.
+
+        Video/image features listed in ``deferred_video_keys`` (set via
+        :meth:`create`) may be omitted from the frame; their observations will
+        be attached later via :meth:`attach_video`.
         """
         # Convert torch to numpy if needed
         for name in frame:
             if isinstance(frame[name], torch.Tensor):
                 frame[name] = frame[name].numpy()
 
-        validate_frame(frame, self.features)
+        deferred = getattr(self, "deferred_video_keys", set())
+        validate_frame(frame, self.features, deferred_features=deferred or None)
 
         if self.episode_buffer is None:
             self.episode_buffer = self.create_episode_buffer()
@@ -1628,12 +1647,19 @@ class LeRobotDataset(BaseDataset):
             episode_data (dict | None, optional): Dict containing the episode data to save. If None, this will
                 save the current episode in self.episode_buffer, which is filled with 'add_frame'. Defaults to
                 None.
+
+        Note:
+            When ``deferred_video_keys`` are configured, the corresponding video
+            features are excluded from validation, encoding, and existence
+            checks. Use :meth:`attach_video` after saving episodes to supply
+            the video files.
         """
         episode_buffer = self.episode_buffer if episode_data is None else episode_data
         if episode_buffer is None:
             raise RuntimeError("No episode data provided and no episode buffer exists. Call add_frame first.")
 
-        validate_episode_buffer(episode_buffer, self.meta.total_episodes, self.features)
+        deferred = getattr(self, "deferred_video_keys", set())
+        validate_episode_buffer(episode_buffer, self.meta.total_episodes, self.features, deferred or None)
 
         # size and task are special cases that won't be added to hf_dataset
         episode_length = episode_buffer.pop("size")
@@ -1658,17 +1684,26 @@ class LeRobotDataset(BaseDataset):
             # are processed separately by storing image path and frame info as meta data
             if key in ["index", "episode_index", "task_index"] or ft["dtype"] in ["image", "video"]:
                 continue
+            if key in deferred:
+                continue
             episode_buffer[key] = np.stack(episode_buffer[key])
 
         self._wait_image_writer()
         self._save_episode_table(episode_buffer, episode_index)
-        ep_stats = compute_episode_stats(
-            episode_buffer, self.features, skip_video_stats=getattr(self, "skip_video_stats", False)
-        )
 
-        if len(self.meta.video_keys) > 0:
-            video_paths = self.encode_episode_videos(episode_index)
-            for key in self.meta.video_keys:
+        # When deferred video keys exist, always skip video stats since images
+        # are not available yet.
+        skip_video = getattr(self, "skip_video_stats", False) or bool(deferred)
+        # Build a features dict that excludes deferred keys so compute_episode_stats
+        # does not try to read image paths that don't exist.
+        effective_features = {k: v for k, v in self.features.items() if k not in deferred}
+        ep_stats = compute_episode_stats(episode_buffer, effective_features, skip_video_stats=skip_video)
+
+        # Encode videos for non-deferred video keys only
+        non_deferred_video_keys = [k for k in self.meta.video_keys if k not in deferred]
+        if non_deferred_video_keys:
+            video_paths = self.encode_episode_videos(episode_index, skip_keys=deferred)
+            for key in non_deferred_video_keys:
                 episode_buffer[key] = video_paths[key]
 
         # `meta.save_episode` be executed after encoding the videos
@@ -1690,6 +1725,8 @@ class LeRobotDataset(BaseDataset):
         missing_videos: list[str] = []
         for ep_idx in range(expected_episodes):
             for vid_key in self.meta.video_keys:
+                if vid_key in deferred:
+                    continue
                 video_path = self.root / self.meta.get_video_file_path(ep_idx, vid_key)
                 if not video_path.is_file():
                     missing_videos.append(str(video_path))
@@ -1773,14 +1810,20 @@ class LeRobotDataset(BaseDataset):
         for ep_idx in range(self.meta.total_episodes):
             self.encode_episode_videos(ep_idx)
 
-    def encode_episode_videos(self, episode_index: int) -> dict:
+    def encode_episode_videos(self, episode_index: int, skip_keys: set[str] | None = None) -> dict:
         """
         Use ffmpeg to convert frames stored as png into mp4 videos.
         Note: `encode_video_frames` is a blocking call. Making it asynchronous shouldn't speedup encoding,
         since video encoding with ffmpeg is already using multithreading.
+
+        Args:
+            episode_index: Index of the episode to encode.
+            skip_keys: Optional set of video keys to skip (e.g. deferred video keys).
         """
         video_paths = {}
         for key in self.meta.video_keys:
+            if skip_keys and key in skip_keys:
+                continue
             video_path = self.root / self.meta.get_video_file_path(episode_index, key)
             video_paths[key] = str(video_path)
             if video_path.is_file():
@@ -1792,6 +1835,97 @@ class LeRobotDataset(BaseDataset):
             encode_video_frames(img_dir, video_path, self.fps, overwrite=True)
 
         return video_paths
+
+    def attach_video(
+        self,
+        episode_index: int,
+        video_key: str,
+        input_video_path: str | Path,
+        overwrite: bool = False,
+        vcodec: str = "libsvtav1",
+        pix_fmt: str = "yuv420p",
+        g: int | None = 2,
+        crf: int | None = 30,
+    ) -> Path:
+        """Attach a pre-recorded MP4 video to an episode with deferred video observations.
+
+        The source video is resampled to the dataset's FPS and trimmed so it
+        contains exactly as many frames as the episode.  The resulting file is
+        placed in the standard video path for the dataset.
+
+        This method is meant to be called **after** :meth:`save_episode` for
+        episodes whose video observations were deferred (see the
+        ``deferred_video_keys`` parameter of :meth:`create`).
+
+        After attaching videos for all deferred keys and episodes, you should
+        call :meth:`update_video_info` to update the dataset metadata with the
+        actual video properties (resolution, codec, etc.).
+
+        Args:
+            episode_index: Index of the episode to attach the video to.
+            video_key: The video feature key (e.g. ``"observation.images.top"``).
+            input_video_path: Path to the source MP4 file.
+            overwrite: Whether to overwrite an existing video at the target path.
+            vcodec: Video codec for re-encoding. Defaults to "libsvtav1".
+            pix_fmt: Pixel format. Defaults to "yuv420p".
+            g: GOP size. Defaults to 2.
+            crf: Constant Rate Factor. Defaults to 30.
+
+        Returns:
+            Path to the written video file inside the dataset.
+
+        Raises:
+            ValueError: If ``video_key`` is not a declared video feature, or the
+                episode index does not exist.
+            FileNotFoundError: If ``input_video_path`` does not exist.
+        """
+        if video_key not in self.meta.video_keys:
+            raise ValueError(
+                f"'{video_key}' is not a video feature. Available video keys: {self.meta.video_keys}"
+            )
+        if episode_index not in self.meta.episodes:
+            raise ValueError(
+                f"Episode {episode_index} does not exist. "
+                f"Total episodes: {self.meta.total_episodes}"
+            )
+
+        episode_length = self.meta.episodes[episode_index]["length"]
+        output_path = self.root / self.meta.get_video_file_path(episode_index, video_key)
+
+        if output_path.is_file() and not overwrite:
+            logging.info(
+                "Video already exists at %s, skipping (use overwrite=True to replace).",
+                output_path,
+            )
+            return output_path
+
+        resample_and_trim_video(
+            input_path=input_video_path,
+            output_path=output_path,
+            target_fps=self.fps,
+            num_frames=episode_length,
+            vcodec=vcodec,
+            pix_fmt=pix_fmt,
+            g=g,
+            crf=crf,
+            overwrite=overwrite,
+        )
+
+        logging.info(
+            "Attached video for episode %d, key '%s': %s -> %s (%d frames @ %d fps)",
+            episode_index, video_key, input_video_path, output_path, episode_length, self.fps,
+        )
+        return output_path
+
+    def update_video_info(self) -> None:
+        """Update video metadata from the first episode's video files.
+
+        Call this after attaching all deferred videos to populate the ``info``
+        field of each video feature with actual video properties (resolution,
+        codec, etc.) and persist the updated metadata to disk.
+        """
+        self.meta.update_video_info()
+        write_info(self.meta.info, self.meta.root)
 
     @staticmethod
     def compute_delta_params(
@@ -1862,8 +1996,20 @@ class LeRobotDataset(BaseDataset):
         vector_resample_strategy: str = "nearest",
         standardize: bool = True,
         skip_video_stats: bool = False,
+        deferred_video_keys: set[str] | None = None,
     ) -> "LeRobotDataset":
-        """Create a LeRobot Dataset from scratch in order to record data."""
+        """Create a LeRobot Dataset from scratch in order to record data.
+
+        Args:
+            deferred_video_keys: Optional set of video feature keys whose image
+                observations will be provided later via :meth:`attach_video`
+                instead of being passed to :meth:`add_frame`. When set, these
+                keys are omitted from frame validation, episode video encoding,
+                and post-save video existence checks. After all episodes are
+                recorded, call :meth:`attach_video` for each episode to supply
+                an MP4 that will be resampled to the dataset FPS and trimmed to
+                the episode length.
+        """
         obj = cls.__new__(cls)
         obj.meta = LeRobotDatasetMetadata.create(
             repo_id=repo_id,
@@ -1881,6 +2027,16 @@ class LeRobotDataset(BaseDataset):
 
         if image_writer_processes or image_writer_threads:
             obj.start_image_writer(image_writer_processes, image_writer_threads)
+
+        # Deferred video keys: video features whose observations are attached later
+        obj.deferred_video_keys = set(deferred_video_keys) if deferred_video_keys else set()
+        if obj.deferred_video_keys:
+            unknown = obj.deferred_video_keys - set(obj.meta.video_keys)
+            if unknown:
+                raise ValueError(
+                    f"deferred_video_keys {unknown} are not declared as video features. "
+                    f"Available video keys: {obj.meta.video_keys}"
+                )
 
         # TODO(aliberts, rcadene, alexander-soare): Merge this with OnlineBuffer/DataBuffer
         obj.episode_buffer = obj.create_episode_buffer()

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -1885,8 +1885,7 @@ class LeRobotDataset(BaseDataset):
             )
         if episode_index not in self.meta.episodes:
             raise ValueError(
-                f"Episode {episode_index} does not exist. "
-                f"Total episodes: {self.meta.total_episodes}"
+                f"Episode {episode_index} does not exist. Total episodes: {self.meta.total_episodes}"
             )
 
         episode_length = self.meta.episodes[episode_index]["length"]
@@ -1913,7 +1912,12 @@ class LeRobotDataset(BaseDataset):
 
         logging.info(
             "Attached video for episode %d, key '%s': %s -> %s (%d frames @ %d fps)",
-            episode_index, video_key, input_video_path, output_path, episode_length, self.fps,
+            episode_index,
+            video_key,
+            input_video_path,
+            output_path,
+            episode_length,
+            self.fps,
         )
         return output_path
 

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -1593,7 +1593,7 @@ class LeRobotDataset(BaseDataset):
         temporary directory — nothing is written to disk. To save those frames, the 'save_episode()' method
         then needs to be called.
 
-        Video/image features listed in ``deferred_video_keys`` (set via
+        Video features listed in ``deferred_video_keys`` (set via
         :meth:`create`) may be omitted from the frame; their observations will
         be attached later via :meth:`attach_video`.
         """
@@ -1691,13 +1691,27 @@ class LeRobotDataset(BaseDataset):
         self._wait_image_writer()
         self._save_episode_table(episode_buffer, episode_index)
 
-        # When deferred video keys exist, always skip video stats since images
-        # are not available yet.
-        skip_video = getattr(self, "skip_video_stats", False) or bool(deferred)
+        # Deferred keys are excluded from effective_features below, so only
+        # honor the explicit dataset-level setting for skipping video stats.
+        skip_video = getattr(self, "skip_video_stats", False)
         # Build a features dict that excludes deferred keys so compute_episode_stats
-        # does not try to read image paths that don't exist.
+        # does not try to read image paths that don't exist, while still
+        # computing stats for non-deferred image/video features.
         effective_features = {k: v for k, v in self.features.items() if k not in deferred}
         ep_stats = compute_episode_stats(episode_buffer, effective_features, skip_video_stats=skip_video)
+
+        # Add placeholder stats for deferred video keys so downstream code
+        # (standardization, dataset mixing) never encounters missing keys.
+        for key in deferred:
+            shape = self.features[key]["shape"]
+            c = shape[0] if len(shape) >= 3 else 3
+            ep_stats[key] = {
+                "min": np.zeros((c, 1, 1), dtype=np.float64),
+                "max": np.ones((c, 1, 1), dtype=np.float64),
+                "mean": np.full((c, 1, 1), 0.5, dtype=np.float64),
+                "std": np.full((c, 1, 1), 0.5, dtype=np.float64),
+                "count": np.array([episode_length]),
+            }
 
         # Encode videos for non-deferred video keys only
         non_deferred_video_keys = [k for k in self.meta.video_keys if k not in deferred]
@@ -1807,8 +1821,9 @@ class LeRobotDataset(BaseDataset):
         Note: `encode_video_frames` is a blocking call. Making it asynchronous shouldn't speedup encoding,
         since video encoding with ffmpeg is already using multithreading.
         """
+        skip_keys = getattr(self, "deferred_video_keys", None)
         for ep_idx in range(self.meta.total_episodes):
-            self.encode_episode_videos(ep_idx)
+            self.encode_episode_videos(ep_idx, skip_keys=skip_keys)
 
     def encode_episode_videos(self, episode_index: int, skip_keys: set[str] | None = None) -> dict:
         """

--- a/src/opentau/datasets/utils.py
+++ b/src/opentau/datasets/utils.py
@@ -1058,7 +1058,7 @@ class IterableNamespace(SimpleNamespace):
         return vars(self).keys()
 
 
-def validate_frame(frame: dict, features: dict) -> None:
+def validate_frame(frame: dict, features: dict, deferred_features: set[str] | None = None) -> None:
     """Validate that a frame dictionary matches the expected features.
 
     Checks that all required features are present, no unexpected features exist,
@@ -1067,11 +1067,17 @@ def validate_frame(frame: dict, features: dict) -> None:
     Args:
         frame: Dictionary containing frame data to validate.
         features: Dictionary of expected feature specifications.
+        deferred_features: Optional set of feature names whose data will be
+            provided later (e.g. video observations attached after episode
+            recording). These features are treated as optional during
+            validation.
 
     Raises:
         ValueError: If the frame doesn't match the feature specifications.
     """
     optional_features = {"timestamp"}
+    if deferred_features:
+        optional_features = optional_features | deferred_features
     expected_features = (set(features) - set(DEFAULT_FEATURES.keys())) | {"task"}
     actual_features = set(frame.keys())
 
@@ -1102,7 +1108,7 @@ def validate_features_presence(
         Error message string (empty if validation passes).
     """
     error_message = ""
-    missing_features = expected_features - actual_features
+    missing_features = expected_features - actual_features - optional_features
     extra_features = actual_features - (expected_features | optional_features)
 
     if missing_features or extra_features:
@@ -1232,7 +1238,12 @@ def validate_feature_string(name: str, value: str) -> str:
     return ""
 
 
-def validate_episode_buffer(episode_buffer: dict, total_episodes: int, features: dict) -> None:
+def validate_episode_buffer(
+    episode_buffer: dict,
+    total_episodes: int,
+    features: dict,
+    deferred_features: set[str] | None = None,
+) -> None:
     """Validate that an episode buffer is properly formatted.
 
     Checks that required keys exist, episode_index matches total_episodes,
@@ -1242,6 +1253,8 @@ def validate_episode_buffer(episode_buffer: dict, total_episodes: int, features:
         episode_buffer: Dictionary containing episode data to validate.
         total_episodes: Total number of episodes already in the dataset.
         features: Dictionary of expected feature specifications.
+        deferred_features: Optional set of feature names whose data will be
+            provided later and may be absent from the episode buffer.
 
     Raises:
         ValueError: If the buffer is missing required keys, is empty, or has
@@ -1265,9 +1278,10 @@ def validate_episode_buffer(episode_buffer: dict, total_episodes: int, features:
         raise ValueError("You must add one or several frames with `add_frame` before calling `add_episode`.")
 
     buffer_keys = set(episode_buffer.keys()) - {"task", "size"}
-    if not buffer_keys == set(features):
+    expected_keys = set(features) - (deferred_features or set())
+    if not buffer_keys == expected_keys:
         raise ValueError(
             f"Features from `episode_buffer` don't match the ones in `features`."
-            f"In episode_buffer not in features: {buffer_keys - set(features)}"
-            f"In features not in episode_buffer: {set(features) - buffer_keys}"
+            f"In episode_buffer not in features: {buffer_keys - expected_keys}"
+            f"In features not in episode_buffer: {expected_keys - buffer_keys}"
         )

--- a/src/opentau/datasets/video_utils.py
+++ b/src/opentau/datasets/video_utils.py
@@ -752,14 +752,20 @@ def resample_and_trim_video(
     if ffprobe_path:
         result = subprocess.run(
             [
-                ffprobe_path, "-v", "error",
-                "-select_streams", "v:0",
+                ffprobe_path,
+                "-v",
+                "error",
+                "-select_streams",
+                "v:0",
                 "-count_frames",
-                "-show_entries", "stream=nb_read_frames",
-                "-of", "csv=p=0",
+                "-show_entries",
+                "stream=nb_read_frames",
+                "-of",
+                "csv=p=0",
                 str(output_path),
             ],
-            capture_output=True, text=True,
+            capture_output=True,
+            text=True,
         )
         if result.returncode == 0 and result.stdout.strip().isdigit():
             actual_frames = int(result.stdout.strip())

--- a/src/opentau/datasets/video_utils.py
+++ b/src/opentau/datasets/video_utils.py
@@ -646,3 +646,126 @@ def get_image_pixel_channels(image: Image) -> int:
         return 4  # RGBA
     else:
         raise ValueError("Unknown format")
+
+
+def resample_and_trim_video(
+    input_path: Path | str,
+    output_path: Path | str,
+    target_fps: int,
+    num_frames: int,
+    vcodec: str = "libsvtav1",
+    pix_fmt: str = "yuv420p",
+    g: int | None = 2,
+    crf: int | None = 30,
+    fast_decode: int = 0,
+    log_level: str | None = "error",
+    overwrite: bool = False,
+) -> None:
+    """Resample a video to the target FPS and trim it to exactly *num_frames* frames.
+
+    This is used to attach a pre-recorded MP4 to a :class:`LeRobotDataset`
+    episode whose non-visual observations have already been saved.  The source
+    video is re-encoded at ``target_fps`` and cropped so that the output
+    contains exactly ``num_frames`` frames (i.e. a duration of
+    ``num_frames / target_fps`` seconds, starting from the beginning of the
+    input).
+
+    Args:
+        input_path: Path to the source video file.
+        output_path: Path where the resampled/trimmed video will be written.
+        target_fps: Desired output frames per second.
+        num_frames: Exact number of frames the output video must contain.
+        vcodec: Video codec to use. Defaults to "libsvtav1".
+        pix_fmt: Pixel format. Defaults to "yuv420p".
+        g: GOP (Group of Pictures) size. Defaults to 2.
+        crf: Constant Rate Factor for quality control. Defaults to 30.
+        fast_decode: Fast decode parameter for libsvtav1. Defaults to 0.
+        log_level: FFmpeg log level. Defaults to "error".
+        overwrite: Whether to overwrite an existing output file. Defaults to False.
+
+    Raises:
+        FileNotFoundError: If ``input_path`` does not exist.
+        OSError: If ffmpeg is not found or the output file is not produced.
+        ValueError: If the resulting video does not have the expected number of
+            frames (tolerance of ±1 frame to account for codec rounding).
+    """
+    input_path = Path(input_path)
+    output_path = Path(output_path)
+
+    if not input_path.is_file():
+        raise FileNotFoundError(f"Input video not found: {input_path}")
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    ffmpeg_path = shutil.which("ffmpeg")
+    if ffmpeg_path is None:
+        raise OSError("ffmpeg not found in PATH. Install ffmpeg to process videos.")
+
+    if vcodec == "libsvtav1":
+        vcodec = get_safe_encoding_vcodec()
+
+    # Duration to keep: num_frames / target_fps
+    duration = num_frames / target_fps
+
+    ffmpeg_args = OrderedDict(
+        [
+            ("-i", str(input_path)),
+            ("-t", f"{duration:.6f}"),
+            ("-r", str(target_fps)),
+            ("-vcodec", vcodec),
+            ("-pix_fmt", pix_fmt),
+        ]
+    )
+
+    if g is not None:
+        ffmpeg_args["-g"] = str(g)
+
+    if crf is not None:
+        ffmpeg_args["-crf"] = str(crf)
+
+    if fast_decode:
+        key = "-svtav1-params" if vcodec == "libsvtav1" else "-tune"
+        value = f"fast-decode={fast_decode}" if vcodec == "libsvtav1" else "fastdecode"
+        ffmpeg_args[key] = value
+
+    if log_level is not None:
+        ffmpeg_args["-loglevel"] = str(log_level)
+
+    ffmpeg_args_list = [item for pair in ffmpeg_args.items() for item in pair]
+    if overwrite:
+        ffmpeg_args_list.append("-y")
+
+    ffmpeg_cmd = [ffmpeg_path] + ffmpeg_args_list + [str(output_path)]
+    subprocess.run(ffmpeg_cmd, check=True, stdin=subprocess.DEVNULL)
+
+    if not output_path.exists():
+        raise OSError(
+            f"Video resampling/trimming did not work. File not found: {output_path}. "
+            f"Try running the command manually to debug: `{' '.join(ffmpeg_cmd)}`"
+        )
+
+    # Verify frame count
+    info = get_video_info(str(output_path))
+    actual_fps = info["video.fps"]
+    # Re-read via ffprobe to get actual frame count
+    ffprobe_path = shutil.which("ffprobe")
+    if ffprobe_path:
+        result = subprocess.run(
+            [
+                ffprobe_path, "-v", "error",
+                "-select_streams", "v:0",
+                "-count_frames",
+                "-show_entries", "stream=nb_read_frames",
+                "-of", "csv=p=0",
+                str(output_path),
+            ],
+            capture_output=True, text=True,
+        )
+        if result.returncode == 0 and result.stdout.strip().isdigit():
+            actual_frames = int(result.stdout.strip())
+            if abs(actual_frames - num_frames) > 1:
+                raise ValueError(
+                    f"Resampled video has {actual_frames} frames but expected {num_frames}. "
+                    f"Source: {input_path}, target FPS: {target_fps}, duration: {duration:.4f}s. "
+                    f"Actual FPS in output: {actual_fps}"
+                )

--- a/src/opentau/datasets/video_utils.py
+++ b/src/opentau/datasets/video_utils.py
@@ -692,6 +692,12 @@ def resample_and_trim_video(
     input_path = Path(input_path)
     output_path = Path(output_path)
 
+    if num_frames <= 0:
+        raise ValueError(f"`num_frames` must be > 0, got {num_frames}.")
+
+    if target_fps <= 0:
+        raise ValueError(f"`target_fps` must be > 0, got {target_fps}.")
+
     if not input_path.is_file():
         raise FileNotFoundError(f"Input video not found: {input_path}")
 
@@ -745,33 +751,43 @@ def resample_and_trim_video(
         )
 
     # Verify frame count
+    ffprobe_path = shutil.which("ffprobe")
+    if not ffprobe_path:
+        raise OSError(
+            "ffprobe is required to validate the output video frame count but was not found in PATH. "
+            "Install ffprobe (usually distributed with ffmpeg) and retry."
+        )
+
     info = get_video_info(str(output_path))
     actual_fps = info["video.fps"]
-    # Re-read via ffprobe to get actual frame count
-    ffprobe_path = shutil.which("ffprobe")
-    if ffprobe_path:
-        result = subprocess.run(
-            [
-                ffprobe_path,
-                "-v",
-                "error",
-                "-select_streams",
-                "v:0",
-                "-count_frames",
-                "-show_entries",
-                "stream=nb_read_frames",
-                "-of",
-                "csv=p=0",
-                str(output_path),
-            ],
-            capture_output=True,
-            text=True,
+
+    result = subprocess.run(
+        [
+            ffprobe_path,
+            "-v",
+            "error",
+            "-select_streams",
+            "v:0",
+            "-count_frames",
+            "-show_entries",
+            "stream=nb_read_frames",
+            "-of",
+            "csv=p=0",
+            str(output_path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0 or not result.stdout.strip().isdigit():
+        raise OSError(
+            f"Failed to validate output video frame count with ffprobe for {output_path}. "
+            f"Return code: {result.returncode}. stderr: {result.stderr.strip()}"
         )
-        if result.returncode == 0 and result.stdout.strip().isdigit():
-            actual_frames = int(result.stdout.strip())
-            if abs(actual_frames - num_frames) > 1:
-                raise ValueError(
-                    f"Resampled video has {actual_frames} frames but expected {num_frames}. "
-                    f"Source: {input_path}, target FPS: {target_fps}, duration: {duration:.4f}s. "
-                    f"Actual FPS in output: {actual_fps}"
-                )
+
+    actual_frames = int(result.stdout.strip())
+    if abs(actual_frames - num_frames) > 1:
+        raise ValueError(
+            f"Resampled video has {actual_frames} frames but expected {num_frames}. "
+            f"Source: {input_path}, target FPS: {target_fps}, duration: {duration:.4f}s. "
+            f"Actual FPS in output: {actual_fps}"
+        )

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -457,3 +457,186 @@ def test_dataset_feature_with_forward_slash_raises_error():
 def test_vqa_dataset_imports():
     for dataset in available_vqa_datasets:
         import_module(f"opentau.datasets.vqa.{dataset}")
+
+
+def _make_dummy_mp4(path, fps=60, num_frames=100, width=128, height=96):
+    """Create a minimal MP4 test video using ffmpeg with solid-color frames."""
+    import shutil
+    import subprocess
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    ffmpeg = shutil.which("ffmpeg")
+    if ffmpeg is None:
+        pytest.skip("ffmpeg not available")
+    duration = num_frames / fps
+    subprocess.run(
+        [
+            ffmpeg,
+            "-y",
+            "-f", "lavfi",
+            "-i", f"color=c=blue:s={width}x{height}:r={fps}:d={duration:.6f}",
+            "-pix_fmt", "yuv420p",
+            "-c:v", "libx264",
+            "-g", "2",
+            str(path),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return path
+
+
+def test_deferred_video_add_frame_and_save(tmp_path, empty_lerobot_dataset_factory):
+    """Test that frames can be added without image data for deferred video keys."""
+    features = {
+        "state": {"dtype": "float32", "shape": (2,), "names": None},
+        "observation.images.top": {
+            "dtype": "video",
+            "shape": (3, 96, 128),
+            "names": ["channels", "height", "width"],
+            "info": None,
+        },
+    }
+    dataset = empty_lerobot_dataset_factory(
+        root=tmp_path / "deferred_test",
+        features=features,
+        deferred_video_keys={"observation.images.top"},
+    )
+
+    # Add frames without video data
+    for i in range(10):
+        dataset.add_frame({
+            "state": np.array([float(i), float(i + 1)], dtype=np.float32),
+            "task": "Dummy task",
+        })
+
+    # save_episode should succeed without video data
+    dataset.save_episode()
+
+    assert dataset.meta.total_episodes == 1
+    assert dataset.meta.total_frames == 10
+
+    # The parquet file should exist
+    parquet_path = dataset.root / dataset.meta.get_data_file_path(0)
+    assert parquet_path.is_file()
+
+    # The video file should NOT exist yet
+    video_path = dataset.root / dataset.meta.get_video_file_path(0, "observation.images.top")
+    assert not video_path.is_file()
+
+
+def test_deferred_video_attach_video(tmp_path, empty_lerobot_dataset_factory):
+    """Test full workflow: add frames, save episode, attach video."""
+    features = {
+        "state": {"dtype": "float32", "shape": (2,), "names": None},
+        "observation.images.top": {
+            "dtype": "video",
+            "shape": (3, 96, 128),
+            "names": ["channels", "height", "width"],
+            "info": None,
+        },
+    }
+    target_fps = 10
+    num_frames = 5
+    dataset = LeRobotDataset.create(
+        repo_id=DUMMY_REPO_ID,
+        fps=target_fps,
+        root=tmp_path / "attach_test",
+        features=features,
+        deferred_video_keys={"observation.images.top"},
+        standardize=False,
+    )
+
+    for i in range(num_frames):
+        dataset.add_frame({
+            "state": np.array([float(i), float(i + 1)], dtype=np.float32),
+            "task": "Dummy task",
+        })
+    dataset.save_episode()
+
+    # Create a source video at a different FPS (60fps, 100 frames = 1.67s)
+    src_video = _make_dummy_mp4(tmp_path / "source.mp4", fps=60, num_frames=100, width=128, height=96)
+
+    # Attach the video - it should be resampled to 10fps and trimmed to 5 frames
+    result_path = dataset.attach_video(
+        episode_index=0,
+        video_key="observation.images.top",
+        input_video_path=src_video,
+        overwrite=True,
+    )
+
+    assert result_path.is_file()
+
+    # Verify the output video exists at the expected dataset path
+    expected_path = dataset.root / dataset.meta.get_video_file_path(0, "observation.images.top")
+    assert expected_path.is_file()
+    assert result_path == expected_path
+
+
+def test_deferred_video_invalid_key(tmp_path, empty_lerobot_dataset_factory):
+    """Creating a dataset with invalid deferred video keys should raise ValueError."""
+    features = {
+        "state": {"dtype": "float32", "shape": (2,), "names": None},
+    }
+    with pytest.raises(ValueError, match="not declared as video features"):
+        empty_lerobot_dataset_factory(
+            root=tmp_path / "invalid_deferred",
+            features=features,
+            deferred_video_keys={"nonexistent_camera"},
+        )
+
+
+def test_deferred_video_multi_episode(tmp_path, empty_lerobot_dataset_factory):
+    """Test deferred video with multiple episodes."""
+    features = {
+        "state": {"dtype": "float32", "shape": (2,), "names": None},
+        "observation.images.top": {
+            "dtype": "video",
+            "shape": (3, 96, 128),
+            "names": ["channels", "height", "width"],
+            "info": None,
+        },
+    }
+    dataset = LeRobotDataset.create(
+        repo_id=DUMMY_REPO_ID,
+        fps=10,
+        root=tmp_path / "multi_ep_test",
+        features=features,
+        deferred_video_keys={"observation.images.top"},
+        standardize=False,
+    )
+
+    # Episode 0: 5 frames
+    for i in range(5):
+        dataset.add_frame({
+            "state": np.array([float(i), 0.0], dtype=np.float32),
+            "task": "Task A",
+        })
+    dataset.save_episode()
+
+    # Episode 1: 8 frames
+    for i in range(8):
+        dataset.add_frame({
+            "state": np.array([0.0, float(i)], dtype=np.float32),
+            "task": "Task B",
+        })
+    dataset.save_episode()
+
+    assert dataset.meta.total_episodes == 2
+    assert dataset.meta.total_frames == 13
+
+    # Attach videos for both episodes
+    src_video = _make_dummy_mp4(tmp_path / "source.mp4", fps=60, num_frames=300, width=128, height=96)
+
+    for ep_idx in range(2):
+        dataset.attach_video(
+            episode_index=ep_idx,
+            video_key="observation.images.top",
+            input_video_path=src_video,
+            overwrite=True,
+        )
+
+    # Verify both videos exist
+    for ep_idx in range(2):
+        video_path = dataset.root / dataset.meta.get_video_file_path(ep_idx, "observation.images.top")
+        assert video_path.is_file()

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -473,11 +473,16 @@ def _make_dummy_mp4(path, fps=60, num_frames=100, width=128, height=96):
         [
             ffmpeg,
             "-y",
-            "-f", "lavfi",
-            "-i", f"color=c=blue:s={width}x{height}:r={fps}:d={duration:.6f}",
-            "-pix_fmt", "yuv420p",
-            "-c:v", "libx264",
-            "-g", "2",
+            "-f",
+            "lavfi",
+            "-i",
+            f"color=c=blue:s={width}x{height}:r={fps}:d={duration:.6f}",
+            "-pix_fmt",
+            "yuv420p",
+            "-c:v",
+            "libx264",
+            "-g",
+            "2",
             str(path),
         ],
         check=True,
@@ -505,10 +510,12 @@ def test_deferred_video_add_frame_and_save(tmp_path, empty_lerobot_dataset_facto
 
     # Add frames without video data
     for i in range(10):
-        dataset.add_frame({
-            "state": np.array([float(i), float(i + 1)], dtype=np.float32),
-            "task": "Dummy task",
-        })
+        dataset.add_frame(
+            {
+                "state": np.array([float(i), float(i + 1)], dtype=np.float32),
+                "task": "Dummy task",
+            }
+        )
 
     # save_episode should succeed without video data
     dataset.save_episode()
@@ -548,10 +555,12 @@ def test_deferred_video_attach_video(tmp_path, empty_lerobot_dataset_factory):
     )
 
     for i in range(num_frames):
-        dataset.add_frame({
-            "state": np.array([float(i), float(i + 1)], dtype=np.float32),
-            "task": "Dummy task",
-        })
+        dataset.add_frame(
+            {
+                "state": np.array([float(i), float(i + 1)], dtype=np.float32),
+                "task": "Dummy task",
+            }
+        )
     dataset.save_episode()
 
     # Create a source video at a different FPS (60fps, 100 frames = 1.67s)
@@ -608,18 +617,22 @@ def test_deferred_video_multi_episode(tmp_path, empty_lerobot_dataset_factory):
 
     # Episode 0: 5 frames
     for i in range(5):
-        dataset.add_frame({
-            "state": np.array([float(i), 0.0], dtype=np.float32),
-            "task": "Task A",
-        })
+        dataset.add_frame(
+            {
+                "state": np.array([float(i), 0.0], dtype=np.float32),
+                "task": "Task A",
+            }
+        )
     dataset.save_episode()
 
     # Episode 1: 8 frames
     for i in range(8):
-        dataset.add_frame({
-            "state": np.array([0.0, float(i)], dtype=np.float32),
-            "task": "Task B",
-        })
+        dataset.add_frame(
+            {
+                "state": np.array([0.0, float(i)], dtype=np.float32),
+                "task": "Task B",
+            }
+        )
     dataset.save_episode()
 
     assert dataset.meta.total_episodes == 2


### PR DESCRIPTION
## Summary

- Add `deferred_video_keys` parameter to `LeRobotDataset.create()` to declare video features whose image observations will be provided later
- Allow `add_frame()` to accept frames without image data for deferred video keys
- Add `attach_video()` method that resamples a source MP4 to the dataset's FPS and trims it to the episode's frame count, then places it in the correct dataset location
- Add `resample_and_trim_video()` utility in `video_utils.py` for ffmpeg-based video resampling and trimming

This enables a workflow where non-visual observations (state, action, etc.) are recorded first, and a separately captured video is attached afterward — useful when video comes from an external source at a different FPS.

## Test plan

- [x] `test_deferred_video_add_frame_and_save` — frames added without video, episode saved successfully
- [x] `test_deferred_video_attach_video` — full workflow: add frames → save → attach MP4
- [x] `test_deferred_video_invalid_key` — error raised for non-existent deferred keys
- [x] `test_deferred_video_multi_episode` — multiple episodes with deferred video attachment
- [x] All existing `add_frame` / `save_episode` tests still pass

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/datasets/test_datasets.py -k deferred
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

https://claude.ai/code/session_01VqdyuyveQaKMkTgUWEizxB