### PR TITLE
refactor(recordhuman_to_lerobot): use deferred video attachment

### DIFF
--- a/src/opentau/scripts/recordhuman_to_lerobot.py
+++ b/src/opentau/scripts/recordhuman_to_lerobot.py
@@ -555,9 +555,9 @@ def main():
 
     states: list[np.ndarray] = []
     head_poses: list[np.ndarray] = []
-    cap = cv2.VideoCapture(str(video_path))
 
     if overlay_writer:
+        cap = cv2.VideoCapture(str(video_path))
         next_sample = 0
         for frame_idx in range(total_video_frames):
             ret, frame = cap.read()
@@ -601,16 +601,15 @@ def main():
                 head_poses.append(np.concatenate([head_pos_tracking, head_rot]).astype(np.float32))
                 next_sample += 1
 
+        cap.release()
         overlay_writer.release()
         print(f"Overlay video written to {overlay_path}")
     else:
+        # Pose-only pass: no video decoding needed since states are derived
+        # purely from the pose JSON. The source video will be attached later
+        # via dataset.attach_video().
         for i in range(num_output_frames):
             fidx = sampled_indices[i]
-            cap.set(cv2.CAP_PROP_POS_FRAMES, fidx)
-            ret, frame = cap.read()
-            if not ret:
-                break
-
             video_time = fidx / video_fps + args.time_offset
             pidx = int(np.clip(np.searchsorted(pose_timestamps, video_time), 0, len(pose_timestamps) - 1))
             if pidx > 0 and abs(pose_timestamps[pidx - 1] - video_time) < abs(
@@ -625,8 +624,6 @@ def main():
             state, _, _ = compute_frame_state(pf, head_pos_tracking, head_rot, eye_offset)
             states.append(state)
             head_poses.append(np.concatenate([head_pos_tracking, head_rot]).astype(np.float32))
-
-    cap.release()
 
     num_frames = len(states)
     if num_frames == 0:
@@ -671,21 +668,14 @@ def main():
         robot_type="human",
         features=features,
         use_videos=True,
+        deferred_video_keys={image_key},
     )
 
-    # --- Pass 2: read sampled frames and add to dataset ---
+    # --- Pass 2: add pose-derived frames (video is attached below) ---
     print(f"Writing LeRobot dataset ({num_frames} frames, fps={fps_int}) ...")
-    cap = cv2.VideoCapture(str(video_path))
     for i in range(num_frames):
-        fidx = sampled_indices[i]
-        cap.set(cv2.CAP_PROP_POS_FRAMES, fidx)
-        ret, frame = cap.read()
-        if not ret:
-            break
-        frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
         dataset.add_frame(
             {
-                image_key: frame_rgb,
                 state_key: states[i],
                 action_key: actions[i],
                 "task": args.prompt,
@@ -693,9 +683,25 @@ def main():
         )
         if (i + 1) % 100 == 0:
             print(f"  {i + 1}/{num_frames}")
-    cap.release()
 
     dataset.save_episode()
+
+    # Attach the source MP4: resampled to target FPS and trimmed to num_frames.
+    # This replaces the old PNG round-trip: no per-frame decode or re-encode.
+    try:
+        dataset.attach_video(
+            episode_index=0,
+            video_key=image_key,
+            input_video_path=video_path,
+            overwrite=True,
+        )
+    except ValueError as err:
+        print(
+            f"Error: failed to attach source video '{video_path}' to episode 0: {err}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    dataset.update_video_info()
     print(f"LeRobot dataset written to {output_path} ({num_frames} frames, 1 episode)")
 
 


### PR DESCRIPTION
## What this does

Refactors `src/opentau/scripts/recordhuman_to_lerobot.py` to use the deferred video attachment API introduced in #158.

**Before**: the script decoded the source MP4 two or three times, saved every frame as a PNG, then let `dataset.save_episode()` re-encode all the PNGs back to MP4. Wasteful.

**After**:
- Declare the camera feature as deferred via `LeRobotDataset.create(..., deferred_video_keys={image_key})`.
- Non-overlay Pass 1 no longer opens `cv2.VideoCapture` at all — state is computed purely from the pose JSON (verified: `compute_frame_state` never touches a frame).
- Pass 2's frame-decode loop is gone; `add_frame()` is called with state/action/task only.
- After `save_episode()`, `dataset.attach_video()` resamples the source MP4 to the target FPS and trims to the episode frame count in a single ffmpeg pass, followed by `dataset.update_video_info()` to populate the video feature info block.
- Overlay path (`--overlay`) is unchanged: it still draws skeletons onto frames and writes a separate debug MP4 at the user-supplied path. The dataset always gets the resampled source video, not the overlay.

## How it was tested

Verified end-to-end with synthetic inputs (ffmpeg `testsrc` + generated pose JSON at 90 Hz):

| Run | Reported frames | `ffprobe nb_read_frames` | `r_frame_rate` |
|---|---|---|---|
| `--fps 30` | 150 | 150 | 30/1 |
| `--fps 15` | 75 | 75 | 15/1 |
| `--fps 60` | 300 | 300 | 60/1 |
| `--fps 30 --overlay` | 150 | 150 (dataset video) | 30/1 |

- **Determinism**: two 30 fps runs produce byte-identical `observation.state` and `action` parquet columns (states are pose-derived only).
- **Video metadata**: `info.json` has the populated info block for `observation.images.camera` (codec=av1, width=640, height=480, pix_fmt=yuv420p, fps=30).
- **Overlay path**: separate overlay MP4 written to `/tmp/overlay.mp4`, dataset video is the resampled source — distinct files.
- **Parquet shapes**: state = 364-D, action = 371-D, 150 rows at 30 fps — unchanged from before.

## How to checkout & try? (for the reviewer)

```bash
# Synthesize inputs
ffmpeg -y -f lavfi -i "testsrc=size=640x480:rate=30:duration=5" \
    -pix_fmt yuv420p /tmp/synth.mp4
python3 -c "
import json, math
frames = []
for i in range(450):
    t = i / 90.0
    frames.append({
        't': t,
        'head_pos': [0.0, 1.6 + 0.05*math.sin(t), 0.1*math.cos(t)],
        'head_rot': [0.0, math.sin(0.05*math.sin(t)), 0.0, math.cos(0.05*math.sin(t))],
        'left_joints': [x for j in range(26) for x in [0.1*j + 0.01*math.sin(t+j), 1.2, 0.3, 0, 0, 0, 1]],
        'right_joints': [x for j in range(26) for x in [0.1*j + 0.01*math.cos(t+j), 1.2, -0.3, 0, 0, 0, 1]],
        'left_tracked': True, 'right_tracked': True,
    })
json.dump({'frames': frames}, open('/tmp/synth.json', 'w'))
"

# Run
python src/opentau/scripts/recordhuman_to_lerobot.py \
    --video /tmp/synth.mp4 --poses /tmp/synth.json \
    --output /tmp/ds --prompt "test pickup" --fps 30
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

https://claude.ai/code/session_01VqdyuyveQaKMkTgUWEizxB