### PR TITLE
Adding script to parse subtask.json and add response field to parquet…

### DIFF
--- a/configs/examples/add_subtask_response.json
+++ b/configs/examples/add_subtask_response.json
@@ -2,7 +2,7 @@
     "datasets": [
         {
             "repo_id": "TensorAuto/ice-lemonade",
-            "root": "/home/ashah/Documents/IceLemonade"
+            "root": "/path/to/local/dataset"
         }
     ]
 }

--- a/configs/examples/add_subtask_response.json
+++ b/configs/examples/add_subtask_response.json
@@ -1,0 +1,8 @@
+{
+    "datasets": [
+        {
+            "repo_id": "TensorAuto/ice-lemonade",
+            "root": "/home/ashah/Documents/IceLemonade"
+        }
+    ]
+}

--- a/docs/source/tutorials/datasets.rst
+++ b/docs/source/tutorials/datasets.rst
@@ -77,3 +77,76 @@ Each training config should contain a dataset mixture definition. To evaluate th
         --num_workers=10
 
 This will output a token count for each language key in the dataset mixture, and save it to ``outputs/stats/token_count.json``.
+
+Adding subtask responses to a dataset
+--------------------------------------
+
+Some policies (e.g. π0.5) can be trained with per-frame subtask annotations that tell the model *what* sub-goal is active at each timestep.
+The ``add_subtask_response`` script reads per-episode subtask JSON files, converts the time-based subtask boundaries to frame indices using the dataset FPS, and writes the active subtask string into a ``response`` column in each episode parquet file.
+
+Prerequisites:
+
+- Each dataset must have a ``subtask_path`` field in its ``meta/info.json`` that points to per-episode subtask JSON files
+  (e.g. ``"subtask_path": "subtask/episode_{episode_index:06d}.json"``).
+- Each subtask JSON is a list of objects with ``"time"`` (in seconds) and ``"subtask"`` (a string) keys:
+
+  .. code-block:: javascript
+
+      [
+          {"time": 0.0, "subtask": "pick up the cup"},
+          {"time": 2.5, "subtask": "pour water into the cup"},
+          {"time": 5.1, "subtask": "place the cup on the table"}
+      ]
+
+Create a config file that lists the datasets you want to process, each with a local ``root`` path:
+
+.. code-block:: javascript
+
+    {
+        "datasets": [
+            {
+                "repo_id": "TensorAuto/ice-lemonade",
+                "root": "/path/to/local/dataset"
+            }
+        ]
+    }
+
+Then run the script:
+
+.. code-block:: bash
+
+    python src/opentau/scripts/add_subtask_response.py \
+        --config_path=configs/examples/add_subtask_response.json
+
+The script will:
+
+1. Read ``meta/info.json`` for each dataset to determine the FPS and subtask file path template.
+2. For each episode, load the subtask JSON, map time-based boundaries to frame indices, and
+   assign the active subtask string to every frame in that range.
+3. Write (or overwrite) the ``response`` column in the episode parquet file.
+4. Add a ``response`` feature entry to ``meta/info.json`` if it doesn't already exist.
+
+If a subtask JSON is missing for an episode, the ``response`` column is filled with empty strings and a warning is emitted.
+
+To use the subtask responses during training, map the ``response`` key in your dataset config:
+
+.. code-block:: javascript
+
+    {
+        "dataset_mixture": {
+            "datasets": [
+                {
+                    "repo_id": "TensorAuto/IceLemonade_100",
+                    "data_features_name_mapping": {
+                        "camera0": "observation.images.rgb",
+                        "state": "observation.state",
+                        "actions": "action",
+                        "prompt": "task",
+                        "response": "response"
+                    }
+                }
+            ],
+            ...
+        },
+        ...
+    }

--- a/src/opentau/scripts/add_subtask_response.py
+++ b/src/opentau/scripts/add_subtask_response.py
@@ -26,12 +26,12 @@ If a subtask JSON is missing for an episode a warning is emitted and the
 Example::
 
     python src/opentau/scripts/add_subtask_response.py \
-        --config_path configs/examples/pi05_subtask.json
+        --config_path configs/examples/add_subtask_response.json
 """
 
 import json
 import logging
-import warnings
+import os
 from pathlib import Path
 
 import pyarrow as pa
@@ -46,9 +46,9 @@ from opentau.datasets.utils import (
     load_info,
     write_info,
 )
+from opentau.utils.utils import init_logging
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
 
 def _get_parquet_path(root: Path, data_path_template: str, ep_index: int, chunks_size: int) -> Path:
@@ -57,7 +57,7 @@ def _get_parquet_path(root: Path, data_path_template: str, ep_index: int, chunks
 
 
 def _build_response_array(
-    subtasks: list[dict],
+    subtasks: list[dict[str, float | str]],
     fps: int,
     episode_length: int,
     episode_index: int,
@@ -76,22 +76,24 @@ def _build_response_array(
     subtasks = sorted(subtasks, key=lambda s: s["time"])
 
     for i, entry in enumerate(subtasks):
-        start_frame = int(entry["time"] * fps)
+        start_frame = round(entry["time"] * fps)
         if start_frame >= episode_length:
-            warnings.warn(
-                f"Episode {episode_index}: subtask '{entry['subtask']}' starts at frame "
-                f"{start_frame} which is beyond episode length {episode_length}; skipping.",
-                stacklevel=2,
+            logger.warning(
+                "Episode %d: subtask '%s' starts at frame %d which is beyond episode length %d; skipping.",
+                episode_index,
+                entry["subtask"],
+                start_frame,
+                episode_length,
             )
             continue
 
         if i + 1 < len(subtasks):
-            end_frame = min(int(subtasks[i + 1]["time"] * fps), episode_length)
+            end_frame = min(round(subtasks[i + 1]["time"] * fps), episode_length)
         else:
             end_frame = episode_length
 
-        for f in range(start_frame, end_frame):
-            responses[f] = entry["subtask"]
+        if end_frame > start_frame:
+            responses[start_frame:end_frame] = [entry["subtask"]] * (end_frame - start_frame)
 
     return responses
 
@@ -133,31 +135,30 @@ def _process_dataset(root: Path) -> None:
         parquet_path = _get_parquet_path(root, data_path_template, ep_index, chunks_size)
 
         if not parquet_path.is_file():
-            warnings.warn(
-                f"Episode {ep_index}: parquet file not found at {parquet_path}; skipping.", stacklevel=2
-            )
+            logger.warning("Episode %d: parquet file not found at %s; skipping.", ep_index, parquet_path)
             continue
 
         subtask_file = root / subtask_path_template.format(episode_index=ep_index)
 
         if subtask_file.is_file():
             with open(subtask_file) as f:
-                subtasks: list[dict] = json.load(f)
+                subtasks: list[dict[str, float | str]] = json.load(f)
             responses = _build_response_array(subtasks, fps, ep_length, ep_index)
         else:
-            warnings.warn(
-                f"Episode {ep_index}: subtask file not found at {subtask_file}; "
-                "filling response with empty strings.",
-                stacklevel=2,
+            logger.warning(
+                "Episode %d: subtask file not found at %s; filling response with empty strings.",
+                ep_index,
+                subtask_file,
             )
             responses = [""] * ep_length
 
         table = pq.read_table(parquet_path)
         if table.num_rows != ep_length:
-            warnings.warn(
-                f"Episode {ep_index}: parquet has {table.num_rows} rows but "
-                f"episodes.jsonl reports length {ep_length}. Using parquet row count.",
-                stacklevel=2,
+            logger.warning(
+                "Episode %d: parquet has %d rows but episodes.jsonl reports length %d. Using parquet row count.",
+                ep_index,
+                table.num_rows,
+                ep_length,
             )
             if len(responses) < table.num_rows:
                 responses.extend([""] * (table.num_rows - len(responses)))
@@ -167,12 +168,22 @@ def _process_dataset(root: Path) -> None:
         response_col = pa.array(responses, type=pa.string())
 
         if "response" in table.column_names:
+            logger.warning(
+                "Episode %d: overwriting existing 'response' column in %s.", ep_index, parquet_path
+            )
             col_idx = table.schema.get_field_index("response")
             table = table.set_column(col_idx, "response", response_col)
         else:
             table = table.append_column("response", response_col)
 
-        pq.write_table(table, parquet_path)
+        tmp_path = parquet_path.with_suffix(parquet_path.suffix + ".tmp")
+        try:
+            pq.write_table(table, tmp_path)
+            os.replace(tmp_path, parquet_path)
+        except Exception:
+            if tmp_path.exists():
+                tmp_path.unlink()
+            raise
 
     if "response" not in info.get("features", {}):
         info.setdefault("features", {})["response"] = {
@@ -189,6 +200,8 @@ def _process_dataset(root: Path) -> None:
 @parser.wrap()
 def add_subtask_response(cfg: DatasetMixtureConfig) -> None:
     """Add subtask response column to all datasets in the mixture config."""
+    init_logging()
+
     if not cfg.datasets:
         raise ValueError("No datasets specified in the config.")
 

--- a/src/opentau/scripts/add_subtask_response.py
+++ b/src/opentau/scripts/add_subtask_response.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python
+#
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Add a ``response`` column to LeRobot dataset parquet files from per-episode subtask JSONs.
+
+For every episode the script reads the subtask JSON (located via the
+``subtask_path`` template in ``meta/info.json``), converts the time-based
+subtask boundaries to frame indices using the dataset FPS, and writes the
+active subtask string into a ``response`` column in the episode parquet.
+
+If a subtask JSON is missing for an episode a warning is emitted and the
+``response`` column is filled with empty strings.
+
+Example::
+
+    python src/opentau/scripts/add_subtask_response.py \
+        --config_path configs/examples/pi05_subtask.json
+"""
+
+import json
+import logging
+import warnings
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+from tqdm import tqdm
+
+from opentau.configs import parser
+from opentau.configs.default import DatasetMixtureConfig
+from opentau.datasets.utils import (
+    DEFAULT_CHUNK_SIZE,
+    load_episodes,
+    load_info,
+    write_info,
+)
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+
+def _get_parquet_path(root: Path, data_path_template: str, ep_index: int, chunks_size: int) -> Path:
+    ep_chunk = ep_index // chunks_size
+    return root / data_path_template.format(episode_chunk=ep_chunk, episode_index=ep_index)
+
+
+def _build_response_array(
+    subtasks: list[dict],
+    fps: int,
+    episode_length: int,
+    episode_index: int,
+) -> list[str]:
+    """Map time-based subtask entries to per-frame response strings.
+
+    Each frame between subtask *i*'s start frame and subtask *i+1*'s start
+    frame receives subtask *i*'s string.  The last subtask extends to the
+    end of the episode.  Frames before the first subtask's start frame
+    (if > 0) receive an empty string.
+    """
+    responses = [""] * episode_length
+    if not subtasks:
+        return responses
+
+    subtasks = sorted(subtasks, key=lambda s: s["time"])
+
+    for i, entry in enumerate(subtasks):
+        start_frame = int(entry["time"] * fps)
+        if start_frame >= episode_length:
+            warnings.warn(
+                f"Episode {episode_index}: subtask '{entry['subtask']}' starts at frame "
+                f"{start_frame} which is beyond episode length {episode_length}; skipping.",
+                stacklevel=2,
+            )
+            continue
+
+        if i + 1 < len(subtasks):
+            end_frame = min(int(subtasks[i + 1]["time"] * fps), episode_length)
+        else:
+            end_frame = episode_length
+
+        for f in range(start_frame, end_frame):
+            responses[f] = entry["subtask"]
+
+    return responses
+
+
+def _process_dataset(root: Path) -> None:
+    """Add ``response`` column to every episode parquet in one dataset."""
+    root = root.resolve()
+    if not root.is_dir():
+        raise ValueError(f"Dataset root does not exist: {root}")
+
+    info = load_info(root)
+    fps: int = info["fps"]
+    data_path_template: str = info["data_path"]
+    chunks_size: int = info.get("chunks_size", DEFAULT_CHUNK_SIZE)
+
+    subtask_path_template: str | None = info.get("subtask_path")
+    if subtask_path_template is None:
+        raise ValueError(
+            f"info.json at {root} does not contain a 'subtask_path' field. "
+            "Cannot locate per-episode subtask JSON files."
+        )
+
+    episodes = load_episodes(root)
+    if not episodes:
+        logger.warning("No episodes found in %s — nothing to do.", root)
+        return
+
+    logger.info(
+        "Processing %d episodes in %s (fps=%d, subtask_path=%s)",
+        len(episodes),
+        root,
+        fps,
+        subtask_path_template,
+    )
+
+    for ep_index in tqdm(sorted(episodes), desc=str(root.name), unit="ep"):
+        ep_info = episodes[ep_index]
+        ep_length: int = ep_info["length"]
+        parquet_path = _get_parquet_path(root, data_path_template, ep_index, chunks_size)
+
+        if not parquet_path.is_file():
+            warnings.warn(
+                f"Episode {ep_index}: parquet file not found at {parquet_path}; skipping.", stacklevel=2
+            )
+            continue
+
+        subtask_file = root / subtask_path_template.format(episode_index=ep_index)
+
+        if subtask_file.is_file():
+            with open(subtask_file) as f:
+                subtasks: list[dict] = json.load(f)
+            responses = _build_response_array(subtasks, fps, ep_length, ep_index)
+        else:
+            warnings.warn(
+                f"Episode {ep_index}: subtask file not found at {subtask_file}; "
+                "filling response with empty strings.",
+                stacklevel=2,
+            )
+            responses = [""] * ep_length
+
+        table = pq.read_table(parquet_path)
+        if table.num_rows != ep_length:
+            warnings.warn(
+                f"Episode {ep_index}: parquet has {table.num_rows} rows but "
+                f"episodes.jsonl reports length {ep_length}. Using parquet row count.",
+                stacklevel=2,
+            )
+            if len(responses) < table.num_rows:
+                responses.extend([""] * (table.num_rows - len(responses)))
+            else:
+                responses = responses[: table.num_rows]
+
+        response_col = pa.array(responses, type=pa.string())
+
+        if "response" in table.column_names:
+            col_idx = table.schema.get_field_index("response")
+            table = table.set_column(col_idx, "response", response_col)
+        else:
+            table = table.append_column("response", response_col)
+
+        pq.write_table(table, parquet_path)
+
+    if "response" not in info.get("features", {}):
+        info.setdefault("features", {})["response"] = {
+            "dtype": "string",
+            "shape": (1,),
+            "names": None,
+        }
+        write_info(info, root)
+        logger.info("Added 'response' feature to info.json")
+
+    logger.info("Done processing %s", root)
+
+
+@parser.wrap()
+def add_subtask_response(cfg: DatasetMixtureConfig) -> None:
+    """Add subtask response column to all datasets in the mixture config."""
+    if not cfg.datasets:
+        raise ValueError("No datasets specified in the config.")
+
+    for ds_cfg in cfg.datasets:
+        if ds_cfg.root is None:
+            raise ValueError(
+                f"Dataset '{ds_cfg.repo_id}' has no 'root' specified. "
+                "A local dataset root path is required for this script."
+            )
+        _process_dataset(Path(ds_cfg.root))
+
+
+if __name__ == "__main__":
+    add_subtask_response()

--- a/tests/scripts/test_add_subtask_response.py
+++ b/tests/scripts/test_add_subtask_response.py
@@ -1,0 +1,114 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import pytest
+
+from opentau.scripts.add_subtask_response import _build_response_array
+
+
+class TestBuildResponseArray:
+    def test_empty_subtasks_returns_empty_strings(self):
+        assert _build_response_array([], fps=30, episode_length=5, episode_index=0) == [""] * 5
+
+    def test_zero_length_episode(self):
+        assert (
+            _build_response_array([{"time": 0.0, "subtask": "a"}], fps=30, episode_length=0, episode_index=0)
+            == []
+        )
+
+    def test_single_subtask_covers_whole_episode(self):
+        subtasks = [{"time": 0.0, "subtask": "pick up cup"}]
+        out = _build_response_array(subtasks, fps=10, episode_length=5, episode_index=0)
+        assert out == ["pick up cup"] * 5
+
+    def test_two_subtasks_split_at_boundary(self):
+        subtasks = [
+            {"time": 0.0, "subtask": "a"},
+            {"time": 0.3, "subtask": "b"},
+        ]
+        # fps=10, so boundary is frame 3.
+        out = _build_response_array(subtasks, fps=10, episode_length=6, episode_index=0)
+        assert out == ["a", "a", "a", "b", "b", "b"]
+
+    def test_gap_before_first_subtask_gets_empty_string(self):
+        subtasks = [{"time": 0.2, "subtask": "a"}]
+        # fps=10 → starts at frame 2.
+        out = _build_response_array(subtasks, fps=10, episode_length=5, episode_index=0)
+        assert out == ["", "", "a", "a", "a"]
+
+    def test_last_subtask_extends_to_episode_end(self):
+        subtasks = [
+            {"time": 0.0, "subtask": "a"},
+            {"time": 0.2, "subtask": "b"},
+        ]
+        out = _build_response_array(subtasks, fps=10, episode_length=5, episode_index=0)
+        assert out == ["a", "a", "b", "b", "b"]
+
+    def test_unsorted_input_is_sorted_by_time(self):
+        subtasks = [
+            {"time": 0.3, "subtask": "b"},
+            {"time": 0.0, "subtask": "a"},
+        ]
+        out = _build_response_array(subtasks, fps=10, episode_length=6, episode_index=0)
+        assert out == ["a", "a", "a", "b", "b", "b"]
+
+    def test_subtask_beyond_episode_length_is_skipped(self, caplog):
+        subtasks = [
+            {"time": 0.0, "subtask": "a"},
+            {"time": 10.0, "subtask": "too_late"},
+        ]
+        with caplog.at_level("WARNING"):
+            out = _build_response_array(subtasks, fps=10, episode_length=5, episode_index=7)
+        assert out == ["a"] * 5
+        assert "too_late" in caplog.text
+        assert "Episode 7" in caplog.text
+
+    def test_boundary_clamped_to_episode_length(self):
+        subtasks = [
+            {"time": 0.0, "subtask": "a"},
+            {"time": 0.9, "subtask": "b"},
+        ]
+        # fps=10 → b would start at frame 9, but episode is length 5, so b is skipped.
+        out = _build_response_array(subtasks, fps=10, episode_length=5, episode_index=0)
+        assert out == ["a"] * 5
+
+    def test_rounding_handles_floating_point_drift(self):
+        # 2.5 * 30 = 74.99999... in fp64; int() would truncate to 74.
+        subtasks = [
+            {"time": 0.0, "subtask": "a"},
+            {"time": 2.5, "subtask": "b"},
+        ]
+        out = _build_response_array(subtasks, fps=30, episode_length=150, episode_index=0)
+        assert out[74] == "a"
+        assert out[75] == "b"
+
+    @pytest.mark.parametrize(
+        "subtasks,fps,length,expected",
+        [
+            # Simultaneous times: later in list wins only for the zero-width gap.
+            (
+                [
+                    {"time": 0.0, "subtask": "a"},
+                    {"time": 0.0, "subtask": "b"},
+                ],
+                10,
+                3,
+                ["b", "b", "b"],
+            ),
+        ],
+    )
+    def test_parametrized_edge_cases(self, subtasks, fps, length, expected):
+        assert _build_response_array(subtasks, fps=fps, episode_length=length, episode_index=0) == expected


### PR DESCRIPTION
## What this does
Adds script for adding subtask annotation to parquet files

## How it was tested
added subtask to Icelemonde dataset using the above script

## How to checkout & try? (for the reviewer)
python src/opentau/scripts/add_subtask_response.py \
        --config_path configs/examples/add_subtask_response.json

## Checklist

- [X] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
