### PR TITLE
fix: placeholder stats for deferred video keys respect channel axis

### DIFF
--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -1704,7 +1704,20 @@ class LeRobotDataset(BaseDataset):
         # (standardization, dataset mixing) never encounters missing keys.
         for key in deferred:
             shape = self.features[key]["shape"]
-            c = shape[0] if len(shape) >= 3 else 3
+            names = self.features[key].get("names") or []
+            # Locate channel axis; LeRobot v2.1's default image convention is
+            # (H, W, C) with names ["height", "width", "channel"], but some
+            # callers declare (C, H, W). Look it up by name, falling back to
+            # the CHW convention that aggregate_stats's (3, 1, 1) assertion
+            # ultimately expects.
+            if "channel" in names:
+                c = shape[names.index("channel")]
+            elif "channels" in names:
+                c = shape[names.index("channels")]
+            elif len(shape) >= 3:
+                c = shape[0]
+            else:
+                c = 3
             ep_stats[key] = {
                 "min": np.zeros((c, 1, 1), dtype=np.float64),
                 "max": np.ones((c, 1, 1), dtype=np.float64),

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -582,6 +582,50 @@ def test_deferred_video_attach_video(tmp_path, empty_lerobot_dataset_factory):
     assert result_path == expected_path
 
 
+def test_deferred_video_multi_episode_hwc_convention(tmp_path, empty_lerobot_dataset_factory):
+    """Saving two episodes in sequence with deferred video keys declared in
+    LeRobot v2.1's (H, W, C) convention must not crash.
+
+    Regression test for a bug in the placeholder-stats fallback: it assumed
+    shape[0] was the channel axis, which is true for (C, H, W) but produces
+    shape (H, 1, 1) for (H, W, C) — aggregate_stats then rejected it on the
+    second save_episode because its shape-check requires (3, 1, 1) for
+    features with 'image' in the key.
+    """
+    features = {
+        "state": {"dtype": "float32", "shape": (2,), "names": None},
+        "observation.images.top": {
+            "dtype": "video",
+            "shape": (96, 128, 3),
+            "names": ["height", "width", "channel"],
+            "info": None,
+        },
+    }
+    dataset = empty_lerobot_dataset_factory(
+        root=tmp_path / "hwc_test",
+        features=features,
+        deferred_video_keys={"observation.images.top"},
+    )
+    for ep in range(2):
+        for i in range(3):
+            dataset.add_frame(
+                {
+                    "state": np.array([float(i), float(i + ep)], dtype=np.float32),
+                    "task": "Dummy task",
+                }
+            )
+        dataset.save_episode()
+
+    assert dataset.meta.total_episodes == 2
+    # Placeholder stats for the deferred key must use the channel axis (3),
+    # not the height axis (96).
+    stats = dataset.meta.stats["observation.images.top"]
+    assert stats["min"].shape == (3, 1, 1)
+    assert stats["max"].shape == (3, 1, 1)
+    assert stats["mean"].shape == (3, 1, 1)
+    assert stats["std"].shape == (3, 1, 1)
+
+
 def test_deferred_video_invalid_key(tmp_path, empty_lerobot_dataset_factory):
     """Creating a dataset with invalid deferred video keys should raise ValueError."""
     features = {


### PR DESCRIPTION
## What this does

LeRobotDataset.save_episode synthesizes placeholder statistics for deferred video keys so downstream stat-aggregation code never sees a missing entry. The fallback pulled the channel count from shape[0], which is only correct for (C, H, W) callers — LeRobot v2.1's default image convention is (H, W, C) with names ["height", "width", "channel"], where shape[0] is the height.

Concretely, a 480×640×3 deferred video key produced placeholder stats with shape (480, 1, 1). On the second save_episode call, aggregate_stats → _assert_type_and_shape rejected it because the assertion requires (3, 1, 1) for any feature with "image" in the key. Datasets with only one episode never hit this because aggregate_stats needs two entries to merge.

Fix: look up the channel axis via the feature's ``names`` list (handling both "channel" and "channels"), falling back to the existing shape[0] behavior when names are absent or don't mention a channel axis, and to 3 as a last resort. Preserves current behavior for every (C, H, W) caller, including the existing tests at tests/datasets/test_datasets.py that declare shape (3, 96, 128) with names ["channels", ...].

Adds a regression test that declares a deferred video key in (H, W, C) order and saves two episodes — this fails on main and passes with the fix.

## How it was tested
Ran a test that declares a deferred video key in (H, W, C) order and saves two episodes — this fails on main and passes with the fix.

## How to checkout & try? (for the reviewer)
Run a test that declares a deferred video key in (H, W, C) order and saves two episodes — this fails on main and passes with the fix.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

