### PR TITLE
Add start_time validation for video resampling

### DIFF
--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -91,19 +91,19 @@ from abc import abstractmethod
 from pathlib import Path
 from typing import Callable
 
+import datasets
 import numpy as np
 import packaging.version
 import PIL.Image
 import torch
 import torch.nn.functional as F  # noqa: N812
 import torch.utils
+from datasets import concatenate_datasets, load_dataset
 from einops import rearrange
 from huggingface_hub import HfApi, snapshot_download
 from huggingface_hub.constants import REPOCARD_NAME
 from huggingface_hub.errors import RevisionNotFoundError
 
-import datasets
-from datasets import concatenate_datasets, load_dataset
 from opentau.configs.train import TrainPipelineConfig
 from opentau.constants import HF_OPENTAU_HOME
 from opentau.datasets.compute_stats import aggregate_stats, compute_episode_stats

--- a/src/opentau/datasets/video_utils.py
+++ b/src/opentau/datasets/video_utils.py
@@ -109,10 +109,9 @@ from typing import Any, ClassVar
 import pyarrow as pa
 import torch
 import torchvision
+from datasets.features.features import register_feature
 from packaging import version
 from PIL import Image
-
-from datasets.features.features import register_feature
 
 
 def get_safe_default_codec() -> str:

--- a/src/opentau/datasets/video_utils.py
+++ b/src/opentau/datasets/video_utils.py
@@ -97,6 +97,7 @@ Example:
 import importlib
 import json
 import logging
+import math
 import shutil
 import subprocess
 import warnings
@@ -702,6 +703,9 @@ def resample_and_trim_video(
 
     if target_fps <= 0:
         raise ValueError(f"`target_fps` must be > 0, got {target_fps}.")
+
+    if start_time is not None and (not math.isfinite(start_time) or start_time < 0):
+        raise ValueError(f"`start_time` must be a finite non-negative number, got {start_time}.")
 
     if not input_path.is_file():
         raise FileNotFoundError(f"Input video not found: {input_path}")

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -654,9 +654,7 @@ def test_deferred_video_attach_video_start_time(tmp_path):
         return dataset
 
     # Source video has time-varying content so different offsets yield different pixels.
-    src_video = _make_time_varying_mp4(
-        tmp_path / "source.mp4", fps=60, num_frames=300, width=128, height=96
-    )
+    src_video = _make_time_varying_mp4(tmp_path / "source.mp4", fps=60, num_frames=300, width=128, height=96)
 
     ds_no_offset = _build_dataset(tmp_path / "ds_no_offset")
     ds_no_offset.attach_video(
@@ -675,12 +673,8 @@ def test_deferred_video_attach_video_start_time(tmp_path):
         start_time=2.0,
     )
 
-    path_no_offset = ds_no_offset.root / ds_no_offset.meta.get_video_file_path(
-        0, "observation.images.top"
-    )
-    path_offset = ds_offset.root / ds_offset.meta.get_video_file_path(
-        0, "observation.images.top"
-    )
+    path_no_offset = ds_no_offset.root / ds_no_offset.meta.get_video_file_path(0, "observation.images.top")
+    path_offset = ds_offset.root / ds_offset.meta.get_video_file_path(0, "observation.images.top")
 
     frames_no_offset = decode_video_frames(path_no_offset, [0.0], tolerance_s=0.1)
     frames_offset = decode_video_frames(path_offset, [0.0], tolerance_s=0.1)

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -491,6 +491,42 @@ def _make_dummy_mp4(path, fps=60, num_frames=100, width=128, height=96):
     return path
 
 
+def _make_time_varying_mp4(path, fps=60, num_frames=300, width=128, height=96):
+    """Create an MP4 whose content changes over time.
+
+    Uses ffmpeg's ``testsrc2`` filter, which renders a test card with a
+    changing timer — every frame is visibly different from the last.
+    """
+    import shutil
+    import subprocess
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    ffmpeg = shutil.which("ffmpeg")
+    if ffmpeg is None:
+        pytest.skip("ffmpeg not available")
+    duration = num_frames / fps
+    subprocess.run(
+        [
+            ffmpeg,
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            f"testsrc2=size={width}x{height}:rate={fps}:duration={duration:.6f}",
+            "-pix_fmt",
+            "yuv420p",
+            "-c:v",
+            "libx264",
+            "-g",
+            "2",
+            str(path),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return path
+
+
 def test_deferred_video_add_frame_and_save(tmp_path, empty_lerobot_dataset_factory):
     """Test that frames can be added without image data for deferred video keys."""
     features = {
@@ -580,6 +616,96 @@ def test_deferred_video_attach_video(tmp_path, empty_lerobot_dataset_factory):
     expected_path = dataset.root / dataset.meta.get_video_file_path(0, "observation.images.top")
     assert expected_path.is_file()
     assert result_path == expected_path
+
+
+def test_deferred_video_attach_video_start_time(tmp_path):
+    """A non-zero ``start_time`` must shift the extracted segment."""
+    from opentau.datasets.video_utils import decode_video_frames
+
+    features = {
+        "state": {"dtype": "float32", "shape": (2,), "names": None},
+        "observation.images.top": {
+            "dtype": "video",
+            "shape": (3, 96, 128),
+            "names": ["channels", "height", "width"],
+            "info": None,
+        },
+    }
+    target_fps = 10
+    num_frames = 5
+
+    def _build_dataset(root):
+        dataset = LeRobotDataset.create(
+            repo_id=DUMMY_REPO_ID,
+            fps=target_fps,
+            root=root,
+            features=features,
+            deferred_video_keys={"observation.images.top"},
+            standardize=False,
+        )
+        for i in range(num_frames):
+            dataset.add_frame(
+                {
+                    "state": np.array([float(i), float(i + 1)], dtype=np.float32),
+                    "task": "Dummy task",
+                }
+            )
+        dataset.save_episode()
+        return dataset
+
+    # Source video has time-varying content so different offsets yield different pixels.
+    src_video = _make_time_varying_mp4(
+        tmp_path / "source.mp4", fps=60, num_frames=300, width=128, height=96
+    )
+
+    ds_no_offset = _build_dataset(tmp_path / "ds_no_offset")
+    ds_no_offset.attach_video(
+        episode_index=0,
+        video_key="observation.images.top",
+        input_video_path=src_video,
+        overwrite=True,
+    )
+
+    ds_offset = _build_dataset(tmp_path / "ds_offset")
+    ds_offset.attach_video(
+        episode_index=0,
+        video_key="observation.images.top",
+        input_video_path=src_video,
+        overwrite=True,
+        start_time=2.0,
+    )
+
+    path_no_offset = ds_no_offset.root / ds_no_offset.meta.get_video_file_path(
+        0, "observation.images.top"
+    )
+    path_offset = ds_offset.root / ds_offset.meta.get_video_file_path(
+        0, "observation.images.top"
+    )
+
+    frames_no_offset = decode_video_frames(path_no_offset, [0.0], tolerance_s=0.1)
+    frames_offset = decode_video_frames(path_offset, [0.0], tolerance_s=0.1)
+
+    assert frames_no_offset.shape == frames_offset.shape
+    # The two first frames should be clearly distinct (testsrc2 is different every frame).
+    assert not torch.allclose(frames_no_offset, frames_offset, atol=1e-2)
+
+
+def test_resample_and_trim_video_invalid_start_time(tmp_path):
+    """``start_time`` must be finite and non-negative."""
+    from opentau.datasets.video_utils import resample_and_trim_video
+
+    src = _make_dummy_mp4(tmp_path / "src.mp4", fps=30, num_frames=30)
+    out = tmp_path / "out.mp4"
+
+    for bad in (-1.0, float("inf"), float("-inf"), float("nan")):
+        with pytest.raises(ValueError, match="start_time"):
+            resample_and_trim_video(
+                input_path=src,
+                output_path=out,
+                target_fps=10,
+                num_frames=5,
+                start_time=bad,
+            )
 
 
 def test_deferred_video_invalid_key(tmp_path, empty_lerobot_dataset_factory):


### PR DESCRIPTION
## What this does
Adds validation for the `start_time` parameter in `resample_and_trim_video()` to ensure it is a finite non-negative number. This prevents invalid inputs (negative values, infinity, NaN) from being silently accepted.

**Label:** 🐛 Bug

## How it was tested
Added two new test cases:
1. `test_deferred_video_attach_video_start_time` - Tests that `start_time` correctly shifts the extracted video segment by comparing frames extracted with and without an offset from a time-varying video source.
2. `test_resample_and_trim_video_invalid_start_time` - Tests that invalid `start_time` values (-1.0, inf, -inf, nan) raise `ValueError` with appropriate error message.

Also added helper function `_make_time_varying_mp4()` to generate test videos with time-varying content (using ffmpeg's `testsrc2` filter) to enable proper validation of video segment extraction.

## How to checkout & try?
```bash
pytest -sx tests/datasets/test_datasets.py::test_deferred_video_attach_video_start_time
pytest -sx tests/datasets/test_datasets.py::test_resample_and_trim_video_invalid_start_time
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.

https://claude.ai/code/session_019kspWqq95n9fBHrtdAEiV7