### PR TITLE
perf: parallelize ffmpeg trims in segment_lerobot_dataset

### DIFF
--- a/src/opentau/scripts/segment_lerobot_dataset.py
+++ b/src/opentau/scripts/segment_lerobot_dataset.py
@@ -29,6 +29,7 @@ An example of segments.json can be found in `configs/examples/segments.json`.
 
 import argparse
 import json
+import logging
 import math
 import os
 import shutil
@@ -54,6 +55,10 @@ from opentau.datasets.utils import (
     write_json,
 )
 
+logger = logging.getLogger(__name__)
+
+FFMPEG_MAX_WORKERS_ENV_VAR = "OPENTAU_FFMPEG_MAX_WORKERS"
+
 
 def parse_args() -> argparse.Namespace:
     """Parse command-line arguments for dataset segmentation.
@@ -69,6 +74,17 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("input_root", type=Path, help="Path to source LeRobot dataset root.")
     parser.add_argument("output_root", type=Path, help="Path to output dataset root (must not exist).")
     parser.add_argument("segments_json", type=Path, help="Path to JSON segmentation plan.")
+    parser.add_argument(
+        "--ffmpeg-max-workers",
+        type=int,
+        default=None,
+        help=(
+            "Override the worker count used to dispatch parallel ffmpeg trim jobs. "
+            "Must be an integer in [1, 64]. When unset, falls back to the "
+            f"{FFMPEG_MAX_WORKERS_ENV_VAR} environment variable, then to "
+            "min(16, (os.cpu_count() or 4) * 2)."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -191,48 +207,68 @@ def _trim_video_segment(src_video_path: Path, dst_video_path: Path, start_frame:
         )
 
 
-def _trim_video_segment_job(task: tuple[Path, Path, int, int]) -> None:
-    """Run a single ffmpeg trim as a worker callable for ``ThreadPoolExecutor``.
-
-    This is a thin adapter around :func:`_trim_video_segment` that unpacks a
-    4-tuple task, so the trim calls can be submitted to a pool without
-    capturing local variables from the main loop.
-
-    Args:
-        task: A tuple ``(src_video_path, dst_video_path, start_frame, end_frame)``
-            describing one trim job. ``start_frame`` is inclusive and
-            ``end_frame`` is exclusive, matching the source parquet indexing.
-
-    Raises:
-        RuntimeError: Propagated from :func:`_trim_video_segment` if the
-            underlying ffmpeg process returns a non-zero exit code.
-    """
-    src_video_path, dst_video_path, start_frame, end_frame = task
-    _trim_video_segment(src_video_path, dst_video_path, start_frame, end_frame)
-
-
-def _ffmpeg_trim_max_workers() -> int:
+def _ffmpeg_trim_max_workers(override: int | None = None) -> int:
     """Return the worker count for parallel ffmpeg trimming.
 
-    The value is resolved in this order:
+    Resolution order:
 
-    1. If the environment variable ``TUNER_FFMPEG_MAX_WORKERS`` is set to an
-       integer in the closed range ``[1, 64]``, that value is used. Values
-       outside the range or non-integer values are silently ignored.
-    2. Otherwise, fall back to ``min(16, (os.cpu_count() or 4) * 2)``. The
-       ``* 2`` over-subscription is intentional because each worker spends
-       most of its time waiting on an external ffmpeg subprocess (I/O bound),
-       and the hard cap of 16 prevents thrashing on large machines.
+    1. If ``override`` is not ``None``, it is treated as the authoritative
+       value (typically sourced from the ``--ffmpeg-max-workers`` CLI flag).
+       It must be an integer in the closed range ``[1, 64]``; otherwise
+       :class:`ValueError` is raised — explicit user overrides never fall
+       back silently.
+    2. Otherwise, if the environment variable ``OPENTAU_FFMPEG_MAX_WORKERS``
+       is set, it must parse as an integer in ``[1, 64]``. Invalid or
+       out-of-range values are rejected with a logged warning and the
+       default is used instead (never silently fall through).
+    3. Otherwise, fall back to ``min(16, (os.cpu_count() or 4) * 2)``.
+
+    The default is a pragmatic cap for dispatching external ffmpeg
+    processes. ``ThreadPoolExecutor`` is appropriate here because the
+    Python threads only launch subprocesses and wait for them to finish;
+    the actual work happens in ffmpeg itself, so the GIL is not a concern.
+    For CPU-heavy codecs (e.g. AV1 software decode), shared decoder CPU can
+    become the bottleneck before the worker count is saturated — in that
+    case tune via ``--ffmpeg-max-workers`` or the environment variable.
+
+    Args:
+        override: Explicit worker count from a CLI flag. ``None`` means no
+            override was provided; otherwise it must be in ``[1, 64]``.
 
     Returns:
         The number of threads to use in the ``ThreadPoolExecutor`` that
         dispatches ffmpeg trim jobs. Guaranteed to be at least ``1``.
+
+    Raises:
+        ValueError: If ``override`` is provided but not an integer in
+            ``[1, 64]``.
     """
-    raw = os.environ.get("TUNER_FFMPEG_MAX_WORKERS", "").strip()
-    if raw.isdigit():
-        v = int(raw)
-        if 1 <= v <= 64:
-            return v
+    if override is not None:
+        if not isinstance(override, int) or isinstance(override, bool) or not (1 <= override <= 64):
+            raise ValueError(
+                f"--ffmpeg-max-workers must be an integer in [1, 64], got {override!r}."
+            )
+        return override
+
+    raw = os.environ.get(FFMPEG_MAX_WORKERS_ENV_VAR)
+    if raw is not None and raw.strip() != "":
+        stripped = raw.strip()
+        try:
+            v = int(stripped)
+        except ValueError:
+            logger.warning(
+                "Ignoring %s=%r: not an integer. Falling back to the default worker count.",
+                FFMPEG_MAX_WORKERS_ENV_VAR,
+                raw,
+            )
+        else:
+            if 1 <= v <= 64:
+                return v
+            logger.warning(
+                "Ignoring %s=%d: outside the allowed range [1, 64]. Falling back to the default worker count.",
+                FFMPEG_MAX_WORKERS_ENV_VAR,
+                v,
+            )
     cpu = os.cpu_count() or 4
     return max(1, min(16, cpu * 2))
 
@@ -327,6 +363,7 @@ def segment_dataset(
     input_root: Path,
     output_root: Path,
     segments_by_episode: dict[int, list[tuple[int, int]]],
+    ffmpeg_max_workers: int | None = None,
 ) -> None:
     """Create a new segmented dataset from one or more source episodes.
 
@@ -335,6 +372,10 @@ def segment_dataset(
         output_root: Destination directory for the new dataset. Must not exist.
         segments_by_episode: Mapping from source episode id to list of
             ``(start, end)`` frame ranges in ``[start, end)`` form.
+        ffmpeg_max_workers: Explicit worker count for the parallel ffmpeg
+            trim pool. ``None`` lets :func:`_ffmpeg_trim_max_workers` decide
+            based on the ``OPENTAU_FFMPEG_MAX_WORKERS`` env var or the
+            CPU-based default.
 
     Notes:
         For visual features (``dtype`` in ``{"image", "video"}``), per-episode
@@ -528,16 +569,20 @@ def segment_dataset(
                 pbar.update(seg_len)
 
     if ffmpeg_jobs:
-        n_workers = _ffmpeg_trim_max_workers()
+        n_workers = _ffmpeg_trim_max_workers(ffmpeg_max_workers)
         with ThreadPoolExecutor(max_workers=n_workers) as pool:
-            futures = [pool.submit(_trim_video_segment_job, job) for job in ffmpeg_jobs]
-            for fut in tqdm(
-                as_completed(futures),
-                total=len(futures),
-                desc=f"Trimming videos ({n_workers} workers)",
-                unit="clip",
-            ):
-                fut.result()
+            futures = [pool.submit(_trim_video_segment, *job) for job in ffmpeg_jobs]
+            try:
+                for fut in tqdm(
+                    as_completed(futures),
+                    total=len(futures),
+                    desc=f"Trimming videos ({n_workers} workers)",
+                    unit="clip",
+                ):
+                    fut.result()
+            except BaseException:
+                pool.shutdown(wait=False, cancel_futures=True)
+                raise
 
     for episode in output_episodes:
         append_jsonlines(episode, output_root / EPISODES_PATH)
@@ -561,6 +606,7 @@ def main() -> None:
         input_root=args.input_root,
         output_root=args.output_root,
         segments_by_episode=segments_by_episode,
+        ffmpeg_max_workers=args.ffmpeg_max_workers,
     )
 
 

--- a/src/opentau/scripts/segment_lerobot_dataset.py
+++ b/src/opentau/scripts/segment_lerobot_dataset.py
@@ -30,8 +30,10 @@ An example of segments.json can be found in `configs/examples/segments.json`.
 import argparse
 import json
 import math
+import os
 import shutil
 import subprocess
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from copy import deepcopy
 from pathlib import Path
 from typing import Any, cast
@@ -187,6 +189,22 @@ def _trim_video_segment(src_video_path: Path, dst_video_path: Path, start_frame:
             f"Failed to trim video segment {start_frame}:{end_frame} from '{src_video_path}'. "
             f"ffmpeg stderr: {result.stderr.strip()}"
         )
+
+
+def _trim_video_segment_job(task: tuple[Path, Path, int, int]) -> None:
+    """Worker entry for parallel ffmpeg (ThreadPoolExecutor)."""
+    src_video_path, dst_video_path, start_frame, end_frame = task
+    _trim_video_segment(src_video_path, dst_video_path, start_frame, end_frame)
+
+
+def _ffmpeg_trim_max_workers() -> int:
+    raw = os.environ.get("TUNER_FFMPEG_MAX_WORKERS", "").strip()
+    if raw.isdigit():
+        v = int(raw)
+        if 1 <= v <= 64:
+            return v
+    cpu = os.cpu_count() or 4
+    return max(1, min(16, cpu * 2))
 
 
 def _copy_segment_images_and_rewrite_column(
@@ -348,6 +366,7 @@ def segment_dataset(
     video_path_template_str = cast(str, video_path_template) if video_path_template is not None else ""
     source_tables: dict[int, pa.Table] = {}
     output_episode_index = 0
+    ffmpeg_jobs: list[tuple[Path, Path, int, int]] = []
 
     with tqdm(total=total_frames_to_process, desc="Segmenting frames", unit="frame") as pbar:
         for episode_id, segments in segments_by_episode.items():
@@ -461,7 +480,7 @@ def segment_dataset(
 
                 write_episode_stats(output_episode_index, episode_stats, output_root)
 
-                # Copy and trim source videos for this segment, if any.
+                # Defer ffmpeg trims — run in parallel after all parquet/stats are written.
                 for video_key in source_meta.video_keys:
                     src_video_path = input_root / source_meta.get_video_file_path(episode_id, video_key)
                     if not src_video_path.is_file():
@@ -472,11 +491,23 @@ def segment_dataset(
                         episode_index=output_episode_index,
                     )
                     dst_video_path.parent.mkdir(parents=True, exist_ok=True)
-                    _trim_video_segment(src_video_path, dst_video_path, start, end)
+                    ffmpeg_jobs.append((src_video_path, dst_video_path, start, end))
 
                 global_index_offset += seg_len
                 output_episode_index += 1
                 pbar.update(seg_len)
+
+    if ffmpeg_jobs:
+        n_workers = _ffmpeg_trim_max_workers()
+        with ThreadPoolExecutor(max_workers=n_workers) as pool:
+            futures = [pool.submit(_trim_video_segment_job, job) for job in ffmpeg_jobs]
+            for fut in tqdm(
+                as_completed(futures),
+                total=len(futures),
+                desc=f"Trimming videos ({n_workers} workers)",
+                unit="clip",
+            ):
+                fut.result()
 
     for episode in output_episodes:
         append_jsonlines(episode, output_root / EPISODES_PATH)

--- a/src/opentau/scripts/segment_lerobot_dataset.py
+++ b/src/opentau/scripts/segment_lerobot_dataset.py
@@ -192,12 +192,42 @@ def _trim_video_segment(src_video_path: Path, dst_video_path: Path, start_frame:
 
 
 def _trim_video_segment_job(task: tuple[Path, Path, int, int]) -> None:
-    """Worker entry for parallel ffmpeg (ThreadPoolExecutor)."""
+    """Run a single ffmpeg trim as a worker callable for ``ThreadPoolExecutor``.
+
+    This is a thin adapter around :func:`_trim_video_segment` that unpacks a
+    4-tuple task, so the trim calls can be submitted to a pool without
+    capturing local variables from the main loop.
+
+    Args:
+        task: A tuple ``(src_video_path, dst_video_path, start_frame, end_frame)``
+            describing one trim job. ``start_frame`` is inclusive and
+            ``end_frame`` is exclusive, matching the source parquet indexing.
+
+    Raises:
+        RuntimeError: Propagated from :func:`_trim_video_segment` if the
+            underlying ffmpeg process returns a non-zero exit code.
+    """
     src_video_path, dst_video_path, start_frame, end_frame = task
     _trim_video_segment(src_video_path, dst_video_path, start_frame, end_frame)
 
 
 def _ffmpeg_trim_max_workers() -> int:
+    """Return the worker count for parallel ffmpeg trimming.
+
+    The value is resolved in this order:
+
+    1. If the environment variable ``TUNER_FFMPEG_MAX_WORKERS`` is set to an
+       integer in the closed range ``[1, 64]``, that value is used. Values
+       outside the range or non-integer values are silently ignored.
+    2. Otherwise, fall back to ``min(16, (os.cpu_count() or 4) * 2)``. The
+       ``* 2`` over-subscription is intentional because each worker spends
+       most of its time waiting on an external ffmpeg subprocess (I/O bound),
+       and the hard cap of 16 prevents thrashing on large machines.
+
+    Returns:
+        The number of threads to use in the ``ThreadPoolExecutor`` that
+        dispatches ffmpeg trim jobs. Guaranteed to be at least ``1``.
+    """
     raw = os.environ.get("TUNER_FFMPEG_MAX_WORKERS", "").strip()
     if raw.isdigit():
         v = int(raw)

--- a/src/opentau/scripts/segment_lerobot_dataset.py
+++ b/src/opentau/scripts/segment_lerobot_dataset.py
@@ -245,9 +245,7 @@ def _ffmpeg_trim_max_workers(override: int | None = None) -> int:
     """
     if override is not None:
         if not isinstance(override, int) or isinstance(override, bool) or not (1 <= override <= 64):
-            raise ValueError(
-                f"--ffmpeg-max-workers must be an integer in [1, 64], got {override!r}."
-            )
+            raise ValueError(f"--ffmpeg-max-workers must be an integer in [1, 64], got {override!r}.")
         return override
 
     raw = os.environ.get(FFMPEG_MAX_WORKERS_ENV_VAR)

--- a/tests/datasets/test_segment_lerobot_dataset.py
+++ b/tests/datasets/test_segment_lerobot_dataset.py
@@ -23,8 +23,20 @@ import pyarrow.parquet as pq
 import pytest
 
 from opentau.datasets.lerobot_dataset import LeRobotDatasetMetadata
-from opentau.datasets.utils import load_episodes, load_episodes_stats, load_info, write_json, write_stats
-from opentau.scripts.segment_lerobot_dataset import _load_segments_by_episode, segment_dataset
+from opentau.datasets.utils import (
+    DEFAULT_VIDEO_PATH,
+    load_episodes,
+    load_episodes_stats,
+    load_info,
+    write_json,
+    write_stats,
+)
+from opentau.scripts.segment_lerobot_dataset import (
+    FFMPEG_MAX_WORKERS_ENV_VAR,
+    _ffmpeg_trim_max_workers,
+    _load_segments_by_episode,
+    segment_dataset,
+)
 
 
 def _extract_image_path(cell: Any) -> str | None:
@@ -431,3 +443,293 @@ def test_trim_video_segment_uses_frame_range_filter(tmp_path: Path) -> None:
     assert "-vf" in cmd
     vf_expr = cmd[cmd.index("-vf") + 1]
     assert "trim=start_frame=5:end_frame=15" in vf_expr
+
+
+@pytest.mark.parametrize("valid", ["1", "8", "64", " 16 ", "+4"])
+def test_ffmpeg_trim_max_workers_env_var_valid(monkeypatch: pytest.MonkeyPatch, valid: str) -> None:
+    """Valid integer env values in [1, 64] are used verbatim.
+
+    Leading ``+`` signs are accepted (regression guard for the pre-review
+    ``isdigit()`` check, which rejected them silently).
+
+    Args:
+        monkeypatch: pytest fixture for environment manipulation.
+        valid: A string representation of a valid worker count.
+    """
+    monkeypatch.setenv(FFMPEG_MAX_WORKERS_ENV_VAR, valid)
+    assert _ffmpeg_trim_max_workers() == int(valid.strip())
+
+
+@pytest.mark.parametrize("bad", ["0", "-1", "65", "100", "abc", "", "  ", "3.14"])
+def test_ffmpeg_trim_max_workers_env_var_invalid_falls_back(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, bad: str
+) -> None:
+    """Invalid env values are rejected with a warning and ignored.
+
+    Args:
+        monkeypatch: pytest fixture for environment manipulation.
+        caplog: pytest fixture capturing emitted log records.
+        bad: A string representation of a rejected value.
+    """
+    monkeypatch.setenv(FFMPEG_MAX_WORKERS_ENV_VAR, bad)
+    monkeypatch.setattr("opentau.scripts.segment_lerobot_dataset.os.cpu_count", lambda: 4)
+    with caplog.at_level("WARNING", logger="opentau.scripts.segment_lerobot_dataset"):
+        result = _ffmpeg_trim_max_workers()
+    # CPU-based default: min(16, (4)*2) == 8
+    assert result == 8
+    # Empty / whitespace values are indistinguishable from unset and should
+    # not emit a warning. Every other rejected value must log one.
+    if bad.strip() != "":
+        assert any(FFMPEG_MAX_WORKERS_ENV_VAR in rec.message for rec in caplog.records)
+
+
+def test_ffmpeg_trim_max_workers_env_var_unset_uses_cpu_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the env var is unset, the CPU-based default is returned.
+
+    Args:
+        monkeypatch: pytest fixture for environment manipulation.
+    """
+    monkeypatch.delenv(FFMPEG_MAX_WORKERS_ENV_VAR, raising=False)
+    monkeypatch.setattr("opentau.scripts.segment_lerobot_dataset.os.cpu_count", lambda: 6)
+    # min(16, 6*2) == 12
+    assert _ffmpeg_trim_max_workers() == 12
+
+
+def test_ffmpeg_trim_max_workers_env_var_caps_at_16(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The CPU-based default is capped at 16 even on large machines.
+
+    Args:
+        monkeypatch: pytest fixture for environment manipulation.
+    """
+    monkeypatch.delenv(FFMPEG_MAX_WORKERS_ENV_VAR, raising=False)
+    monkeypatch.setattr("opentau.scripts.segment_lerobot_dataset.os.cpu_count", lambda: 128)
+    assert _ffmpeg_trim_max_workers() == 16
+
+
+def test_ffmpeg_trim_max_workers_handles_none_cpu_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``os.cpu_count()`` returning ``None`` must not crash the helper.
+
+    Args:
+        monkeypatch: pytest fixture for environment manipulation.
+    """
+    monkeypatch.delenv(FFMPEG_MAX_WORKERS_ENV_VAR, raising=False)
+    monkeypatch.setattr("opentau.scripts.segment_lerobot_dataset.os.cpu_count", lambda: None)
+    # Fallback cpu=4 -> min(16, 8) == 8
+    assert _ffmpeg_trim_max_workers() == 8
+
+
+@pytest.mark.parametrize("override", [1, 8, 64])
+def test_ffmpeg_trim_max_workers_override_takes_precedence(
+    monkeypatch: pytest.MonkeyPatch, override: int
+) -> None:
+    """An explicit override wins over the env var and the CPU default.
+
+    Args:
+        monkeypatch: pytest fixture for environment manipulation.
+        override: The integer override under test.
+    """
+    monkeypatch.setenv(FFMPEG_MAX_WORKERS_ENV_VAR, "32")
+    assert _ffmpeg_trim_max_workers(override) == override
+
+
+@pytest.mark.parametrize("bad", [0, -1, 65, 100, True, 3.14, "4"])
+def test_ffmpeg_trim_max_workers_rejects_invalid_override(bad: Any) -> None:
+    """Invalid overrides must raise ValueError, not silently fall back.
+
+    Args:
+        bad: A value that must be rejected by the override path.
+    """
+    with pytest.raises(ValueError, match=r"--ffmpeg-max-workers"):
+        _ffmpeg_trim_max_workers(bad)
+
+
+def _inject_fake_video_feature(input_root: Path, video_key: str) -> Path:
+    """Declare a fake video feature on an image dataset and materialize the file.
+
+    Registers a ``dtype=video`` entry under ``meta/info.json`` and creates a
+    zero-byte stub file at the canonical video path so
+    :func:`segment_dataset` will enqueue an ffmpeg job for it (we mock
+    ``_trim_video_segment`` in tests, so the stub never has to be playable).
+
+    Args:
+        input_root: Root of the source dataset to mutate in place.
+        video_key: Feature key for the fake video stream.
+
+    Returns:
+        Absolute path to the created stub video file.
+    """
+    info = load_info(input_root)
+    info["features"][video_key] = {
+        "dtype": "video",
+        "shape": [3, 8, 8],
+        "names": ["channel", "height", "width"],
+        "info": {
+            "video.fps": info.get("fps", 30),
+            "video.codec": "mp4v",
+            "video.pix_fmt": "yuv420p",
+            "video.is_depth_map": False,
+            "has_audio": False,
+        },
+    }
+    if info.get("video_path") is None:
+        info["video_path"] = DEFAULT_VIDEO_PATH
+    write_json(info, input_root / "meta" / "info.json")
+
+    rel_path = DEFAULT_VIDEO_PATH.format(
+        episode_chunk=0, video_key=video_key, episode_index=0
+    )
+    src_video = input_root / rel_path
+    src_video.parent.mkdir(parents=True, exist_ok=True)
+    src_video.write_bytes(b"fake-video-stub")
+    return src_video
+
+
+def test_segment_dataset_dispatches_ffmpeg_jobs_in_parallel(
+    tmp_path: Path, empty_lerobot_dataset_factory: Any
+) -> None:
+    """Assert segment_dataset submits one trim per (segment, video_key) and
+    propagates worker results via fut.result().
+
+    Args:
+        tmp_path: Temporary directory fixture provided by pytest.
+        empty_lerobot_dataset_factory: Fixture that creates a writable dataset.
+    """
+    input_root = tmp_path / "src_with_fake_video"
+    output_root = tmp_path / "dst_with_fake_video"
+    features = {
+        "state": {"dtype": "float32", "shape": (1,), "names": None},
+        "actions": {"dtype": "float32", "shape": (1,), "names": None},
+    }
+    dataset = empty_lerobot_dataset_factory(root=input_root, features=features, use_videos=False)
+    for i in range(8):
+        dataset.add_frame(
+            {
+                "state": np.array([float(i)], dtype=np.float32),
+                "actions": np.array([float(i)], dtype=np.float32),
+                "task": "parallel-dispatch",
+            }
+        )
+    dataset.save_episode()
+
+    video_key = "observation.images.fake_cam"
+    _inject_fake_video_feature(input_root, video_key)
+
+    with patch(
+        "opentau.scripts.segment_lerobot_dataset._trim_video_segment"
+    ) as trim_mock:
+        segment_dataset(
+            input_root=input_root,
+            output_root=output_root,
+            segments_by_episode={0: [(0, 3), (3, 8)]},
+        )
+
+    # 2 segments × 1 fake video key = 2 trim calls.
+    assert trim_mock.call_count == 2
+    frame_ranges = sorted(
+        (call.args[2], call.args[3]) for call in trim_mock.call_args_list
+    )
+    assert frame_ranges == [(0, 3), (3, 8)]
+    for call in trim_mock.call_args_list:
+        src_path, dst_path, *_ = call.args
+        assert Path(src_path).is_file()
+        # Parent directory for the destination must be pre-created by the main
+        # loop so workers never race on mkdir.
+        assert Path(dst_path).parent.is_dir()
+
+
+def test_segment_dataset_propagates_worker_exceptions(
+    tmp_path: Path, empty_lerobot_dataset_factory: Any
+) -> None:
+    """Exceptions raised inside ffmpeg workers must surface via fut.result().
+
+    Regression guard for accidentally dropping ``fut.result()`` in the
+    parallel-dispatch loop.
+
+    Args:
+        tmp_path: Temporary directory fixture provided by pytest.
+        empty_lerobot_dataset_factory: Fixture that creates a writable dataset.
+    """
+    input_root = tmp_path / "src_worker_error"
+    output_root = tmp_path / "dst_worker_error"
+    features = {
+        "state": {"dtype": "float32", "shape": (1,), "names": None},
+        "actions": {"dtype": "float32", "shape": (1,), "names": None},
+    }
+    dataset = empty_lerobot_dataset_factory(root=input_root, features=features, use_videos=False)
+    for i in range(6):
+        dataset.add_frame(
+            {
+                "state": np.array([float(i)], dtype=np.float32),
+                "actions": np.array([float(i)], dtype=np.float32),
+                "task": "worker-error",
+            }
+        )
+    dataset.save_episode()
+
+    _inject_fake_video_feature(input_root, "observation.images.fake_cam")
+
+    def _boom(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError("synthetic ffmpeg failure")
+
+    with (
+        patch("opentau.scripts.segment_lerobot_dataset._trim_video_segment", side_effect=_boom),
+        pytest.raises(RuntimeError, match="synthetic ffmpeg failure"),
+    ):
+        segment_dataset(
+            input_root=input_root,
+            output_root=output_root,
+            segments_by_episode={0: [(0, 2), (2, 6)]},
+        )
+
+
+def test_segment_dataset_accepts_ffmpeg_max_workers_override(
+    tmp_path: Path, empty_lerobot_dataset_factory: Any
+) -> None:
+    """The ``ffmpeg_max_workers`` kwarg must reach ``ThreadPoolExecutor``.
+
+    Args:
+        tmp_path: Temporary directory fixture provided by pytest.
+        empty_lerobot_dataset_factory: Fixture that creates a writable dataset.
+    """
+    input_root = tmp_path / "src_pool_size"
+    output_root = tmp_path / "dst_pool_size"
+    features = {
+        "state": {"dtype": "float32", "shape": (1,), "names": None},
+        "actions": {"dtype": "float32", "shape": (1,), "names": None},
+    }
+    dataset = empty_lerobot_dataset_factory(root=input_root, features=features, use_videos=False)
+    for i in range(4):
+        dataset.add_frame(
+            {
+                "state": np.array([float(i)], dtype=np.float32),
+                "actions": np.array([float(i)], dtype=np.float32),
+                "task": "pool-size",
+            }
+        )
+    dataset.save_episode()
+
+    _inject_fake_video_feature(input_root, "observation.images.fake_cam")
+
+    from concurrent.futures import ThreadPoolExecutor as _RealPool
+
+    observed_max_workers: list[int] = []
+
+    class _SpyPool(_RealPool):
+        def __init__(self, max_workers: int | None = None, *args: Any, **kwargs: Any) -> None:
+            observed_max_workers.append(int(max_workers) if max_workers is not None else -1)
+            super().__init__(max_workers=max_workers, *args, **kwargs)
+
+    with (
+        patch("opentau.scripts.segment_lerobot_dataset.ThreadPoolExecutor", _SpyPool),
+        patch("opentau.scripts.segment_lerobot_dataset._trim_video_segment"),
+    ):
+        segment_dataset(
+            input_root=input_root,
+            output_root=output_root,
+            segments_by_episode={0: [(0, 2), (2, 4)]},
+            ffmpeg_max_workers=3,
+        )
+
+    assert observed_max_workers == [3]

--- a/tests/datasets/test_segment_lerobot_dataset.py
+++ b/tests/datasets/test_segment_lerobot_dataset.py
@@ -577,9 +577,7 @@ def _inject_fake_video_feature(input_root: Path, video_key: str) -> Path:
         info["video_path"] = DEFAULT_VIDEO_PATH
     write_json(info, input_root / "meta" / "info.json")
 
-    rel_path = DEFAULT_VIDEO_PATH.format(
-        episode_chunk=0, video_key=video_key, episode_index=0
-    )
+    rel_path = DEFAULT_VIDEO_PATH.format(episode_chunk=0, video_key=video_key, episode_index=0)
     src_video = input_root / rel_path
     src_video.parent.mkdir(parents=True, exist_ok=True)
     src_video.write_bytes(b"fake-video-stub")
@@ -616,9 +614,7 @@ def test_segment_dataset_dispatches_ffmpeg_jobs_in_parallel(
     video_key = "observation.images.fake_cam"
     _inject_fake_video_feature(input_root, video_key)
 
-    with patch(
-        "opentau.scripts.segment_lerobot_dataset._trim_video_segment"
-    ) as trim_mock:
+    with patch("opentau.scripts.segment_lerobot_dataset._trim_video_segment") as trim_mock:
         segment_dataset(
             input_root=input_root,
             output_root=output_root,
@@ -627,9 +623,7 @@ def test_segment_dataset_dispatches_ffmpeg_jobs_in_parallel(
 
     # 2 segments × 1 fake video key = 2 trim calls.
     assert trim_mock.call_count == 2
-    frame_ranges = sorted(
-        (call.args[2], call.args[3]) for call in trim_mock.call_args_list
-    )
+    frame_ranges = sorted((call.args[2], call.args[3]) for call in trim_mock.call_args_list)
     assert frame_ranges == [(0, 3), (3, 8)]
     for call in trim_mock.call_args_list:
         src_path, dst_path, *_ = call.args

--- a/tests/datasets/test_segment_lerobot_dataset.py
+++ b/tests/datasets/test_segment_lerobot_dataset.py
@@ -719,7 +719,7 @@ def test_segment_dataset_accepts_ffmpeg_max_workers_override(
     class _SpyPool(_RealPool):
         def __init__(self, max_workers: int | None = None, *args: Any, **kwargs: Any) -> None:
             observed_max_workers.append(int(max_workers) if max_workers is not None else -1)
-            super().__init__(max_workers=max_workers, *args, **kwargs)
+            super().__init__(max_workers, *args, **kwargs)
 
     with (
         patch("opentau.scripts.segment_lerobot_dataset.ThreadPoolExecutor", _SpyPool),


### PR DESCRIPTION
## What this does

Parallelize the ffmpeg video-trim step in `segment_lerobot_dataset.py` so that
many short clips / many camera views can be trimmed concurrently instead of one
at a time. ⚡️ Performance — **5.48× end-to-end speedup** measured on a real
dataset (see "How it was tested"). Output dataset layout and per-clip trim
behavior are byte-equivalent to before; only the scheduling changes.

Previously, `_trim_video_segment` was called inline inside the per-segment loop,
so ffmpeg invocations ran strictly one-at-a-time and became the dominant
bottleneck for datasets with many short segments / many camera views.

This PR changes the flow to:

1. During the main loop, collect each `(src_video_path, dst_video_path, start, end)`
   trim into a `ffmpeg_jobs` list instead of executing immediately. Parquet
   writing, stats, and metadata are unchanged and still written in-order.
2. After all parquet/stats/metadata are finalized, dispatch the collected trims
   through a `ThreadPoolExecutor` and show a `tqdm` progress bar over
   `as_completed(...)`. Threads are sufficient because `_trim_video_segment`
   only invokes `subprocess.run(ffmpeg, ...)` (I/O + external-process bound),
   so the GIL is not an issue.
3. Worker count is picked by `_ffmpeg_trim_max_workers()`:
   - If env var `TUNER_FFMPEG_MAX_WORKERS` is set to an integer in `[1, 64]`,
     use it.
   - Otherwise default to `min(16, (os.cpu_count() or 4) * 2)`.

## How it was tested

### Benchmark

Tested on a real dataset, 2 source episodes with 1 AV1 1080p camera stream each
(`observation.images.camera`), segmented into 20 non-overlapping ranges per
episode for a total of **40 output episodes / 40 ffmpeg trims**.

**Environment**

- CPU: 12th Gen Intel(R) Core(TM) i7-12700K, 20 cores / 20 threads
- ffmpeg 4.2.7 (Ubuntu 20.04)
- Input: LeRobot v2.1, 2 episodes, 12,523 frames total, AV1 @ 1920×1080, 50 fps
- Segment plan: episode 0 (7,723 frames) → 20 segments of 386–387 frames;
  episode 1 (4,800 frames) → 20 segments of 240 frames

**Wall-clock**

| Run | `TUNER_FFMPEG_MAX_WORKERS` | ffmpeg-trim wall-clock | Total wall-clock |
|---|---:|---:|---:|
| Serial (baseline) | `1` | 44m 11s | **44m 20s** (2,660s) |
| Parallel (default) | `16` (auto = `min(16, cpu*2)`) | 7m 59s | **8m 05s** (485s) |

**Speedup: 5.48× end-to-end** on this workload.

The speedup is below the ideal 16× for two CPU-bound reasons, neither of which
is caused by this PR: (1) AV1 software decoding fully saturates all 20 cores
once more than ~8 ffmpeg processes run concurrently, so the bottleneck shifts
from per-trim I/O waits to shared decoder CPU; (2) the existing
`trim=start_frame:end_frame` filter decodes the source from frame 0 up to
`start_frame` for each segment (the 20th serial clip alone took 119s), and that
decoding work does not shrink under parallelism — it is only amortized across
cores. 5.48× is consistent with what we'd expect when the workload is dominated
by shared AV1 decode CPU.

**Correctness**

- Both runs produced **40 parquet files + 40 mp4 files** under
  `data/chunk-000/` and `videos/chunk-000/observation.images.camera/`.
- `ffprobe -count_frames` on a sample (episodes 0, 10, 20, 30, 39) returned
  identical frame counts between the serial and parallel outputs, and they
  matched the plan exactly (386, 386, 240, 240, 240).
- `episodes.jsonl` lengths match the ffprobe-reported frame counts.

## How to checkout & try? (for the reviewer)

```bash
git fetch origin paralle_ffmpeg_video_trimming
git checkout paralle_ffmpeg_video_trimming

# Parallel (new default)
python src/opentau/scripts/segment_lerobot_dataset.py \
    <input_dataset> <output_dataset> <segments.json>

# Serial baseline, for comparison
TUNER_FFMPEG_MAX_WORKERS=1 python src/opentau/scripts/segment_lerobot_dataset.py \
    <input_dataset> <output_dataset> <segments.json>
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).