### PR TITLE
feat: per-dataset validation loss reporting

### DIFF
--- a/src/opentau/datasets/dataset_mixture.py
+++ b/src/opentau/datasets/dataset_mixture.py
@@ -373,13 +373,9 @@ class WeightedDatasetMixture:
             return [type(ds).__name__ + f"_{i}" for i, ds in enumerate(datasets)]
 
         raw_names = [
-            (dc.repo_id or dc.vqa or type(ds).__name__)
-            for dc, ds in zip(dataset_cfgs, datasets, strict=True)
+            (dc.repo_id or dc.vqa or type(ds).__name__) for dc, ds in zip(dataset_cfgs, datasets, strict=True)
         ]
-        return [
-            f"{name}#{idx}" if raw_names.count(name) > 1 else name
-            for idx, name in enumerate(raw_names)
-        ]
+        return [f"{name}#{idx}" if raw_names.count(name) > 1 else name for idx, name in enumerate(raw_names)]
 
     def _log_dataset_info(self) -> None:
         """Log information about all datasets in the mixture."""

--- a/src/opentau/datasets/dataset_mixture.py
+++ b/src/opentau/datasets/dataset_mixture.py
@@ -335,7 +335,7 @@ class WeightedDatasetMixture:
         self.datasets = datasets
         self.dataset_weights = dataset_weights
         self.action_freq = action_freq  # Frequency used for resampling action output
-        self.dataset_names = [type(ds).__name__ + f"_{i}" for i, ds in enumerate(datasets)]  # For logging
+        self.dataset_names = self._make_dataset_names(cfg, datasets)  # For logging
 
         logging.info("Initializing WeightedDatasetMixture...")
         self._log_dataset_info()
@@ -357,6 +357,29 @@ class WeightedDatasetMixture:
         if not all(hasattr(ds, "meta") and ds.meta is not None for ds in datasets):
             raise ValueError("All datasets must have a 'meta' attribute with valid metadata.")
         self.meta = DatasetMixtureMetadata(cfg, [ds.meta for ds in datasets], dataset_weights)
+
+    @staticmethod
+    def _make_dataset_names(cfg: TrainPipelineConfig, datasets: List[BaseDataset]) -> List[str]:
+        """Derive human-readable names for each dataset in the mixture.
+
+        Uses each ``DatasetConfig``'s ``repo_id`` or ``vqa`` identifier when
+        available (ordered to match ``cfg.dataset_mixture.datasets``). Duplicate
+        identifiers are disambiguated with a ``#<idx>`` suffix. Falls back to the
+        dataset class name plus index when the config list cannot be lined up
+        with ``datasets`` (e.g. in tests that construct a mixture directly).
+        """
+        dataset_cfgs = getattr(getattr(cfg, "dataset_mixture", None), "datasets", None)
+        if dataset_cfgs is None or len(dataset_cfgs) != len(datasets):
+            return [type(ds).__name__ + f"_{i}" for i, ds in enumerate(datasets)]
+
+        raw_names = [
+            (dc.repo_id or dc.vqa or type(ds).__name__)
+            for dc, ds in zip(dataset_cfgs, datasets, strict=True)
+        ]
+        return [
+            f"{name}#{idx}" if raw_names.count(name) > 1 else name
+            for idx, name in enumerate(raw_names)
+        ]
 
     def _log_dataset_info(self) -> None:
         """Log information about all datasets in the mixture."""
@@ -491,3 +514,38 @@ class WeightedDatasetMixture:
         logging.info("DataLoader created successfully.")
         logging.info("-" * 30)
         return dataloader
+
+    def get_per_dataset_dataloaders(self) -> dict[str, DataLoader]:
+        """Create one sequential DataLoader per underlying dataset.
+
+        Intended for per-dataset evaluation (e.g. per-dataset validation loss),
+        where each dataset should be iterated exactly once rather than mixed
+        via weighted hierarchical sampling. Empty datasets are skipped.
+
+        Returns:
+            Mapping from ``dataset_name`` to its DataLoader.
+        """
+        worker_name_mapping_overrides = self._get_worker_name_mapping_overrides()
+        worker_init_fn = None
+        if worker_name_mapping_overrides:
+            worker_init_fn = functools.partial(
+                _apply_data_feature_name_mapping_overrides,
+                mapping_overrides=worker_name_mapping_overrides,
+            )
+
+        loaders: dict[str, DataLoader] = {}
+        for name, ds in zip(self.dataset_names, self.datasets, strict=True):
+            if len(ds) == 0:
+                logging.info(f"Skipping per-dataset DataLoader for empty dataset '{name}'.")
+                continue
+            loaders[name] = DataLoader(
+                ds,
+                batch_size=self.cfg.dataloader_batch_size,
+                shuffle=False,
+                num_workers=self.cfg.num_workers,
+                pin_memory=torch.cuda.is_available(),
+                drop_last=False,
+                prefetch_factor=self.cfg.prefetch_factor,
+                worker_init_fn=worker_init_fn,
+            )
+        return loaders

--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -327,7 +327,7 @@ def train(cfg: TrainPipelineConfig):
         if is_val_step:
             policy.eval()
 
-            def _make_val_tracker() -> MetricsTracker:
+            def _make_val_tracker(current_step: int = step) -> MetricsTracker:
                 return MetricsTracker(
                     cfg.batch_size * accelerator.num_processes,
                     {
@@ -337,7 +337,7 @@ def train(cfg: TrainPipelineConfig):
                         "l1_loss": AverageMeter("val_l1_loss", ":.3f"),
                         "accuracy": AverageMeter("val_accuracy", ":.3f"),
                     },
-                    initial_step=step,
+                    initial_step=current_step,
                 )
 
             agg_tracker = _make_val_tracker()
@@ -373,10 +373,7 @@ def train(cfg: TrainPipelineConfig):
                             .item()
                         )
                         ce_loss = (
-                            accelerator.gather_for_metrics(losses["CE"])
-                            .to(dtype=torch.float32)
-                            .mean()
-                            .item()
+                            accelerator.gather_for_metrics(losses["CE"]).to(dtype=torch.float32).mean().item()
                         )
                         l1_loss = (
                             accelerator.gather_for_metrics(losses.get("L1", zero))

--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -211,10 +211,19 @@ def train(cfg: TrainPipelineConfig):
 
     if cfg.val_freq > 0:
         train_dataloader = train_dataset.get_dataloader()
-        val_dataloader = val_dataset.get_dataloader()
-        policy, optimizer, train_dataloader, val_dataloader, lr_scheduler = accelerator.prepare(
-            policy, optimizer, train_dataloader, val_dataloader, lr_scheduler
+        # One DataLoader per underlying val dataset so we can report per-dataset
+        # validation losses. The aggregate is computed by averaging across all.
+        per_dataset_val_dataloaders = val_dataset.get_per_dataset_dataloaders()
+        val_names = list(per_dataset_val_dataloaders.keys())
+        prepared = accelerator.prepare(
+            policy,
+            optimizer,
+            train_dataloader,
+            lr_scheduler,
+            *per_dataset_val_dataloaders.values(),
         )
+        policy, optimizer, train_dataloader, lr_scheduler = prepared[:4]
+        per_dataset_val_dataloaders = dict(zip(val_names, prepared[4:], strict=True))
     else:
         train_dataloader = train_dataset.get_dataloader()
         policy, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
@@ -317,65 +326,96 @@ def train(cfg: TrainPipelineConfig):
 
         if is_val_step:
             policy.eval()
-            val_metrics = {
-                "loss": AverageMeter("val_total_loss", ":.3f"),
-                "mse_loss": AverageMeter("val_mse_loss", ":.3f"),
-                "ce_loss": AverageMeter("val_ce_loss", ":.3f"),
-                "l1_loss": AverageMeter("val_l1_loss", ":.3f"),
-                "accuracy": AverageMeter("val_accuracy", ":.3f"),
+
+            def _make_val_tracker() -> MetricsTracker:
+                return MetricsTracker(
+                    cfg.batch_size * accelerator.num_processes,
+                    {
+                        "loss": AverageMeter("val_total_loss", ":.3f"),
+                        "mse_loss": AverageMeter("val_mse_loss", ":.3f"),
+                        "ce_loss": AverageMeter("val_ce_loss", ":.3f"),
+                        "l1_loss": AverageMeter("val_l1_loss", ":.3f"),
+                        "accuracy": AverageMeter("val_accuracy", ":.3f"),
+                    },
+                    initial_step=step,
+                )
+
+            agg_tracker = _make_val_tracker()
+            per_dataset_trackers: dict[str, MetricsTracker] = {
+                name: _make_val_tracker() for name in per_dataset_val_dataloaders
             }
-            val_tracker = MetricsTracker(
-                cfg.batch_size * accelerator.num_processes,
-                val_metrics,
-                initial_step=step,
-            )
 
             logging.info(f"Validation at step {step}...")
 
             with torch.no_grad():
-                for batch in val_dataloader:
-                    losses = policy.forward(batch)
-                    loss = cfg.loss_weighting["MSE"] * losses["MSE"] + cfg.loss_weighting["CE"] * losses["CE"]
+                for ds_name, ds_loader in per_dataset_val_dataloaders.items():
+                    ds_tracker = per_dataset_trackers[ds_name]
+                    for batch in ds_loader:
+                        losses = policy.forward(batch)
+                        loss = (
+                            cfg.loss_weighting["MSE"] * losses["MSE"]
+                            + cfg.loss_weighting["CE"] * losses["CE"]
+                        )
 
-                    # Gather and average metrics across processes
-                    _first_loss_tensor = next(lt for lt in losses.values() if isinstance(lt, torch.Tensor))
-                    zero = torch.tensor(0.0, device=_first_loss_tensor.device, dtype=_first_loss_tensor.dtype)
+                        # Gather and average metrics across processes
+                        _first_loss_tensor = next(
+                            lt for lt in losses.values() if isinstance(lt, torch.Tensor)
+                        )
+                        zero = torch.tensor(
+                            0.0, device=_first_loss_tensor.device, dtype=_first_loss_tensor.dtype
+                        )
 
-                    loss = accelerator.gather_for_metrics(loss).mean().item()
-                    mse_loss = (
-                        accelerator.gather_for_metrics(losses["MSE"]).to(dtype=torch.float32).mean().item()
-                    )
-                    ce_loss = (
-                        accelerator.gather_for_metrics(losses["CE"]).to(dtype=torch.float32).mean().item()
-                    )
-                    l1_loss = (
-                        accelerator.gather_for_metrics(losses.get("L1", zero))
-                        .to(dtype=torch.float32)
-                        .mean()
-                        .item()
-                    )
-                    accuracy = (
-                        accelerator.gather_for_metrics(losses.get("Accuracy", zero))
-                        .to(dtype=torch.float32)
-                        .mean()
-                        .item()
-                    )
+                        loss = accelerator.gather_for_metrics(loss).mean().item()
+                        mse_loss = (
+                            accelerator.gather_for_metrics(losses["MSE"])
+                            .to(dtype=torch.float32)
+                            .mean()
+                            .item()
+                        )
+                        ce_loss = (
+                            accelerator.gather_for_metrics(losses["CE"])
+                            .to(dtype=torch.float32)
+                            .mean()
+                            .item()
+                        )
+                        l1_loss = (
+                            accelerator.gather_for_metrics(losses.get("L1", zero))
+                            .to(dtype=torch.float32)
+                            .mean()
+                            .item()
+                        )
+                        accuracy = (
+                            accelerator.gather_for_metrics(losses.get("Accuracy", zero))
+                            .to(dtype=torch.float32)
+                            .mean()
+                            .item()
+                        )
 
-                    if accelerator.is_main_process:
-                        val_tracker.loss = loss
-                        val_tracker.mse_loss = mse_loss
-                        val_tracker.ce_loss = ce_loss
-                        val_tracker.l1_loss = l1_loss
-                        val_tracker.accuracy = accuracy
+                        if accelerator.is_main_process:
+                            for tracker in (ds_tracker, agg_tracker):
+                                tracker.loss = loss
+                                tracker.mse_loss = mse_loss
+                                tracker.ce_loss = ce_loss
+                                tracker.l1_loss = l1_loss
+                                tracker.accuracy = accuracy
 
             if accelerator.is_main_process:
-                logging.info(val_tracker)
-                val_dict = val_tracker.to_dict(use_avg=True)
-                accelerator.log({"Validation/Loss": val_dict["loss"]}, step=step)
-                accelerator.log({"Validation/MSE Loss": val_dict["mse_loss"]}, step=step)
-                accelerator.log({"Validation/CE Loss": val_dict["ce_loss"]}, step=step)
-                accelerator.log({"Validation/L1 Loss": val_dict["l1_loss"]}, step=step)
-                accelerator.log({"Validation/Accuracy": val_dict["accuracy"]}, step=step)
+                logging.info(f"Validation/aggregate {agg_tracker}")
+                agg_dict = agg_tracker.to_dict(use_avg=True)
+                accelerator.log({"Validation/Loss": agg_dict["loss"]}, step=step)
+                accelerator.log({"Validation/MSE Loss": agg_dict["mse_loss"]}, step=step)
+                accelerator.log({"Validation/CE Loss": agg_dict["ce_loss"]}, step=step)
+                accelerator.log({"Validation/L1 Loss": agg_dict["l1_loss"]}, step=step)
+                accelerator.log({"Validation/Accuracy": agg_dict["accuracy"]}, step=step)
+
+                for ds_name, ds_tracker in per_dataset_trackers.items():
+                    logging.info(f"Validation/{ds_name} {ds_tracker}")
+                    ds_dict = ds_tracker.to_dict(use_avg=True)
+                    accelerator.log({f"Validation/{ds_name}/Loss": ds_dict["loss"]}, step=step)
+                    accelerator.log({f"Validation/{ds_name}/MSE Loss": ds_dict["mse_loss"]}, step=step)
+                    accelerator.log({f"Validation/{ds_name}/CE Loss": ds_dict["ce_loss"]}, step=step)
+                    accelerator.log({f"Validation/{ds_name}/L1 Loss": ds_dict["l1_loss"]}, step=step)
+                    accelerator.log({f"Validation/{ds_name}/Accuracy": ds_dict["accuracy"]}, step=step)
 
             # This barrier is probably necessary to ensure
             # other processes wait for the main process to finish saving


### PR DESCRIPTION
## What this does

Implements per-dataset validation loss reporting so training runs with multiple datasets can track each dataset's validation metrics independently rather than only the aggregate.

- Adds `WeightedDatasetMixture.get_per_dataset_dataloaders()`, which returns one sequential `DataLoader` per underlying dataset (empty datasets skipped).
- In `train.py`, the validation step now iterates each per-dataset loader in sequence, updating a per-dataset `MetricsTracker` and an aggregate tracker at the same time. Each step emits both `Validation/<name>/Loss` (plus MSE/CE/L1/Accuracy) and the existing `Validation/Loss` aggregate scalars.
- Uses each `DatasetConfig`'s `repo_id` / `vqa` identifier as the logged dataset name (with `#<idx>` disambiguation when duplicated), falling back to the old `ClassName_i` scheme when the config list cannot be lined up with the datasets (e.g. unit tests that construct a mixture directly).

This changes the validation semantics from "sample `len(concat)` times via hierarchical weighted sampling with replacement" to "fully iterate each val subset once", which is the conventional choice for validation and is what makes per-dataset reporting meaningful.

## How it was tested

- Verified the name-derivation logic in isolation across unique, duplicate, VQA, mismatched-length, and missing-config cases.
- `python -c "import ast; ast.parse(...)"` on both modified files.
- Existing `tests/datasets/test_dataset_mixture.py` assertions on `len(mixture.dataset_names)` still hold (the public shape is unchanged).
- Full GPU validation in a real run is still pending (no GPU available in this environment).

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/datasets/test_dataset_mixture.py
```

Then launch any training config with `val_freq > 0` and multiple datasets in `dataset_mixture.datasets`, and confirm wandb shows both the aggregate `Validation/*` scalars and one `Validation/<repo_id>/*` group per dataset.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

https://claude.ai/code/session_019zJCa5a31uULbXPrFjtiTr