### PR TITLE
fix(train): re-seed new ranks deterministically when resuming on more GPUs

### DIFF
--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -50,6 +50,7 @@ from opentau.utils.train_utils import (
     load_training_state,
     load_training_step,
     prune_old_checkpoints,
+    reseed_new_ranks_on_resume,
     save_checkpoint,
 )
 from opentau.utils.utils import (
@@ -248,6 +249,11 @@ def train(cfg: TrainPipelineConfig):
         # load accelerator state
         # This will load the model, optimizer, and lr_scheduler state
         accelerator.load_state(cfg.checkpoint_path)
+
+        # Per-rank random_states_<rank>.pkl is loaded by accelerator.load_state above,
+        # but missing files (when resuming on more GPUs than were saved) are silently
+        # skipped. Re-seed those new ranks deterministically.
+        reseed_new_ranks_on_resume(cfg.checkpoint_path, accelerator, cfg.seed)
 
         # all processes should load the step & rng states
         step = load_training_state(cfg.checkpoint_path)

--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -400,11 +400,6 @@ def train(cfg: TrainPipelineConfig):
         # This will load the model, optimizer, and lr_scheduler state
         accelerator.load_state(cfg.checkpoint_path)
 
-        # Per-rank random_states_<rank>.pkl is loaded by accelerator.load_state above,
-        # but missing files (when resuming on more GPUs than were saved) are silently
-        # skipped. Re-seed those new ranks deterministically.
-        reseed_new_ranks_on_resume(cfg.checkpoint_path, accelerator, cfg.seed)
-
         # When the master-weights wrapper is in use, the live bf16 weights
         # have just been overwritten by ``accelerator.load_state``. Rebuild
         # the fp32 masters from those weights so the inner optimizer's
@@ -417,6 +412,17 @@ def train(cfg: TrainPipelineConfig):
 
         # all processes should load the step & rng states
         step = load_training_state(cfg.checkpoint_path)
+
+        # load_training_state above applies the consolidated rng_state.safetensors
+        # to every rank, which would clobber any per-rank reseed. Run the per-rank
+        # reseed AFTER the consolidated load so the new ranks end up decorrelated.
+        # Per-rank random_states_<rank>.pkl is loaded by accelerator.load_state, but
+        # missing files (when resuming on more GPUs than were saved) are silently
+        # skipped, leaving new ranks with whichever RNG the consolidated load gave
+        # them — identical across all new ranks. Re-seed those new ranks
+        # deterministically here.
+        reseed_new_ranks_on_resume(cfg.checkpoint_path, accelerator, cfg.seed)
+
         logging.info(f"Resuming training from checkpoint {cfg.checkpoint_path}")
 
     policy.train()

--- a/src/opentau/utils/train_utils.py
+++ b/src/opentau/utils/train_utils.py
@@ -23,6 +23,7 @@ managing checkpoint directories, and pruning old checkpoints.
 import logging
 import shutil
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from termcolor import colored
 from torch.optim import Optimizer
@@ -36,6 +37,9 @@ from opentau.constants import (
 )
 from opentau.datasets.utils import load_json, write_json
 from opentau.utils.random_utils import load_rng_state, save_rng_state
+
+if TYPE_CHECKING:
+    import accelerate
 
 
 def log_output_dir(out_dir):
@@ -162,13 +166,17 @@ def reseed_new_ranks_on_resume(
             "Ranks %d..%d had no per-rank RNG file; re-seeding them deterministically "
             "from cfg.seed. Note: global batch size has changed by a factor of %.3fx; "
             "consider scaling cfg.gradient_accumulation_steps to compensate.",
-            current, saved, saved, current - 1, current / saved,
+            current,
+            saved,
+            saved,
+            current - 1,
+            current / saved,
         )
         if accelerator.process_index >= saved:
             if seed is None:
                 logging.warning(
-                    "cfg.seed is None; rank %d will retain its default startup RNG "
-                    "(not reproducible).", accelerator.process_index,
+                    "cfg.seed is None; rank %d will retain its default startup RNG (not reproducible).",
+                    accelerator.process_index,
                 )
             else:
                 set_seed(seed, accelerator=accelerator)
@@ -178,7 +186,11 @@ def reseed_new_ranks_on_resume(
             "Per-rank RNG files for ranks %d..%d are ignored. Note: global batch size "
             "has changed by a factor of %.3fx; consider scaling "
             "cfg.gradient_accumulation_steps to compensate.",
-            current, saved, current, saved - 1, current / saved,
+            current,
+            saved,
+            current,
+            saved - 1,
+            current / saved,
         )
 
 

--- a/src/opentau/utils/train_utils.py
+++ b/src/opentau/utils/train_utils.py
@@ -160,18 +160,28 @@ def reseed_new_ranks_on_resume(
     current = accelerator.num_processes
     if saved == current:
         return
+    if saved == 0:
+        if accelerator.is_main_process:
+            logging.warning(
+                "No random_states_*.pkl files found in %s; skipping per-rank RNG reseed. "
+                "This may indicate a corrupt or partial checkpoint, or a checkpoint produced "
+                "by a future Accelerate layout.",
+                checkpoint_dir,
+            )
+        return
     if saved < current:
-        logging.warning(
-            "Resuming on more processes (%d) than the checkpoint was saved with (%d). "
-            "Ranks %d..%d had no per-rank RNG file; re-seeding them deterministically "
-            "from cfg.seed. Note: global batch size has changed by a factor of %.3fx; "
-            "consider scaling cfg.gradient_accumulation_steps to compensate.",
-            current,
-            saved,
-            saved,
-            current - 1,
-            current / saved,
-        )
+        if accelerator.is_main_process:
+            logging.warning(
+                "Resuming on more processes (%d) than the checkpoint was saved with (%d). "
+                "Ranks %d..%d had no per-rank RNG file; re-seeding them deterministically "
+                "from cfg.seed. Note: global batch size has changed by a factor of %.3fx; "
+                "consider scaling cfg.gradient_accumulation_steps to compensate.",
+                current,
+                saved,
+                saved,
+                current - 1,
+                current / saved,
+            )
         if accelerator.process_index >= saved:
             if seed is None:
                 logging.warning(
@@ -181,17 +191,18 @@ def reseed_new_ranks_on_resume(
             else:
                 set_seed(seed, accelerator=accelerator)
     else:
-        logging.info(
-            "Resuming on fewer processes (%d) than the checkpoint was saved with (%d). "
-            "Per-rank RNG files for ranks %d..%d are ignored. Note: global batch size "
-            "has changed by a factor of %.3fx; consider scaling "
-            "cfg.gradient_accumulation_steps to compensate.",
-            current,
-            saved,
-            current,
-            saved - 1,
-            current / saved,
-        )
+        if accelerator.is_main_process:
+            logging.info(
+                "Resuming on fewer processes (%d) than the checkpoint was saved with (%d). "
+                "Per-rank RNG files for ranks %d..%d are ignored. Note: global batch size "
+                "has changed by a factor of %.3fx; consider scaling "
+                "cfg.gradient_accumulation_steps to compensate.",
+                current,
+                saved,
+                current,
+                saved - 1,
+                current / saved,
+            )
 
 
 def load_training_state(checkpoint_dir: Path) -> tuple[int, Optimizer, LRScheduler | None]:

--- a/src/opentau/utils/train_utils.py
+++ b/src/opentau/utils/train_utils.py
@@ -126,6 +126,62 @@ def save_checkpoint(
     save_rng_state(checkpoint_dir)
 
 
+def reseed_new_ranks_on_resume(
+    checkpoint_dir: Path,
+    accelerator: "accelerate.Accelerator",
+    seed: int | None,
+) -> None:
+    """Re-seed ranks that have no per-rank RNG file in the checkpoint.
+
+    Accelerate's ``load_state`` reads ``random_states_<process_index>.pkl`` per
+    rank and silently logs ``"Could not load random states"`` at INFO level when
+    the file is missing. When resuming on more GPUs than the checkpoint was
+    saved with, the new ranks are left with whatever default RNG state the
+    process happened to start with -- correlated across ranks and
+    irreproducible. This helper detects that case and assigns each new rank a
+    deterministic, decorrelated seed via ``set_seed``.
+
+    Surviving ranks (whose files loaded successfully) are not touched.
+
+    Args:
+        checkpoint_dir: Directory holding the saved ``random_states_*.pkl`` files.
+        accelerator: The current Accelerator (provides ``num_processes`` and
+            ``process_index``).
+        seed: Base training seed (``cfg.seed``). If ``None``, no re-seeding is
+            performed and a warning is emitted instead.
+    """
+    from opentau.utils.random_utils import set_seed
+
+    saved = len(list(checkpoint_dir.glob("random_states_*.pkl")))
+    current = accelerator.num_processes
+    if saved == current:
+        return
+    if saved < current:
+        logging.warning(
+            "Resuming on more processes (%d) than the checkpoint was saved with (%d). "
+            "Ranks %d..%d had no per-rank RNG file; re-seeding them deterministically "
+            "from cfg.seed. Note: global batch size has changed by a factor of %.3fx; "
+            "consider scaling cfg.gradient_accumulation_steps to compensate.",
+            current, saved, saved, current - 1, current / saved,
+        )
+        if accelerator.process_index >= saved:
+            if seed is None:
+                logging.warning(
+                    "cfg.seed is None; rank %d will retain its default startup RNG "
+                    "(not reproducible).", accelerator.process_index,
+                )
+            else:
+                set_seed(seed, accelerator=accelerator)
+    else:
+        logging.info(
+            "Resuming on fewer processes (%d) than the checkpoint was saved with (%d). "
+            "Per-rank RNG files for ranks %d..%d are ignored. Note: global batch size "
+            "has changed by a factor of %.3fx; consider scaling "
+            "cfg.gradient_accumulation_steps to compensate.",
+            current, saved, current, saved - 1, current / saved,
+        )
+
+
 def load_training_state(checkpoint_dir: Path) -> tuple[int, Optimizer, LRScheduler | None]:
     """Load training state including step, optimizer, scheduler, and RNG state.
 

--- a/tests/utils/test_train_utils.py
+++ b/tests/utils/test_train_utils.py
@@ -25,6 +25,7 @@ from opentau.utils.train_utils import (
     get_step_identifier,
     load_training_step,
     prune_old_checkpoints,
+    reseed_new_ranks_on_resume,
     save_training_step,
     update_last_checkpoint,
 )
@@ -233,3 +234,88 @@ class TestPruneOldCheckpoints:
             mock_logging.info.assert_called_once_with(
                 "Starting cleanup in '/path/to/checkpoints'. Keeping checkpoint: '000100'"
             )
+
+
+def _make_accelerator(num_processes: int, process_index: int, is_main: bool | None = None):
+    """Build a stub Accelerator that ``reseed_new_ranks_on_resume`` and ``set_seed`` accept."""
+    acc = Mock()
+    acc.num_processes = num_processes
+    acc.process_index = process_index
+    acc.is_main_process = is_main if is_main is not None else (process_index == 0)
+    return acc
+
+
+def _populate_rng_files(checkpoint_dir: Path, count: int) -> None:
+    for i in range(count):
+        (checkpoint_dir / f"random_states_{i}.pkl").write_bytes(b"\x00")
+
+
+class TestReseedNewRanksOnResume:
+    """Cover the file-counting branches of ``reseed_new_ranks_on_resume``."""
+
+    def test_same_world_size_is_noop(self, tmp_path):
+        _populate_rng_files(tmp_path, 4)
+        acc = _make_accelerator(num_processes=4, process_index=2)
+        with patch("opentau.utils.random_utils.set_seed") as mock_set_seed:
+            reseed_new_ranks_on_resume(tmp_path, acc, seed=1234)
+        mock_set_seed.assert_not_called()
+
+    def test_scale_up_reseeds_only_new_ranks(self, tmp_path):
+        # Saved on 4 ranks, resuming on 8: ranks 4..7 must be reseeded.
+        _populate_rng_files(tmp_path, 4)
+        with patch("opentau.utils.random_utils.set_seed") as mock_set_seed:
+            for rank in range(8):
+                acc = _make_accelerator(num_processes=8, process_index=rank)
+                reseed_new_ranks_on_resume(tmp_path, acc, seed=42)
+        # Only ranks 4..7 should have triggered a reseed.
+        assert mock_set_seed.call_count == 4
+        reseeded_ranks = sorted(
+            call.kwargs["accelerator"].process_index for call in mock_set_seed.call_args_list
+        )
+        assert reseeded_ranks == [4, 5, 6, 7]
+
+    def test_scale_up_with_seed_none_skips_set_seed(self, tmp_path, caplog):
+        _populate_rng_files(tmp_path, 2)
+        acc = _make_accelerator(num_processes=4, process_index=3)
+        with (
+            patch("opentau.utils.random_utils.set_seed") as mock_set_seed,
+            caplog.at_level("WARNING"),
+        ):
+            reseed_new_ranks_on_resume(tmp_path, acc, seed=None)
+        mock_set_seed.assert_not_called()
+        assert any("cfg.seed is None" in rec.message for rec in caplog.records)
+
+    def test_scale_down_does_not_reseed(self, tmp_path):
+        _populate_rng_files(tmp_path, 8)
+        acc = _make_accelerator(num_processes=4, process_index=0)
+        with patch("opentau.utils.random_utils.set_seed") as mock_set_seed:
+            reseed_new_ranks_on_resume(tmp_path, acc, seed=42)
+        mock_set_seed.assert_not_called()
+
+    def test_no_rng_files_early_returns_without_zerodiv(self, tmp_path, caplog):
+        # Empty checkpoint dir: must not raise ZeroDivisionError, must warn on main only.
+        acc_main = _make_accelerator(num_processes=4, process_index=0, is_main=True)
+        with (
+            patch("opentau.utils.random_utils.set_seed") as mock_set_seed,
+            caplog.at_level("WARNING"),
+        ):
+            reseed_new_ranks_on_resume(tmp_path, acc_main, seed=42)
+        mock_set_seed.assert_not_called()
+        assert any("No random_states_*.pkl files found" in rec.message for rec in caplog.records)
+
+    def test_top_level_log_gated_on_main_process(self, tmp_path, caplog):
+        _populate_rng_files(tmp_path, 2)
+        # Non-main rank should not emit the high-level scale-up warning.
+        acc_nonmain = _make_accelerator(num_processes=4, process_index=1, is_main=False)
+        with patch("opentau.utils.random_utils.set_seed"), caplog.at_level("WARNING"):
+            reseed_new_ranks_on_resume(tmp_path, acc_nonmain, seed=42)
+        scale_up_msgs = [rec for rec in caplog.records if "Resuming on more processes" in rec.message]
+        assert scale_up_msgs == []
+
+    def test_scale_down_log_gated_on_main_process(self, tmp_path, caplog):
+        _populate_rng_files(tmp_path, 8)
+        acc_nonmain = _make_accelerator(num_processes=4, process_index=2, is_main=False)
+        with caplog.at_level("INFO"):
+            reseed_new_ranks_on_resume(tmp_path, acc_nonmain, seed=42)
+        scale_down_msgs = [rec for rec in caplog.records if "Resuming on fewer processes" in rec.message]
+        assert scale_down_msgs == []


### PR DESCRIPTION
## Summary

When resuming DDP training with `--resume` on a **different number of GPUs** than the checkpoint was saved with, Accelerate's `load_state` behavior is asymmetric and silent — correct for scale-down but lossy for scale-up. This PR adds `reseed_new_ranks_on_resume` (called inside `cfg.resume` in `train.py`) that detects the mismatch by counting `random_states_*.pkl` files in the checkpoint, re-seeds new ranks deterministically in the scale-up case, and surfaces the change to operators so they know to adjust `gradient_accumulation_steps`.

## Background: what Accelerate does today

`accelerator.save_state` writes one `random_states_<process_index>.pkl` per rank (plus the consolidated `model.safetensors`, `optimizer.bin`, `scheduler.bin`). On load, `accelerate/checkpointing.py:287-309` only opens **the single file matching the current rank's `process_index`**, inside a `try/except Exception` that falls through to `logger.info("Could not load random states")`. It never enumerates or cross-checks file count vs. `num_processes`.

I verified this behavior against `accelerate==1.12.0` (OpenTau's pin) with a standalone smoke test — see the "Test plan" section.

## Behavior per direction (before this PR)

### Scale-down: 8 GPUs → 4 GPUs

- **Per-rank RNG files 4–7 are silently ignored.** Accelerate only reads the file matching the current rank (0–3), so the extras are never opened. Even a corrupt `random_states_7.pkl` wouldn't be noticed. Surviving ranks (0–3) correctly restore their per-rank RNG from the checkpoint.
- **Model / optimizer / scheduler / training step** all load correctly — they're consolidated single-file artifacts, rank-count-independent.
- **OpenTau's consolidated `rng_state.safetensors`** (via `random_utils.py:load_rng_state`) is loaded by all 4 ranks and gives them identical Python/NumPy/Torch CPU RNG.
- **Global batch size halves.** `train.py:269` computes `cfg.batch_size * accelerator.num_processes`, so going 8→4 cuts effective batch in half and changes the optimizer-step semantics (same LR schedule now covers half the data per step).
- **DataLoader re-shards** from 8-way to 4-way stripe under `accelerator.prepare`; sampler position is not checkpointed today, so data ordering diverges from the original run either way.
- **No warning or error is emitted** by anything in the current code path — operators have no signal that the effective batch size changed.

### Scale-up: 4 GPUs → 8 GPUs

- **Ranks 0–3 restore their per-rank RNG correctly** from existing files.
- **Ranks 4–7 have no matching file.** Accelerate's `try/except` catches the `FileNotFoundError`, logs `"Could not load random states"` at INFO (easy to miss), and those ranks continue with whatever default RNG the process happened to start with — correlated across ranks and non-reproducible.
- **Consolidated `rng_state.safetensors`** gives all 8 ranks the same CPU RNG state; CUDA/dropout/augmentation RNG on the new ranks is undefined.
- **Global batch size doubles**, same caveat as above but in the opposite direction.

## What this PR changes

`reseed_new_ranks_on_resume(checkpoint_dir, accelerator, seed)`:

- Counts `random_states_*.pkl` in the checkpoint to infer the saved world size.
- **Scale-up** (`current > saved`): emits a `logging.warning` naming both rank counts and the global-batch scale factor, and re-seeds each new rank (`process_index >= saved`) via `set_seed(cfg.seed, accelerator)`, which yields `cfg.seed + process_index * 12345` per rank — deterministic and decorrelated. Surviving ranks are not touched.
- **Scale-down** (`current < saved`): emits a `logging.info` naming both rank counts and the global-batch scale factor. No RNG mutation — Accelerate's silent-ignore of extra files is already correct; this PR just makes the change visible in the log.
- **Same world size**: silent no-op.
- **`cfg.seed is None`**: emits a secondary warning instead of re-seeding (no deterministic seed to use).

In both scale-up and scale-down cases, the log message includes the phrase _"global batch size has changed by a factor of Nx; consider scaling cfg.gradient_accumulation_steps to compensate"_ so operators have a clear cue.

## Out of scope

- **Auto-adjusting `gradient_accumulation_steps` / `batch_size`** — left as an operator decision; the warning surfaces it. Halving grad-accum when going 4→8 (or doubling it when going 8→4) preserves global batch and LR-schedule semantics; `batch_size` scaling would additionally change per-forward BN-like behavior, so grad-accum is usually the right knob.
- **Dataloader sampler state** — OpenTau does not checkpoint `DistributedSampler` position today, so data re-sharding on rank-count change is pre-existing behavior in both directions.
- **FSDP / DeepSpeed paths** — optimizer state is sharded per rank and handled separately by those frameworks; this PR only touches the standard DDP resume path.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.

## Test plan

- [x] Verified Accelerate 1.12.0 behavior via a standalone smoke test driving `load_accelerator_state` directly:
  - Missing `random_states_<rank>.pkl` (scale-up case) → `try/except Exception` in `accelerate/checkpointing.py:287-309` silently logs INFO and returns; confirmed.
  - Extra `random_states_<rank>.pkl` files (scale-down case) are never opened; corrupt extras are ignored; confirmed.
- [x] Smoke-tested the helper logic across 5 cases (scale-up new rank, scale-up surviving rank, scale-down, same size, `seed=None`) — all pass; new rank's RNG matches the deterministic `seed + process_index * 12345` reconstruction exactly.
- [x] Ran `pre-commit run --files src/opentau/scripts/train.py src/opentau/utils/train_utils.py` locally — all hooks pass.
- [ ] End-to-end test on a real multi-GPU node: save on 4 GPUs, resume on 8; inspect the new `WARNING` and verify loss trajectory.
- [ ] End-to-end test the reverse: save on 8, resume on 4; verify the `INFO` log and that global-batch guidance is acted on.

https://claude.ai/code/session_016YyNbCipf9hgp7jcPUxepn

---
_Generated by [Claude Code](https://claude.ai/code/session_016YyNbCipf9hgp7jcPUxepn)_