### PR TITLE
feat: overlay-repo support for LeRobot v2.x datasets

### DIFF
--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -84,6 +84,7 @@ Example:
 import contextlib
 import copy
 import functools
+import json
 import logging
 import math
 import shutil
@@ -101,7 +102,7 @@ import torch.nn.functional as F  # noqa: N812
 import torch.utils
 from datasets import concatenate_datasets, load_dataset
 from einops import rearrange
-from huggingface_hub import HfApi, snapshot_download
+from huggingface_hub import HfApi, hf_hub_download, snapshot_download
 from huggingface_hub.constants import REPOCARD_NAME
 from huggingface_hub.errors import RevisionNotFoundError
 
@@ -209,6 +210,11 @@ def retry_random_on_failure(f):
 
 
 CODEBASE_VERSION = "v2.1"
+
+# Set of repo_ids for which we've already emitted the "missing control_mode" warning.
+# Keyed at module level so duplicates are suppressed across multiple LeRobotDataset
+# instances within a single process (e.g., train + val constructed for the same repo).
+_CONTROL_MODE_WARNED: set[str] = set()
 
 
 class DatasetMetadata:
@@ -438,6 +444,11 @@ class LeRobotDatasetMetadata(DatasetMetadata):
     def robot_type(self) -> str | None:
         """Robot type used in recording this dataset."""
         return self.info["robot_type"]
+
+    @property
+    def control_mode(self) -> str:
+        """Control-mode label from info.json. Defaults to 'unknown' when absent."""
+        return self.info.get("control_mode", "unknown")
 
     @property
     def fps(self) -> int:
@@ -1232,6 +1243,59 @@ class LeRobotDataset(BaseDataset):
         self.meta = LeRobotDatasetMetadata(
             self.repo_id, self.root, self.revision, force_cache_sync=force_cache_sync
         )
+
+        # Overlay setup: when info.json declares a `videos.source_repo`, all video
+        # reads are routed to that upstream repo. Fetch its info.json once (for
+        # the path template + chunks_size) and cache under the canonical
+        # HF_OPENTAU_HOME/<source_repo> location, so a future vanilla load of the
+        # source repo reuses the same files. Must run before get_episodes_file_paths().
+        self._overlay: dict | None = None
+        videos_meta = self.meta.info.get("videos") or {}
+        if videos_meta.get("source_repo"):
+            src_repo = videos_meta["source_repo"]
+            src_revision = videos_meta.get("source_revision")
+            src_root = HF_OPENTAU_HOME / src_repo
+            src_info_path = src_root / INFO_PATH
+            if not src_info_path.is_file():
+                acc = get_proc_accelerator()
+                if acc is not None and acc.num_processes > 1:
+                    if acc.is_main_process:
+                        src_info_path.parent.mkdir(exist_ok=True, parents=True)
+                        hf_hub_download(
+                            repo_id=src_repo,
+                            filename=INFO_PATH,
+                            repo_type="dataset",
+                            revision=src_revision,
+                            local_dir=src_root,
+                        )
+                    acc.wait_for_everyone()
+                else:
+                    src_info_path.parent.mkdir(exist_ok=True, parents=True)
+                    hf_hub_download(
+                        repo_id=src_repo,
+                        filename=INFO_PATH,
+                        repo_type="dataset",
+                        revision=src_revision,
+                        local_dir=src_root,
+                    )
+            src_info = json.loads(src_info_path.read_text())
+            self._overlay = {
+                "source_repo": src_repo,
+                "source_revision": src_revision,
+                "source_root": src_root,
+                "video_path": src_info["video_path"],
+                "chunks_size": src_info["chunks_size"],
+            }
+
+        self.control_mode = self.meta.control_mode
+        if "control_mode" not in self.meta.info and self.repo_id not in _CONTROL_MODE_WARNED:
+            _CONTROL_MODE_WARNED.add(self.repo_id)
+            logging.warning(
+                "Dataset %r has no `control_mode` field in meta/info.json; defaulting to 'unknown'. "
+                "Please add `control_mode` ∈ {'joint', 'ee', 'mixed'} to keep the mixture sampler honest.",
+                self.repo_id,
+            )
+
         if self.episodes is not None and self.meta._version >= packaging.version.parse("v2.1"):
             episodes_stats = [self.meta.episodes_stats[ep_idx] for ep_idx in self.episodes]
             self.stats = aggregate_stats(episodes_stats)
@@ -1400,7 +1464,9 @@ class LeRobotDataset(BaseDataset):
         """
         episodes = self.episodes if self.episodes is not None else list(range(self.meta.total_episodes))
         fpaths = [str(self.meta.get_data_file_path(ep_idx)) for ep_idx in episodes]
-        if len(self.meta.video_keys) > 0:
+        # Overlay repos don't carry videos themselves — those are pulled lazily
+        # from the source repo by _resolve_video_path on first access.
+        if len(self.meta.video_keys) > 0 and self._overlay is None:
             video_files = [
                 str(self.meta.get_video_file_path(ep_idx, vid_key))
                 for vid_key in self.meta.video_keys
@@ -1594,6 +1660,34 @@ class LeRobotDataset(BaseDataset):
             if key not in self.meta.video_keys
         }
 
+    def _resolve_video_path(self, ep_idx: int, vid_key: str) -> Path:
+        """Resolve the on-disk video file path for a given episode + video key.
+
+        For vanilla datasets, returns the local-layout path under ``self.root``.
+        For overlay datasets, formats the source repo's ``video_path`` template
+        (using ``original_episode_index`` from ``meta/episodes.jsonl`` when
+        present, else the dense ``ep_idx``) and lazily downloads the file from
+        the source repo into ``HF_OPENTAU_HOME/<source_repo>/videos/...`` so
+        the cache is shared with future vanilla loads of the source repo.
+        """
+        if self._overlay is None:
+            return self.root / self.meta.get_video_file_path(ep_idx, vid_key)
+
+        src_ep = self.meta.episodes[ep_idx].get("original_episode_index", ep_idx)
+        ovl = self._overlay
+        chunk = src_ep // ovl["chunks_size"]
+        filename = ovl["video_path"].format(episode_chunk=chunk, video_key=vid_key, episode_index=src_ep)
+        local_path = ovl["source_root"] / filename
+        if not local_path.is_file():
+            hf_hub_download(
+                repo_id=ovl["source_repo"],
+                filename=filename,
+                repo_type="dataset",
+                revision=ovl["source_revision"],
+                local_dir=ovl["source_root"],
+            )
+        return local_path
+
     def _query_videos(self, query_timestamps: dict[str, np.ndarray], ep_idx: int) -> dict[str, torch.Tensor]:
         """Note: When using data workers (e.g. DataLoader with num_workers>0), do not call this function
         in the main process (e.g. by using a second Dataloader with num_workers=0). It will result in a
@@ -1602,7 +1696,7 @@ class LeRobotDataset(BaseDataset):
         """
         item = {}
         for vid_key, query_ts in query_timestamps.items():
-            video_path = self.root / self.meta.get_video_file_path(ep_idx, vid_key)
+            video_path = self._resolve_video_path(ep_idx, vid_key)
             frame_indices_soft = query_ts * self.fps
             if self.image_resample_strategy == "linear":
                 frame_indices_floor = np.floor(frame_indices_soft).astype(int)

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -15,9 +15,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
+import logging
 import re
 from copy import deepcopy
 from importlib import import_module
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -817,3 +819,86 @@ def test_deferred_video_multi_episode(tmp_path, empty_lerobot_dataset_factory):
     for ep_idx in range(2):
         video_path = dataset.root / dataset.meta.get_video_file_path(ep_idx, "observation.images.top")
         assert video_path.is_file()
+
+
+def test_overlay_resolves_video_to_source_repo(tmp_path, monkeypatch, lerobot_dataset_factory, info_factory):
+    """Overlay datasets resolve videos against the source repo, lazily caching
+    them under HF_OPENTAU_HOME/<source_repo> and reusing the file on repeat
+    calls. The path is formatted with `original_episode_index` from
+    episodes.jsonl, not the dense partition-local `episode_index`."""
+    src_repo = "src-org/source-dataset"
+    monkeypatch.setattr("opentau.datasets.lerobot_dataset.HF_OPENTAU_HOME", tmp_path / "cache")
+    src_root = tmp_path / "cache" / src_repo
+
+    # Pre-populate the source info.json so __init__ skips the network fetch.
+    src_info_path = src_root / "meta" / "info.json"
+    src_info_path.parent.mkdir(parents=True, exist_ok=True)
+    src_info_path.write_text(
+        json.dumps(
+            {
+                "video_path": "videos/chunk-{episode_chunk:03d}/{video_key}/episode_{episode_index:06d}.mp4",
+                "chunks_size": 1000,
+            }
+        )
+    )
+
+    info = info_factory(total_episodes=3, total_frames=150, total_tasks=1)
+    info["videos"] = {"source_repo": src_repo, "source_revision": "abc123"}
+
+    task = "Perform action 0."
+    eps = {
+        0: {"episode_index": 0, "tasks": [task], "length": 50, "original_episode_index": 17},
+        1: {"episode_index": 1, "tasks": [task], "length": 50, "original_episode_index": 42},
+        2: {"episode_index": 2, "tasks": [task], "length": 50, "original_episode_index": 99},
+    }
+
+    with patch("opentau.datasets.lerobot_dataset.hf_hub_download") as mock_dl:
+        ds = lerobot_dataset_factory(root=tmp_path / "ds", info=info, episode_dicts=eps)
+        # Pre-populated info.json must short-circuit the source-info download.
+        mock_dl.assert_not_called()
+
+    vid_key = ds.meta.video_keys[0]
+    expected = src_root / f"videos/chunk-000/{vid_key}/episode_000017.mp4"
+
+    with patch("opentau.datasets.lerobot_dataset.hf_hub_download") as mock_dl:
+        # Local file missing → download is triggered with source-repo args.
+        result = ds._resolve_video_path(0, vid_key)
+        assert result == expected
+        mock_dl.assert_called_once_with(
+            repo_id=src_repo,
+            filename=f"videos/chunk-000/{vid_key}/episode_000017.mp4",
+            repo_type="dataset",
+            revision="abc123",
+            local_dir=src_root,
+        )
+
+        # Place the file at the expected location → second call skips re-download
+        # (this is what lets a future vanilla load of the source repo reuse it).
+        expected.parent.mkdir(parents=True, exist_ok=True)
+        expected.touch()
+        mock_dl.reset_mock()
+        assert ds._resolve_video_path(0, vid_key) == expected
+        mock_dl.assert_not_called()
+
+    # Overlay datasets must not list video files for snapshot_download / local existence checks.
+    assert all(not p.startswith("videos/") for p in ds.get_episodes_file_paths())
+
+
+def test_control_mode_warning_emitted_once_per_repo(tmp_path, lerobot_dataset_factory, info_factory, caplog):
+    """When info.json lacks `control_mode`, the loader warns exactly once per
+    repo_id within a process even across multiple LeRobotDataset instances."""
+    from opentau.datasets import lerobot_dataset as ld_mod
+
+    test_repo = "warn-once/test-repo"
+    ld_mod._CONTROL_MODE_WARNED.discard(test_repo)
+
+    info = info_factory(total_episodes=3, total_frames=150, total_tasks=1)  # no `control_mode` key
+
+    with caplog.at_level(logging.WARNING):
+        ds_a = lerobot_dataset_factory(root=tmp_path / "a", repo_id=test_repo, info=info)
+        ds_b = lerobot_dataset_factory(root=tmp_path / "b", repo_id=test_repo, info=info)
+
+    assert ds_a.control_mode == "unknown"
+    assert ds_b.control_mode == "unknown"
+    matching = [r for r in caplog.records if "control_mode" in r.getMessage() and r.args == (test_repo,)]
+    assert len(matching) == 1


### PR DESCRIPTION
## What this does

Adds **overlay** support to the LeRobot dataset loader so we can publish derivative datasets (added action columns, multi-embodiment partitions, etc.) without re-uploading the videos — which make up roughly 99% of dataset bytes and are bit-identical to upstream. The contract is in the dataset-curation handoff doc: `info.json` may now declare a pointer to a source repo, and the loader fetches videos from there transparently.

* **Schema additions** in `meta/info.json` (all optional; vanilla repos load unchanged):
  * `control_mode` ∈ {`joint`, `ee`, `mixed`} — exposed on `LeRobotDataset.control_mode`. Defaults to `"unknown"` with a one-time WARNING per repo when missing.
  * `videos.source_repo` + `videos.source_revision` — when present, video reads are routed to that upstream repo.
* **Per-row `original_episode_index`** in `episodes.jsonl` — used for partitioned overlays where the partition's `episode_index` is densified but the source-repo videos remain keyed by the original index. Loader prefers it; falls back to `episode_index`.
* **Caching invariant**: source-repo files cache to `HF_OPENTAU_HOME/<source_repo>/` — the same canonical OpenTau location vanilla loads use. Loading X (overlay) and Y (its source) in either order reuses the same MP4s; nothing lands in `~/.cache/huggingface/hub/`. `_resolve_video_path` checks the local file first and only calls `hf_hub_download(local_dir=...)` on miss.

🗃️ Feature

## How it was tested

* Added `test_overlay_resolves_video_to_source_repo` in [tests/datasets/test_datasets.py](tests/datasets/test_datasets.py) — verifies path formatting uses `original_episode_index`, asserts `hf_hub_download` is called with source-repo args on miss, and skipped on a second call once the file is on disk; also asserts `get_episodes_file_paths` excludes video paths in overlay mode.
* Added `test_control_mode_warning_emitted_once_per_repo` — asserts the warning fires exactly once per `repo_id` across multiple `LeRobotDataset` instances and that `control_mode == "unknown"`.
* Full `tests/datasets/` suite (314 tests) passes — proves the vanilla path is unchanged.
* End-to-end smoke tests against real overlay repos will be done by the dataset-curation side once they publish the test repos (vanilla `lerobot/aloha_static_battery@v2.1`, overlay `TensorAuto/agibot_g1_picks_up_cardboard_box-overlay`, partitioned overlay `TensorAuto/humanoid_everyday-overlay-g1`, gated source).

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/datasets/test_datasets.py::test_overlay_resolves_video_to_source_repo tests/datasets/test_datasets.py::test_control_mode_warning_emitted_once_per_repo
```

```bash
pytest -x tests/datasets/
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).