### PR TITLE
chore(ci): add CLAUDE.md and three Claude integration workflows

### DIFF
--- a/.github/workflows/claude-implement-fixes.yml
+++ b/.github/workflows/claude-implement-fixes.yml
@@ -38,6 +38,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      id-token: write  # claude-code-action does an OIDC handshake at startup
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/claude-implement-fixes.yml
+++ b/.github/workflows/claude-implement-fixes.yml
@@ -1,0 +1,72 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Claude Implement Fixes
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+# Serialize implement-fix runs against the same PR so two rapid `@claude fix`
+# comments don't race on the PR branch.
+concurrency:
+  group: claude-implement-fixes-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  implement:
+    if: |
+      (github.event.issue.pull_request || github.event.pull_request) &&
+      contains(github.event.comment.body, '@claude fix') &&
+      github.event.comment.user.type != 'Bot'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            A reviewer asked you to address review feedback on this PR.
+
+            1. Read all review comments on the PR (resolved and unresolved).
+            2. For each actionable comment, implement the fix on the PR's branch.
+            3. Skip comments that are questions, taste preferences, or already addressed.
+            4. Run the test command from CLAUDE.md before pushing.
+            5. Make ONE commit at the end of the session that addresses every
+               comment you decided to act on — do NOT push one commit per
+               comment. Subject line (must be < 80 chars per CLAUDE.md):
+
+                   [claude-fix] address review feedback on #${{ github.event.issue.number || github.event.pull_request.number }}
+
+               Commit body: a bulleted list, one bullet per addressed comment:
+
+                   - addresses @<reviewer> (<short topic>): <what you changed>
+
+               Then push the single commit to the PR branch.
+            6. Reply individually to each addressed comment on the PR with
+               what you changed and the new commit SHA. Every reply MUST start
+               with `[claude-fix]` so reviewers can scan/filter.
+            7. If a comment is unclear or you disagree, reply asking for clarification
+               instead of guessing.

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -27,6 +27,7 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
+  id-token: write  # claude-code-action does an OIDC handshake at startup
 
 jobs:
   review:

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,0 +1,108 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+# Cancel a stale review when a new commit is pushed to the same PR.
+concurrency:
+  group: claude-pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  review:
+    # Skip on `synchronize` when the pusher is a Claude bot — otherwise the
+    # implement-fixes workflow's pushes would re-trigger us in a loop and we'd
+    # end up reviewing our own fixes. Always run on `opened` (auto-reviewing a
+    # Claude-opened PR is the whole point of this workflow).
+    if: >-
+      github.event.action == 'opened'
+      || !contains(github.event.sender.login, 'claude')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: |
+            --model claude-opus-4-7
+          prompt: |
+            You are reviewing PR #${{ github.event.pull_request.number }} in
+            ${{ github.repository }}.
+
+            ## Comment hygiene — DO THIS BEFORE POSTING ANYTHING
+
+            On every run you MUST leave at most ONE summary comment on this PR
+            (edited in place across pushes), and you MUST clear stale inline
+            findings from previous runs. Concretely:
+
+            1. List existing comments with:
+                 gh pr view ${{ github.event.pull_request.number }} \
+                   --repo ${{ github.repository }} \
+                   --json comments,reviews
+               Find a prior summary comment of yours whose body starts with
+               the marker `<!-- claude-review:v1 -->`. Capture its `id`.
+            2. If a prior summary comment exists, EDIT it in place — do not
+               post a new one — via:
+                 gh api -X PATCH \
+                   /repos/${{ github.repository }}/issues/comments/<id> \
+                   -f body='<new body>'
+               If none exists, create one with `gh pr comment`.
+            3. For prior reviews of yours that have inline comments still
+               attached, dismiss them so stale line-anchored findings stop
+               showing as active:
+                 gh api -X PUT \
+                   /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews/<review_id>/dismissals \
+                   -f message='superseded by newer review'
+
+            ## What to review
+
+            Focus on:
+            - Correctness bugs and logic errors
+            - Violations of conventions in CLAUDE.md and .claude/rules/
+            - Missing tests for new behavior
+            - PyTorch/ML-specific issues: device placement, dtype mismatches,
+              non-deterministic ops, gradient flow, memory leaks in training loops
+            - Distributed training pitfalls if the change touches multi-GPU code
+
+            Skip: style nits a linter would catch, taste preferences,
+            speculative refactors.
+
+            ## How to post
+
+            Submit a fresh review (`gh pr review --comment`) with inline
+            findings on specific lines. Then upsert your single summary
+            comment. The summary body MUST begin with these two lines exactly:
+
+                <!-- claude-review:v1 -->
+                [claude-review] summary for commit <short-sha>
+
+            Followed by a markdown list, one bullet per finding, formatted:
+                - **blocking** | **suggestion** | **nit** — `path/to/file:line` — short description
+
+            If the PR is clean, the body after the marker should say
+            "No blocking issues found." in one line. Don't manufacture issues.

--- a/.github/workflows/extract-claude-lessons.yml
+++ b/.github/workflows/extract-claude-lessons.yml
@@ -1,0 +1,57 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Extract Claude Lessons
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  extract-lessons:
+    if: >-
+      github.event.pull_request.merged == true
+      && contains(github.event.pull_request.user.login, 'claude')
+      && !startsWith(github.event.pull_request.title, 'chore(claude): learn from')
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            Review the comments on this merged PR. If any reviewer feedback
+            reveals a missing rule in CLAUDE.md or .claude/rules/, open a
+            new PR titled "chore(claude): learn from #${{ github.event.pull_request.number }}"
+            with the proposed updates.
+
+            Additionally, if the PR's diff or review comments make clear that
+            something already written in CLAUDE.md or .claude/rules/ is no
+            longer factually correct or no longer relevant (e.g. a referenced
+            file/command/path no longer exists, a rule contradicts a decision
+            the team has now adopted, or guidance describes behavior that has
+            since changed), include a correction or removal in the same PR.
+            Apply this edit sparingly and only when necessary — when in doubt,
+            leave the existing text alone. Prefer minimal surgical edits over
+            rewrites, and never delete a rule purely because it wasn't
+            exercised by this PR.
+
+            If nothing rule-worthy and nothing stale, exit cleanly.

--- a/.github/workflows/extract-claude-lessons.yml
+++ b/.github/workflows/extract-claude-lessons.yml
@@ -21,6 +21,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write  # claude-code-action does an OIDC handshake at startup
 
 jobs:
   extract-lessons:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,134 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Hard rules for Claude in this repo
+
+These override defaults — read them before running anything.
+
+1. **Never start a real training run.** Real configs train for 100k+ steps on multi-A100 nodes — they cost money and burn hours, and a botched config wastes both. When you need to exercise the training path, only ever launch:
+   - `configs/dev/dev_config.json` or `configs/dev/ci_config.json` (small `steps`, tiny batch, public dataset), or
+   - `configs/examples/pi05_training_config.json` (already a smoke config: `steps: 40`, `batch_size: 2`), or
+   - `src/opentau/scripts/fake_tensor_training.py` (uses `FakeTensorContext` from `utils/fake_tensor.py` — no real allocation, just shape inference).
+
+   If you find yourself overriding `--steps` to anything > a few hundred, stop and ask.
+
+2. **Default to the CPU test subset.** Local dev typically has no NVIDIA GPU; running the full suite will fail confusingly partway through GPU-only tests.
+   - Local / CI-equivalent: `pytest -m "not gpu" -n auto` — this is what `cpu_test.yml` runs and what should always pass.
+   - GPU-only subset: `pytest -m "gpu" -n 0` — only run on a CUDA box (the slurm `oracle` cluster or `mlbox`); on a Mac/CPU laptop it will fail at fixture setup. Markers are defined in `pyproject.toml::[tool.pytest.ini_options]`.
+   - When CI shows a failure under `-m "gpu"` and you can't reproduce locally, say so explicitly — don't pretend you ran it.
+
+3. **Verify determinism on any change to the training loop or model.** ML bugs hide in stochasticity: a bad change can still produce loss curves that *look* plausible. After touching anything in `scripts/train.py`, `policies/*/modeling_*.py`, `optim/`, or `datasets/sampler.py`, run a smoke config twice with the same `seed` and confirm the per-step loss series is bit-identical (not just "close"). Seeding utilities live in `src/opentau/utils/random_utils.py` (`set_seed`, `serialize_python_rng_state`, etc.). If two seeded runs diverge, that's a bug — investigate before claiming the change works.
+
+## Project overview
+
+OpenTau is Tensor's open-source PyTorch training toolchain for vision-language-action (VLA) models — a fork of LeRobot with extra capabilities (heterogeneous-dataset co-training, discrete actions for π₀.₅, knowledge insulation, dropout in PaliGemma, π*₀.₆-style RL, validation splits, profilers). Any LeRobot-compliant policy and dataset works directly. Pinned to **Python 3.10**.
+
+## Environment & install
+
+Dependency management is **`uv` only** — `pyproject.toml`/`uv.lock` are authoritative; do not edit `requirements.txt` (none exists) or call `pip install` against the env.
+
+```bash
+uv sync --extra dev --extra libero          # standard dev setup (matches CI)
+uv sync --all-extras                         # everything (note: libero + urdf are mutually exclusive — see [tool.uv].conflicts)
+source .venv/bin/activate
+```
+
+Re-run `uv sync` whenever `pyproject.toml`/`uv.lock` change. Add deps with `uv add <pkg>`; lock with `uv lock`.
+
+Installable extras: `dev` (pre-commit, sphinx, pytest), `libero` (sim env — pulls a forked LIBERO from `shuheng-liu/LIBERO`, pins numpy<2), `urdf` (rerun ≥0.28, requires numpy 2.x — incompatible with `libero`), `trt` (TensorRT, Linux/Win x86_64 only).
+
+## Common commands
+
+### Testing
+
+```bash
+pytest -m "not gpu" -n auto                  # CPU suite (what cpu_test.yml runs)
+pytest -m "gpu" -n 0                         # GPU suite (what gpu_test.yml runs)
+pytest -sx tests/path/to/test_x.py::test_y   # single test, fail-fast, no capture
+```
+
+Markers defined in `pyproject.toml`: `slow` (>1s runtime), `gpu` (needs GPU). Tests requiring LIBERO need `LIBERO_CONFIG_PATH` set (CI points it at `.github/assets/libero`). CI also runs nightly regression tests on g6.12xlarge — see `.github/workflows/regression_test.yml`.
+
+### Linting / pre-commit
+
+```bash
+pre-commit install                           # one-time
+pre-commit run --all-files                   # run all hooks
+```
+
+The pre-commit suite runs ruff (lint + format, line-length 110, py310), pyupgrade, gitleaks, zizmor (GitHub Actions security), bandit (config in `[tool.bandit]`), and typos. **Run pre-commit *before* tests** — formatters can rewrite files mid-iteration.
+
+### Training / eval / export (console scripts)
+
+`pyproject.toml` defines four console entry points that wrap `accelerate launch` (defined in `src/opentau/scripts/launch.py`):
+
+```bash
+# Single-node multi-GPU training (uses 8 GPUs by default — edit num_processes)
+opentau-train \
+    --accelerate-config configs/examples/accelerate_ddp_config.yaml \
+    --config_path=configs/examples/pi05_training_config.json
+
+opentau-eval --accelerate-config <yaml> --config_path=<json>      # eval
+opentau-export --config_path=<json>                                # ONNX export (no accelerate)
+opentau-dataset-viz --config_path=<json>                           # dataset visualizer (no accelerate)
+```
+
+Configs are **draccus-based JSON** (see `configs/examples/`). Any field can be overridden on the CLI: `--policy.type=pi05 --batch_size=8 --steps=1000`. Use `pi_config.json` style for π₀, `pi05_*.json` for π₀.₅. Accelerate configs: `accelerate_ddp_config.yaml` (DDP) or `accelerate_deepspeed_config.yaml` (ZeRO).
+
+Direct invocation (bypasses the launcher; useful in slurm/sbatch wrappers): `accelerate launch --config_file <yaml> src/opentau/scripts/train.py --config_path=<json>`.
+
+### Diagnostics
+
+Three drop-in profiling scripts read the same `TrainPipelineConfig`:
+
+- `src/opentau/scripts/profile_step.py` — per-step wall-clock breakdown (forward / backward / optimizer / sync)
+- `src/opentau/scripts/profile_dataloader.py` — dataloader-only ceiling, no model
+- `src/opentau/scripts/find_unused_params.py` — lists params that DDP would drop with `find_unused_parameters=False`
+
+`FIND_UNUSED_PARAMS=false` (env var, read in `train.py`) reclaims ~10-15% of step time once a config has been audited.
+
+## Architecture
+
+### Configuration system (draccus)
+
+Everything starts from a `TrainPipelineConfig` (`src/opentau/configs/train.py`) decorated as a draccus dataclass. The `@parser.wrap()` decorator on `train()` / `eval()` is OpenTau's extension over draccus that supports loading a config from a local path or HuggingFace Hub via `--config_path=...`, then merging in CLI overrides. The pattern is **never instantiate config objects directly in scripts** — always go through `parser.wrap` so that hub paths, plugin discovery (`PLUGIN_DISCOVERY_SUFFIX = "discover_packages_path"`), and CLI overrides all flow correctly.
+
+Key invariant on `TrainPipelineConfig`: `batch_size == dataloader_batch_size * gradient_accumulation_steps`. When sweeping per-rank batch, override all three together — the validator will reject inconsistent combinations. When using DeepSpeed, `gradient_accumulation_steps` must also match the value in the DeepSpeed JSON.
+
+`PreTrainedConfig` (`configs/policies.py`) is the abstract base for policy configs. Subclasses register themselves via the `policy.type` choice key (draccus `CHOICE_TYPE_KEY`). To add a new policy: subclass `PreTrainedConfig`, subclass `PreTrainedPolicy`, and register both in `policies/factory.py::get_policy_class` / `get_policy_class_config`.
+
+### Module layout (`src/opentau/`)
+
+- `configs/` — dataclass configs (train, eval, policies, envs, optim, deployment, libero, ros2lerobot)
+- `datasets/` — LeRobot-compatible datasets, `WeightedDatasetMixture` (heterogeneous co-training), VQA datasets, v1→v2 / v2→v2.1 converters under `v2/`, `v21/`
+- `envs/` — gym/gymnasium envs (currently LIBERO); `factory.make_envs()`
+- `optim/` — optimizer + LR-scheduler dataclass-configured factories
+- `planner/` — high-level planner using `prompts.yaml`
+- `policies/` — `pi0`, `pi05`, `pi05_mem`, `pi07_paligemma/{high_level_planner,low_level_planner}`, `value`. Each subdir has a `configuration_*.py` and `modeling_*.py`. Vision backbone wrapper is `paligemma_with_expert.py`.
+- `scripts/` — entry points (train/eval/launch), profilers, dataset converters (LIBERO, ROS, human video, RECAP), gRPC inference server, ONNX/TensorRT export
+- `utils/` — `accelerate_utils` (sets process-global accelerator for rank detection), `train_utils` (checkpoint save/load/prune), `logging_utils` (`AverageMeter`, `MetricsTracker`), `transformers_patch`, `monkey_patch`
+
+### Training loop (`scripts/train.py`)
+
+`train()` is the entry; uses `accelerate.Accelerator` for distributed coordination. Loss is a weighted sum of `MSE` (action regression) and `CE` (discrete-action / language) terms — weights from `cfg.loss_weighting`. Metrics use `MetricsTracker` whose `__setattr__` is **not idempotent** — setting `metrics.loss = x` calls `AverageMeter.update(x)`, so repeat assignments accumulate a running mean rather than overwriting. Every reduction goes through `accelerator.gather_for_metrics` for rank-0 logging.
+
+`save_checkpoint` / `load_training_state` (in `utils/train_utils.py`) handle resume — when resuming, the checkpoint config takes precedence over CLI args. `prune_old_checkpoints` keeps the most recent N.
+
+## PR / contribution workflow
+
+- **Always run pre-commit hooks before running unit tests.** The hooks (ruff format, end-of-file-fixer, trailing-whitespace, pyupgrade) will rewrite files or prompt for fixes; running tests first wastes a run when the formatter then changes the source. Sequence: `pre-commit run --all-files` → `pytest`.
+- **Commit messages: keep them simple. The first line must be under 80 characters.** No long preambles in the subject.
+- **PRs must follow `.github/PULL_REQUEST_TEMPLATE.md` verbatim.** The `check-pr-checklist.yml` CI grep-matches the exact phrases for the docstring and policy-change checkboxes — do not rephrase them, do not delete sections. Fill in `What this does`, `How it was tested`, and `How to checkout & try`.
+- Policy-related PRs require running GPU pytests + nightly regression tests; check both boxes.
+- Required tests/lint that gate merge: `cpu_test.yml` (PRs/pushes) and `pre-commit.yml`. `gpu_test.yml` and `regression_test.yml` run nightly on AWS g6 runners (cron 10:00 UTC).
+- Per-file ruff overrides in `pyproject.toml`: gRPC server (PascalCase methods, `N802`), `recordhuman_to_lerobot.py` (math-convention uppercase names, `N803`/`N806`).
+
+## Reference paths
+
+- Console-scripts: defined in `pyproject.toml [project.scripts]`
+- Training entry: `src/opentau/scripts/launch.py::train` → `accelerate launch src/opentau/scripts/train.py`
+- Example configs: `configs/examples/*.json`
+- Local notebooks: `notebooks/pi05_training.ipynb`, `notebooks/pi05_evaluation_only.ipynb`
+- Docs source (Sphinx, RTD-built): `docs/source/`
+- Pretrained checkpoints: `huggingface.co/TensorAuto/*` (see README table)


### PR DESCRIPTION
## What this does

Adds a `CLAUDE.md` for the OpenTau repo (project orientation: hard rules, install, commands, architecture, PR workflow) and three GitHub Actions workflows that wire Claude into the contribution flow:

- **`.github/workflows/claude-pr-review.yml`** — auto-review on `pull_request` open/synchronize. Maintains exactly **one** summary comment per PR, edited in place across pushes via the `<!-- claude-review:v1 -->` marker (instead of stacking a fresh review on every force-push). Skips on `synchronize` when the pusher is a Claude bot, breaking the review-of-fix-of-review loop.
- **`.github/workflows/claude-implement-fixes.yml`** — triggered by `@claude fix` in PR or inline review comments. Coalesces all addressed feedback into a **single** commit per session (instead of one micro-commit per comment) and posts per-comment replies tagged `[claude-fix]` for filterability. Bot author guard prevents self-trigger.
- **`.github/workflows/extract-claude-lessons.yml`** — fires when a Claude-authored PR is merged. Reviews reviewer feedback and opens a `chore(claude): learn from #N` PR proposing CLAUDE.md / `.claude/rules/` updates if anything is rule-worthy or stale. Title-prefix guard prevents recursion on its own chore PRs.

All three set `timeout-minutes`, `persist-credentials: false`, an Apache-2.0/Tensor-Auto copyright header, and an appropriate `concurrency:` group. Requires `ANTHROPIC_API_KEY` in repo secrets to actually run.

## How it was tested

- `actionlint` clean against all three new files (exit 0).
- pre-commit hooks (check-yaml, typos, gitleaks, **zizmor** GitHub Actions security check, end-of-file-fixer, trailing-whitespace) all pass.
- End-to-end behavior — single edited summary comment across pushes, no review re-trigger after a Claude push, single coalesced fix commit — is only fully observable on a live PR after merge.

## How to checkout & try? (for the reviewer)

```bash
gh pr checkout <this-PR-number>
brew install actionlint   # if not already
actionlint .github/workflows/claude-pr-review.yml \
           .github/workflows/claude-implement-fixes.yml \
           .github/workflows/extract-claude-lessons.yml
```

End-to-end: after merging, open a small follow-up PR and confirm:
1. Exactly one comment with the `[claude-review]` prefix appears.
2. Pushing follow-up commits *edits* that same comment, not duplicates it.
3. Leaving 2 review comments + `@claude fix` produces one coalesced commit listing both, plus 2 `[claude-fix]`-prefixed replies.
4. `claude-pr-review` does **not** re-fire after Claude's push.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.