### PR TITLE
feat: surface robot_type and control_mode in standard data format

### DIFF
--- a/docs/source/concepts.rst
+++ b/docs/source/concepts.rst
@@ -118,14 +118,30 @@ keys when the dataset has been enriched with segment metadata (see
 future video frames. Each optional key is **always present**. Numeric
 and image keys pair with an ``{key}_is_pad`` boolean flag — zero-filled
 + flag True means "unavailable or masked". String keys
-(``response``, ``memory``, ``next_memory``) don't get a separate flag:
-the empty string ``""`` is itself the pad signal, which also keeps the
-default PyTorch collate happy (list of strings, same length as batch).
+(``response``, ``memory``, ``next_memory``, ``robot_type``,
+``control_mode``) don't get a separate flag: the empty string ``""``
+is itself the pad signal, which also keeps the default PyTorch collate
+happy (list of strings, same length as batch).
+
+``robot_type`` and ``control_mode`` are **dataset-level identifiers**
+(constant for every sample within a given dataset, distinct across
+datasets in a mixture batch) sourced directly from ``meta/info.json``.
+Unlike the segment-metadata keys below, they are **not** subject to
+training-time dropout — see :ref:`Training-time dropout
+<standard-data-format-optional-keys-dropout>`.
 
 .. code-block:: python
 
     {
         # ... core keys above ...
+
+        "robot_type": str,         # e.g. "aloha", "panda", "human" — copied verbatim
+                                   # from `meta/info.json["robot_type"]` (a standard
+                                   # LeRobot v2 field). Empty string ("") when the key
+                                   # is absent or null (e.g. VQA datasets).
+        "control_mode": str,       # One of {"joint", "ee", "mixed"} when the dataset
+                                   # opted in (see PR #183). Empty string ("") when
+                                   # `meta/info.json["control_mode"]` is absent.
 
         "memory": str,             # Cumulative subtask summary for the current frame's segment.
                                    # Empty string ("") when memory_raw is absent
@@ -177,11 +193,15 @@ Datasets opt in to subgoals by adding the key; the loader then uses the
 frame-selection machinery (end-of-segment vs. uniform ``[t, t+4 s]``)
 described below.
 
+.. _standard-data-format-optional-keys-dropout:
+
 Training-time dropout
 ^^^^^^^^^^^^^^^^^^^^^
 
 Six probability fields on ``DatasetMixtureConfig`` control how often
-each optional key is masked during a single ``__getitem__`` call. Masks
+each optional key is masked during a single ``__getitem__`` call.
+``robot_type`` and ``control_mode`` are exempt — they are passed through
+unchanged regardless of any drop roll. Masks
 are independent per sample (each call rolls fresh). ``DataLoader``
 workers seed their own torch RNG, so samples within a batch are
 independent across workers; seed globally via ``torch.manual_seed(...)``

--- a/docs/source/concepts.rst
+++ b/docs/source/concepts.rst
@@ -126,9 +126,9 @@ happy (list of strings, same length as batch).
 ``robot_type`` and ``control_mode`` are **dataset-level identifiers**
 (constant for every sample within a given dataset, distinct across
 datasets in a mixture batch) sourced directly from ``meta/info.json``.
-Unlike the segment-metadata keys below, they are **not** subject to
-training-time dropout — see :ref:`Training-time dropout
-<standard-data-format-optional-keys-dropout>`.
+Like ``speed``, ``mistake``, and ``quality``, they participate in the
+``metadata_drop_all_prob`` / ``metadata_drop_each_prob`` dropout rolls —
+see :ref:`Training-time dropout <standard-data-format-optional-keys-dropout>`.
 
 .. code-block:: python
 
@@ -200,8 +200,7 @@ Training-time dropout
 
 Six probability fields on ``DatasetMixtureConfig`` control how often
 each optional key is masked during a single ``__getitem__`` call.
-``robot_type`` and ``control_mode`` are exempt — they are passed through
-unchanged regardless of any drop roll. Masks
+Masks
 are independent per sample (each call rolls fresh). ``DataLoader``
 workers seed their own torch RNG, so samples within a batch are
 independent across workers; seed globally via ``torch.manual_seed(...)``
@@ -235,12 +234,13 @@ for reproducibility.
        would remove the primary task signal).
    * - ``metadata_drop_all_prob``
      - ``0.15``
-     - Masks ``speed``, ``mistake``, and ``quality`` together.
+     - Masks ``speed``, ``mistake``, ``quality``, ``robot_type``, and
+       ``control_mode`` together.
    * - ``metadata_drop_each_prob``
      - ``0.05``
      - Per-field independent mask roll for each of ``speed``,
-       ``mistake``, ``quality``. Only rolled when the shared drop did
-       not fire.
+       ``mistake``, ``quality``, ``robot_type``, ``control_mode``.
+       Only rolled when the shared drop did not fire.
    * - ``val_enable_optional_key_dropout``
      - ``False``
      - Whether the five drop rolls above also fire on the **validation**

--- a/src/opentau/configs/default.py
+++ b/src/opentau/configs/default.py
@@ -154,11 +154,12 @@ class DatasetMixtureConfig:
             text) during a single ``__getitem__`` call. Only rolled when
             subgoals are not dropped. Must be in ``[0, 1]``. Defaults to 0.3.
         metadata_drop_all_prob: Probability of dropping ``speed``, ``mistake``,
-            and ``quality`` together during a single ``__getitem__`` call.
-            Must be in ``[0, 1]``. Defaults to 0.15.
+            ``quality``, ``robot_type``, and ``control_mode`` together during a
+            single ``__getitem__`` call. Must be in ``[0, 1]``. Defaults to 0.15.
         metadata_drop_each_prob: Per-field independent drop probability for
-            ``speed``, ``mistake``, and ``quality``. Only rolled when
-            ``metadata_drop_all_prob`` did not fire. Must be in ``[0, 1]``.
+            ``speed``, ``mistake``, ``quality``, ``robot_type``, and
+            ``control_mode``. Only rolled when ``metadata_drop_all_prob`` did not
+            fire. Must be in ``[0, 1]``.
             Defaults to 0.05.
         val_enable_optional_key_dropout: Whether to apply the five
             ``*_drop_prob`` rolls above to the validation split. Defaults to

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -820,15 +820,10 @@ class BaseDataset(torch.utils.data.Dataset):
         else:
             standard_item["obs_history_is_pad"] = torch.tensor([False], dtype=torch.bool)
 
-        # Emit optional keys (memory, next_memory, speed, mistake, quality, subgoalK)
-        # with their _is_pad siblings, applying training-time dropout rolls.
+        # Emit optional keys (memory, next_memory, speed, mistake, quality,
+        # robot_type, control_mode, subgoalK) with their _is_pad siblings,
+        # applying training-time dropout rolls.
         self._emit_optional_keys(item, standard_item)
-
-        # Dataset-level identifiers, surfaced per-sample so policies/collators
-        # can read them uniformly. "" signals "field absent in meta/info.json"
-        # (same convention as response / memory / next_memory).
-        standard_item["robot_type"] = self.meta.info.get("robot_type") or ""
-        standard_item["control_mode"] = self.meta.info.get("control_mode") or ""
 
         # cast all tensors in standard_item to bfloat16
         for key, value in standard_item.items():
@@ -842,9 +837,10 @@ class BaseDataset(torch.utils.data.Dataset):
 
         All emitted keys are always present (zero/empty-filled when absent or
         masked). Numeric / image keys come with a parallel ``{key}_is_pad``
-        bool; string keys (``response``, ``memory``, ``next_memory``) use the
-        empty string itself as the pad signal — a consumer seeing ``""`` can
-        assume the field was unavailable or was masked this step.
+        bool; string keys (``response``, ``memory``, ``next_memory``,
+        ``robot_type``, ``control_mode``) use the empty string itself as the
+        pad signal — a consumer seeing ``""`` can assume the field was
+        unavailable or was masked this step.
 
         Dropout order:
             1. ``history_state_drop_prob``: zero ``state`` and historical camera
@@ -853,9 +849,9 @@ class BaseDataset(torch.utils.data.Dataset):
                single ``subgoal_is_pad`` flag to True (subgoals are all-or-none).
             3. ``response_drop_prob``: only when subgoals were NOT dropped, mask
                ``response`` to the empty string.
-            4. ``metadata_drop_all_prob``: mask {speed, mistake, quality}
-               together. If this didn't fire, ``metadata_drop_each_prob`` rolls
-               independently for each of the three.
+            4. ``metadata_drop_all_prob``: mask {speed, mistake, quality,
+               robot_type, control_mode} together. If this didn't fire,
+               ``metadata_drop_each_prob`` rolls independently for each field.
 
         Dropout rolls use the default torch RNG (auto-seeded per worker).
 
@@ -926,7 +922,8 @@ class BaseDataset(torch.utils.data.Dataset):
         next_memory_raw = item.get("next_memory_raw")
         standard_item["next_memory"] = next_memory_raw if isinstance(next_memory_raw, str) else ""
 
-        # (5) Metadata drops.
+        # (5) Metadata drops: numeric fields get a _is_pad flag; string
+        # identifier fields use "" as the pad signal (no separate flag).
         drop_meta_all = _roll(self.metadata_drop_all_prob)
         for key, dtype in (("speed", torch.long), ("mistake", torch.bool), ("quality", torch.long)):
             raw_key = f"{key}_raw"
@@ -940,6 +937,10 @@ class BaseDataset(torch.utils.data.Dataset):
                 value = bool(raw) if dtype is torch.bool else int(raw)
                 standard_item[key] = torch.tensor(value, dtype=dtype)
                 standard_item[f"{key}_is_pad"] = torch.tensor(False)
+        for key in ("robot_type", "control_mode"):
+            val = self.meta.info.get(key) or ""
+            drop_this = drop_meta_all or _roll(self.metadata_drop_each_prob)
+            standard_item[key] = "" if drop_this else val
 
     def resize_with_pad(self, img, width, height, pad_value=0) -> torch.Tensor:
         """Resize an image to target dimensions with padding.

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -824,6 +824,12 @@ class BaseDataset(torch.utils.data.Dataset):
         # with their _is_pad siblings, applying training-time dropout rolls.
         self._emit_optional_keys(item, standard_item)
 
+        # Dataset-level identifiers, surfaced per-sample so policies/collators
+        # can read them uniformly. "" signals "field absent in meta/info.json"
+        # (same convention as response / memory / next_memory).
+        standard_item["robot_type"] = self.meta.info.get("robot_type") or ""
+        standard_item["control_mode"] = self.meta.info.get("control_mode") or ""
+
         # cast all tensors in standard_item to bfloat16
         for key, value in standard_item.items():
             if isinstance(value, torch.Tensor) and value.dtype.is_floating_point:

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -902,3 +902,38 @@ def test_control_mode_warning_emitted_once_per_repo(tmp_path, lerobot_dataset_fa
     assert ds_b.control_mode == "unknown"
     matching = [r for r in caplog.records if "control_mode" in r.getMessage() and r.args == (test_repo,)]
     assert len(matching) == 1
+
+
+def test_robot_type_and_control_mode_in_meta_info(tmp_path, lerobot_dataset_factory, info_factory):
+    """robot_type and control_mode are surfaced as optional fields in the
+    standard data format. Verify the underlying meta/info.json values that
+    BaseDataset._to_standard_data_format reads via ``self.meta.info.get(...)``.
+
+    The unit tests in tests/datasets/test_optional_keys.py::TestRobotTypeControlMode
+    cover the actual emission lines; this test just guards against a regression
+    in how the factory threads info.json into ds.meta.info.
+    """
+    info_with = info_factory(
+        robot_type="aloha",
+        total_episodes=3,
+        total_frames=150,
+        total_tasks=1,
+    )
+    info_with["control_mode"] = "joint"
+    ds_with = lerobot_dataset_factory(root=tmp_path / "with-fields", info=info_with)
+    assert ds_with.meta.info["robot_type"] == "aloha"
+    assert ds_with.meta.info["control_mode"] == "joint"
+
+    info_without = info_factory(
+        robot_type=None,  # null robot_type is allowed by the type signature
+        total_episodes=3,
+        total_frames=150,
+        total_tasks=1,
+    )  # no `control_mode` key — emulates pre-PR-#183 datasets
+    ds_without = lerobot_dataset_factory(
+        root=tmp_path / "without-fields",
+        repo_id="missing-fields/test-repo",
+        info=info_without,
+    )
+    assert ds_without.meta.info["robot_type"] is None
+    assert "control_mode" not in ds_without.meta.info

--- a/tests/datasets/test_optional_keys.py
+++ b/tests/datasets/test_optional_keys.py
@@ -455,9 +455,9 @@ class TestDefaultCollate:
         assert batch["quality_is_pad"].tolist() == [False, True]
 
 
-# Dataset-level identifiers (robot_type, control_mode) emitted by
-# _to_standard_data_format read directly from self.meta.info and are not
-# subject to any training-time dropout.
+# Dataset-level identifiers (robot_type, control_mode) are emitted inside
+# _emit_optional_keys and participate in the metadata_drop_all_prob /
+# metadata_drop_each_prob dropout rolls, same as speed / mistake / quality.
 
 
 def _full_raw_item(dataset: _DummyBaseDataset) -> dict:
@@ -498,9 +498,9 @@ class TestRobotTypeControlMode:
         out = ds._to_standard_data_format(_full_raw_item(ds))
         assert out["robot_type"] == ""
 
-    def test_pass_through_under_all_dropouts(self):
-        # Lock in the contract: even with every drop probability cranked to 1.0
-        # and dropout enabled, robot_type / control_mode are unchanged.
+    def test_dropped_when_metadata_drop_all_prob_is_one(self):
+        # When metadata_drop_all_prob=1.0, robot_type / control_mode collapse to
+        # "" — they participate in the same metadata drop group as speed/mistake.
         ds = _DummyBaseDataset(
             num_cams=1,
             meta_info={"robot_type": "panda", "control_mode": "ee"},
@@ -509,6 +509,20 @@ class TestRobotTypeControlMode:
             response_drop_prob=1.0,
             metadata_drop_all_prob=1.0,
             metadata_drop_each_prob=1.0,
+        )
+        assert ds.enable_optional_key_dropout is True
+        out = ds._to_standard_data_format(_full_raw_item(ds))
+        assert out["robot_type"] == ""
+        assert out["control_mode"] == ""
+
+    def test_pass_through_when_drop_probs_zero(self):
+        # With all drop probabilities at zero, robot_type / control_mode pass
+        # through unchanged even when dropout is enabled.
+        ds = _DummyBaseDataset(
+            num_cams=1,
+            meta_info={"robot_type": "panda", "control_mode": "ee"},
+            metadata_drop_all_prob=0.0,
+            metadata_drop_each_prob=0.0,
         )
         assert ds.enable_optional_key_dropout is True
         out = ds._to_standard_data_format(_full_raw_item(ds))

--- a/tests/datasets/test_optional_keys.py
+++ b/tests/datasets/test_optional_keys.py
@@ -22,6 +22,8 @@ covered by tests/scripts/test_attach_metadata.py (slow, network-dependent).
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import torch
 
 from opentau.datasets.lerobot_dataset import BaseDataset
@@ -62,6 +64,7 @@ class _DummyBaseDataset(BaseDataset):
         response_drop_prob=0.0,
         metadata_drop_all_prob=0.0,
         metadata_drop_each_prob=0.0,
+        meta_info: dict | None = None,
     ):
         torch.utils.data.Dataset.__init__(self)
         self.resolution = resolution
@@ -77,6 +80,9 @@ class _DummyBaseDataset(BaseDataset):
         self.metadata_drop_all_prob = metadata_drop_all_prob
         self.metadata_drop_each_prob = metadata_drop_each_prob
         self.enable_optional_key_dropout = True
+        # Stub meta surface so _to_standard_data_format can read robot_type /
+        # control_mode without instantiating a real LeRobotDatasetMetadata.
+        self.meta = SimpleNamespace(info=meta_info if meta_info is not None else {})
 
     def _get_feature_mapping_key(self) -> str:
         return _TEST_MAPPING_KEY
@@ -447,3 +453,75 @@ class TestDefaultCollate:
         # is_pad flags align 1:1 with their samples.
         assert batch["subgoal_is_pad"].tolist() == [False, True]
         assert batch["quality_is_pad"].tolist() == [False, True]
+
+
+# Dataset-level identifiers (robot_type, control_mode) emitted by
+# _to_standard_data_format read directly from self.meta.info and are not
+# subject to any training-time dropout.
+
+
+def _full_raw_item(dataset: _DummyBaseDataset) -> dict:
+    """Minimal raw item that ``_to_standard_data_format`` can consume end-to-end."""
+    h, w = dataset.resolution
+    return {
+        "camera0": torch.full((3, h, w), 0.5, dtype=torch.float32),
+        "state": torch.zeros(dataset.max_state_dim, dtype=torch.float32),
+        "actions": torch.zeros((dataset.action_chunk, dataset.max_action_dim), dtype=torch.float32),
+        "actions_is_pad": torch.zeros(dataset.action_chunk, dtype=torch.bool),
+        "prompt": "do the thing",
+        "response": "ok",
+    }
+
+
+class TestRobotTypeControlMode:
+    def test_both_present_pass_through(self):
+        ds = _DummyBaseDataset(
+            num_cams=1,
+            meta_info={"robot_type": "aloha", "control_mode": "joint"},
+        )
+        out = ds._to_standard_data_format(_full_raw_item(ds))
+        assert out["robot_type"] == "aloha"
+        assert out["control_mode"] == "joint"
+
+    def test_both_absent_emit_empty_string(self):
+        # Default _DummyBaseDataset has empty meta.info — mirrors VQA datasets and
+        # legacy LeRobot datasets that pre-date PR #183.
+        ds = _DummyBaseDataset(num_cams=1)
+        out = ds._to_standard_data_format(_full_raw_item(ds))
+        assert out["robot_type"] == ""
+        assert out["control_mode"] == ""
+
+    def test_robot_type_none_emit_empty_string(self):
+        # `info["robot_type"]` is typed `str | None`; both None and missing must
+        # collapse to the same "" sentinel so the downstream contract is uniform.
+        ds = _DummyBaseDataset(num_cams=1, meta_info={"robot_type": None})
+        out = ds._to_standard_data_format(_full_raw_item(ds))
+        assert out["robot_type"] == ""
+
+    def test_pass_through_under_all_dropouts(self):
+        # Lock in the contract: even with every drop probability cranked to 1.0
+        # and dropout enabled, robot_type / control_mode are unchanged.
+        ds = _DummyBaseDataset(
+            num_cams=1,
+            meta_info={"robot_type": "panda", "control_mode": "ee"},
+            history_state_drop_prob=1.0,
+            subgoal_drop_prob=1.0,
+            response_drop_prob=1.0,
+            metadata_drop_all_prob=1.0,
+            metadata_drop_each_prob=1.0,
+        )
+        assert ds.enable_optional_key_dropout is True
+        out = ds._to_standard_data_format(_full_raw_item(ds))
+        assert out["robot_type"] == "panda"
+        assert out["control_mode"] == "ee"
+
+    def test_emitted_as_python_strings_for_default_collate(self):
+        # Default PyTorch collate batches str fields into list[str]; verify the
+        # emitted values are plain strings (not bytes / np.str_ / 0-dim tensors).
+        ds = _DummyBaseDataset(
+            num_cams=1,
+            meta_info={"robot_type": "human", "control_mode": "mixed"},
+        )
+        out = ds._to_standard_data_format(_full_raw_item(ds))
+        assert type(out["robot_type"]) is str
+        assert type(out["control_mode"]) is str


### PR DESCRIPTION
## What this does

Adds two optional string fields — **`robot_type`** and **`control_mode`** — to the dict returned by every dataset's `__getitem__`. Both are sourced from `self.meta.info` and fall back to the empty-string sentinel `""` when absent, matching the existing optional-string convention used by `response`, `memory`, and `next_memory`.

* **`robot_type`** is already a first-class field in standard LeRobot v2 `meta/info.json` (e.g. `"aloha"`, `"panda"`, `"human"`); previously reachable only via `LeRobotDataset.meta.robot_type`.
* **`control_mode`** was added to `meta/info.json` in #183 with allowed values `{"joint", "ee", "mixed"}`; previously reachable only via `LeRobotDataset.control_mode` / `LeRobotDataset.meta.control_mode`.

Promoting them to per-sample fields gives multi-embodiment / control-mode-aware policies a uniform signal that survives the dataloader, dataset mixture, and collator. They are **not** subject to training-time dropout — they're dataset-level identifiers, constant per dataset; like `prompt` / `loss_type`. The existing missing-`control_mode` warning at `LeRobotDataset.__init__` and the `LeRobotDatasetMetadata.control_mode` property's `"unknown"` default are unchanged (they serve curation, not the data format).

VQA datasets emit `""` for both, since `VQADatasetMetadata.info` carries neither key — the standard format stays uniform across robot and vqa datasets.

🗃️ Feature

## How it was tested

* Added `TestRobotTypeControlMode` in `tests/datasets/test_optional_keys.py` — 5 unit tests covering: both fields present (pass-through), both absent (`""` sentinel), `robot_type=None` (allowed by the type signature), every drop probability cranked to 1.0 with dropout enabled (pass-through still holds), and Python-`str` typing (default PyTorch collate compatibility).
* Added `test_robot_type_and_control_mode_in_meta_info` in `tests/datasets/test_datasets.py` — integration check that the LeRobotDataset factory threads `info.json` values into `ds.meta.info` for both populated and missing cases.
* Extended `_DummyBaseDataset` in `tests/datasets/test_optional_keys.py` to accept a `meta_info` dict so existing direct-emission tests keep working without setup changes.
* `pytest -m "not gpu and not slow" -n auto tests/datasets/` → **310 passed, 7 skipped, 0 failed** (the 7 skipped are the existing GPU/slow markers; nothing regresses).
* `pytest -m "not gpu and not slow" -n auto tests/scripts/test_attach_metadata.py tests/configs/test_default.py` → **31 passed** (adjacent suites that exercise the standard format end-to-end).
* `pre-commit run --files <four changed files>` → clean.

Documentation: extended the **Optional Standard-Format Keys** section in `docs/source/concepts.rst` to document the two new keys, the `""` sentinel, and the dropout exemption.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/datasets/test_optional_keys.py::TestRobotTypeControlMode \
          tests/datasets/test_datasets.py::test_robot_type_and_control_mode_in_meta_info \
          tests/datasets/test_datasets.py::test_control_mode_warning_emitted_once_per_repo
```

```bash
pytest -m "not gpu and not slow" -n auto tests/datasets/
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).