### PR TITLE
docs(claude): mention Claude integration workflows in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,7 @@ Key invariant on `TrainPipelineConfig`: `batch_size == dataloader_batch_size * g
 - Policy-related PRs require running GPU pytests + nightly regression tests; check both boxes.
 - Required tests/lint that gate merge: `cpu_test.yml` (PRs/pushes) and `pre-commit.yml`. `gpu_test.yml` and `regression_test.yml` run nightly on AWS g6 runners (cron 10:00 UTC).
 - Per-file ruff overrides in `pyproject.toml`: gRPC server (PascalCase methods, `N802`), `recordhuman_to_lerobot.py` (math-convention uppercase names, `N803`/`N806`).
+- **Claude integration:** `.github/workflows/claude-*.yml` adds three bots — auto-review on PR open/sync (single edit-in-place summary tagged `[claude-review]`), `@claude fix` to address feedback in one coalesced commit (replies tagged `[claude-fix]`), and post-merge lessons extraction into `chore(claude): learn from #N` PRs.
 
 ## Reference paths
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,7 +123,7 @@ Key invariant on `TrainPipelineConfig`: `batch_size == dataloader_batch_size * g
 - Policy-related PRs require running GPU pytests + nightly regression tests; check both boxes.
 - Required tests/lint that gate merge: `cpu_test.yml` (PRs/pushes) and `pre-commit.yml`. `gpu_test.yml` and `regression_test.yml` run nightly on AWS g6 runners (cron 10:00 UTC).
 - Per-file ruff overrides in `pyproject.toml`: gRPC server (PascalCase methods, `N802`), `recordhuman_to_lerobot.py` (math-convention uppercase names, `N803`/`N806`).
-- **Claude integration:** `.github/workflows/claude-*.yml` adds three bots — auto-review on PR open/sync (single edit-in-place summary tagged `[claude-review]`), `@claude fix` to address feedback in one coalesced commit (replies tagged `[claude-fix]`), and post-merge lessons extraction into `chore(claude): learn from #N` PRs.
+- **Claude integration:** three workflows under `.github/workflows/` add bots — `claude-pr-review.yml` does auto-review on PR open/sync (single edit-in-place summary tagged `[claude-review]`), `claude-implement-fixes.yml` handles `@claude fix` and addresses feedback in one coalesced commit (replies tagged `[claude-fix]`), and `extract-claude-lessons.yml` does post-merge lessons extraction into `chore(claude): learn from #N` PRs.
 
 ## Reference paths
 


### PR DESCRIPTION
## What this does

Smoke test for the three Claude integration workflows merged in #199. Adds a single bullet to CLAUDE.md's PR / contribution workflow section pointing to `.github/workflows/claude-*.yml` so contributors know the bots exist and what to expect.

This PR exists primarily to verify the workflows fire correctly end-to-end:
- `claude-pr-review.yml` should leave one `[claude-review]` summary comment on open.
- A follow-up push should *edit* that comment in place (not duplicate).
- `@claude fix <something>` in a comment should produce one coalesced commit and `[claude-fix]`-prefixed replies.

## How it was tested

Local: pre-commit (typos, end-of-file-fixer, trailing-whitespace) clean. The change is doc-only — one bullet added.

End-to-end: that's what this PR is for. CI (cpu_test, pre-commit) should be unaffected since no code changes.

## How to checkout & try? (for the reviewer)

```bash
gh pr checkout <this-PR-number>
cat CLAUDE.md | grep -A1 "Claude integration"
```

After this lands, the next PR's review experience is the actual user-facing test.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.