### PR TITLE
fix(ci): grant Claude workflows bypassPermissions for tool calls

### DIFF
--- a/.github/workflows/claude-implement-fixes.yml
+++ b/.github/workflows/claude-implement-fixes.yml
@@ -48,6 +48,8 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: |
+            --permission-mode bypassPermissions
           prompt: |
             A reviewer asked you to address review feedback on this PR.
 

--- a/.github/workflows/claude-implement-fixes.yml
+++ b/.github/workflows/claude-implement-fixes.yml
@@ -19,6 +19,13 @@ on:
     types: [created]
   pull_request_review_comment:
     types: [created]
+  # GitHub does NOT fire pull_request_review_comment.created for line comments
+  # bundled into a submitted review — only for standalone replies via the
+  # inline "Reply" button. Listening to pull_request_review.submitted catches
+  # the bundled-line-comment case (e.g. "Add review" → "Submit review" with
+  # @claude fix in a line comment and an empty review body).
+  pull_request_review:
+    types: [submitted]
 
 # Serialize implement-fix runs against the same PR so two rapid `@claude fix`
 # comments don't race on the PR branch.
@@ -28,10 +35,22 @@ concurrency:
 
 jobs:
   implement:
-    if: |
-      (github.event.issue.pull_request || github.event.pull_request) &&
-      contains(github.event.comment.body, '@claude fix') &&
-      github.event.comment.user.type != 'Bot'
+    if: >-
+      (
+        github.event_name == 'issue_comment'
+        && github.event.issue.pull_request != null
+        && contains(github.event.comment.body, '@claude fix')
+        && github.event.comment.user.type != 'Bot'
+      )
+      || (
+        github.event_name == 'pull_request_review_comment'
+        && contains(github.event.comment.body, '@claude fix')
+        && github.event.comment.user.type != 'Bot'
+      )
+      || (
+        github.event_name == 'pull_request_review'
+        && github.event.review.user.type != 'Bot'
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -40,12 +59,44 @@ jobs:
       issues: write
       id-token: write  # claude-code-action does an OIDC handshake at startup
     steps:
+      # For pull_request_review.submitted, scan the review's line comments
+      # (which the event payload does not include) for the trigger phrase.
+      # If absent, exit before paying for a Claude run. For comment events,
+      # the if: above already filtered on body, so this step is a no-op.
+      - name: Gate on @claude fix presence
+        id: gate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Untrusted user input — never interpolate directly into shell.
+          EVENT_NAME: ${{ github.event_name }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REVIEW_ID: ${{ github.event.review.id }}
+          REVIEW_BODY: ${{ github.event.review.body }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" != "pull_request_review" ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          LINE_BODIES=$(gh api \
+            "/repos/${REPO}/pulls/${PR_NUMBER}/reviews/${REVIEW_ID}/comments" \
+            --jq 'map(.body) | join("\n---\n")')
+          if printf '%s\n%s\n' "$REVIEW_BODY" "$LINE_BODIES" | grep -qF '@claude fix'; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No '@claude fix' found in submitted review (body or any line comment); skipping."
+          fi
+
       - uses: actions/checkout@v4
+        if: steps.gate.outputs.should_run == 'true'
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - uses: anthropics/claude-code-action@v1
+        if: steps.gate.outputs.should_run == 'true'
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |
@@ -54,7 +105,11 @@ jobs:
             A reviewer asked you to address review feedback on this PR.
 
             1. Read all review comments on the PR (resolved and unresolved).
-            2. For each actionable comment, implement the fix on the PR's branch.
+               Some line comments may have been bundled into a submitted review
+               — fetch them with:
+                   gh api /repos/${{ github.repository }}/pulls/${{ github.event.issue.number || github.event.pull_request.number }}/reviews/<review_id>/comments
+            2. For each actionable comment containing `@claude fix`, implement
+               the fix on the PR's branch.
             3. Skip comments that are questions, taste preferences, or already addressed.
             4. Run the test command from CLAUDE.md before pushing.
             5. Make ONE commit at the end of the session that addresses every

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -51,6 +51,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |
             --model claude-opus-4-7
+            --permission-mode bypassPermissions
           prompt: |
             You are reviewing PR #${{ github.event.pull_request.number }} in
             ${{ github.repository }}.

--- a/.github/workflows/extract-claude-lessons.yml
+++ b/.github/workflows/extract-claude-lessons.yml
@@ -38,6 +38,8 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: |
+            --permission-mode bypassPermissions
           prompt: |
             Review the comments on this merged PR. If any reviewer feedback
             reveals a missing rule in CLAUDE.md or .claude/rules/, open a


### PR DESCRIPTION
## What this does

Adds `--permission-mode bypassPermissions` to `claude_args` in all three Claude integration workflows (`claude-pr-review.yml`, `claude-implement-fixes.yml`, `extract-claude-lessons.yml`).

**Why this is needed:** Claude Code's default permission policy is built for interactive sessions — every `Bash` call (e.g. `gh pr view`, `gh pr comment`, `gh api PATCH`) prompts the user for approval. In CI there is no human approver, so all tool calls auto-deny. The action ran successfully on PR #206 but exited with `permission_denials_count: 11` and posted nothing — looks healthy in the Actions UI, does literally nothing.

**Why bypass mode is safe here:** The action restores `CLAUDE.md`, `.claude/`, `.mcp.json`, and other config files from `origin/main` before invoking Claude (visible in run logs as: `Restoring ... from origin/main (PR head is untrusted)`). A malicious PR cannot poison the prompt or expand tool access through changes to those paths. Combined with the workflow-level `permissions:` blocks (e.g. `contents: read` for the review job), the worst Claude can do in any of these flows is what its `permissions:` block already authorizes.

## How it was tested

- `actionlint` clean on all three files (exit 0).
- `pre-commit` (typos, gitleaks, **zizmor** GitHub Actions security check, end-of-file-fixer, trailing-whitespace) all pass.
- The bug was diagnosed empirically from PR #206 run #25132013653 where the SDK reported `permission_denials_count: 11`.
- End-to-end verification (Claude actually posts a `[claude-review]` summary comment) requires this PR to merge first, then the smoke-test PR #206 will exercise the fixed workflows on its next push.

**Note for the reviewer:** This PR's own `review` check will fail with `App token exchange failed: 401 Unauthorized — Workflow validation failed. The workflow file must exist and have identical content to the version on the repository's default branch.` This is expected: the action enforces a security check that rejects any PR which modifies the workflow file calling it (so a PR can't escalate its own permissions). All other CI (cpu_test, pre-commit, check-checklist) should pass normally.

## How to checkout & try? (for the reviewer)

\`\`\`bash
gh pr checkout <this-PR-number>
git diff origin/main -- .github/workflows/claude-*.yml
actionlint .github/workflows/claude-*.yml
\`\`\`

After merge: `gh pr comment 206 --body "rerun please"` won't trigger anything; instead push a no-op commit to #206's branch (the `synchronize` event will use the new workflow from main).

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.