### PR TITLE
feat(ci): pin Claude workflows to Opus 4.7 1M, allow test-skip on doc fixes

### DIFF
--- a/.github/workflows/claude-implement-fixes.yml
+++ b/.github/workflows/claude-implement-fixes.yml
@@ -100,6 +100,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |
+            --model ${{ vars.CLAUDE_MODEL || 'claude-opus-4-7[1m]' }}
             --permission-mode bypassPermissions
           prompt: |
             A reviewer asked you to address review feedback on this PR.
@@ -111,16 +112,33 @@ jobs:
             2. For each actionable comment containing `@claude fix`, implement
                the fix on the PR's branch.
             3. Skip comments that are questions, taste preferences, or already addressed.
-            4. Run the test command from CLAUDE.md before pushing.
+            4. Decide whether to run tests:
+               - If the diff is purely documentation, comments, formatting,
+                 string-literal text, or otherwise CANNOT change runtime behavior,
+                 you MAY skip tests. Be honest about confidence — when in doubt, run.
+                 If you skip, the commit body MUST contain a line of the form:
+                     tests: skipped — <one-sentence reason>
+               - Otherwise (changes touching imports, function bodies, control
+                 flow, types, configs read at runtime, dependencies, or build
+                 manifests): run `pytest -m "not gpu" -n auto`. Scope to the
+                 changed subtree where possible (e.g. `pytest tests/policies/test_pi05.py`
+                 for a pi05 change) to keep the run fast. The commit body MUST contain:
+                     tests: passed — <exact command run>
+                 If tests fail: do NOT push; reply on the relevant PR comment
+                 explaining the failure and stop.
             5. Make ONE commit at the end of the session that addresses every
                comment you decided to act on — do NOT push one commit per
                comment. Subject line (must be < 80 chars per CLAUDE.md):
 
                    [claude-fix] address review feedback on #${{ github.event.issue.number || github.event.pull_request.number }}
 
-               Commit body: a bulleted list, one bullet per addressed comment:
+               Commit body: a bulleted list, one bullet per addressed comment,
+               followed by the `tests:` line from step 4:
 
                    - addresses @<reviewer> (<short topic>): <what you changed>
+                   ...
+                   tests: passed — pytest -m "not gpu" tests/policies/test_pi05.py
+                   (or: tests: skipped — comment-only change, no runtime impact)
 
                Then push the single commit to the PR branch.
             6. Reply individually to each addressed comment on the PR with

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |
-            --model claude-opus-4-7
+            --model ${{ vars.CLAUDE_MODEL || 'claude-opus-4-7[1m]' }}
             --permission-mode bypassPermissions
           prompt: |
             You are reviewing PR #${{ github.event.pull_request.number }} in

--- a/.github/workflows/extract-claude-lessons.yml
+++ b/.github/workflows/extract-claude-lessons.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |
+            --model ${{ vars.CLAUDE_MODEL || 'claude-opus-4-7[1m]' }}
             --permission-mode bypassPermissions
           prompt: |
             Review the comments on this merged PR. If any reviewer feedback


### PR DESCRIPTION
## What this does

Two improvements to the three Claude integration workflows.

### 1. Pin to Opus 4.7 with 1M-context, model controlled by a repo variable

All three workflows (`claude-pr-review.yml`, `claude-implement-fixes.yml`, `extract-claude-lessons.yml`) now pass `--model` via `claude_args`, evaluating to:

```yaml
--model ${{ vars.CLAUDE_MODEL || 'claude-opus-4-7[1m]' }}
```

- **Default:** `claude-opus-4-7[1m]` — Opus 4.7 with the 1M-context variant. Largest context, top-tier reasoning.
- **Override:** set repo variable `CLAUDE_MODEL` (Settings → Secrets and variables → Actions → Variables) to any model alias the action accepts. Bumping models = changing one variable, no PR. Useful when Anthropic ships a newer Opus.
- The alias `claude-opus-4-7` (no date suffix) auto-tracks the latest snapshot of Opus 4.7. Cross-major-version bumps (4.7 → 4.8 → 5.x) still need an explicit update — but that's a once-a-quarter-ish thing, not a per-PR concern.

Previously only `claude-pr-review` had `--model` set; the other two ran on whatever the action's default was.

### 2. Test-skip discretion in `claude-implement-fixes`

Step 4 of the implement-fixes prompt was rigid: *"Run the test command from CLAUDE.md before pushing."* The CPU suite alone takes ~9 min and is wasted on doc-only / comment-only / formatting fixes, blowing each `@claude fix` cycle out to 15-20 min.

New step 4 gives Claude discretion + an audit trail:

- **May skip** when the diff is purely documentation, comments, formatting, or string-literal text — the kind of change that *cannot* alter runtime behavior. Commit body must contain `tests: skipped — <one-sentence reason>`.
- **Must run** otherwise (imports, function bodies, control flow, types, runtime configs, deps, build manifests). Commit body must contain `tests: passed — <exact command run>`. Scope to the changed subtree where possible (`pytest tests/policies/test_pi05.py` for a pi05 change) to keep the run fast.
- "When in doubt, run" — explicit fallback to the safer default.
- If tests fail: do NOT push; reply on the PR comment thread with the failure and stop.

The audit-trail line in the commit body lets reviewers second-guess if Claude underestimated risk.

## How it was tested

- `actionlint` clean on all three files (exit 0).
- `pre-commit` (typos, gitleaks, zizmor, end-of-file-fixer, trailing-whitespace) all pass.
- The `[1m]` model-ID syntax has not been verified against the action's `--model` parser yet. If the CLI rejects it, fall back to `claude-opus-4-7` (no `[1m]`) by setting the `CLAUDE_MODEL` repo variable to that — no code change needed.
- Test-skip discretion can only be observed end-to-end after merge, by leaving an `@claude fix` on a doc-only change and confirming the commit body contains `tests: skipped` and total runtime drops below ~3 minutes.

**Note for the reviewer:** This PR's own `Claude PR Review` check will fail with `App token exchange failed: 401 Unauthorized — Workflow validation failed.` This is expected: the action enforces a security check that rejects any PR which modifies the workflow file calling it. All other CI passes normally.

## How to checkout & try? (for the reviewer)

\`\`\`bash
gh pr checkout <this-PR-number>
git diff origin/main -- .github/workflows/claude-*.yml
actionlint .github/workflows/claude-*.yml
\`\`\`

After merge:
1. (Optional) Set repo variable `CLAUDE_MODEL` to override the default.
2. To exercise the test-skip path: leave an `@claude fix` comment on any future doc-only PR; expect the run to finish in ~2-3 min with `tests: skipped — ...` in the commit body.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.