### PR TITLE
fix(ci): gate extract-claude-lessons on head branch, not PR author

### DIFF
--- a/.github/workflows/extract-claude-lessons.yml
+++ b/.github/workflows/extract-claude-lessons.yml
@@ -25,9 +25,13 @@ permissions:
 
 jobs:
   extract-lessons:
+    # Gate on the head branch name, not user.login: in this repo Claude Code
+    # pushes to a `claude/*` branch and a human opens the PR, so the PR's
+    # `user.login` never contains 'claude'. The branch prefix is the reliable
+    # signal that Claude touched the PR.
     if: >-
       github.event.pull_request.merged == true
-      && contains(github.event.pull_request.user.login, 'claude')
+      && startsWith(github.event.pull_request.head.ref, 'claude/')
       && !startsWith(github.event.pull_request.title, 'chore(claude): learn from')
     runs-on: ubuntu-latest
     timeout-minutes: 20


### PR DESCRIPTION
## What this does

`.github/workflows/extract-claude-lessons.yml` was added in #199 but
its `if:` gate has never let a job run. The previous condition was:

```yaml
if: >-
  github.event.pull_request.merged == true
  && contains(github.event.pull_request.user.login, 'claude')
  && !startsWith(github.event.pull_request.title, 'chore(claude): learn from')
```

Two notes on why this was failing — both from looking at the recent
merged PRs (#171, #178, #182, #183, #189, #190, #198, #199, #204, #207,
#208, #209, #206):

1. **`[closed]` is the right trigger** — there is no `[merged]` action
   type for `pull_request` in GitHub Actions. `closed` fires for both
   close-without-merge and merge, and the `merged == true` check
   correctly narrows it. So the trigger isn't the bug.
2. **`user.login` is the wrong field.** In this repo, Claude Code on
   the web pushes to a `claude/<slug>` branch, then a human (e.g.
   `shuheng-liu`) opens the PR. So `pull_request.user.login` is the
   human, never `claude*`, and `contains(..., 'claude')` is always
   false. The reliable signal is the head branch prefix, which is
   under Claude Code's control.

This PR swaps the filter to `startsWith(head.ref, 'claude/')`. Backfill
across the 14 most-recent merged PRs:

| filter | match count |
|--------|-------------|
| `contains(user.login, 'claude')` (old) | 0 |
| `startsWith(head.ref, 'claude/')` (new) | 13 |

Tag: 🐛 Bug

## How it was tested

- Confirmed via the GitHub API (`gh api .../pulls?state=closed`) that
  every recent PR's `user.login` is the human reviewer's login and
  every Claude-touched PR's `head.ref` starts with `claude/`.
- Verified the YAML still parses (only the boolean expression in the
  `if:` changed).
- Did NOT run `pre-commit run --all-files` — the sandbox this PR was
  authored in has no `pre-commit` binary. Please run it locally if the
  CI hook complains.
- No runtime code changed, so no `pytest` was run.
  `tests: skipped — workflow YAML condition only, no Python touched.`

## How to checkout & try? (for the reviewer)

The workflow only fires on `pull_request: closed`, so the real test is
to merge this PR and watch the next merged `claude/*` PR — the
`extract-lessons` job should now appear in the Actions tab and either
open a `chore(claude): learn from #N` PR or exit cleanly.

```bash
git fetch origin claude/fix-ci-closed-prs-LnVFT
git diff main...origin/claude/fix-ci-closed-prs-LnVFT -- .github/workflows/extract-claude-lessons.yml
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

(This PR only touches a single GitHub Actions YAML file — no Python
functions are added or changed, so the docstring item is vacuously
satisfied. The policy-changes box is correctly unchecked.)

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
