### PR TITLE
fix(build): pin cmake<4 in egl-probe PEP 517 build isolation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ OpenTau is Tensor's open-source PyTorch training toolchain for vision-language-a
 
 ## Environment & install
 
-Dependency management is **`uv` only** — `pyproject.toml`/`uv.lock` are authoritative; do not edit `requirements.txt` (none exists) or call `pip install` against the env.
+Dependency management is **`uv` (>= 0.8.4) only** — `pyproject.toml`/`uv.lock` are authoritative; do not edit `requirements.txt` (none exists) or call `pip install` against the env. The `>= 0.8.4` floor is enforced by `required-version` in `[tool.uv]` and is needed because `[tool.uv].extra-build-dependencies` (which pins `cmake<4` inside `egl-probe`'s PEP 517 build isolation) is only honored by uv 0.8.4+.
 
 ```bash
 uv sync --extra dev --extra libero          # standard dev setup (matches CI)

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -114,8 +114,12 @@ Follow these steps to start contributing:
 
    🚨 **Do not** work on the ``main`` branch.
 
-4. for development, we advise to use a tool like ``uv`` instead of just ``pip`` to easily track our dependencies.
+4. for development, we advise to use a tool like ``uv`` (>= 0.8.4) instead of just ``pip`` to easily track our dependencies.
    Follow the instructions to `install uv <https://docs.astral.sh/uv/getting-started/installation/#installation-methods>`_ if you don't have it already.
+   OpenTau requires ``uv >= 0.8.4`` (enforced by ``required-version`` in ``[tool.uv]``)
+   because ``[tool.uv].extra-build-dependencies`` is only honored by that version
+   onwards; older ``uv`` would silently skip the ``cmake<4`` pin needed to build
+   ``egl-probe`` from the ``libero`` extra. Upgrade with ``uv self update`` if needed.
    To develop on OpenTau, you will at least need to install the ``dev`` extras dependencies along with the core library:
 
    using ``uv``

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -62,10 +62,16 @@ Download the source code:
 Environment Setup
 ^^^^^^^^^^^^^^^^^
 
-We recommend using `uv <https://docs.astral.sh/uv/>`_ for fast and simple Python dependency management.
+We recommend using `uv <https://docs.astral.sh/uv/>`_ (>= 0.8.4) for fast and simple Python dependency management.
 
 1. **Install uv**
    Follow the `official uv installation instructions <https://docs.astral.sh/uv/getting-started/installation/>`_.
+   OpenTau requires **uv >= 0.8.4** because ``pyproject.toml`` uses
+   ``[tool.uv].extra-build-dependencies`` (introduced in 0.8.4) to pin
+   ``cmake<4`` inside the PEP 517 build isolation of ``egl-probe`` (a
+   transitive dependency of the ``libero`` extra). Older ``uv`` is rejected
+   via ``required-version``, so the sync will fail loudly rather than
+   silently regressing to a confusing CMake 4 error.
 
 2. **Install dependencies**
    Sync all required dependencies. To install all extras:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,14 @@ conflicts = [
     { extra = "urdf" },
   ],
 ]
+# egl-probe (transitive via robomimic in the libero extra) ships an sdist whose
+# CMakeLists declares cmake_minimum_required(VERSION 2.8.12). CMake 4.0 dropped
+# pre-3.5 compatibility, so the build aborts on systems where the build's `cmake`
+# resolves to a 4.x binary. Pin cmake<4 in egl-probe's PEP 517 build isolation:
+# uv puts the build venv's bin at the front of PATH for the build subprocess,
+# so the bundled 3.x cmake wins regardless of what's installed system-wide.
+# Requires uv >= 0.8.4 (older versions silently ignore this key).
+extra-build-dependencies = { egl-probe = ["cmake<4"] }
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,11 @@ libero = { git = "https://github.com/shuheng-liu/LIBERO" , branch = "master" }  
 
 # libero depends on gym, which depends on numpy 1.x, while rerun only supports urdf in v0.28 which requires numpy 2.x
 [tool.uv]
+# `extra-build-dependencies` (used below for egl-probe's CMake pin) is only
+# honored by uv >= 0.8.4. Without this guard, older uv silently ignores the key
+# and the build regresses to the original CMake 4 failure with a confusing
+# message. Bumping this floor errors loudly with a clear pointer instead.
+required-version = ">=0.8.4"
 conflicts = [
   [
     { extra = "libero" },
@@ -159,7 +164,6 @@ conflicts = [
 # resolves to a 4.x binary. Pin cmake<4 in egl-probe's PEP 517 build isolation:
 # uv puts the build venv's bin at the front of PATH for the build subprocess,
 # so the bundled 3.x cmake wins regardless of what's installed system-wide.
-# Requires uv >= 0.8.4 (older versions silently ignore this key).
 extra-build-dependencies = { egl-probe = ["cmake<4"] }
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## What this does

Fixes `uv sync --extra dev --extra libero` aborting with the following while building `egl-probe==1.0.2` (a transitive dep of `robomimic==0.2.0` from the `libero` extra):

```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.
```

**Root cause.** `egl-probe`'s `CMakeLists.txt` declares `cmake_minimum_required(VERSION 2.8.12)`. CMake 4.0 (released March 2025) dropped pre-3.5 compatibility and refuses to configure such projects. The build aborts on any system where the build's bare `cmake` command resolves to a 4.x binary — including the case where a project's existing `.venv/bin/cmake` is 4.x from a prior `uv sync` that ran without `--extra libero` (when the `cmake<4` runtime pin from the libero extra was not active).

**Why the existing `cmake<4` pin doesn't help.** That pin in `[project.optional-dependencies] libero` is a *runtime* dep of the project venv, not visible inside `egl-probe`'s PEP 517 isolated build env. The build's `cmake` invocation falls through to the inherited `PATH`.

**Fix.** Add `extra-build-dependencies = { egl-probe = ["cmake<4"] }` to the `[tool.uv]` table. uv installs `cmake<4` into `egl-probe`'s PEP 517 build isolation venv and puts that venv's `bin/` at the front of `PATH` for the build subprocess, so `cmake ..; make -j` always resolves to the bundled CMake 3.x binary regardless of what's installed system-wide or in any other venv.

`uv.lock` is unchanged — build-time deps do not affect the runtime resolution graph.

**Requires `uv >= 0.8.4`** (older versions silently ignore this key).

## How it was tested

Verified `uv sync --extra dev --extra libero` succeeds end-to-end on:

- **Linux x86_64** (Ubuntu 24.04) with a CMake 4.x binary on the PATH inherited by the build (the original failing environment) — sync now completes; runtime venv ends up with `cmake==3.31.x` per the `cmake<4` constraint.
- **macOS arm64** with system CMake 4.x — sync succeeds; new `egl_probe-1.0.2.dist-info` artifact in `~/.cache/uv/archive-v0/` confirms a fresh build (not a cache hit).

In each freshly synced venv:
```
.venv/bin/python -c "import egl_probe"                 # OK
.venv/bin/python -c "import robomimic, robosuite, mujoco"  # OK
.venv/bin/cmake --version                              # 3.31.x (cmake<4 honored)
```

CPU CI (`cpu_test.yml`) runs the same `uv sync --extra dev --extra libero` and is unaffected by this change — system CMake on the runner image is already <4, so the build env override is a no-op there. It does, however, harden CI against the day GitHub bumps the runner image to one with CMake 4.x.

## How to checkout & try? (for the reviewer)

```bash
git fetch origin claude/eloquent-easley-c78a48
git checkout claude/eloquent-easley-c78a48
# Optionally, to simulate the failure mode, point PATH at a CMake >= 4.x binary first.
uv sync --extra dev --extra libero
.venv/bin/python -c "import egl_probe; print('OK')"
.venv/bin/cmake --version    # expect 3.x
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.