### PR TITLE
ci: ignore broken pi07 test in GPU CI; dedupe TODO in cpu_test

### DIFF
--- a/.github/workflows/cpu_test.yml
+++ b/.github/workflows/cpu_test.yml
@@ -103,7 +103,6 @@ jobs:
           python3 -c "import libero.libero" && echo "LIBERO config set successfully."
           echo "Running cpu based pytest and generating coverage report..."
           # TODO(#210): drop --ignore=tests/policies/test_pi07_paligemma_low_level_planner.py once pi07 migrates to SpaceTimeSiglipVideoEncoder (#192).
-          # TODO(#210): drop --ignore=tests/policies/test_pi07_paligemma_low_level_planner.py once pi07 migrates to SpaceTimeSiglipVideoEncoder (#192).
           pytest -m "not gpu" -n auto -v --cov=lerobot/ --cov-report=xml:cpu_test/cpu_test.xml --ignore=tests/planner/test_planner.py --ignore tests/utils/test_libero_utils.py --ignore=tests/policies/test_pi07_paligemma_low_level_planner.py --deselect=tests/envs/test_factory.py::TestMakeEnv::test_make_env_async_vector_env --deselect=tests/envs/test_factory.py::TestMakeEnv::test_make_env_sync_vector_env tests/
           echo "Pytest execution and coverage report generation completed."
 

--- a/.github/workflows/gpu_test.yml
+++ b/.github/workflows/gpu_test.yml
@@ -91,7 +91,8 @@ jobs:
           source .venv/bin/activate
           mkdir -p /tmp/libero-assets/libero/libero
           export LIBERO_CONFIG_PATH="$(pwd)/.github/assets/libero"
-          pytest -m "gpu" -n 0 -v tests/
+          # TODO(#210): drop --ignore=tests/policies/test_pi07_paligemma_low_level_planner.py once pi07 migrates to SpaceTimeSiglipVideoEncoder (#192).
+          pytest -m "gpu" -n 0 -v --ignore=tests/policies/test_pi07_paligemma_low_level_planner.py tests/
 
   stop-runner:
     name: Stop GPU Runner


### PR DESCRIPTION
## What this does

Follow-up to #209, which only patched CPU CI. Two leftover items from that PR's review threads:

1. **GPU CI** — `.github/workflows/gpu_test.yml:94` runs `pytest -m "gpu" -n 0 -v tests/` and would fail at **collection** on the same `VJEPA2VideoEncoder` ImportError, because `tests/policies/test_pi07_paligemma_low_level_planner.py` imports `pi07_paligemma/.../modeling_pi07_low_level.py` at module scope. Applies the symmetric `--ignore=tests/policies/test_pi07_paligemma_low_level_planner.py` (option (a) that @shuheng-liu agreed to on #209 but never landed — the GitHub App was rejected pushing to `.github/workflows/`). Adds the same `# TODO(#210)` comment as the CPU side for symmetry.

2. **`cpu_test.yml` duplicate TODO** — Lines 105–106 of the merged file are two identical `# TODO(#210): drop --ignore=...` comments. The dedup got applied wrong twice on #209 (echo → comment swap, but the duplicate persisted). Drops one.

The pi07 module is still broken at import (anyone instantiating `PI07LowLevelPlannerPolicy` would hit the same `ImportError`); the proper migration to `SpaceTimeSiglipVideoEncoder` is tracked in #210 / #192 and remains out of scope here.

Label: 🐛 Bug

## How it was tested

- YAML syntax validated with `yaml.safe_load` for both files.
- `pre-commit run --files .github/workflows/cpu_test.yml .github/workflows/gpu_test.yml` — all hooks pass (`check yaml`, `zizmor`, `gitleaks`, `typos`, `trim trailing whitespace`, `fix end of files`).
- The ignored test file's tests are all `@pytest.mark.gpu`-marked, so the only behavior change in GPU CI is dropping a hard collection failure; no test that was previously running gets skipped.
- Couldn't run pytest end-to-end locally (`uv sync` is timing out on `imageio-ffmpeg` download in this sandbox); GPU CI itself is the verification target.

## How to checkout & try? (for the reviewer)

```bash
git fetch origin claude/review-gpu-tests-pr-zFNmV
git checkout claude/review-gpu-tests-pr-zFNmV
git diff main -- .github/workflows/cpu_test.yml .github/workflows/gpu_test.yml
```

The diff is 2 files, +2/-2:

- `cpu_test.yml`: drop one of two identical TODO lines.
- `gpu_test.yml`: add `# TODO(#210)` + `--ignore=tests/policies/test_pi07_paligemma_low_level_planner.py` to the `pytest -m "gpu"` invocation.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

Refs: #209, #210, #192, #167, #171.

https://claude.ai/code/session_018wbimujescN52j3QiDXnys

---
_Generated by [Claude Code](https://claude.ai/code/session_018wbimujescN52j3QiDXnys)_