### PR TITLE
feat(datasets): override + require non-empty robot_type/control_mode

### DIFF
--- a/src/opentau/configs/default.py
+++ b/src/opentau/configs/default.py
@@ -70,6 +70,14 @@ class DatasetConfig:
             Each value is a dictionary with 'mean' and 'std' arrays. Defaults to None.
         data_features_name_mapping: Optional mapping from dataset feature names to
             standard feature names. Defaults to None.
+        robot_type: Optional override for the dataset's ``robot_type`` metadata
+            field. When provided (including the empty string), takes precedence
+            over the value loaded from ``meta/info.json``. ``None`` (default)
+            leaves the loaded value untouched.
+        control_mode: Optional override for the dataset's ``control_mode``
+            metadata field. When provided (including the empty string), takes
+            precedence over the value loaded from ``meta/info.json``. ``None``
+            (default) leaves the loaded value untouched.
 
     Raises:
         ValueError: If both or neither of `repo_id` and `vqa` are set, or
@@ -90,6 +98,12 @@ class DatasetConfig:
 
     # optional standard data format mapping for the dataset if mapping is not already in standard_data_format_mapping.py
     data_features_name_mapping: dict[str, str] | None = None
+
+    # Optional overrides for the metadata fields read from `meta/info.json`.
+    # `None` means "do not override". Any string value (including "") is
+    # written through to `dataset.meta.info[...]` after the dataset is built.
+    robot_type: str | None = None
+    control_mode: str | None = None
 
     # Ratio of the dataset to be used for validation. Please specify a value.
     # If `val_freq` is set to 0, a validation dataset will not be created and this value will be ignored.
@@ -167,6 +181,14 @@ class DatasetMixtureConfig:
             aren't polluted by training-time augmentation. Subgoal *frame*
             sampling (end-of-segment vs. uniform in the next 4s) stays active
             either way; only the masking logic is gated.
+        require_non_empty_robot_type: If True, every dataset in the mixture
+            must have a non-empty ``robot_type`` after the optional
+            ``DatasetConfig.robot_type`` override has been applied. Defaults to
+            ``False`` (empty / missing values are allowed).
+        require_non_empty_control_mode: If True, every dataset in the mixture
+            must have a non-empty ``control_mode`` after the optional
+            ``DatasetConfig.control_mode`` override has been applied. Defaults
+            to ``False`` (empty / missing values are allowed).
 
     Note:
         Dropout rolls use the default torch RNG. PyTorch DataLoader workers
@@ -214,6 +236,13 @@ class DatasetMixtureConfig:
     # Default keeps validation deterministic-ish (no masking); subgoal frame
     # selection stays random either way.
     val_enable_optional_key_dropout: bool = False
+
+    # When True, require every dataset in the mixture to have a non-empty
+    # robot_type / control_mode after `DatasetConfig.{robot_type,control_mode}`
+    # overrides have been applied. Defaults are False — empty values are
+    # tolerated unless the caller opts in to the stricter check.
+    require_non_empty_robot_type: bool = False
+    require_non_empty_control_mode: bool = False
 
     def __post_init__(self):
         """Validate dataset mixture configuration."""

--- a/src/opentau/datasets/factory.py
+++ b/src/opentau/datasets/factory.py
@@ -78,6 +78,7 @@ from opentau.configs.default import DatasetConfig
 from opentau.configs.train import TrainPipelineConfig
 from opentau.datasets.dataset_mixture import WeightedDatasetMixture
 from opentau.datasets.lerobot_dataset import (
+    _CONTROL_MODE_WARNED,
     BaseDataset,
     LeRobotDataset,
     LeRobotDatasetMetadata,
@@ -92,6 +93,24 @@ IMAGENET_STATS = {
     "mean": [[[0.485]], [[0.456]], [[0.406]]],  # (c,1,1)
     "std": [[[0.229]], [[0.224]], [[0.225]]],  # (c,1,1)
 }
+
+
+def _apply_metadata_overrides(dataset: BaseDataset, dataset_cfg: DatasetConfig) -> None:
+    """Apply ``robot_type`` / ``control_mode`` overrides from a DatasetConfig.
+
+    The overrides are written through to ``dataset.meta.info`` so downstream
+    consumers (``meta.control_mode``, ``_emit_optional_keys``) observe the
+    overridden value. ``None`` means "do not override"; any string value
+    (including ``""``) is applied.
+    """
+    if dataset_cfg.robot_type is not None:
+        dataset.meta.info["robot_type"] = dataset_cfg.robot_type
+    if dataset_cfg.control_mode is not None:
+        dataset.meta.info["control_mode"] = dataset_cfg.control_mode
+        # `LeRobotDataset.__init__` caches `self.control_mode = self.meta.control_mode`
+        # before this override fires, so refresh the attribute when present.
+        if hasattr(dataset, "control_mode"):
+            dataset.control_mode = dataset_cfg.control_mode
 
 
 def resolve_delta_timestamps(
@@ -181,6 +200,10 @@ def make_dataset(
     elif isinstance(cfg.repo_id, str):
         ds_meta = LeRobotDatasetMetadata(cfg.repo_id, root=cfg.root, revision=cfg.revision)
         dt_mean, dt_std, dt_lower, dt_upper = resolve_delta_timestamps(train_cfg, cfg, ds_meta)
+        # Suppress the "missing control_mode" warning when the user is
+        # providing an explicit override — they already know it's missing.
+        if cfg.control_mode is not None:
+            _CONTROL_MODE_WARNED.add(cfg.repo_id)
         dataset = LeRobotDataset(
             train_cfg,
             cfg.repo_id,
@@ -199,6 +222,8 @@ def make_dataset(
         )
     else:
         raise ValueError("Exactly one of `cfg.vqa` and `cfg.repo_id` should be provided.")
+
+    _apply_metadata_overrides(dataset, cfg)
 
     # TODO vqa datasets implement stats in original feature names, but camera_keys are standardized names
     if (
@@ -261,6 +286,38 @@ def _resolve_weights(
     return weights
 
 
+def _validate_metadata_requirements(cfg: TrainPipelineConfig, datasets: list, label: str) -> None:
+    """Raise if the mixture requires non-empty robot_type / control_mode and
+    any dataset (after overrides) still has an empty value.
+    """
+    require_robot = cfg.dataset_mixture.require_non_empty_robot_type
+    require_control = cfg.dataset_mixture.require_non_empty_control_mode
+    if not (require_robot or require_control):
+        return
+
+    dataset_cfgs = cfg.dataset_mixture.datasets
+    if len(dataset_cfgs) != len(datasets):
+        return
+
+    bad: list[str] = []
+    for dc, ds in zip(dataset_cfgs, datasets, strict=True):
+        info = ds.meta.info
+        identifier = dc.repo_id or dc.vqa or type(ds).__name__
+        if require_robot and not (info.get("robot_type") or ""):
+            bad.append(f"{identifier}: robot_type is empty")
+        if require_control and not (info.get("control_mode") or ""):
+            bad.append(f"{identifier}: control_mode is empty")
+
+    if bad:
+        raise ValueError(
+            "DatasetMixtureConfig requires non-empty metadata fields, but the "
+            f"following {label} datasets are missing values after overrides:\n  - "
+            + "\n  - ".join(bad)
+            + "\nSet `DatasetConfig.robot_type` / `DatasetConfig.control_mode` "
+            "on the offending dataset(s) to provide an override."
+        )
+
+
 def make_dataset_mixture(
     cfg: TrainPipelineConfig, return_advantage_input: bool = False
 ) -> Union[WeightedDatasetMixture, Tuple[WeightedDatasetMixture, WeightedDatasetMixture]]:
@@ -285,6 +342,10 @@ def make_dataset_mixture(
             val_datasets.append(res[1])
         else:
             datasets.append(res)
+
+    _validate_metadata_requirements(cfg, datasets, label="train")
+    if val_datasets:
+        _validate_metadata_requirements(cfg, val_datasets, label="val")
 
     train_weights = _resolve_weights(cfg.dataset_mixture.weights, datasets, label="train")
     train_mixture = WeightedDatasetMixture(cfg, datasets, train_weights, cfg.dataset_mixture.action_freq)

--- a/src/opentau/datasets/factory.py
+++ b/src/opentau/datasets/factory.py
@@ -78,10 +78,10 @@ from opentau.configs.default import DatasetConfig
 from opentau.configs.train import TrainPipelineConfig
 from opentau.datasets.dataset_mixture import WeightedDatasetMixture
 from opentau.datasets.lerobot_dataset import (
-    _CONTROL_MODE_WARNED,
     BaseDataset,
     LeRobotDataset,
     LeRobotDatasetMetadata,
+    suppress_control_mode_warning,
 )
 from opentau.datasets.standard_data_format_mapping import DATA_FEATURES_NAME_MAPPING
 from opentau.datasets.transforms import ImageTransforms
@@ -202,8 +202,10 @@ def make_dataset(
         dt_mean, dt_std, dt_lower, dt_upper = resolve_delta_timestamps(train_cfg, cfg, ds_meta)
         # Suppress the "missing control_mode" warning when the user is
         # providing an explicit override — they already know it's missing.
+        # Ordering invariant: this MUST run before `LeRobotDataset(...)` below;
+        # once `__init__` emits the warning the suppression is a no-op.
         if cfg.control_mode is not None:
-            _CONTROL_MODE_WARNED.add(cfg.repo_id)
+            suppress_control_mode_warning(cfg.repo_id)
         dataset = LeRobotDataset(
             train_cfg,
             cfg.repo_id,
@@ -296,8 +298,14 @@ def _validate_metadata_requirements(cfg: TrainPipelineConfig, datasets: list, la
         return
 
     dataset_cfgs = cfg.dataset_mixture.datasets
-    if len(dataset_cfgs) != len(datasets):
-        return
+    # Invariant from `make_dataset_mixture`: each dataset_cfg appends exactly
+    # one entry to `datasets` (and at most one to `val_datasets`). Assert
+    # rather than silently skipping so a future refactor that breaks the
+    # invariant doesn't quietly bypass the require_non_empty_* checks.
+    assert len(dataset_cfgs) == len(datasets), (
+        f"dataset_cfgs ({len(dataset_cfgs)}) and {label} datasets ({len(datasets)}) "
+        "must be 1:1; cannot validate metadata requirements."
+    )
 
     bad: list[str] = []
     for dc, ds in zip(dataset_cfgs, datasets, strict=True):

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -217,6 +217,18 @@ CODEBASE_VERSION = "v2.1"
 _CONTROL_MODE_WARNED: set[str] = set()
 
 
+def suppress_control_mode_warning(repo_id: str) -> None:
+    """Mark ``repo_id`` as already-warned so the missing-``control_mode`` warning
+    does not fire for it during subsequent ``LeRobotDataset.__init__`` calls.
+
+    Intended for callers that supply an explicit ``control_mode`` override and
+    therefore already know the on-disk metadata is missing the field. Must be
+    invoked *before* the ``LeRobotDataset`` is constructed for ``repo_id``;
+    once ``__init__`` has emitted the warning, further calls are a no-op.
+    """
+    _CONTROL_MODE_WARNED.add(repo_id)
+
+
 class DatasetMetadata:
     """Base class for dataset metadata containing info and statistics.
 

--- a/tests/datasets/test_dataset_mixture.py
+++ b/tests/datasets/test_dataset_mixture.py
@@ -650,3 +650,184 @@ class TestDatasetMixtureOptionalKeyDropProbs:
         # Boundary values are permitted (0 disables dropout, 1 forces it).
         DatasetMixtureConfig(**{field: 0.0})
         DatasetMixtureConfig(**{field: 1.0})
+
+
+class TestRobotTypeControlModeOverridesAndRequirements:
+    """Dataset-level override + mixture-level non-empty requirement contracts.
+
+    Covers the pair introduced in PR #204:
+        - ``DatasetConfig.{robot_type,control_mode}`` write through to
+          ``dataset.meta.info`` after construction.
+        - ``DatasetMixtureConfig.require_non_empty_{robot_type,control_mode}``
+          flag empty values across the mixture, defaulting OFF (empty allowed).
+    """
+
+    def test_dataset_config_defaults_allow_empty(self):
+        # Defaults match the project contract: no override, empty allowed.
+        cfg = DatasetConfig(repo_id="x/y")
+        assert cfg.robot_type is None
+        assert cfg.control_mode is None
+
+    def test_dataset_config_accepts_overrides(self):
+        cfg = DatasetConfig(repo_id="x/y", robot_type="aloha", control_mode="joint")
+        assert cfg.robot_type == "aloha"
+        assert cfg.control_mode == "joint"
+
+    def test_dataset_config_accepts_explicit_empty_string(self):
+        # Empty string is an explicit "clear the loaded value" override —
+        # distinct from None, which means "do not override".
+        cfg = DatasetConfig(repo_id="x/y", robot_type="", control_mode="")
+        assert cfg.robot_type == ""
+        assert cfg.control_mode == ""
+
+    def test_mixture_config_require_flags_default_off(self):
+        cfg = DatasetMixtureConfig()
+        assert cfg.require_non_empty_robot_type is False
+        assert cfg.require_non_empty_control_mode is False
+
+    def test_apply_metadata_overrides_writes_through(self):
+        from opentau.datasets.factory import _apply_metadata_overrides
+
+        # Minimal stand-in for a BaseDataset: only `meta.info` is read.
+        dataset = SimpleNamespace(meta=SimpleNamespace(info={}), control_mode="unknown")
+        cfg = DatasetConfig(repo_id="x/y", robot_type="panda", control_mode="ee")
+        _apply_metadata_overrides(dataset, cfg)
+        assert dataset.meta.info["robot_type"] == "panda"
+        assert dataset.meta.info["control_mode"] == "ee"
+        # The cached LeRobotDataset attribute is refreshed in lock-step.
+        assert dataset.control_mode == "ee"
+
+    def test_apply_metadata_overrides_none_is_noop(self):
+        from opentau.datasets.factory import _apply_metadata_overrides
+
+        info = {"robot_type": "aloha", "control_mode": "joint"}
+        dataset = SimpleNamespace(meta=SimpleNamespace(info=info), control_mode="joint")
+        cfg = DatasetConfig(repo_id="x/y")  # no overrides
+        _apply_metadata_overrides(dataset, cfg)
+        assert dataset.meta.info["robot_type"] == "aloha"
+        assert dataset.meta.info["control_mode"] == "joint"
+        assert dataset.control_mode == "joint"
+
+    def test_apply_metadata_overrides_empty_string_is_explicit_clear(self):
+        from opentau.datasets.factory import _apply_metadata_overrides
+
+        info = {"robot_type": "aloha", "control_mode": "joint"}
+        dataset = SimpleNamespace(meta=SimpleNamespace(info=info), control_mode="joint")
+        cfg = DatasetConfig(repo_id="x/y", robot_type="", control_mode="")
+        _apply_metadata_overrides(dataset, cfg)
+        assert dataset.meta.info["robot_type"] == ""
+        assert dataset.meta.info["control_mode"] == ""
+
+    def test_apply_metadata_overrides_skips_control_mode_attr_when_absent(self):
+        """VQA datasets don't define the ``control_mode`` attribute. The helper
+        must still update ``meta.info`` without raising AttributeError.
+        """
+        from opentau.datasets.factory import _apply_metadata_overrides
+
+        # No `control_mode` attribute on the dataset object.
+        dataset = SimpleNamespace(meta=SimpleNamespace(info={}))
+        cfg = DatasetConfig(vqa="dummy", control_mode="ee")
+        _apply_metadata_overrides(dataset, cfg)
+        assert dataset.meta.info["control_mode"] == "ee"
+        assert not hasattr(dataset, "control_mode")
+
+    @staticmethod
+    def _mixture_cfg(**mixture_kwargs):
+        """Build a TrainPipelineConfig stand-in that exposes only what
+        ``_validate_metadata_requirements`` reads.
+        """
+        ds_cfgs = mixture_kwargs.pop("datasets", [])
+        return SimpleNamespace(
+            dataset_mixture=SimpleNamespace(
+                datasets=ds_cfgs,
+                require_non_empty_robot_type=mixture_kwargs.get("require_non_empty_robot_type", False),
+                require_non_empty_control_mode=mixture_kwargs.get("require_non_empty_control_mode", False),
+            )
+        )
+
+    @staticmethod
+    def _stub_dataset(info: dict):
+        return SimpleNamespace(meta=SimpleNamespace(info=info))
+
+    def test_validate_metadata_requirements_noop_when_flags_off(self):
+        from opentau.datasets.factory import _validate_metadata_requirements
+
+        cfg = self._mixture_cfg(datasets=[DatasetConfig(repo_id="x/y")])
+        # Both flags off — empty values are tolerated.
+        _validate_metadata_requirements(cfg, [self._stub_dataset({})], label="train")
+
+    def test_validate_metadata_requirements_passes_when_values_present(self):
+        from opentau.datasets.factory import _validate_metadata_requirements
+
+        cfg = self._mixture_cfg(
+            datasets=[DatasetConfig(repo_id="x/y")],
+            require_non_empty_robot_type=True,
+            require_non_empty_control_mode=True,
+        )
+        ds = self._stub_dataset({"robot_type": "panda", "control_mode": "joint"})
+        _validate_metadata_requirements(cfg, [ds], label="train")
+
+    def test_validate_metadata_requirements_raises_for_empty_robot_type(self):
+        from opentau.datasets.factory import _validate_metadata_requirements
+
+        cfg = self._mixture_cfg(
+            datasets=[DatasetConfig(repo_id="x/y")],
+            require_non_empty_robot_type=True,
+        )
+        ds = self._stub_dataset({"robot_type": "", "control_mode": "ee"})
+        with pytest.raises(ValueError, match="robot_type is empty"):
+            _validate_metadata_requirements(cfg, [ds], label="train")
+
+    def test_validate_metadata_requirements_raises_for_none_robot_type(self):
+        from opentau.datasets.factory import _validate_metadata_requirements
+
+        cfg = self._mixture_cfg(
+            datasets=[DatasetConfig(repo_id="x/y")],
+            require_non_empty_robot_type=True,
+        )
+        # Legacy datasets store robot_type=None; the validator treats None as empty.
+        ds = self._stub_dataset({"robot_type": None})
+        with pytest.raises(ValueError, match="robot_type is empty"):
+            _validate_metadata_requirements(cfg, [ds], label="train")
+
+    def test_validate_metadata_requirements_raises_for_missing_control_mode(self):
+        from opentau.datasets.factory import _validate_metadata_requirements
+
+        cfg = self._mixture_cfg(
+            datasets=[DatasetConfig(repo_id="x/y")],
+            require_non_empty_control_mode=True,
+        )
+        ds = self._stub_dataset({"robot_type": "panda"})  # no control_mode key
+        with pytest.raises(ValueError, match="control_mode is empty"):
+            _validate_metadata_requirements(cfg, [ds], label="train")
+
+    def test_validate_metadata_requirements_reports_label_and_repo_id(self):
+        from opentau.datasets.factory import _validate_metadata_requirements
+
+        cfg = self._mixture_cfg(
+            datasets=[DatasetConfig(repo_id="acme/dataset")],
+            require_non_empty_robot_type=True,
+        )
+        ds = self._stub_dataset({})
+        with pytest.raises(ValueError) as excinfo:
+            _validate_metadata_requirements(cfg, [ds], label="val")
+        msg = str(excinfo.value)
+        assert "val" in msg
+        assert "acme/dataset" in msg
+
+    def test_validate_metadata_requirements_aggregates_multiple_failures(self):
+        from opentau.datasets.factory import _validate_metadata_requirements
+
+        cfg = self._mixture_cfg(
+            datasets=[DatasetConfig(repo_id="a/x"), DatasetConfig(repo_id="b/y")],
+            require_non_empty_robot_type=True,
+            require_non_empty_control_mode=True,
+        )
+        datasets = [self._stub_dataset({}), self._stub_dataset({"robot_type": "panda"})]
+        with pytest.raises(ValueError) as excinfo:
+            _validate_metadata_requirements(cfg, datasets, label="train")
+        msg = str(excinfo.value)
+        assert "a/x: robot_type is empty" in msg
+        assert "a/x: control_mode is empty" in msg
+        assert "b/y: control_mode is empty" in msg
+        assert "b/y: robot_type is empty" not in msg  # b/y has a robot_type


### PR DESCRIPTION
## What this does

Refs #204.

Adds two related knobs for `robot_type` and `control_mode` metadata:

- **Dataset-level overrides** — `DatasetConfig.robot_type` and
  `DatasetConfig.control_mode` (both `str | None`, default `None` = no
  override). When set, they are written through to `dataset.meta.info` after
  the dataset is constructed in `make_dataset`. An explicit `""` is treated as
  "clear the loaded value" (distinct from `None`).
- **Mixture-level non-empty requirements** — `DatasetMixtureConfig.require_non_empty_robot_type`
  and `require_non_empty_control_mode` (both `bool`, default `False`).
  Defaults preserve today's behavior: empty values are tolerated. When opted
  into, `make_dataset_mixture` raises with a per-dataset breakdown of which
  field is missing.

When a `control_mode` override is provided, the "missing control_mode" warning
in `LeRobotDataset.__init__` is pre-suppressed for the affected repo_id —
the user already knew it was missing and is providing a value on purpose.

## How it was tested

- Added `TestRobotTypeControlModeOverridesAndRequirements` in
  `tests/datasets/test_dataset_mixture.py` (15 tests):
  - `DatasetConfig` defaults / accepts overrides / accepts explicit `""`.
  - `DatasetMixtureConfig` require flags default `False`.
  - `_apply_metadata_overrides`: writes through, no-op on `None`, `""` clears,
    skips `dataset.control_mode` attr update for VQA datasets that don't have
    one.
  - `_validate_metadata_requirements`: no-op when flags off; passes when
    populated; raises for empty / `None` / missing values; reports `label` +
    `repo_id`; aggregates multiple failures.
- `pre-commit run --all-files` clean.
- `pytest -m "not gpu and not slow" tests/datasets/test_dataset_mixture.py
  tests/datasets/test_datasets.py tests/datasets/test_optional_keys.py` all green.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/datasets/test_dataset_mixture.py::TestRobotTypeControlModeOverridesAndRequirements
```

Example config snippet that opts in to the strict checks:
```json
{
  "dataset_mixture": {
    "datasets": [
      {"repo_id": "lerobot/droid_100", "robot_type": "panda", "control_mode": "joint"}
    ],
    "require_non_empty_robot_type": true,
    "require_non_empty_control_mode": true
  }
}
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).


---
_Generated by [Claude Code](https://claude.ai/code/session_01MKZzZUv6Q4pgkLK8oZMDM2)_