### PR TITLE
feat(configs): support $ref include in JSON configs

### DIFF
--- a/configs/examples/refs/droid_mixture.json
+++ b/configs/examples/refs/droid_mixture.json
@@ -1,0 +1,9 @@
+{
+  "datasets": [
+    {
+      "repo_id": "lerobot/droid_100",
+      "revision": "v2.1"
+    }
+  ],
+  "weights": [1.0]
+}

--- a/configs/examples/refs/train_with_ref.json
+++ b/configs/examples/refs/train_with_ref.json
@@ -1,0 +1,5 @@
+{
+  "dataset_mixture": {
+    "$ref": "droid_mixture.json"
+  }
+}

--- a/src/opentau/configs/parser.py
+++ b/src/opentau/configs/parser.py
@@ -31,6 +31,7 @@ from typing import Sequence
 
 import draccus
 
+from opentau.configs.refs import resolve_refs_to_tempfile
 from opentau.utils.utils import has_method
 
 PATH_KEY = "path"
@@ -383,8 +384,14 @@ def wrap(config_path: Path | None = None):
                 if has_method(argtype, "from_pretrained") and config_path_cli:
                     cli_args = filter_arg("config_path", cli_args)
                     cfg = argtype.from_pretrained(config_path_cli, cli_args=cli_args)
+                elif config_path is not None:
+                    tmp_config = resolve_refs_to_tempfile(config_path)
+                    try:
+                        cfg = draccus.parse(config_class=argtype, config_path=str(tmp_config), args=cli_args)
+                    finally:
+                        tmp_config.unlink(missing_ok=True)
                 else:
-                    cfg = draccus.parse(config_class=argtype, config_path=config_path, args=cli_args)
+                    cfg = draccus.parse(config_class=argtype, config_path=None, args=cli_args)
             response = fn(cfg, *args, **kwargs)
             return response
 

--- a/src/opentau/configs/policies.py
+++ b/src/opentau/configs/policies.py
@@ -34,6 +34,7 @@ from huggingface_hub import hf_hub_download
 from huggingface_hub.constants import CONFIG_NAME
 from huggingface_hub.errors import HfHubHTTPError
 
+from opentau.configs.refs import resolve_refs
 from opentau.configs.types import FeatureType, NormalizationMode, PolicyFeature
 from opentau.optim.optimizers import OptimizerConfig
 from opentau.optim.schedulers import LRSchedulerConfig
@@ -95,16 +96,23 @@ def strip_deprecated_fields_from_json(path: Path) -> None:
 
 
 def load_stripped_config_to_tempfile(source_path: str | Path) -> Path:
-    """Read a config JSON, strip deprecated/removed fields in memory, write to
-    a fresh temp file, and return its path. Does not mutate ``source_path``.
+    """Read a config JSON, resolve ``$ref`` includes, strip deprecated/removed
+    fields in memory, write to a fresh temp file, and return its path. Does
+    not mutate ``source_path``.
 
     Use this on incoming config files (HF Hub downloads, user-supplied paths)
     before handing them to ``draccus.parse``: HF cache paths are symlinks into
     a content-addressed blob store, so an in-place rewrite would corrupt the
     cache; user-supplied paths shouldn't be mutated as a side effect of load.
+
+    See :mod:`opentau.configs.refs` for ``$ref`` semantics.
     """
-    with open(source_path) as f:
-        data = json.load(f)
+    data = resolve_refs(source_path)
+    if not isinstance(data, dict):
+        raise TypeError(
+            f"Top-level config at {source_path} must be a JSON object after "
+            f"$ref resolution, got {type(data).__name__}"
+        )
 
     _strip_keys(data, _STRIPPED_FIELDS)
 
@@ -130,10 +138,12 @@ def warn_deprecated_latency_fields(config_path: str | Path) -> None:
 
     Checks both top-level fields and fields nested under a ``"policy"`` key.
     Should be called before loading a config so users are aware the fields
-    will be ignored.
+    will be ignored. Resolves ``$ref`` includes so fields hidden behind a
+    reference are still detected.
     """
-    with open(config_path) as f:
-        data = json.load(f)
+    data = resolve_refs(config_path)
+    if not isinstance(data, dict):
+        return
 
     found = _find_present_keys(data, _DEPRECATED_LATENCY_FIELDS)
     if found:
@@ -152,10 +162,12 @@ def warn_removed_policy_fields(config_path: str | Path) -> None:
     Removed fields (e.g. ``init_strategy``) are stripped at load time so old
     saved configs continue to parse, but the user's explicit choice is dropped
     on the floor — surface that with a warning so they know to re-save and
-    update any downstream tooling that still emits the old key.
+    update any downstream tooling that still emits the old key. Resolves
+    ``$ref`` includes so fields hidden behind a reference are still detected.
     """
-    with open(config_path) as f:
-        data = json.load(f)
+    data = resolve_refs(config_path)
+    if not isinstance(data, dict):
+        return
 
     found = _find_present_keys(data, _REMOVED_POLICY_FIELDS)
     if found:

--- a/src/opentau/configs/policies.py
+++ b/src/opentau/configs/policies.py
@@ -164,7 +164,11 @@ def _find_present_keys(data: dict, keys: tuple[str, ...]) -> list[str]:
     return found
 
 
-def _warn_deprecated_latency_fields_from_dict(data: dict, config_path: str | Path) -> None:
+def warn_deprecated_latency_fields_from_dict(data: dict, config_path: str | Path) -> None:
+    """Like :func:`warn_deprecated_latency_fields` but operating on an
+    already-resolved config dict, so callers that already loaded the dict
+    don't pay for a second ``$ref`` walk. ``config_path`` is used only for
+    the warning message."""
     found = _find_present_keys(data, _DEPRECATED_LATENCY_FIELDS)
     if found:
         warnings.warn(
@@ -176,7 +180,10 @@ def _warn_deprecated_latency_fields_from_dict(data: dict, config_path: str | Pat
         )
 
 
-def _warn_removed_policy_fields_from_dict(data: dict, config_path: str | Path) -> None:
+def warn_removed_policy_fields_from_dict(data: dict, config_path: str | Path) -> None:
+    """Like :func:`warn_removed_policy_fields` but operating on an
+    already-resolved config dict. ``config_path`` is used only for the
+    warning message."""
     found = _find_present_keys(data, _REMOVED_POLICY_FIELDS)
     if found:
         warnings.warn(
@@ -195,7 +202,7 @@ def warn_deprecated_latency_fields(config_path: str | Path) -> None:
     will be ignored. Resolves ``$ref`` includes so fields hidden behind a
     reference are still detected.
     """
-    _warn_deprecated_latency_fields_from_dict(load_resolved_config_dict(config_path), config_path)
+    warn_deprecated_latency_fields_from_dict(load_resolved_config_dict(config_path), config_path)
 
 
 def warn_removed_policy_fields(config_path: str | Path) -> None:
@@ -207,7 +214,7 @@ def warn_removed_policy_fields(config_path: str | Path) -> None:
     update any downstream tooling that still emits the old key. Resolves
     ``$ref`` includes so fields hidden behind a reference are still detected.
     """
-    _warn_removed_policy_fields_from_dict(load_resolved_config_dict(config_path), config_path)
+    warn_removed_policy_fields_from_dict(load_resolved_config_dict(config_path), config_path)
 
 
 @dataclass
@@ -472,8 +479,8 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):
         # Resolve $refs once and reuse — the warn helpers and the strip step
         # would otherwise each walk the full ref tree from disk.
         config_data = load_resolved_config_dict(config_file)
-        _warn_deprecated_latency_fields_from_dict(config_data, config_file)
-        _warn_removed_policy_fields_from_dict(config_data, config_file)
+        warn_deprecated_latency_fields_from_dict(config_data, config_file)
+        warn_removed_policy_fields_from_dict(config_data, config_file)
         # Strip deprecated/removed keys via a temp file rather than mutating the
         # source — `config_file` may be an HF cache symlink to a content-addressed
         # blob, where a rewrite would silently corrupt the cache.

--- a/src/opentau/configs/policies.py
+++ b/src/opentau/configs/policies.py
@@ -95,6 +95,49 @@ def strip_deprecated_fields_from_json(path: Path) -> None:
             json.dump(data, f, indent=4)
 
 
+def load_resolved_config_dict(source_path: str | Path) -> dict:
+    """Resolve ``$ref`` includes in a config JSON and return the resulting dict.
+
+    Centralizes both the ref resolution and the top-level shape check so that
+    every loader in this module fails consistently on a non-object root, and
+    so that a single ``from_pretrained`` call can resolve once and pass the
+    dict to all downstream helpers (warnings, stripping) instead of re-walking
+    the ref tree from disk for each.
+    """
+    data = resolve_refs(source_path)
+    if not isinstance(data, dict):
+        raise TypeError(
+            f"Top-level config at {source_path} must be a JSON object after "
+            f"$ref resolution, got {type(data).__name__}"
+        )
+    return data
+
+
+def write_stripped_config_to_tempfile(data: dict) -> Path:
+    """Strip deprecated/removed fields from ``data`` and write to a temp file.
+
+    ``data`` is treated as read-only (a defensive copy is made before
+    stripping). Caller owns the returned path and must unlink it.
+    """
+    # `_strip_keys` only ever deletes from the top-level dict and the "policy"
+    # sub-dict, so a two-level shallow copy is enough to keep the caller's
+    # dict untouched without paying for a deep copy of (potentially large)
+    # nested configs.
+    data = dict(data)
+    if isinstance(data.get("policy"), dict):
+        data["policy"] = dict(data["policy"])
+    _strip_keys(data, _STRIPPED_FIELDS)
+
+    fd, tmp_path = tempfile.mkstemp(prefix="opentau_config_", suffix=".json")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=4)
+    except BaseException:
+        Path(tmp_path).unlink(missing_ok=True)
+        raise
+    return Path(tmp_path)
+
+
 def load_stripped_config_to_tempfile(source_path: str | Path) -> Path:
     """Read a config JSON, resolve ``$ref`` includes, strip deprecated/removed
     fields in memory, write to a fresh temp file, and return its path. Does
@@ -107,19 +150,7 @@ def load_stripped_config_to_tempfile(source_path: str | Path) -> Path:
 
     See :mod:`opentau.configs.refs` for ``$ref`` semantics.
     """
-    data = resolve_refs(source_path)
-    if not isinstance(data, dict):
-        raise TypeError(
-            f"Top-level config at {source_path} must be a JSON object after "
-            f"$ref resolution, got {type(data).__name__}"
-        )
-
-    _strip_keys(data, _STRIPPED_FIELDS)
-
-    fd, tmp_path = tempfile.mkstemp(prefix="opentau_config_", suffix=".json")
-    with os.fdopen(fd, "w") as f:
-        json.dump(data, f, indent=4)
-    return Path(tmp_path)
+    return write_stripped_config_to_tempfile(load_resolved_config_dict(source_path))
 
 
 def _find_present_keys(data: dict, keys: tuple[str, ...]) -> list[str]:
@@ -133,6 +164,29 @@ def _find_present_keys(data: dict, keys: tuple[str, ...]) -> list[str]:
     return found
 
 
+def _warn_deprecated_latency_fields_from_dict(data: dict, config_path: str | Path) -> None:
+    found = _find_present_keys(data, _DEPRECATED_LATENCY_FIELDS)
+    if found:
+        warnings.warn(
+            f"Config '{config_path}' contains deprecated latency fields that are no longer "
+            f"used and will be ignored: {', '.join(found)}. "
+            "Consider re-saving the config to remove them.",
+            DeprecationWarning,
+            stacklevel=4,
+        )
+
+
+def _warn_removed_policy_fields_from_dict(data: dict, config_path: str | Path) -> None:
+    found = _find_present_keys(data, _REMOVED_POLICY_FIELDS)
+    if found:
+        warnings.warn(
+            f"Config '{config_path}' contains fields that have been removed and will be "
+            f"ignored: {', '.join(found)}. Re-save the config to drop them.",
+            DeprecationWarning,
+            stacklevel=4,
+        )
+
+
 def warn_deprecated_latency_fields(config_path: str | Path) -> None:
     """Emit a deprecation warning if a config JSON file contains latency fields.
 
@@ -141,19 +195,7 @@ def warn_deprecated_latency_fields(config_path: str | Path) -> None:
     will be ignored. Resolves ``$ref`` includes so fields hidden behind a
     reference are still detected.
     """
-    data = resolve_refs(config_path)
-    if not isinstance(data, dict):
-        return
-
-    found = _find_present_keys(data, _DEPRECATED_LATENCY_FIELDS)
-    if found:
-        warnings.warn(
-            f"Config '{config_path}' contains deprecated latency fields that are no longer "
-            f"used and will be ignored: {', '.join(found)}. "
-            "Consider re-saving the config to remove them.",
-            DeprecationWarning,
-            stacklevel=3,
-        )
+    _warn_deprecated_latency_fields_from_dict(load_resolved_config_dict(config_path), config_path)
 
 
 def warn_removed_policy_fields(config_path: str | Path) -> None:
@@ -165,18 +207,7 @@ def warn_removed_policy_fields(config_path: str | Path) -> None:
     update any downstream tooling that still emits the old key. Resolves
     ``$ref`` includes so fields hidden behind a reference are still detected.
     """
-    data = resolve_refs(config_path)
-    if not isinstance(data, dict):
-        return
-
-    found = _find_present_keys(data, _REMOVED_POLICY_FIELDS)
-    if found:
-        warnings.warn(
-            f"Config '{config_path}' contains fields that have been removed and will be "
-            f"ignored: {', '.join(found)}. Re-save the config to drop them.",
-            DeprecationWarning,
-            stacklevel=3,
-        )
+    _warn_removed_policy_fields_from_dict(load_resolved_config_dict(config_path), config_path)
 
 
 @dataclass
@@ -438,12 +469,15 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):
         if config_file is None:
             return draccus.parse(cls, config_file, args=cli_overrides)
 
-        warn_deprecated_latency_fields(config_file)
-        warn_removed_policy_fields(config_file)
+        # Resolve $refs once and reuse — the warn helpers and the strip step
+        # would otherwise each walk the full ref tree from disk.
+        config_data = load_resolved_config_dict(config_file)
+        _warn_deprecated_latency_fields_from_dict(config_data, config_file)
+        _warn_removed_policy_fields_from_dict(config_data, config_file)
         # Strip deprecated/removed keys via a temp file rather than mutating the
         # source — `config_file` may be an HF cache symlink to a content-addressed
         # blob, where a rewrite would silently corrupt the cache.
-        tmp_config = load_stripped_config_to_tempfile(config_file)
+        tmp_config = write_stripped_config_to_tempfile(config_data)
         try:
             return draccus.parse(cls, str(tmp_config), args=cli_overrides)
         finally:

--- a/src/opentau/configs/refs.py
+++ b/src/opentau/configs/refs.py
@@ -1,0 +1,144 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Resolve ``$ref`` includes inside JSON config files.
+
+Lets a JSON config split itself across multiple files. Anywhere a JSON value
+is expected, an object of the form ``{"$ref": "path/to/other.json"}`` loads
+that file's content and inlines it. Sibling keys deep-merge over the loaded
+content (sibling values win on conflict), enabling small, targeted overrides
+of a referenced fragment.
+
+Example:
+
+.. code-block:: json
+
+    // main.json
+    {
+        "dataset_mixture": {
+            "$ref": "mixtures/big_mixture.json",
+            "weights": [0.5, 0.5]
+        }
+    }
+
+Rules:
+
+- ``$ref`` value must be a string. Relative paths resolve against the file
+  that contains the ``$ref`` (not CWD).
+- Refs may appear at any depth, in dicts or list elements.
+- Refs may chain (a referenced file may itself contain ``$ref`` keys); cycles
+  raise :class:`RefError`.
+- Sibling keys are only allowed when the referenced content is a JSON object.
+- Currently only whole-file references are supported (no JSON-pointer
+  fragments). HuggingFace Hub paths are not resolved here — only local files.
+"""
+
+import copy
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+REF_KEY = "$ref"
+
+
+class RefError(Exception):
+    """Raised when ``$ref`` resolution fails."""
+
+
+def resolve_refs(config_path: str | Path) -> Any:
+    """Load a JSON file and recursively resolve all ``$ref`` includes.
+
+    Args:
+        config_path: Path to the root JSON file.
+
+    Returns:
+        The fully resolved JSON tree (typically a dict, but may be a list or
+        scalar depending on what the file and its includes contain).
+
+    Raises:
+        RefError: If a referenced file is missing, contains invalid JSON,
+            forms a cycle, has a non-string ``$ref`` value, or has sibling
+            keys alongside a ``$ref`` whose target is not a JSON object.
+    """
+    abs_path = Path(config_path).resolve()
+    return _resolve_file(abs_path, _stack=())
+
+
+def resolve_refs_to_tempfile(config_path: str | Path) -> Path:
+    """Resolve ``$ref`` includes and write the result to a temp JSON file.
+
+    The caller is responsible for unlinking the returned path.
+    """
+    resolved = resolve_refs(config_path)
+    fd, tmp_path = tempfile.mkstemp(prefix="opentau_refs_", suffix=".json")
+    with os.fdopen(fd, "w") as f:
+        json.dump(resolved, f, indent=4)
+    return Path(tmp_path)
+
+
+def _resolve_file(abs_path: Path, _stack: tuple[Path, ...]) -> Any:
+    if abs_path in _stack:
+        chain = " -> ".join(str(p) for p in (*_stack, abs_path))
+        raise RefError(f"Cyclic $ref detected: {chain}")
+    if not abs_path.is_file():
+        raise RefError(f"$ref target not found: {abs_path}")
+    try:
+        with open(abs_path) as f:
+            data = json.load(f)
+    except json.JSONDecodeError as e:
+        raise RefError(f"Invalid JSON in {abs_path}: {e}") from e
+    return _resolve_node(data, base_dir=abs_path.parent, _stack=(*_stack, abs_path))
+
+
+def _resolve_node(node: Any, base_dir: Path, _stack: tuple[Path, ...]) -> Any:
+    if isinstance(node, dict):
+        if REF_KEY in node:
+            ref_value = node[REF_KEY]
+            if not isinstance(ref_value, str):
+                raise RefError(
+                    f"{REF_KEY} value must be a string path, got {type(ref_value).__name__} "
+                    f"in {_stack[-1] if _stack else '<root>'}"
+                )
+            target = (base_dir / ref_value).resolve()
+            loaded = _resolve_file(target, _stack)
+            siblings = {k: v for k, v in node.items() if k != REF_KEY}
+            if not siblings:
+                return loaded
+            if not isinstance(loaded, dict):
+                raise RefError(
+                    f"Cannot merge sibling keys {sorted(siblings)} with non-object "
+                    f"content loaded from {target}"
+                )
+            resolved_siblings = {k: _resolve_node(v, base_dir, _stack) for k, v in siblings.items()}
+            return _deep_merge(loaded, resolved_siblings)
+        return {k: _resolve_node(v, base_dir, _stack) for k, v in node.items()}
+    if isinstance(node, list):
+        return [_resolve_node(item, base_dir, _stack) for item in node]
+    return node
+
+
+def _deep_merge(base: dict, overrides: dict) -> dict:
+    """Return a deep-merged copy of ``base`` with ``overrides`` applied.
+
+    For each key in ``overrides``: if both sides hold a dict, recurse; else the
+    override value replaces the base value (lists are replaced, not concatenated).
+    """
+    result = copy.deepcopy(base)
+    for key, value in overrides.items():
+        if isinstance(result.get(key), dict) and isinstance(value, dict):
+            result[key] = _deep_merge(result[key], value)
+        else:
+            result[key] = value
+    return result

--- a/src/opentau/configs/refs.py
+++ b/src/opentau/configs/refs.py
@@ -41,6 +41,12 @@ Rules:
 - Sibling keys are only allowed when the referenced content is a JSON object.
 - Currently only whole-file references are supported (no JSON-pointer
   fragments). HuggingFace Hub paths are not resolved here — only local files.
+- Path resolution follows symlinks (``Path.resolve()``). HuggingFace cache
+  snapshots are symlinks into a content-addressed blob directory, so a
+  relative ``$ref`` inside an HF-cached config will resolve against that
+  flat blob dir — not the snapshot dir — and is unlikely to find the target.
+  Use absolute paths or copy the config out of the HF cache before adding
+  ``$ref`` includes.
 """
 
 import copy
@@ -83,8 +89,12 @@ def resolve_refs_to_tempfile(config_path: str | Path) -> Path:
     """
     resolved = resolve_refs(config_path)
     fd, tmp_path = tempfile.mkstemp(prefix="opentau_refs_", suffix=".json")
-    with os.fdopen(fd, "w") as f:
-        json.dump(resolved, f, indent=4)
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(resolved, f, indent=4)
+    except BaseException:
+        Path(tmp_path).unlink(missing_ok=True)
+        raise
     return Path(tmp_path)
 
 

--- a/src/opentau/configs/train.py
+++ b/src/opentau/configs/train.py
@@ -35,10 +35,10 @@ from opentau.configs.default import DatasetMixtureConfig, EvalConfig, WandBConfi
 from opentau.configs.deployment import ServerConfig
 from opentau.configs.policies import (
     PreTrainedConfig,
-    _warn_deprecated_latency_fields_from_dict,
-    _warn_removed_policy_fields_from_dict,
     load_resolved_config_dict,
     strip_deprecated_fields_from_json,
+    warn_deprecated_latency_fields_from_dict,
+    warn_removed_policy_fields_from_dict,
     write_stripped_config_to_tempfile,
 )
 from opentau.envs.configs import EnvConfig
@@ -411,8 +411,8 @@ class TrainPipelineConfig(HubMixin):
         # Resolve $refs once and reuse — the warn helpers and the strip step
         # would otherwise each walk the full ref tree from disk.
         config_data = load_resolved_config_dict(config_file)
-        _warn_deprecated_latency_fields_from_dict(config_data, config_file)
-        _warn_removed_policy_fields_from_dict(config_data, config_file)
+        warn_deprecated_latency_fields_from_dict(config_data, config_file)
+        warn_removed_policy_fields_from_dict(config_data, config_file)
         # Strip deprecated/removed keys via a temp file rather than mutating the
         # source — `config_file` may be an HF cache symlink to a content-addressed
         # blob, where a rewrite would silently corrupt the cache.

--- a/src/opentau/configs/train.py
+++ b/src/opentau/configs/train.py
@@ -35,10 +35,11 @@ from opentau.configs.default import DatasetMixtureConfig, EvalConfig, WandBConfi
 from opentau.configs.deployment import ServerConfig
 from opentau.configs.policies import (
     PreTrainedConfig,
-    load_stripped_config_to_tempfile,
+    _warn_deprecated_latency_fields_from_dict,
+    _warn_removed_policy_fields_from_dict,
+    load_resolved_config_dict,
     strip_deprecated_fields_from_json,
-    warn_deprecated_latency_fields,
-    warn_removed_policy_fields,
+    write_stripped_config_to_tempfile,
 )
 from opentau.envs.configs import EnvConfig
 from opentau.optim import OptimizerConfig
@@ -407,12 +408,15 @@ class TrainPipelineConfig(HubMixin):
         if config_file is None:
             return draccus.parse(cls, config_file, args=cli_args)
 
-        warn_deprecated_latency_fields(config_file)
-        warn_removed_policy_fields(config_file)
+        # Resolve $refs once and reuse — the warn helpers and the strip step
+        # would otherwise each walk the full ref tree from disk.
+        config_data = load_resolved_config_dict(config_file)
+        _warn_deprecated_latency_fields_from_dict(config_data, config_file)
+        _warn_removed_policy_fields_from_dict(config_data, config_file)
         # Strip deprecated/removed keys via a temp file rather than mutating the
         # source — `config_file` may be an HF cache symlink to a content-addressed
         # blob, where a rewrite would silently corrupt the cache.
-        tmp_config = load_stripped_config_to_tempfile(config_file)
+        tmp_config = write_stripped_config_to_tempfile(config_data)
         try:
             return draccus.parse(cls, str(tmp_config), args=cli_args)
         finally:

--- a/src/opentau/scripts/calculate_value.py
+++ b/src/opentau/scripts/calculate_value.py
@@ -55,6 +55,7 @@ import torch
 from torch.utils.data import DataLoader
 
 from opentau.configs.default import DatasetMixtureConfig
+from opentau.configs.refs import resolve_refs_to_tempfile
 from opentau.configs.train import TrainPipelineConfig
 from opentau.datasets.factory import make_dataset
 from opentau.policies.factory import get_policy_class
@@ -128,11 +129,15 @@ def main(cfg: TrainPipelineConfig, args: argparse.Namespace):
 
     if dataset_mixture_path:
         logging.info(f"Overriding dataset: loading mixture from {dataset_mixture_path}")
-        mixture_cfg = draccus.parse(
-            config_class=DatasetMixtureConfig,
-            config_path=dataset_mixture_path,
-            args=[],
-        )
+        tmp_mixture = resolve_refs_to_tempfile(dataset_mixture_path)
+        try:
+            mixture_cfg = draccus.parse(
+                config_class=DatasetMixtureConfig,
+                config_path=str(tmp_mixture),
+                args=[],
+            )
+        finally:
+            tmp_mixture.unlink(missing_ok=True)
     else:
         logging.info("Using dataset mixture from train config")
         mixture_cfg = cfg.dataset_mixture

--- a/src/opentau/scripts/get_advantage_and_percentiles.py
+++ b/src/opentau/scripts/get_advantage_and_percentiles.py
@@ -33,6 +33,7 @@ from torch.utils.data import DataLoader
 
 from opentau.configs import parser
 from opentau.configs.default import DatasetMixtureConfig
+from opentau.configs.refs import resolve_refs_to_tempfile
 from opentau.configs.train import TrainPipelineConfig
 from opentau.datasets.factory import make_dataset
 from opentau.datasets.utils import ADVANTAGES_PATH
@@ -110,9 +111,13 @@ def main(cfg: TrainPipelineConfig):
 
     if dataset_mixture_path:
         logging.info(f"Loading dataset config from separate file: {dataset_mixture_path}")
-        mixture_cfg = draccus.parse(
-            config_class=DatasetMixtureConfig, config_path=dataset_mixture_path, args=[]
-        )
+        tmp_mixture = resolve_refs_to_tempfile(dataset_mixture_path)
+        try:
+            mixture_cfg = draccus.parse(
+                config_class=DatasetMixtureConfig, config_path=str(tmp_mixture), args=[]
+            )
+        finally:
+            tmp_mixture.unlink(missing_ok=True)
     else:
         logging.info("Using the dataset mixture config from the TrainPipelineConfig")
         mixture_cfg = cfg.dataset_mixture

--- a/tests/configs/test_refs.py
+++ b/tests/configs/test_refs.py
@@ -207,3 +207,99 @@ def test_train_pipeline_config_from_pretrained_with_ref(tmp_path):
         "dummy",
     ]
     assert list(cfg.dataset_mixture.weights) == [1.0, 1.0, 1.0]
+
+
+def _decompose_into_refs(full: dict, sections: tuple[str, ...], out_dir: Path) -> dict:
+    """Split each top-level ``section`` of ``full`` into its own file under
+    ``out_dir`` and replace it in ``full`` with a ``$ref``."""
+    decomposed = dict(full)
+    for section in sections:
+        _write(out_dir / f"{section}.json", full[section])
+        decomposed[section] = {REF_KEY: f"{section}.json"}
+    return decomposed
+
+
+def test_train_config_round_trip_matches_baseline(tmp_path):
+    """Regression: decomposing a real train config across multiple sub-files
+    via $ref must yield a TrainPipelineConfig structurally identical to the
+    one loaded from the original monolithic JSON.
+
+    Covers the sections most likely to bloat a real config (datasets, policy,
+    optimizer, scheduler, wandb), so the round-trip exercises ref resolution
+    against the full draccus type system — not just a contrived dict.
+    """
+    from opentau.configs.train import TrainPipelineConfig
+
+    artifact = Path("tests/artifacts/configs/train_config.json")
+    full = json.loads(artifact.read_text())
+
+    # Baseline: load the original monolithic config.
+    baseline_path = _write(tmp_path / "baseline.json", full)
+    baseline_cfg = TrainPipelineConfig.from_pretrained(pretrained_name_or_path=baseline_path)
+
+    # Decomposed: split several large sections into their own files.
+    decomposed_dir = tmp_path / "decomposed"
+    decomposed_dir.mkdir()
+    decomposed = _decompose_into_refs(
+        full,
+        sections=("dataset_mixture", "policy", "optimizer", "scheduler", "wandb"),
+        out_dir=decomposed_dir,
+    )
+    decomposed_path = _write(decomposed_dir / "train_config.json", decomposed)
+    decomposed_cfg = TrainPipelineConfig.from_pretrained(pretrained_name_or_path=decomposed_path)
+
+    # Compare via draccus.encode — the canonical serialized form. Equality at
+    # this level catches any field that drifted, not just spot-checks.
+    import draccus
+
+    assert draccus.encode(decomposed_cfg) == draccus.encode(baseline_cfg)
+
+
+def test_train_config_chained_refs_match_baseline(tmp_path):
+    """Regression: a $ref chain (parent → mid → leaf) for a real sub-config
+    resolves to the same value as inlining the leaf directly."""
+    from opentau.configs.train import TrainPipelineConfig
+
+    artifact = Path("tests/artifacts/configs/train_config.json")
+    full = json.loads(artifact.read_text())
+
+    baseline_path = _write(tmp_path / "baseline.json", full)
+    baseline_cfg = TrainPipelineConfig.from_pretrained(pretrained_name_or_path=baseline_path)
+
+    # Build a chain: train_config.json → mixture_ref.json → mixture_leaf.json
+    chain_dir = tmp_path / "chain"
+    chain_dir.mkdir()
+    _write(chain_dir / "mixture_leaf.json", full["dataset_mixture"])
+    _write(chain_dir / "mixture_ref.json", {REF_KEY: "mixture_leaf.json"})
+    chained = dict(full)
+    chained["dataset_mixture"] = {REF_KEY: "mixture_ref.json"}
+    chained_path = _write(chain_dir / "train_config.json", chained)
+
+    chained_cfg = TrainPipelineConfig.from_pretrained(pretrained_name_or_path=chained_path)
+
+    import draccus
+
+    assert draccus.encode(chained_cfg) == draccus.encode(baseline_cfg)
+
+
+def test_train_config_sibling_override_applies(tmp_path):
+    """Regression: a sibling key alongside a $ref must override the matching
+    field in the loaded content (deep-merge), not be silently ignored."""
+    from opentau.configs.train import TrainPipelineConfig
+
+    artifact = Path("tests/artifacts/configs/train_config.json")
+    full = json.loads(artifact.read_text())
+
+    # The artifact has weights = [1.0, 1.0, 1.0]; override the first weight to 7.0.
+    _write(tmp_path / "mixture.json", full["dataset_mixture"])
+    full["dataset_mixture"] = {REF_KEY: "mixture.json", "weights": [7.0, 1.0, 1.0]}
+    config_path = _write(tmp_path / "train_config.json", full)
+
+    cfg = TrainPipelineConfig.from_pretrained(pretrained_name_or_path=config_path)
+    assert list(cfg.dataset_mixture.weights) == [7.0, 1.0, 1.0]
+    # The non-overridden fields from the referenced file must still be present.
+    assert [d.repo_id or d.vqa for d in cfg.dataset_mixture.datasets] == [
+        "lerobot/droid_100",
+        "lerobot/aloha_mobile_cabinet",
+        "dummy",
+    ]

--- a/tests/configs/test_refs.py
+++ b/tests/configs/test_refs.py
@@ -1,0 +1,209 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from pathlib import Path
+
+import pytest
+
+from opentau.configs.refs import (
+    REF_KEY,
+    RefError,
+    resolve_refs,
+    resolve_refs_to_tempfile,
+)
+
+
+def _write(path: Path, data) -> Path:
+    path.write_text(json.dumps(data))
+    return path
+
+
+def test_no_refs_passes_through(tmp_path):
+    src = _write(tmp_path / "a.json", {"x": 1, "y": [1, 2, 3]})
+    assert resolve_refs(src) == {"x": 1, "y": [1, 2, 3]}
+
+
+def test_basic_ref_inlines_object(tmp_path):
+    inner = _write(tmp_path / "inner.json", {"a": 1, "b": 2})
+    outer = _write(tmp_path / "outer.json", {"nested": {REF_KEY: "inner.json"}})
+    assert resolve_refs(outer) == {"nested": {"a": 1, "b": 2}}
+    # Source files must not be mutated.
+    assert json.loads(inner.read_text()) == {"a": 1, "b": 2}
+    assert json.loads(outer.read_text()) == {"nested": {REF_KEY: "inner.json"}}
+
+
+def test_ref_to_array(tmp_path):
+    _write(tmp_path / "list.json", [{"id": 1}, {"id": 2}])
+    outer = _write(tmp_path / "outer.json", {"items": {REF_KEY: "list.json"}})
+    assert resolve_refs(outer) == {"items": [{"id": 1}, {"id": 2}]}
+
+
+def test_ref_inside_list(tmp_path):
+    _write(tmp_path / "d1.json", {"name": "first"})
+    _write(tmp_path / "d2.json", {"name": "second"})
+    outer = _write(
+        tmp_path / "outer.json",
+        {"datasets": [{REF_KEY: "d1.json"}, {REF_KEY: "d2.json"}, {"name": "third"}]},
+    )
+    assert resolve_refs(outer) == {"datasets": [{"name": "first"}, {"name": "second"}, {"name": "third"}]}
+
+
+def test_sibling_keys_override_via_deep_merge(tmp_path):
+    _write(tmp_path / "base.json", {"a": 1, "b": {"c": 2, "d": 3}})
+    outer = _write(
+        tmp_path / "outer.json",
+        {REF_KEY: "base.json", "b": {"c": 99}, "extra": "kept"},
+    )
+    # Sibling `b.c` overrides; sibling `b.d` is not touched; sibling-only `extra` is added.
+    assert resolve_refs(outer) == {"a": 1, "b": {"c": 99, "d": 3}, "extra": "kept"}
+
+
+def test_sibling_list_replaces_base_list(tmp_path):
+    _write(tmp_path / "base.json", {"items": [1, 2, 3]})
+    outer = _write(tmp_path / "outer.json", {REF_KEY: "base.json", "items": [9]})
+    assert resolve_refs(outer) == {"items": [9]}
+
+
+def test_chained_refs(tmp_path):
+    _write(tmp_path / "leaf.json", {"value": "leaf"})
+    _write(tmp_path / "mid.json", {"wrapper": {REF_KEY: "leaf.json"}})
+    outer = _write(tmp_path / "outer.json", {REF_KEY: "mid.json"})
+    assert resolve_refs(outer) == {"wrapper": {"value": "leaf"}}
+
+
+def test_relative_paths_resolve_against_including_file(tmp_path):
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    # `sub/leaf.json` references `../shared.json` — must resolve relative to `sub/`.
+    _write(tmp_path / "shared.json", {"shared": True})
+    _write(sub / "leaf.json", {REF_KEY: "../shared.json"})
+    outer = _write(tmp_path / "outer.json", {"x": {REF_KEY: "sub/leaf.json"}})
+    assert resolve_refs(outer) == {"x": {"shared": True}}
+
+
+def test_cycle_raises(tmp_path):
+    a = tmp_path / "a.json"
+    b = tmp_path / "b.json"
+    _write(a, {REF_KEY: "b.json"})
+    _write(b, {REF_KEY: "a.json"})
+    with pytest.raises(RefError, match="Cyclic"):
+        resolve_refs(a)
+
+
+def test_self_ref_raises(tmp_path):
+    a = _write(tmp_path / "a.json", {REF_KEY: "a.json"})
+    with pytest.raises(RefError, match="Cyclic"):
+        resolve_refs(a)
+
+
+def test_missing_ref_target_raises(tmp_path):
+    outer = _write(tmp_path / "outer.json", {REF_KEY: "does_not_exist.json"})
+    with pytest.raises(RefError, match="not found"):
+        resolve_refs(outer)
+
+
+def test_invalid_json_raises(tmp_path):
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not valid json")
+    outer = _write(tmp_path / "outer.json", {REF_KEY: "bad.json"})
+    with pytest.raises(RefError, match="Invalid JSON"):
+        resolve_refs(outer)
+
+
+def test_non_string_ref_value_raises(tmp_path):
+    outer = _write(tmp_path / "outer.json", {REF_KEY: 42})
+    with pytest.raises(RefError, match="must be a string"):
+        resolve_refs(outer)
+
+
+def test_sibling_keys_with_non_object_target_raises(tmp_path):
+    _write(tmp_path / "list.json", [1, 2, 3])
+    outer = _write(
+        tmp_path / "outer.json",
+        {"items": {REF_KEY: "list.json", "extra": "not_allowed"}},
+    )
+    with pytest.raises(RefError, match="non-object content"):
+        resolve_refs(outer)
+
+
+def test_diamond_share_does_not_trigger_cycle(tmp_path):
+    # Two separate refs to the same file are not a cycle.
+    _write(tmp_path / "shared.json", {"v": 1})
+    outer = _write(
+        tmp_path / "outer.json",
+        {"a": {REF_KEY: "shared.json"}, "b": {REF_KEY: "shared.json"}},
+    )
+    assert resolve_refs(outer) == {"a": {"v": 1}, "b": {"v": 1}}
+
+
+def test_resolve_refs_to_tempfile_writes_resolved(tmp_path):
+    _write(tmp_path / "inner.json", {"a": 1})
+    outer = _write(tmp_path / "outer.json", {"x": {REF_KEY: "inner.json"}})
+    out = resolve_refs_to_tempfile(outer)
+    try:
+        assert out.is_file()
+        assert json.loads(out.read_text()) == {"x": {"a": 1}}
+    finally:
+        out.unlink(missing_ok=True)
+
+
+def test_dataset_mixture_through_load_stripped(tmp_path):
+    """End-to-end: an outer config that splits its dataset_mixture into a ref
+    is correctly assembled by load_stripped_config_to_tempfile."""
+    from opentau.configs.policies import load_stripped_config_to_tempfile
+
+    _write(
+        tmp_path / "mixture.json",
+        {"datasets": [{"repo_id": "lerobot/droid_100"}], "weights": [1.0]},
+    )
+    outer = _write(
+        tmp_path / "train.json",
+        {
+            "batch_size": 32,
+            "dataset_mixture": {REF_KEY: "mixture.json"},
+        },
+    )
+    tmp = load_stripped_config_to_tempfile(outer)
+    try:
+        merged = json.loads(tmp.read_text())
+    finally:
+        tmp.unlink(missing_ok=True)
+    assert merged["batch_size"] == 32
+    assert merged["dataset_mixture"]["datasets"] == [{"repo_id": "lerobot/droid_100"}]
+    assert merged["dataset_mixture"]["weights"] == [1.0]
+
+
+def test_train_pipeline_config_from_pretrained_with_ref(tmp_path):
+    """End-to-end: TrainPipelineConfig.from_pretrained loads a config that
+    factors out its dataset_mixture into a separate file via $ref."""
+    from opentau.configs.train import TrainPipelineConfig
+
+    artifact = Path("tests/artifacts/configs/train_config.json")
+    full = json.loads(artifact.read_text())
+
+    # Split the dataset_mixture into its own file and replace it with a $ref.
+    mixture = full.pop("dataset_mixture")
+    _write(tmp_path / "mixture.json", mixture)
+    full["dataset_mixture"] = {REF_KEY: "mixture.json"}
+    config_path = _write(tmp_path / "train_config.json", full)
+
+    cfg = TrainPipelineConfig.from_pretrained(pretrained_name_or_path=config_path)
+    # Round-tripping through $ref must reproduce the same dataset list.
+    assert [d.repo_id or d.vqa for d in cfg.dataset_mixture.datasets] == [
+        "lerobot/droid_100",
+        "lerobot/aloha_mobile_cabinet",
+        "dummy",
+    ]
+    assert list(cfg.dataset_mixture.weights) == [1.0, 1.0, 1.0]


### PR DESCRIPTION
## What this does

Lets a JSON config split itself across multiple files, so a `TrainPipelineConfig` doesn't have to inline a 100+ entry `dataset_mixture.datasets` list (or any other large nested config). Anywhere a JSON value is expected, an object of the form `{"$ref": "path/to/other.json"}` loads that file's content and inlines it. Sibling keys deep-merge over the loaded content, so small overrides don't require copying the whole file.

**Syntax & semantics:**

```json
// pi05_training_config.json
{
  "dataset_mixture": {
    "$ref": "mixtures/big_mixture.json",
    "weights": [0.5, 0.5]   // overrides the weights from big_mixture.json
  },
  "policy": { ... }
}
```

- `$ref` value must be a string. Paths resolve relative to the **including file**, not CWD.
- Refs may appear at any depth — dict values or list elements.
- Refs may chain (a referenced file may itself contain `$ref`s).
- Sibling keys deep-merge: scalar/list values from siblings replace base; dict values recurse.
- Cycles raise `RefError`.
- Missing files / invalid JSON / non-string `$ref` / sibling keys with non-object target → `RefError`.

**Where it's hooked in:**

1. `load_stripped_config_to_tempfile` (`policies.py`) — covers both `TrainPipelineConfig.from_pretrained` and `PreTrainedConfig.from_pretrained`. Refs are resolved before deprecated-field stripping, so deprecated fields hidden behind a `$ref` are still stripped/warned-about.
2. `parser.wrap` fallback path — for the rare case where the decorator is invoked with an explicit `config_path`.
3. `--dataset_mixture_path` flag in `get_advantage_and_percentiles.py` and `calculate_value.py`.

**Out of scope (filed as follow-up):**

- Fragment includes, e.g. `{"$ref": "file.json#/datasets"}` — currently only whole files.
- HuggingFace Hub paths inside `$ref` — currently only local files. Hub paths still work for the top-level `--config_path`.

## How it was tested

- Added `tests/configs/test_refs.py` with 18 tests covering: pass-through, basic include, refs to arrays, refs inside lists, sibling deep-merge, sibling list replacement, ref chains, relative-path resolution, two cycle cases (A→B→A and self-ref), missing files, invalid JSON, non-string `$ref`, sibling-with-non-object error, diamond dependency (shared file referenced twice — not a cycle), `resolve_refs_to_tempfile` happy path, end-to-end through `load_stripped_config_to_tempfile`, end-to-end through `TrainPipelineConfig.from_pretrained` (splits the existing `tests/artifacts/configs/train_config.json` mixture into a separate file, refs it back, and asserts the parsed dataclass matches).
- Pre-commit (`ruff`, `ruff-format`, `pyupgrade`, `bandit`, etc.) all pass.
- Full `tests/configs/` suite (`pytest -m "not gpu" tests/configs/ -n auto`): 82 passed.
- Verified that the only test failures elsewhere in the suite (`tests/utils/test_hub.py`, `tests/envs/test_factory.py`) reproduce on the base branch without these changes — they're environment issues (missing HF token, missing libero), not regressions.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/configs/test_refs.py
```

Or factor an existing example config:

```bash
# configs/examples/refs/droid_mixture.json contains the dataset list;
# configs/examples/refs/train_with_ref.json refs it.
cat configs/examples/refs/train_with_ref.json
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).


---
_Generated by [Claude Code](https://claude.ai/code/session_01W7a5fuGdmnw9XC7z65im7W)_