### PR TITLE
Remove duplicate val_split_ratio from DatasetConfig

### DIFF
--- a/src/opentau/configs/default.py
+++ b/src/opentau/configs/default.py
@@ -105,11 +105,6 @@ class DatasetConfig:
     robot_type: str | None = None
     control_mode: str | None = None
 
-    # Ratio of the dataset to be used for validation. Please specify a value.
-    # If `val_freq` is set to 0, a validation dataset will not be created and this value will be ignored.
-    # Defaults to 0.05.
-    val_split_ratio: float = 0.05
-
     def __post_init__(self):
         """Validate dataset configuration and register custom mappings if provided."""
         if (self.repo_id is None) == (self.vqa is None):
@@ -277,10 +272,6 @@ class DatasetMixtureConfig:
             value = getattr(self, name)
             if not 0.0 <= value <= 1.0:
                 raise ValueError(f"`{name}` must be in [0, 1], got {value}.")
-
-        # set the val_split_ratio for all datasets in the mixture
-        for dataset_cfg in self.datasets:
-            dataset_cfg.val_split_ratio = self.val_split_ratio
 
 
 @dataclass

--- a/src/opentau/datasets/factory.py
+++ b/src/opentau/datasets/factory.py
@@ -169,7 +169,7 @@ def make_dataset(
 
     A train and validation dataset are returned if `train_cfg.val_freq` is greater than 0.
     The validation dataset is a subset of the train dataset, and is used for evaluation during training.
-    The validation dataset is created by splitting the train dataset into train and validation sets based on `cfg.val_split_ratio`.
+    The validation dataset is created by splitting the train dataset into train and validation sets based on `train_cfg.dataset_mixture.val_split_ratio`.
 
     Args:
         cfg (DatasetConfig): A DatasetConfig used to create a LeRobotDataset.
@@ -243,7 +243,7 @@ def make_dataset(
                 dataset.meta.stats[key][stats_type] = np.array(stats, dtype=np.float32)
 
     if train_cfg.val_freq > 0:
-        val_size = int(len(dataset) * cfg.val_split_ratio)
+        val_size = int(len(dataset) * train_cfg.dataset_mixture.val_split_ratio)
         train_size = len(dataset) - val_size
         train_dataset, val_dataset = torch.utils.data.random_split(dataset, [train_size, val_size])
         train_dataset.meta = copy.deepcopy(dataset.meta)  # type: ignore[assignment]


### PR DESCRIPTION
## What this does

`val_split_ratio` was declared on **both** `DatasetConfig` and `DatasetMixtureConfig`, but in practice the per-dataset value was always overwritten by the mixture-level value inside `DatasetMixtureConfig.__post_init__`:

```python
# old configs/default.py
for dataset_cfg in self.datasets:
    dataset_cfg.val_split_ratio = self.val_split_ratio
```

So setting `val_split_ratio` on a `DatasetConfig` did nothing — it was dead config surface that misled readers into thinking the split could be tuned per-dataset.

This PR:
- Drops `val_split_ratio` from `DatasetConfig`.
- Removes the propagation loop from `DatasetMixtureConfig.__post_init__`.
- Updates `factory.make_dataset` to read `train_cfg.dataset_mixture.val_split_ratio` directly (instead of the per-dataset `cfg.val_split_ratio`).

The mixture-level field — which is what the docs (`docs/source/tutorials/evaluation.rst`) already document as the public knob — and its `[0, 1]` range validation are unchanged.

### ⚠️ Breaking change (config schema only)

Any external draccus JSON config that set `val_split_ratio` *inside* a `datasets[i]` entry (rather than at the mixture level) will now fail to parse with an "unknown field" error. **Runtime behavior does not change** — the per-dataset value was previously overwritten unconditionally by the mixture-level value, so it had no effect. Affected users should move `val_split_ratio` up to the mixture level:

```jsonc
// before
{
  "dataset_mixture": {
    "datasets": [
      {"repo_id": "...", "val_split_ratio": 0.1}
    ]
  }
}

// after
{
  "dataset_mixture": {
    "val_split_ratio": 0.1,
    "datasets": [
      {"repo_id": "..."}
    ]
  }
}
```

No JSON config under `configs/`, no test under `tests/`, and no notebook in this repo uses the per-dataset field, so nothing in-tree breaks.

Tag: 🧹 Cleanup / 📝 Documentation

## How it was tested

- `git grep val_split_ratio` confirms the only remaining references are the mixture-level field, its validator, and the factory site that reads it.
- No JSON config under `configs/`, no test under `tests/`, and no notebook references the per-dataset field, so no caller breaks.
- Files parse cleanly (`python -c "import ast; ast.parse(...)"`) on both edited files.
- Pre-commit and pytest weren't run in this environment (no `uv` venv / no `pre-commit` binary available); please re-run locally before merging:

```bash
pre-commit run --all-files
pytest -m "not gpu" -n auto
```

## How to checkout & try? (for the reviewer)

```bash
git fetch origin claude/remove-duplicate-val-split-kGsSo
git checkout claude/remove-duplicate-val-split-kGsSo
pre-commit run --all-files
pytest -m "not gpu" -n auto
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).

---
_Generated by [Claude Code](https://claude.ai/code/session_01195CkvBEEzJZxghK5HkfBp)_
