### PR TITLE
fix(pi07_paligemma): backport prefix gating + cross-att length to feat/pi07 (#226)

### DIFF
--- a/.github/workflows/cpu_test.yml
+++ b/.github/workflows/cpu_test.yml
@@ -102,7 +102,9 @@ jobs:
           python3 -c "import sys; print(sys.path)"
           python3 -c "import libero.libero" && echo "LIBERO config set successfully."
           echo "Running cpu based pytest and generating coverage report..."
-          pytest -m "not gpu" -n auto -v --cov=lerobot/ --cov-report=xml:cpu_test/cpu_test.xml --ignore=tests/planner/test_planner.py --ignore tests/utils/test_libero_utils.py --deselect=tests/envs/test_factory.py::TestMakeEnv::test_make_env_async_vector_env --deselect=tests/envs/test_factory.py::TestMakeEnv::test_make_env_sync_vector_env tests/
+          # TODO(#210): drop --ignore=tests/policies/test_pi07_paligemma_low_level_planner.py once pi07 migrates to SpaceTimeSiglipVideoEncoder (#192).
+          # TODO(#210): drop --ignore=tests/policies/test_pi07_paligemma_low_level_planner.py once pi07 migrates to SpaceTimeSiglipVideoEncoder (#192).
+          pytest -m "not gpu" -n auto -v --cov=lerobot/ --cov-report=xml:cpu_test/cpu_test.xml --ignore=tests/planner/test_planner.py --ignore tests/utils/test_libero_utils.py --ignore=tests/policies/test_pi07_paligemma_low_level_planner.py --deselect=tests/envs/test_factory.py::TestMakeEnv::test_make_env_async_vector_env --deselect=tests/envs/test_factory.py::TestMakeEnv::test_make_env_sync_vector_env tests/
           echo "Pytest execution and coverage report generation completed."
 
       - name: Upload coverage reports

--- a/.github/workflows/cpu_test.yml
+++ b/.github/workflows/cpu_test.yml
@@ -103,7 +103,6 @@ jobs:
           python3 -c "import libero.libero" && echo "LIBERO config set successfully."
           echo "Running cpu based pytest and generating coverage report..."
           # TODO(#210): drop --ignore=tests/policies/test_pi07_paligemma_low_level_planner.py once pi07 migrates to SpaceTimeSiglipVideoEncoder (#192).
-          # TODO(#210): drop --ignore=tests/policies/test_pi07_paligemma_low_level_planner.py once pi07 migrates to SpaceTimeSiglipVideoEncoder (#192).
           pytest -m "not gpu" -n auto -v --cov=lerobot/ --cov-report=xml:cpu_test/cpu_test.xml --ignore=tests/planner/test_planner.py --ignore tests/utils/test_libero_utils.py --ignore=tests/policies/test_pi07_paligemma_low_level_planner.py --deselect=tests/envs/test_factory.py::TestMakeEnv::test_make_env_async_vector_env --deselect=tests/envs/test_factory.py::TestMakeEnv::test_make_env_sync_vector_env tests/
           echo "Pytest execution and coverage report generation completed."
 

--- a/.github/workflows/gpu_test.yml
+++ b/.github/workflows/gpu_test.yml
@@ -91,7 +91,8 @@ jobs:
           source .venv/bin/activate
           mkdir -p /tmp/libero-assets/libero/libero
           export LIBERO_CONFIG_PATH="$(pwd)/.github/assets/libero"
-          pytest -m "gpu" -n 0 -v tests/
+          # TODO(#210): drop --ignore=tests/policies/test_pi07_paligemma_low_level_planner.py once pi07 migrates to SpaceTimeSiglipVideoEncoder (#192).
+          pytest -m "gpu" -n 0 -v --ignore=tests/policies/test_pi07_paligemma_low_level_planner.py tests/
 
   stop-runner:
     name: Stop GPU Runner

--- a/src/opentau/policies/pi07_paligemma/low_level_planner/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level_planner/modeling_pi07_low_level.py
@@ -908,8 +908,11 @@ class PI07LowLevelPlannerPolicy(PreTrainedPolicy):
 
         # Per-sample flag: True means the subgoal was dropped or absent.
         subgoal_is_pad = batch.get(
-            "subgoal_is_pad", torch.zeros(batch["state"].shape[0], dtype=torch.bool)
+            "subgoal_is_pad", torch.ones(batch["state"].shape[0], dtype=torch.bool)
         )  # (B,) bool or None
+
+        last_subgoal_img: Tensor | None = None
+        last_mask: Tensor | None = None
 
         for key in present_subgoal_img_keys:
             subgoal_img = batch[key]
@@ -931,16 +934,16 @@ class PI07LowLevelPlannerPolicy(PreTrainedPolicy):
 
             subgoal_images.append(subgoal_img)
             subgoal_img_masks.append(mask)
+            last_subgoal_img = subgoal_img
+            last_mask = mask
 
-        # Create image features not present in the batch
-        # as fully 0 padded images.
-        for num_empty_cameras in range(len(missing_subgoal_img_keys)):
-            if num_empty_cameras >= self.config.empty_cameras:
-                break
-            subgoal_img = torch.ones_like(subgoal_img) * -1
-            mask = torch.zeros_like(mask)
-            subgoal_images.append(subgoal_img)
-            subgoal_img_masks.append(mask)
+        # Create image features not present in the batch as fully 0 padded images.
+        if last_subgoal_img is not None and last_mask is not None:
+            for num_empty_cameras in range(len(missing_subgoal_img_keys)):
+                if num_empty_cameras >= self.config.empty_cameras:
+                    break
+                subgoal_images.append(torch.ones_like(last_subgoal_img) * -1)
+                subgoal_img_masks.append(torch.zeros_like(last_mask))
 
         return subgoal_images, subgoal_img_masks
 
@@ -965,9 +968,9 @@ class PI07LowLevelPlannerPolicy(PreTrainedPolicy):
             batch.get("speed", torch.zeros(batch["state"].shape[0], dtype=torch.float32)),
             batch.get("quality", torch.zeros(batch["state"].shape[0], dtype=torch.float32)),
             batch.get("mistake", torch.zeros(batch["state"].shape[0], dtype=torch.float32)),
-            batch.get("speed_is_pad", torch.zeros(batch["state"].shape[0], dtype=torch.bool)),
-            batch.get("quality_is_pad", torch.zeros(batch["state"].shape[0], dtype=torch.bool)),
-            batch.get("mistake_is_pad", torch.zeros(batch["state"].shape[0], dtype=torch.bool)),
+            batch.get("speed_is_pad", torch.ones(batch["state"].shape[0], dtype=torch.bool)),
+            batch.get("quality_is_pad", torch.ones(batch["state"].shape[0], dtype=torch.bool)),
+            batch.get("mistake_is_pad", torch.ones(batch["state"].shape[0], dtype=torch.bool)),
             strict=True,
         ):
             segments = []
@@ -1157,6 +1160,19 @@ class PI07LowLevelPlannerFlowMatching(nn.Module):
         att_masks = []
         bsize = lang_tokens.shape[0]
 
+        # Per-batch presence flags for the optional middle blocks. When all
+        # are False the prefix layout collapses to ``[videos | language |
+        # State: | state | ":\n" | Action: | discrete_actions]`` (the pi05
+        # all-dropped layout), so the surrounding separators around the
+        # optional blocks must be skipped or switched too — not just the
+        # content.
+        has_response = response_tokens is not None and response_masks is not None and response_masks.any()
+        has_subgoal = (
+            bool(subgoal_images) and bool(subgoal_img_masks) and any(m.any() for m in subgoal_img_masks)
+        )
+        has_metadata = metadata_tokens is not None and metadata_masks is not None and metadata_masks.any()
+        has_any_optional = bool(has_response or has_subgoal or has_metadata)
+
         for vid, vid_mask in zip(videos, vid_masks, strict=True):
             vid_emb = self.embed_video(vid)  # (B, num_video_tokens, vlm_hidden)
             vid_emb = vid_emb.to(dtype=_preferred_dtype())
@@ -1211,7 +1227,10 @@ class PI07LowLevelPlannerFlowMatching(nn.Module):
         pad_masks.append(state_mask)
         att_masks += [0] * num_state_tokens  # full attention with video and language
 
-        state_end_indicator_ids = self.language_tokenizer.encode(", ", add_special_tokens=False)
+        # ``", "`` opens the optional middle list; ``":\n"`` terminates the
+        # state segment when no optional follows (matches pi05 layout).
+        state_end_str = ", " if has_any_optional else ":\n"
+        state_end_indicator_ids = self.language_tokenizer.encode(state_end_str, add_special_tokens=False)
         state_end_tokens = torch.tensor(
             [state_end_indicator_ids] * bsize,
             device=lang_tokens.device,
@@ -1228,96 +1247,119 @@ class PI07LowLevelPlannerFlowMatching(nn.Module):
         pad_masks.append(state_end_mask)
         att_masks += [0] * num_state_end_embs
 
-        response_emb = self.paligemma_with_expert.embed_language_tokens(response_tokens)
-        response_emb_dim = response_emb.shape[-1]
-        response_emb = response_emb * math.sqrt(response_emb_dim)
-        embs.append(response_emb)
-        pad_masks.append(response_masks)
-        num_response_embs = response_emb.shape[1]
-        att_masks += [1] + [0] * (num_response_embs - 1)
+        # Only embed response when at least one sample in the batch has real
+        # response tokens. With response_drop_prob=1.0 all masks are False;
+        # skipping avoids a spurious causal-block boundary (att_masks=[1,...])
+        # that would corrupt cumsum for every subsequent token.
+        if has_response:
+            response_emb = self.paligemma_with_expert.embed_language_tokens(response_tokens)
+            response_emb_dim = response_emb.shape[-1]
+            response_emb = response_emb * math.sqrt(response_emb_dim)
+            embs.append(response_emb)
+            pad_masks.append(response_masks)
+            num_response_embs = response_emb.shape[1]
+            att_masks += [1] + [0] * (num_response_embs - 1)
 
-        subgoal_img_start_indicator_ids = self.language_tokenizer.encode(
-            "Subgoal: ", add_special_tokens=False
-        )
-        subgoal_img_start_tokens = torch.tensor(
-            [subgoal_img_start_indicator_ids] * bsize,
-            device=lang_tokens.device,
-            dtype=torch.long,
-        )
-        subgoal_img_start_emb = self.paligemma_with_expert.embed_language_tokens(subgoal_img_start_tokens)
-        subgoal_img_start_dim = subgoal_img_start_emb.shape[-1]
-        subgoal_img_start_emb = subgoal_img_start_emb * math.sqrt(subgoal_img_start_dim)
+        # Only embed the subgoal block (header + images + footer) when subgoal
+        # images are actually present. Unconditionally adding "Subgoal: "
+        # injects real (non-padded) spurious tokens into every prefix even
+        # with subgoal_drop_prob=1.0.
+        if has_subgoal:
+            # Per-sample availability: True iff at least one camera slot has a
+            # real subgoal image for that sample. In a mixed batch (some
+            # samples have subgoals, others don't), the "Subgoal: " header
+            # and trailing ", " footer must follow this same mask — otherwise
+            # pad-only samples would receive real (unmasked) indicator tokens
+            # with no image content behind them.
+            sample_has_subgoal = torch.stack([m.to(dtype=torch.bool) for m in subgoal_img_masks], dim=0).any(
+                dim=0
+            )
 
-        num_subgoal_img_start_embs = subgoal_img_start_emb.shape[1]
-        subgoal_img_start_mask = torch.ones(
-            bsize, num_subgoal_img_start_embs, dtype=torch.bool, device=lang_tokens.device
-        )
+            subgoal_img_start_indicator_ids = self.language_tokenizer.encode(
+                "Subgoal: ", add_special_tokens=False
+            )
+            subgoal_img_start_tokens = torch.tensor(
+                [subgoal_img_start_indicator_ids] * bsize,
+                device=lang_tokens.device,
+                dtype=torch.long,
+            )
+            subgoal_img_start_emb = self.paligemma_with_expert.embed_language_tokens(subgoal_img_start_tokens)
+            subgoal_img_start_dim = subgoal_img_start_emb.shape[-1]
+            subgoal_img_start_emb = subgoal_img_start_emb * math.sqrt(subgoal_img_start_dim)
 
-        embs.append(subgoal_img_start_emb)
-        pad_masks.append(subgoal_img_start_mask)
-        att_masks += [1] + [0] * (num_subgoal_img_start_embs - 1)
+            num_subgoal_img_start_embs = subgoal_img_start_emb.shape[1]
+            subgoal_img_start_mask = sample_has_subgoal[:, None].expand(bsize, num_subgoal_img_start_embs)
 
-        for (
-            subgoal_img,
-            subgoal_img_mask,
-        ) in zip(subgoal_images, subgoal_img_masks, strict=True):
-            subgoal_img_emb = self.paligemma_with_expert.embed_image(subgoal_img)
-            subgoal_img_emb = subgoal_img_emb.to(dtype=_preferred_dtype())
+            embs.append(subgoal_img_start_emb)
+            pad_masks.append(subgoal_img_start_mask)
+            att_masks += [1] + [0] * (num_subgoal_img_start_embs - 1)
 
-            # image embeddings don't need to be unnormalized because `fix/lerobot_openpi` branch of huggingface
-            # already removed the normalization inside PaliGemma
+            for (
+                subgoal_img,
+                subgoal_img_mask,
+            ) in zip(subgoal_images, subgoal_img_masks, strict=True):
+                subgoal_img_emb = self.paligemma_with_expert.embed_image(subgoal_img)
+                subgoal_img_emb = subgoal_img_emb.to(dtype=_preferred_dtype())
 
-            bsize, num_subgoal_img_embs = subgoal_img_emb.shape[:2]
-            subgoal_img_mask = subgoal_img_mask[:, None].expand(bsize, num_subgoal_img_embs)
+                # image embeddings don't need to be unnormalized because `fix/lerobot_openpi` branch of huggingface
+                # already removed the normalization inside PaliGemma
 
-            embs.append(subgoal_img_emb)
-            pad_masks.append(subgoal_img_mask)
+                bsize, num_subgoal_img_embs = subgoal_img_emb.shape[:2]
+                subgoal_img_mask = subgoal_img_mask[:, None].expand(bsize, num_subgoal_img_embs)
 
-            # Create attention masks so that image tokens attend to each other
-            att_masks += [1] + [0] * (num_subgoal_img_embs - 1)
+                embs.append(subgoal_img_emb)
+                pad_masks.append(subgoal_img_mask)
 
-        subgoal_img_end_indicator_ids = self.language_tokenizer.encode(", ", add_special_tokens=False)
-        subgoal_img_end_tokens = torch.tensor(
-            [subgoal_img_end_indicator_ids] * bsize,
-            device=lang_tokens.device,
-            dtype=torch.long,
-        )
-        subgoal_img_end_emb = self.paligemma_with_expert.embed_language_tokens(subgoal_img_end_tokens)
-        subgoal_img_end_dim = subgoal_img_end_emb.shape[-1]
-        subgoal_img_end_emb = subgoal_img_end_emb * math.sqrt(subgoal_img_end_dim)
+                # Create attention masks so that image tokens attend to each other
+                att_masks += [1] + [0] * (num_subgoal_img_embs - 1)
 
-        num_subgoal_img_end_embs = subgoal_img_end_emb.shape[1]
-        subgoal_img_end_mask = torch.ones(
-            bsize, num_subgoal_img_end_embs, dtype=torch.bool, device=lang_tokens.device
-        )
+            subgoal_img_end_indicator_ids = self.language_tokenizer.encode(", ", add_special_tokens=False)
+            subgoal_img_end_tokens = torch.tensor(
+                [subgoal_img_end_indicator_ids] * bsize,
+                device=lang_tokens.device,
+                dtype=torch.long,
+            )
+            subgoal_img_end_emb = self.paligemma_with_expert.embed_language_tokens(subgoal_img_end_tokens)
+            subgoal_img_end_dim = subgoal_img_end_emb.shape[-1]
+            subgoal_img_end_emb = subgoal_img_end_emb * math.sqrt(subgoal_img_end_dim)
 
-        embs.append(subgoal_img_end_emb)
-        pad_masks.append(subgoal_img_end_mask)
-        att_masks += [0] * num_subgoal_img_end_embs
+            num_subgoal_img_end_embs = subgoal_img_end_emb.shape[1]
+            subgoal_img_end_mask = sample_has_subgoal[:, None].expand(bsize, num_subgoal_img_end_embs)
 
-        metadata_emb = self.paligemma_with_expert.embed_language_tokens(metadata_tokens)
-        metadata_emb_dim = metadata_emb.shape[-1]
-        metadata_emb = metadata_emb * math.sqrt(metadata_emb_dim)
-        embs.append(metadata_emb)
-        pad_masks.append(metadata_masks)
-        att_masks += [1] + [0] * (metadata_emb.shape[1] - 1)
+            embs.append(subgoal_img_end_emb)
+            pad_masks.append(subgoal_img_end_mask)
+            att_masks += [0] * num_subgoal_img_end_embs
 
-        prefix_end_indicator_ids = self.language_tokenizer.encode(";\n ", add_special_tokens=False)
-        prefix_end_tokens = torch.tensor(
-            [prefix_end_indicator_ids] * bsize,
-            device=lang_tokens.device,
-            dtype=torch.long,
-        )
-        prefix_end_emb = self.paligemma_with_expert.embed_language_tokens(prefix_end_tokens)
-        prefix_end_dim = prefix_end_emb.shape[-1]
-        prefix_end_emb = prefix_end_emb * math.sqrt(prefix_end_dim)
+        # Only embed metadata when at least one sample has real metadata tokens.
+        if has_metadata:
+            metadata_emb = self.paligemma_with_expert.embed_language_tokens(metadata_tokens)
+            metadata_emb_dim = metadata_emb.shape[-1]
+            metadata_emb = metadata_emb * math.sqrt(metadata_emb_dim)
+            embs.append(metadata_emb)
+            pad_masks.append(metadata_masks)
+            att_masks += [1] + [0] * (metadata_emb.shape[1] - 1)
 
-        num_prefix_end_embs = prefix_end_emb.shape[1]
-        prefix_end_mask = torch.ones(bsize, num_prefix_end_embs, dtype=torch.bool, device=lang_tokens.device)
+        # Prefix-end terminates the optional middle list; skip it entirely
+        # when there is no list to terminate.
+        if has_any_optional:
+            prefix_end_indicator_ids = self.language_tokenizer.encode(";\n ", add_special_tokens=False)
+            prefix_end_tokens = torch.tensor(
+                [prefix_end_indicator_ids] * bsize,
+                device=lang_tokens.device,
+                dtype=torch.long,
+            )
+            prefix_end_emb = self.paligemma_with_expert.embed_language_tokens(prefix_end_tokens)
+            prefix_end_dim = prefix_end_emb.shape[-1]
+            prefix_end_emb = prefix_end_emb * math.sqrt(prefix_end_dim)
 
-        embs.append(prefix_end_emb)
-        pad_masks.append(prefix_end_mask)
-        att_masks += [0] * num_prefix_end_embs
+            num_prefix_end_embs = prefix_end_emb.shape[1]
+            prefix_end_mask = torch.ones(
+                bsize, num_prefix_end_embs, dtype=torch.bool, device=lang_tokens.device
+            )
+
+            embs.append(prefix_end_emb)
+            pad_masks.append(prefix_end_mask)
+            att_masks += [0] * num_prefix_end_embs
 
         if discrete_actions is not None:
             discrete_action_start_indicator_ids = self.language_tokenizer.encode(
@@ -1341,7 +1383,12 @@ class PI07LowLevelPlannerFlowMatching(nn.Module):
 
             embs.append(discrete_action_start_emb)
             pad_masks.append(discrete_action_start_mask)
-            att_masks += [1] + [0] * (num_discrete_action_start_embs - 1)
+            # Each indicator token is its own causal block (matches pi05).
+            # The previous ``[1, 0, ...]`` form made the indicator one
+            # bidirectional block, which shifted every following token's
+            # cumsum by ``num_discrete_action_start_embs - 1`` and silently
+            # changed the prefix_out boundary the discrete-action CE reads.
+            att_masks += [1] * num_discrete_action_start_embs
 
             discrete_action_emb = self.paligemma_with_expert.embed_discrete_actions(discrete_actions)
             embs.append(discrete_action_emb.to(dtype=_preferred_dtype()))
@@ -1487,7 +1534,14 @@ class PI07LowLevelPlannerFlowMatching(nn.Module):
         vlm_2d_attention_mask = make_att_2d_masks(prefix_pad_masks, prefix_att_masks)
         vlm_position_ids = torch.cumsum(prefix_pad_masks, dim=1) - 1
 
-        num_cross_att_tokens = prefix_embs.shape[1] - self.config.discrete_action_max_length
+        # Exclude both the "Action: " indicator and the discrete-action tokens
+        # from cross-attention so the action expert sees the same prefix length
+        # at train and inference (at inference, neither is in the prefix).
+        # Matches pi05's discrete_action_indicator_max_length logic.
+        _action_indicator_len = len(self.language_tokenizer.encode("Action: ", add_special_tokens=False))
+        num_cross_att_tokens = (
+            prefix_embs.shape[1] - _action_indicator_len - self.config.discrete_action_max_length
+        )
 
         (prefix_out, _), past_key_values = self.paligemma_with_expert.forward(
             attention_mask=vlm_2d_attention_mask,
@@ -1525,9 +1579,10 @@ class PI07LowLevelPlannerFlowMatching(nn.Module):
             n_cross_att_tokens=num_cross_att_tokens,
             cross_att_pad_masks=prefix_pad_masks[:, :num_cross_att_tokens],
         )
-        prefix_offsets = torch.sum(prefix_pad_masks[:, : -self.config.discrete_action_max_length], dim=-1)[
-            :, None
-        ]
+        prefix_offsets = torch.sum(
+            prefix_pad_masks[:, : -(_action_indicator_len + self.config.discrete_action_max_length)],
+            dim=-1,
+        )[:, None]
         action_expert_position_ids = prefix_offsets + torch.cumsum(suffix_pad_masks, dim=1) - 1
 
         assert past_key_values is not None

--- a/tests/policies/test_pi07_paligemma_low_level_planner.py
+++ b/tests/policies/test_pi07_paligemma_low_level_planner.py
@@ -187,7 +187,10 @@ class TestPI07LowLevelPlannerIntegration:
         if inference_mode:
             prefix_offsets = torch.sum(prefix_pad_masks, dim=-1)[:, None]
         else:
-            prefix_offsets = torch.sum(prefix_pad_masks[:, :-DISCRETE_ACTION_MAX_LENGTH], dim=-1)[:, None]
+            action_lead = self._indicator_lens(tokenizer)["action_lead"]
+            prefix_offsets = torch.sum(
+                prefix_pad_masks[:, : -(action_lead + DISCRETE_ACTION_MAX_LENGTH)], dim=-1
+            )[:, None]
 
         expected_suffix = prefix_offsets + torch.cumsum(suffix_pad_masks, dim=1) - 1
         assert torch.equal(suffix_position_ids, expected_suffix)
@@ -208,12 +211,14 @@ class TestPI07LowLevelPlannerIntegration:
         prefix_pad_masks,
         suffix_pad_masks,
         suffix_att_masks,
+        tokenizer,
         inference_mode=False,
     ):
         if inference_mode:
             num_cross = prefix_pad_masks.shape[1]
         else:
-            num_cross = prefix_pad_masks.shape[1] - DISCRETE_ACTION_MAX_LENGTH
+            action_lead = self._indicator_lens(tokenizer)["action_lead"]
+            num_cross = prefix_pad_masks.shape[1] - action_lead - DISCRETE_ACTION_MAX_LENGTH
 
         expected = make_att_2d_masks(
             suffix_pad_masks,
@@ -374,6 +379,7 @@ class TestPI07LowLevelPlannerIntegration:
             captured["prefix_pad_masks"],
             captured["suffix_pad_masks"],
             captured["suffix_att_masks"],
+            tokenizer,
         )
 
         assert isinstance(loss, dict)
@@ -481,6 +487,7 @@ class TestPI07LowLevelPlannerIntegration:
             captured_infer["prefix_pad_masks"],
             captured_infer["suffix_pad_masks"],
             captured_infer["suffix_att_masks"],
+            tokenizer,
             inference_mode=True,
         )
 


### PR DESCRIPTION
## What this does

Backports the combined [#205](https://github.com/TensorAuto/OpenTau/pull/205) + [#226](https://github.com/TensorAuto/OpenTau/issues/226) gating fixes from `fix/pi07_paligemma_fixes` into `feat/pi07`'s pi07_paligemma low-level planner. The full set of bugs that #205 + #226 address are present on `feat/pi07` today (only a partial earlier attempt landed via `2949e73 "Applying pi07_paligemma fixes to pi07"`).

`PI07LowLevelPlannerFlowMatching.embed_prefix` (in `src/opentau/policies/pi07_paligemma/low_level_planner/modeling_pi07_low_level.py`):

- **Content gating (#205).** Wrap the response, subgoal (header + image loop + footer), and metadata blocks in `if has_response / has_subgoal / has_metadata` guards computed at the top of `embed_prefix` from the actual masks. Without this, with `*_drop_prob=1.0` every prefix carried real (non-padded) spurious tokens with `att_masks=[1,...]` causal-block boundaries that corrupted cumsum for every following token. Subgoal header / footer pad-masks are now per-sample via `sample_has_subgoal` so mixed batches stay correct.
- **Separator gating (#226).** State-end now switches between `", "` (when an optional follows) and `":\n"` (when nothing does) — matching pi05's all-dropped layout. Prefix-end (`";\n "`) is wrapped in `if has_any_optional:` so it's skipped entirely when there's no optional list to terminate.
- **`"Action: "` indicator att_masks (#226).** Changed from `[1] + [0]*(N-1)` (one bidirectional block) to `[1]*N` (one causal block per token). The embeddings already matched pi05 byte-for-byte, but `make_att_2d_masks` shifted every following discrete-action position's cumsum by `N-1`, silently moving the `prefix_out` boundary the discrete-action CE reads.
- **`forward()` cross-attention length (#205).** `num_cross_att_tokens` and `prefix_offsets` now subtract both the `"Action: "` indicator length and `discrete_action_max_length`, matching pi05's `discrete_action_indicator_max_length` logic so the action expert sees the same prefix length at train and at inference (where neither block is in the prefix).
- **`prepare_subgoal_images` NameError (#205).** Track `last_subgoal_img` / `last_mask` inside the present-keys loop and guard the `empty_cameras` fallback with `if last_subgoal_img is not None and last_mask is not None:`. Default `subgoal_is_pad` initializer flips from `torch.zeros` to `torch.ones` (a missing key means "padded", not "real").
- **`prepare_metadata` defaults.** Same `torch.zeros` → `torch.ones` flip for `speed_is_pad` / `quality_is_pad` / `mistake_is_pad`.

Also cherry-picked from main: [#209](https://github.com/TensorAuto/OpenTau/pull/209) (CPU CI `--ignore` for the GPU+slow integration test) and [#217](https://github.com/TensorAuto/OpenTau/pull/217) (GPU CI `--ignore` + comment dedupe). These workflow changes are already on `main` but had not propagated to `feat/pi07`, leaving CPU CI broken at test collection because of the unrelated pre-existing `VJEPA2VideoEncoder` import (TODO #210 / blocked on #192).

**Out of scope** (separate concerns on `fix/pi07_paligemma_fixes` worth handling in their own PRs against `feat/pi07`):
- V-JEPA2 → SpaceTime SigLIP video-encoder swap.
- The `";\n "` → `":\n"` prefix-end string cleanup (commit `6e3f82a`).
- Any change to the gemma3 pi07 (the *other* policy on this branch) or the high-level planner.

## How it was tested

- `pre-commit run --files src/.../modeling_pi07_low_level.py tests/.../test_pi07_paligemma_low_level_planner.py` — all hooks pass (ruff, ruff-format, pyupgrade, gitleaks, bandit, etc.).
- `PYTHONPATH=src pytest tests/policies/ -m "not gpu" --ignore=tests/policies/test_pi07_paligemma_low_level_planner.py -q` → **125 passed, 2 skipped, 19 deselected** in 152s. (PYTHONPATH override needed locally because the worktree's pi07/ module isn't installed in the parent venv; CI's `uv sync` step makes this unnecessary.)
- The integration test `tests/policies/test_pi07_paligemma_low_level_planner.py::test_complete_pi07_low_level_pipeline` is `@pytest.mark.gpu @pytest.mark.slow` and ignored in both CPU and GPU CI per #209/#217 (TODO #210 / blocked on #192). The change does **not** alter prefix shapes for the all-populated path that test exercises; it only changes the `"Action: "` indicator's `att_masks` pattern, which is captured and re-fed to `make_att_2d_masks`, so `_verify_vlm_attention_mask` continues to hold. `_verify_position_ids` and `_verify_action_expert_attention_mask` were updated to reflect the new `forward()` formulas.
- **Not run:** GPU integration test (no GPU on this dev machine and the test is CI-ignored anyway). A reviewer with GPU access running the test manually would also need to drop the `--ignore` for that one file.

## How to checkout & try? (for the reviewer)

```bash
gh pr checkout 228
uv sync --extra dev --extra libero
pre-commit run --all-files
pytest -m "not gpu" -n auto
```

To exercise the integration test on a GPU box (oracle / mlbox):

```bash
pytest -m "gpu" -sx tests/policies/test_pi07_paligemma_low_level_planner.py::TestPI07LowLevelPlannerIntegration::test_complete_pi07_low_level_pipeline
```

To sanity-check the gating fires (Python REPL on a box where `pi05_mem.video_encoder.VJEPA2VideoEncoder` exists, or once #192 lands):

```python
# Build a minimal batch with no response/subgoal/metadata keys, call
# model.embed_prefix(...) directly, and confirm:
#   - prefix length shrinks by (response_max_length + subgoal_lead +
#     n_subgoal_cams * subgoal_tokens + comma + metadata_max_length +
#     prefix_end) tokens vs the all-populated case
#   - state-end is ":\n" instead of ", "
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [x] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

> GPU pytests checkbox left unchecked because the only relevant GPU test (`test_complete_pi07_low_level_pipeline`) is CI-ignored at import time on `feat/pi07` (pre-existing `VJEPA2VideoEncoder` issue, TODO #210). Happy to run it manually if a reviewer wants — please flag.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).