### PR TITLE
feat(pi07): SDPA attention + gradient checkpointing options

### DIFF
--- a/src/opentau/policies/pi07/gemma3_with_expert.py
+++ b/src/opentau/policies/pi07/gemma3_with_expert.py
@@ -32,6 +32,8 @@ adaptive RMSNorm and `_gated_residual`. The Gemma 3 backbone remains stock —
 its layer-norms return a plain tensor and are used without a `cond=` argument.
 """
 
+import logging
+
 import torch
 from torch import nn
 from transformers import (
@@ -113,6 +115,7 @@ class Gemma3WithExpertConfig(PretrainedConfig):
         load_pretrained_gemma3: bool = False,
         discrete_action_vocab_size: int | None = None,
         dropout: float = 0.1,
+        gradient_checkpointing: bool = False,
         **kwargs,
     ):
         """Initializes the configuration.
@@ -124,11 +127,24 @@ class Gemma3WithExpertConfig(PretrainedConfig):
                 Defaults to a ~860M-parameter Gemma with AdaRMS enabled.
             freeze_vision_encoder: Freeze the SigLIP tower during training.
             train_expert_only: Only update the expert and its heads.
-            attention_implementation: "eager" or "fa2" (fa2 not yet supported).
+            attention_implementation: "eager", "sdpa", or "fa2". "fa2" is not
+                implemented and falls back to eager with a warning. "sdpa"
+                dispatches to ``torch.nn.functional.scaled_dot_product_attention``;
+                see the per-layer note about Gemma 3's interleaved local/global
+                pattern in ``forward()`` — π0.7 deliberately keeps the same
+                block-causal mask at every layer, so the SDPA call sees a
+                regular bool mask and takes the standard fused path.
             load_pretrained_gemma3: Whether to pull pretrained Gemma 3 weights
                 from the Hub (only recommended when He-initializing the expert).
             discrete_action_vocab_size: FAST tokenizer vocab size.
             dropout: Dropout probability applied in the per-layer loop.
+            gradient_checkpointing: Wrap each interleaved decoder-layer body in
+                ``torch.utils.checkpoint.checkpoint`` during training. Trades
+                roughly one extra forward pass per step (~25-33% compute) for
+                a large slice of activation memory per rank, enabling larger
+                per-rank batch sizes. Only safe under plain DDP (MULTI_GPU),
+                single-process (NO), or DeepSpeed ZeRO-1/2 — see the train.py
+                guard. Defaults to False.
             **kwargs: Passed to `PretrainedConfig`.
         """
         self.freeze_vision_encoder = freeze_vision_encoder
@@ -137,6 +153,7 @@ class Gemma3WithExpertConfig(PretrainedConfig):
         self.load_pretrained_gemma3 = load_pretrained_gemma3
         self.discrete_action_vocab_size = discrete_action_vocab_size
         self.dropout = dropout
+        self.gradient_checkpointing = gradient_checkpointing
 
         # Gemma 3 backbone defaults (match google/gemma-3-4b-pt).
         if gemma3_config is None:
@@ -235,10 +252,19 @@ class Gemma3WithExpertConfig(PretrainedConfig):
             raise ValueError(
                 "You set `freeze_vision_encoder=False` and `train_expert_only=True` which are not compatible."
             )
-        if self.attention_implementation not in ["eager", "fa2"]:
+        if self.attention_implementation not in ["eager", "sdpa", "fa2"]:
             raise ValueError(
                 f"Wrong value provided for `attention_implementation` ({self.attention_implementation}). "
-                "Expected 'eager' or 'fa2'."
+                "Expected 'eager', 'sdpa', or 'fa2'."
+            )
+        if self.attention_implementation == "fa2":
+            # fa2 has been considered but never implemented for pi07 because of
+            # Gemma 3's interleaved sliding-window/global mask pattern. Fall
+            # back to eager so configs that historically passed fa2 keep
+            # running; surface a one-time warning so callers can switch.
+            logging.warning(
+                "attention_implementation='fa2' is not implemented for pi07; falling back to 'eager'. "
+                "Use 'sdpa' for the fused PyTorch path (typically ~2x faster on A100 + bf16)."
             )
 
         super().__init__(**kwargs)
@@ -427,11 +453,25 @@ class Gemma3WithExpertModel(PreTrainedModel):
     # Attention core
 
     def get_attention_interface(self):
-        if self.config.attention_implementation == "fa2":
-            raise NotImplementedError(
-                "fa2 attention is not supported for pi07 yet because of the interleaved "
-                "local/global mask pattern — use 'eager' instead."
-            )
+        """Returns the attention implementation function based on config.
+
+        Dispatches on ``self.config.attention_implementation``:
+          - ``"eager"``: per-layer matmul-softmax-matmul in fp32 (historical
+            default; see ``eager_attention_forward``).
+          - ``"sdpa"``: ``torch.nn.functional.scaled_dot_product_attention``
+            which on A100 + bf16 dispatches to FlashAttention-2 / mem-efficient
+            backends. Note π0.7 keeps the same block-causal mask at every
+            layer (sliding window deliberately not enforced — see the comment
+            near ``apply_rope``), so SDPA sees a regular bool mask and does
+            not need a per-layer mask shape branch.
+          - ``"fa2"``: accepted for backward compatibility; falls back to
+            eager with a warning emitted at config validation time.
+        """
+        impl = self.config.attention_implementation
+        if impl == "sdpa":
+            return self.sdpa_attention_forward
+        # "eager" and legacy "fa2" both land here; "fa2" already warned during
+        # config construction.
         return self.eager_attention_forward
 
     def eager_attention_forward(
@@ -486,6 +526,92 @@ class Gemma3WithExpertModel(PreTrainedModel):
         att_output = att_output.reshape(batch_size, -1, num_key_value_heads * num_key_value_groups * head_dim)
         return att_output
 
+    def sdpa_attention_forward(
+        self,
+        attention_mask: torch.Tensor,
+        batch_size: int,
+        head_dim: int,
+        query_states: torch.Tensor,
+        key_states: torch.Tensor,
+        value_states: torch.Tensor,
+        scaling: float | None = None,
+    ) -> torch.Tensor:
+        """SDPA attention forward pass using ``F.scaled_dot_product_attention``.
+
+        Same output shape and semantics as ``eager_attention_forward`` but
+        delegates the scores-softmax-matmul chain to PyTorch's fused SDPA
+        kernel. On A100 + bf16 PyTorch typically dispatches to
+        FlashAttention-2. Q/K are not upcast to float32 (modern attention
+        kernels accumulate the softmax in fp32 internally); training dynamics
+        match eager within bf16 reassociation noise.
+
+        Args:
+            attention_mask: Boolean mask of shape (B, Q, K_total); ``True`` =
+                attend. π0.7 keeps the same block-causal mask at every layer.
+            batch_size: Batch size.
+            head_dim: Per-head dimension.
+            query_states: (B, Q, num_attention_heads, head_dim).
+            key_states: (B, K_total, num_key_value_heads, head_dim).
+            value_states: (B, K_total, num_key_value_heads, head_dim).
+            scaling: Override for the QK scaling factor. Gemma 3 uses
+                ``query_pre_attn_scalar ** -0.5`` rather than the default
+                ``head_dim ** -0.5``; the caller passes this through.
+
+        Returns:
+            torch.Tensor: Attention output of shape
+            (B, Q, num_attention_heads * head_dim).
+        """
+        num_att_heads = self._text_config.num_attention_heads
+        num_key_value_heads = self._text_config.num_key_value_heads
+        num_key_value_groups = num_att_heads // num_key_value_heads
+        sequence_length = key_states.shape[1]
+
+        # GQA expansion mirroring eager_attention_forward; cheap memory-view.
+        key_states = key_states[:, :, :, None, :].expand(
+            batch_size, sequence_length, num_key_value_heads, num_key_value_groups, head_dim
+        )
+        key_states = key_states.reshape(
+            batch_size, sequence_length, num_key_value_heads * num_key_value_groups, head_dim
+        )
+        value_states = value_states[:, :, :, None, :].expand(
+            batch_size, sequence_length, num_key_value_heads, num_key_value_groups, head_dim
+        )
+        value_states = value_states.reshape(
+            batch_size, sequence_length, num_key_value_heads * num_key_value_groups, head_dim
+        )
+
+        # SDPA expects (B, H, S, D_h).
+        query_states = query_states.transpose(1, 2)
+        key_states = key_states.transpose(1, 2)
+        value_states = value_states.transpose(1, 2)
+
+        # Bool mask broadcast across heads. SDPA accepts bool: True = attend.
+        attn_mask = attention_mask[:, None, :, :]
+
+        # Pass `scale=` only when the caller provided one — otherwise SDPA
+        # uses its built-in default of head_dim**-0.5, which matches the
+        # eager fallback when ``scaling`` is None.
+        sdpa_kwargs = {
+            "attn_mask": attn_mask,
+            "dropout_p": 0.0,
+            "is_causal": False,
+        }
+        if scaling is not None:
+            sdpa_kwargs["scale"] = scaling
+
+        att_output = nn.functional.scaled_dot_product_attention(
+            query_states,
+            key_states,
+            value_states,
+            **sdpa_kwargs,
+        )
+
+        # (B, H, S, D_h) → (B, S, H * D_h)
+        att_output = att_output.permute(0, 2, 1, 3)
+        att_output = att_output.reshape(batch_size, -1, num_key_value_heads * num_key_value_groups * head_dim)
+
+        return att_output
+
     # Per-layer interleaved forward
 
     def forward(
@@ -525,8 +651,6 @@ class Gemma3WithExpertModel(PreTrainedModel):
         if adarms_cond is None:
             adarms_cond = [None, None]
 
-        backbone_layers = self._backbone_layers()
-        expert_layers = self.gemma_expert.model.layers
         backbone_norm = self._backbone_final_norm()
         expert_norm = self.gemma_expert.model.norm
 
@@ -541,154 +665,51 @@ class Gemma3WithExpertModel(PreTrainedModel):
 
         head_dim = self._head_dim
 
+        # Hoist the lazy ``past_key_values = {}`` initialization out of the
+        # per-layer body so ``_run_layer`` always receives a non-None dict
+        # when ``fill_kv_cache`` is True. Important for checkpoint recompute
+        # to be idempotent — _run_layer must not mutate past_key_values from
+        # None to {} during recompute (saved-tensor hooks would see a
+        # different argument identity on the second pass).
+        if fill_kv_cache and past_key_values is None:
+            past_key_values = {}
+
+        use_ckpt = self.config.gradient_checkpointing and self.training
         for layer_idx in range(self._num_layers):
-            layer_type = self._layer_types[layer_idx]
-            is_sliding = layer_type == "sliding_attention"
-            layer_rope_theta = self._rope_local if is_sliding else self._rope_global
-
-            layers_this_step = [backbone_layers[layer_idx], expert_layers[layer_idx]]
-            # Both streams MUST use the same RoPE base at this layer. Shared
-            # attention concatenates Q/K along the sequence axis; the dot-product
-            # invariant `R(q,p)·R(k,q) = q·R(q-p)k` only holds when the same θ
-            # produced both rotations. For global Gemma-3 layers (θ=1M) this
-            # means the expert also rotates at 1M even though the config carries
-            # a single fallback `rope_theta=10k`.
-            rope_thetas = [layer_rope_theta, layer_rope_theta]
-
-            query_states = []
-            key_states = []
-            value_states = []
-            gates = []
-            # Track the pre-attention residual + post-attn layernorm output for the
-            # Gemma-3 backbone side, since it needs a second residual around the MLP
-            # using `pre_feedforward_layernorm` / `post_feedforward_layernorm`.
-            backbone_preattn_residual = None
-
-            for stream_idx, hidden_states in enumerate(inputs_embeds):
-                if hidden_states is None:
-                    gates.append(None)
-                    query_states.append(None)
-                    key_states.append(None)
-                    value_states.append(None)
-                    continue
-
-                layer = layers_this_step[stream_idx]
-
-                if stream_idx == 0:
-                    # Gemma 3 backbone.
-                    backbone_preattn_residual = hidden_states
-                    h = layer.input_layernorm(hidden_states)
-                    gate = None
-                else:
-                    # Gemma-v1 expert (patched to return (tensor, gate)).
-                    h, gate = layer.input_layernorm(hidden_states, cond=adarms_cond[stream_idx])
-
-                gates.append(gate)
-                bsize, seq_len, _ = h.shape
-                h = h.to(dtype=_preferred_dtype())
-
-                q = layer.self_attn.q_proj(h).view(bsize, seq_len, -1, head_dim)
-                k = layer.self_attn.k_proj(h).view(bsize, seq_len, -1, head_dim)
-                v = layer.self_attn.v_proj(h).view(bsize, seq_len, -1, head_dim)
-
-                if stream_idx == 0:
-                    # Gemma-3 applies an extra per-head RMSNorm on Q and K.
-                    q_norm = getattr(layer.self_attn, "q_norm", None)
-                    k_norm = getattr(layer.self_attn, "k_norm", None)
-                    if q_norm is not None:
-                        q = q_norm(q)
-                    if k_norm is not None:
-                        k = k_norm(k)
-
-                q = apply_rope(q, position_ids, max_wavelength=rope_thetas[stream_idx])
-                k = apply_rope(k, position_ids, max_wavelength=rope_thetas[stream_idx])
-
-                query_states.append(q)
-                key_states.append(k)
-                value_states.append(v)
-
-            # Drop Nones before concatenating.
-            q_list = [q for q in query_states if q is not None]
-            k_list = [k for k in key_states if k is not None]
-            v_list = [v for v in value_states if v is not None]
-
-            q_concat = torch.cat(q_list, dim=1)
-            k_concat = torch.cat(k_list, dim=1)
-            v_concat = torch.cat(v_list, dim=1)
-
-            if use_cache and past_key_values is not None and layer_idx in past_key_values:
-                k_concat = torch.cat([past_key_values[layer_idx]["key_states"], k_concat], dim=1)
-                v_concat = torch.cat([past_key_values[layer_idx]["value_states"], v_concat], dim=1)
-
-            if fill_kv_cache:
-                if past_key_values is None:
-                    past_key_values = {}
-                if n_cross_att_tokens is None:
-                    raise ValueError("n_cross_att_tokens must be provided when fill_kv_cache is True")
-                past_key_values[layer_idx] = {
-                    "key_states": k_concat[:, :n_cross_att_tokens, :, :],
-                    "value_states": v_concat[:, :n_cross_att_tokens, :, :],
-                }
-
-            # π0.6 keeps the prefix block-causal mask at every layer — the
-            # Gemma 3 sliding-window pattern is deliberately not applied
-            # (see the note next to `apply_rope`).
-            layer_attention_mask = attention_mask
-
-            attention_interface = self.get_attention_interface()
-            att_output = attention_interface(
-                layer_attention_mask,
-                batch_size,
-                head_dim,
-                q_concat,
-                k_concat,
-                v_concat,
-                scaling=self._query_pre_attn_scaling,
-            )
-            att_output = att_output.to(dtype=_preferred_dtype())
-
-            outputs_embeds: list[torch.Tensor | None] = []
-            start = 0
-            for stream_idx, hidden_states in enumerate(inputs_embeds):
-                if hidden_states is None:
-                    outputs_embeds.append(None)
-                    continue
-
-                layer = layers_this_step[stream_idx]
-                seq_len = hidden_states.shape[1]
-                end = start + seq_len
-                part = att_output[:, start:end]
-                start = end
-
-                if part.dtype != layer.self_attn.o_proj.weight.dtype:
-                    part = part.to(layer.self_attn.o_proj.weight.dtype)
-                part = layer.self_attn.o_proj(part)
-                part = self.dropout(part)
-
-                if stream_idx == 0:
-                    # Gemma 3 block: residual + post_attn_norm(attn); then a second
-                    # residual with pre_feedforward_layernorm / mlp / post_feedforward_layernorm.
-                    post_attn = layer.post_attention_layernorm(part)
-                    h = backbone_preattn_residual + post_attn
-
-                    ff_residual = h
-                    h = layer.pre_feedforward_layernorm(h)
-                    h = layer.mlp(h)
-                    h = self.dropout(h)
-                    h = layer.post_feedforward_layernorm(h)
-                    h = ff_residual + h
-                    outputs_embeds.append(h)
-                else:
-                    # Gemma-v1 expert block with AdaRMS gates.
-                    h = modeling_gemma._gated_residual(hidden_states, part, gates[stream_idx])  # noqa: SLF001
-                    ff_residual = h.clone()
-                    h, gate2 = layer.post_attention_layernorm(h, cond=adarms_cond[stream_idx])
-                    h = layer.mlp(h)
-                    h = self.dropout(h)
-                    h = modeling_gemma._gated_residual(ff_residual, h, gate2)  # noqa: SLF001
-                    outputs_embeds.append(h)
-
-            inputs_embeds = outputs_embeds
+            if use_ckpt:
+                # use_reentrant=False is the modern, DDP-safe path; it
+                # preserves RNG state across recompute so dropout is
+                # deterministic, and participates cleanly in autograd's
+                # saved_tensors_hooks.
+                inputs_embeds = torch.utils.checkpoint.checkpoint(
+                    self._run_layer,
+                    layer_idx,
+                    inputs_embeds,
+                    attention_mask,
+                    position_ids,
+                    past_key_values,
+                    n_cross_att_tokens,
+                    use_cache,
+                    fill_kv_cache,
+                    adarms_cond,
+                    batch_size,
+                    head_dim,
+                    use_reentrant=False,
+                )
+            else:
+                inputs_embeds = self._run_layer(
+                    layer_idx,
+                    inputs_embeds,
+                    attention_mask,
+                    position_ids,
+                    past_key_values,
+                    n_cross_att_tokens,
+                    use_cache,
+                    fill_kv_cache,
+                    adarms_cond,
+                    batch_size,
+                    head_dim,
+                )
 
         # Final norms.
         final_outputs: list[torch.Tensor | None] = []
@@ -703,6 +724,178 @@ class Gemma3WithExpertModel(PreTrainedModel):
                 final_outputs.append(out)
 
         return final_outputs, past_key_values
+
+    def _run_layer(
+        self,
+        layer_idx: int,
+        inputs_embeds: list[torch.FloatTensor | None],
+        attention_mask: torch.Tensor | None,
+        position_ids: torch.LongTensor | None,
+        past_key_values: dict | None,
+        n_cross_att_tokens: int | None,
+        use_cache: bool | None,
+        fill_kv_cache: bool | None,
+        adarms_cond: list[torch.Tensor | None],
+        batch_size: int,
+        head_dim: int,
+    ) -> list[torch.FloatTensor | None]:
+        """Run a single layer of the interleaved backbone/expert decoder loop.
+
+        Extracted from ``forward()`` as a standalone method so it can be the
+        unit of ``torch.utils.checkpoint.checkpoint`` wrapping when
+        ``config.gradient_checkpointing`` is enabled. Behavior is bit-identical
+        to the original inlined loop body; the KV-cache write is idempotent
+        across checkpoint recompute because each layer writes its own unique
+        key with the same K/V tensors.
+        """
+        backbone_layers = self._backbone_layers()
+        expert_layers = self.gemma_expert.model.layers
+
+        layer_type = self._layer_types[layer_idx]
+        is_sliding = layer_type == "sliding_attention"
+        layer_rope_theta = self._rope_local if is_sliding else self._rope_global
+
+        layers_this_step = [backbone_layers[layer_idx], expert_layers[layer_idx]]
+        # Both streams MUST use the same RoPE base at this layer. Shared
+        # attention concatenates Q/K along the sequence axis; the dot-product
+        # invariant `R(q,p)·R(k,q) = q·R(q-p)k` only holds when the same θ
+        # produced both rotations. For global Gemma-3 layers (θ=1M) this
+        # means the expert also rotates at 1M even though the config carries
+        # a single fallback `rope_theta=10k`.
+        rope_thetas = [layer_rope_theta, layer_rope_theta]
+
+        query_states: list[torch.Tensor | None] = []
+        key_states: list[torch.Tensor | None] = []
+        value_states: list[torch.Tensor | None] = []
+        gates: list[torch.Tensor | None] = []
+        # Track the pre-attention residual + post-attn layernorm output for the
+        # Gemma-3 backbone side, since it needs a second residual around the MLP
+        # using `pre_feedforward_layernorm` / `post_feedforward_layernorm`.
+        backbone_preattn_residual = None
+
+        for stream_idx, hidden_states in enumerate(inputs_embeds):
+            if hidden_states is None:
+                gates.append(None)
+                query_states.append(None)
+                key_states.append(None)
+                value_states.append(None)
+                continue
+
+            layer = layers_this_step[stream_idx]
+
+            if stream_idx == 0:
+                # Gemma 3 backbone.
+                backbone_preattn_residual = hidden_states
+                h = layer.input_layernorm(hidden_states)
+                gate = None
+            else:
+                # Gemma-v1 expert (patched to return (tensor, gate)).
+                h, gate = layer.input_layernorm(hidden_states, cond=adarms_cond[stream_idx])
+
+            gates.append(gate)
+            bsize, seq_len, _ = h.shape
+            h = h.to(dtype=_preferred_dtype())
+
+            q = layer.self_attn.q_proj(h).view(bsize, seq_len, -1, head_dim)
+            k = layer.self_attn.k_proj(h).view(bsize, seq_len, -1, head_dim)
+            v = layer.self_attn.v_proj(h).view(bsize, seq_len, -1, head_dim)
+
+            if stream_idx == 0:
+                # Gemma-3 applies an extra per-head RMSNorm on Q and K.
+                q_norm = getattr(layer.self_attn, "q_norm", None)
+                k_norm = getattr(layer.self_attn, "k_norm", None)
+                if q_norm is not None:
+                    q = q_norm(q)
+                if k_norm is not None:
+                    k = k_norm(k)
+
+            q = apply_rope(q, position_ids, max_wavelength=rope_thetas[stream_idx])
+            k = apply_rope(k, position_ids, max_wavelength=rope_thetas[stream_idx])
+
+            query_states.append(q)
+            key_states.append(k)
+            value_states.append(v)
+
+        # Drop Nones before concatenating.
+        q_list = [q for q in query_states if q is not None]
+        k_list = [k for k in key_states if k is not None]
+        v_list = [v for v in value_states if v is not None]
+
+        q_concat = torch.cat(q_list, dim=1)
+        k_concat = torch.cat(k_list, dim=1)
+        v_concat = torch.cat(v_list, dim=1)
+
+        if use_cache and past_key_values is not None and layer_idx in past_key_values:
+            k_concat = torch.cat([past_key_values[layer_idx]["key_states"], k_concat], dim=1)
+            v_concat = torch.cat([past_key_values[layer_idx]["value_states"], v_concat], dim=1)
+
+        if fill_kv_cache:
+            if n_cross_att_tokens is None:
+                raise ValueError("n_cross_att_tokens must be provided when fill_kv_cache is True")
+            past_key_values[layer_idx] = {
+                "key_states": k_concat[:, :n_cross_att_tokens, :, :],
+                "value_states": v_concat[:, :n_cross_att_tokens, :, :],
+            }
+
+        # π0.7 keeps the prefix block-causal mask at every layer — the
+        # Gemma 3 sliding-window pattern is deliberately not applied
+        # (see the note next to `apply_rope`).
+        layer_attention_mask = attention_mask
+
+        attention_interface = self.get_attention_interface()
+        att_output = attention_interface(
+            layer_attention_mask,
+            batch_size,
+            head_dim,
+            q_concat,
+            k_concat,
+            v_concat,
+            scaling=self._query_pre_attn_scaling,
+        )
+        att_output = att_output.to(dtype=_preferred_dtype())
+
+        outputs_embeds: list[torch.Tensor | None] = []
+        start = 0
+        for stream_idx, hidden_states in enumerate(inputs_embeds):
+            if hidden_states is None:
+                outputs_embeds.append(None)
+                continue
+
+            layer = layers_this_step[stream_idx]
+            seq_len = hidden_states.shape[1]
+            end = start + seq_len
+            part = att_output[:, start:end]
+            start = end
+
+            if part.dtype != layer.self_attn.o_proj.weight.dtype:
+                part = part.to(layer.self_attn.o_proj.weight.dtype)
+            part = layer.self_attn.o_proj(part)
+            part = self.dropout(part)
+
+            if stream_idx == 0:
+                # Gemma 3 block: residual + post_attn_norm(attn); then a second
+                # residual with pre_feedforward_layernorm / mlp / post_feedforward_layernorm.
+                post_attn = layer.post_attention_layernorm(part)
+                h = backbone_preattn_residual + post_attn
+
+                ff_residual = h
+                h = layer.pre_feedforward_layernorm(h)
+                h = layer.mlp(h)
+                h = self.dropout(h)
+                h = layer.post_feedforward_layernorm(h)
+                h = ff_residual + h
+                outputs_embeds.append(h)
+            else:
+                # Gemma-v1 expert block with AdaRMS gates.
+                h = modeling_gemma._gated_residual(hidden_states, part, gates[stream_idx])  # noqa: SLF001
+                ff_residual = h.clone()
+                h, gate2 = layer.post_attention_layernorm(h, cond=adarms_cond[stream_idx])
+                h = layer.mlp(h)
+                h = self.dropout(h)
+                h = modeling_gemma._gated_residual(ff_residual, h, gate2)  # noqa: SLF001
+                outputs_embeds.append(h)
+
+        return outputs_embeds
 
     # Gemma 3 structural accessors
 

--- a/src/opentau/policies/pi07/high_level_planner/configuration_pi07_high_level.py
+++ b/src/opentau/policies/pi07/high_level_planner/configuration_pi07_high_level.py
@@ -78,10 +78,26 @@ class PI07HighLevelPlannerConfig(PreTrainedConfig):
             for whatever tokenizer the model uses. Defaults to 4.
         dropout: Dropout rate applied in the transformer expert.
             Defaults to 0.1.
-        attention_implementation: Attention backend — ``"eager"`` or
-            ``"fa2"`` (Flash Attention 2). Defaults to ``"eager"``.
+        attention_implementation: Attention backend — ``"eager"``, ``"sdpa"``,
+            or ``"fa2"``. Defaults to ``"eager"``. ``"sdpa"`` dispatches to
+            ``torch.nn.functional.scaled_dot_product_attention`` (typically
+            ~2x faster on A100/H100 + bf16). ``"fa2"`` is accepted for
+            backward compatibility but logs a warning and falls back to
+            eager. The value is propagated to ``vlm_config`` in
+            ``__post_init__`` so a single ``--policy.attention_implementation``
+            override reaches the engine.
         freeze_vision_encoder: Whether to freeze the SigLIP vision encoder
             during fine-tuning. Defaults to True.
+        gradient_checkpointing: Wrap each interleaved Gemma 3 + expert decoder
+            layer body in ``torch.utils.checkpoint.checkpoint`` during
+            training. Trades roughly one extra forward pass per step
+            (~25-33% compute) for a large slice of activation memory per
+            rank, enabling larger per-rank batch sizes. Only safe under
+            plain DDP (MULTI_GPU), single-process (NO), or DeepSpeed
+            ZeRO-1/2 — ``src/opentau/scripts/train.py`` raises if the
+            accelerator's distributed_type is anything else (ZeRO-3, FSDP).
+            Propagated to ``vlm_config.gradient_checkpointing`` in
+            ``__post_init__``. Defaults to False.
         optimizer_lr: Peak learning rate for AdamW. Defaults to 2.5e-5.
         optimizer_betas: Beta parameters for AdamW. Defaults to (0.9, 0.95).
         optimizer_eps: Epsilon for AdamW. Defaults to 1e-8.
@@ -140,6 +156,10 @@ class PI07HighLevelPlannerConfig(PreTrainedConfig):
     # Finetuning settings
     freeze_vision_encoder: bool = True
 
+    # Activation checkpointing for the engine (Gemma 3 backbone + Gemma-v1
+    # expert per-layer body). Plumbed to vlm_config in __post_init__.
+    gradient_checkpointing: bool = False
+
     vlm_config: Gemma3WithExpertConfig = field(
         default_factory=lambda: Gemma3WithExpertConfig(
             freeze_vision_encoder=True,
@@ -163,6 +183,13 @@ class PI07HighLevelPlannerConfig(PreTrainedConfig):
     def __post_init__(self):
         """Validates configuration values after dataclass initialization.
 
+        Also plumbs the policy-level ``attention_implementation`` and
+        ``gradient_checkpointing`` flags into ``vlm_config`` so a single
+        ``--policy.attention_implementation`` / ``--policy.gradient_checkpointing``
+        CLI override reaches the engine. Direct overrides on
+        ``--policy.vlm_config.*`` still work and are honoured as-is when the
+        policy-level field is at its default.
+
         Raises:
             ValueError: If ``n_obs_steps`` is not 1.
         """
@@ -172,6 +199,11 @@ class PI07HighLevelPlannerConfig(PreTrainedConfig):
             raise ValueError(
                 f"Multiple observation steps not handled yet. Got `nobs_steps={self.n_obs_steps}`"
             )
+
+        if self.attention_implementation != "eager":
+            self.vlm_config.attention_implementation = self.attention_implementation
+        if self.gradient_checkpointing:
+            self.vlm_config.gradient_checkpointing = self.gradient_checkpointing
 
     def validate_features(self) -> None:
         """Adds placeholder camera features for empty camera slots.

--- a/src/opentau/policies/pi07/low_level_planner/configuration_pi07_low_level.py
+++ b/src/opentau/policies/pi07/low_level_planner/configuration_pi07_low_level.py
@@ -79,8 +79,14 @@ class PI07LowLevelPlannerConfig(PreTrainedConfig):
         num_steps: Number of flow-matching denoising steps. Defaults to 10.
         max_delay: Maximum number of prefix action steps for real-time
             inference. Defaults to 0.
-        attention_implementation: Attention backend (``"eager"`` or
-            ``"fa2"``). Defaults to ``"eager"``.
+        attention_implementation: Attention backend — ``"eager"``, ``"sdpa"``,
+            or ``"fa2"``. Defaults to ``"eager"``. ``"sdpa"`` dispatches to
+            ``torch.nn.functional.scaled_dot_product_attention`` (typically
+            ~2x faster on A100/H100 + bf16). ``"fa2"`` is accepted for
+            backward compatibility but logs a warning and falls back to
+            eager. Propagated to ``vlm_config`` in ``__post_init__`` so a
+            single ``--policy.attention_implementation`` override reaches
+            the engine.
         freeze_vision_encoder: Whether to freeze the SigLIP vision tower.
             Defaults to True.
         train_expert_only: Whether to train only the action expert.
@@ -91,8 +97,19 @@ class PI07LowLevelPlannerConfig(PreTrainedConfig):
             space-time separable attention.  Defaults to ``4`` (every 4th
             of the 27 SigLIP layers, indices ``[3, 7, 11, 15, 19, 23]``),
             matching the MEM paper / pi05_mem (#171).
-        gradient_checkpointing: If True, wrap each SigLIP encoder layer in
-            ``torch.utils.checkpoint.checkpoint`` during training.
+        gradient_checkpointing: If True, wrap each SpaceTimeSiglip video
+            encoder layer **and** each interleaved Gemma 3 + expert decoder
+            layer body in ``torch.utils.checkpoint.checkpoint`` during
+            training. Trades roughly one extra forward pass per step
+            (~25-33% compute) for a large slice of activation memory per
+            rank, enabling larger per-rank batch sizes. Only safe under
+            plain DDP (MULTI_GPU), single-process (NO), or DeepSpeed
+            ZeRO-1/2 — ``src/opentau/scripts/train.py`` raises if the
+            accelerator's distributed_type is anything else (ZeRO-3, FSDP).
+            The engine half is plumbed via
+            ``vlm_config.gradient_checkpointing`` in ``__post_init__``;
+            the video-encoder half is plumbed at model construction time.
+            Defaults to False.
     """
 
     # Input / output structure.
@@ -198,8 +215,23 @@ class PI07LowLevelPlannerConfig(PreTrainedConfig):
         return (self.n_obs_history - 1) * (self.history_interval or 1) + 1
 
     def __post_init__(self):
-        """Post-initialization validation."""
+        """Post-initialization validation and policy → vlm_config plumbing.
+
+        Plumbs the policy-level ``attention_implementation`` and
+        ``gradient_checkpointing`` flags into ``vlm_config`` so a single
+        ``--policy.attention_implementation`` / ``--policy.gradient_checkpointing``
+        CLI override reaches the engine. The video-encoder half of
+        ``gradient_checkpointing`` is plumbed separately at model construction
+        time (see ``modeling_pi07_low_level.py``). Direct overrides on
+        ``--policy.vlm_config.*`` still work and are honoured as-is when the
+        policy-level field is at its default.
+        """
         super().__post_init__()
+
+        if self.attention_implementation != "eager":
+            self.vlm_config.attention_implementation = self.attention_implementation
+        if self.gradient_checkpointing:
+            self.vlm_config.gradient_checkpointing = self.gradient_checkpointing
 
         if self.n_obs_history is not None:
             if not isinstance(self.n_obs_history, int) or self.n_obs_history < 1:

--- a/tests/policies/test_pi07_cpu.py
+++ b/tests/policies/test_pi07_cpu.py
@@ -802,3 +802,246 @@ class TestEmbedPrefixConditionalGuards:
             "span signals a regression to the old [1]+[0]*(N-1) pattern, which shifts the "
             "cumsum at the indicator -> first-discrete boundary and breaks the CE loss."
         )
+
+
+# Engine-level config validation: SDPA accepted, fa2 falls back to eager with
+# a warning (was: NotImplementedError), garbage values raise.
+
+
+class TestGemma3WithExpertConfig:
+    def test_bad_attention_implementation_raises(self):
+        with pytest.raises(ValueError, match="attention_implementation"):
+            Gemma3WithExpertConfig(discrete_action_vocab_size=2048, attention_implementation="garbage")
+
+    def test_sdpa_attention_implementation_accepted(self):
+        cfg = Gemma3WithExpertConfig(discrete_action_vocab_size=2048, attention_implementation="sdpa")
+        assert cfg.attention_implementation == "sdpa"
+
+    def test_fa2_falls_back_to_eager_with_warning(self, caplog):
+        with caplog.at_level("WARNING"):
+            cfg = Gemma3WithExpertConfig(discrete_action_vocab_size=2048, attention_implementation="fa2")
+        # The config field itself is preserved so callers can introspect what
+        # they asked for; the dispatcher (see TestPi07AttentionDispatcher) is
+        # what falls back to eager at runtime.
+        assert cfg.attention_implementation == "fa2"
+        assert any("falling back to 'eager'" in record.message for record in caplog.records)
+
+
+# Attention dispatcher: routes attention_implementation to the right forward.
+
+
+class TestPi07AttentionDispatcher:
+    def test_dispatcher_returns_sdpa_for_sdpa_impl(self, monkeypatch):
+        monkeypatch.setattr(g3we, "_preferred_dtype", lambda: torch.float32)
+        cfg = _make_tiny_g3we_cfg()
+        cfg.attention_implementation = "sdpa"
+        model = Gemma3WithExpertModel(cfg)
+        assert model.get_attention_interface() == model.sdpa_attention_forward
+
+    def test_dispatcher_returns_eager_for_eager_impl(self, monkeypatch):
+        monkeypatch.setattr(g3we, "_preferred_dtype", lambda: torch.float32)
+        cfg = _make_tiny_g3we_cfg()
+        cfg.attention_implementation = "eager"
+        model = Gemma3WithExpertModel(cfg)
+        assert model.get_attention_interface() == model.eager_attention_forward
+
+    def test_dispatcher_falls_back_to_eager_for_fa2(self, monkeypatch):
+        monkeypatch.setattr(g3we, "_preferred_dtype", lambda: torch.float32)
+        cfg = _make_tiny_g3we_cfg()
+        cfg.attention_implementation = "fa2"
+        model = Gemma3WithExpertModel(cfg)
+        # Old behaviour raised NotImplementedError; new behaviour falls back
+        # to eager (warning was already emitted at config construction time).
+        assert model.get_attention_interface() == model.eager_attention_forward
+
+
+# SDPA vs eager equivalence — drives BOTH streams (backbone + expert) so the
+# Q/K/V concat path along the seq axis is covered. Pi07 is the first policy
+# in this family with that coverage requirement (pi06 tested backbone-only).
+
+
+class TestPi07SdpaEquivalence:
+    def test_eager_vs_sdpa_outputs_close(self, monkeypatch):
+        monkeypatch.setattr(g3we, "_preferred_dtype", lambda: torch.float32)
+        cfg = _make_tiny_g3we_cfg()
+        cfg.attention_implementation = "eager"
+
+        torch.manual_seed(0)
+        model_eager = Gemma3WithExpertModel(cfg).to(dtype=torch.float32)
+
+        cfg_sdpa = _make_tiny_g3we_cfg()
+        cfg_sdpa.attention_implementation = "sdpa"
+        torch.manual_seed(0)
+        model_sdpa = Gemma3WithExpertModel(cfg_sdpa).to(dtype=torch.float32)
+        # Mirror weights so the only delta is the attention math.
+        model_sdpa.load_state_dict(model_eager.state_dict(), strict=True)
+
+        model_eager.eval()
+        model_sdpa.eval()
+
+        batch, seq_len = 1, 4
+        backbone_h = cfg.gemma3_config.text_config.hidden_size
+        expert_h = cfg.gemma_expert_config.hidden_size
+        hidden_backbone = torch.randn(batch, seq_len, backbone_h)
+        hidden_expert = torch.randn(batch, seq_len, expert_h)
+        position_ids = torch.arange(seq_len)[None, :]
+        # Both streams concat along the seq axis → (B, 2*seq_len, 2*seq_len).
+        attention_mask = torch.tril(torch.ones(2 * seq_len, 2 * seq_len, dtype=torch.bool))[None]
+        # Expert AdaRMS layers are constructed with cond_dim=adarms_cond_dim
+        # and have no `weight` parameter — passing cond=None into the cond=None
+        # branch would crash. Provide real conditioning matching cond_dim, and
+        # let it broadcast over the per-stream sequence dim.
+        adarms_cond_value = torch.randn(batch, cfg.gemma_expert_config.adarms_cond_dim)
+        adarms_cond = [None, adarms_cond_value]
+
+        out_eager, _ = model_eager(
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            inputs_embeds=[hidden_backbone, hidden_expert],
+            n_cross_att_tokens=2 * seq_len,
+            use_cache=False,
+            fill_kv_cache=True,
+            adarms_cond=adarms_cond,
+        )
+        out_sdpa, _ = model_sdpa(
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            inputs_embeds=[hidden_backbone, hidden_expert],
+            n_cross_att_tokens=2 * seq_len,
+            use_cache=False,
+            fill_kv_cache=True,
+            adarms_cond=adarms_cond,
+        )
+
+        assert out_eager[0] is not None and out_sdpa[0] is not None
+        assert out_eager[1] is not None and out_sdpa[1] is not None
+        # Eager upcasts QK to fp32; SDPA accumulates the softmax in fp32 too.
+        # Numerical match is tight but not bit-identical due to reassociation.
+        assert torch.allclose(out_eager[0], out_sdpa[0], atol=1e-4, rtol=1e-4)
+        assert torch.allclose(out_eager[1], out_sdpa[1], atol=1e-4, rtol=1e-4)
+
+
+# Gradient-checkpointing forward equivalence — pins that ``_run_layer``
+# extraction is bit-identical to the original inlined loop body.
+
+
+class TestPi07GradCkptEquivalence:
+    def test_grad_ckpt_forward_matches_no_ckpt(self, monkeypatch):
+        """``gradient_checkpointing=True`` must not change the forward output.
+
+        Drives BOTH streams (backbone + expert) so the per-layer Q/K/V
+        concat path (which is what ``_run_layer`` wraps) is the actual
+        codepath under test. Train mode + ``dropout=0`` is required: the
+        checkpoint wrap is gated on ``self.training``, and dropout would
+        introduce stochasticity that masks any extraction bug.
+        """
+        monkeypatch.setattr(g3we, "_preferred_dtype", lambda: torch.float32)
+        cfg = _make_tiny_g3we_cfg()
+        cfg.dropout = 0.0
+
+        torch.manual_seed(0)
+        model_no_ckpt = Gemma3WithExpertModel(cfg).to(dtype=torch.float32)
+        model_no_ckpt.train()
+
+        cfg_ckpt = _make_tiny_g3we_cfg()
+        cfg_ckpt.dropout = 0.0
+        cfg_ckpt.gradient_checkpointing = True
+        torch.manual_seed(0)
+        model_ckpt = Gemma3WithExpertModel(cfg_ckpt).to(dtype=torch.float32)
+        model_ckpt.load_state_dict(model_no_ckpt.state_dict(), strict=True)
+        model_ckpt.train()
+
+        batch, seq_len = 1, 4
+        backbone_h = cfg.gemma3_config.text_config.hidden_size
+        expert_h = cfg.gemma_expert_config.hidden_size
+        hidden_backbone = torch.randn(batch, seq_len, backbone_h)
+        hidden_expert = torch.randn(batch, seq_len, expert_h)
+        position_ids = torch.arange(seq_len)[None, :]
+        attention_mask = torch.tril(torch.ones(2 * seq_len, 2 * seq_len, dtype=torch.bool))[None]
+        # Expert AdaRMS layers require non-None cond — see TestPi07SdpaEquivalence
+        # for the same construction.
+        adarms_cond_value = torch.randn(batch, cfg.gemma_expert_config.adarms_cond_dim)
+        adarms_cond = [None, adarms_cond_value]
+
+        out_a, _ = model_no_ckpt(
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            inputs_embeds=[hidden_backbone, hidden_expert],
+            n_cross_att_tokens=2 * seq_len,
+            use_cache=False,
+            fill_kv_cache=True,
+            adarms_cond=adarms_cond,
+        )
+        out_b, _ = model_ckpt(
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            inputs_embeds=[hidden_backbone, hidden_expert],
+            n_cross_att_tokens=2 * seq_len,
+            use_cache=False,
+            fill_kv_cache=True,
+            adarms_cond=adarms_cond,
+        )
+
+        assert out_a[0] is not None and out_b[0] is not None
+        assert out_a[1] is not None and out_b[1] is not None
+        # ckpt only re-runs forward in backward; forward numerics are
+        # identical up to floating-point reassociation in autograd.
+        assert torch.allclose(out_a[0], out_b[0], atol=1e-6, rtol=1e-6)
+        assert torch.allclose(out_a[1], out_b[1], atol=1e-6, rtol=1e-6)
+
+
+# Policy-level → vlm_config plumbing in __post_init__ — pins that
+# --policy.attention_implementation and --policy.gradient_checkpointing
+# CLI overrides reach the engine for both planners.
+
+
+class TestPi07ConfigPlumbing:
+    def test_post_init_plumbs_grad_ckpt_into_vlm_config(self):
+        from opentau.policies.pi07.high_level_planner.configuration_pi07_high_level import (
+            PI07HighLevelPlannerConfig,
+        )
+        from opentau.policies.pi07.low_level_planner.configuration_pi07_low_level import (
+            PI07LowLevelPlannerConfig,
+        )
+
+        hl = PI07HighLevelPlannerConfig(gradient_checkpointing=True)
+        assert hl.vlm_config.gradient_checkpointing is True
+
+        ll = PI07LowLevelPlannerConfig(gradient_checkpointing=True)
+        assert ll.vlm_config.gradient_checkpointing is True
+
+    def test_post_init_plumbs_attention_impl_into_vlm_config(self):
+        from opentau.policies.pi07.high_level_planner.configuration_pi07_high_level import (
+            PI07HighLevelPlannerConfig,
+        )
+        from opentau.policies.pi07.low_level_planner.configuration_pi07_low_level import (
+            PI07LowLevelPlannerConfig,
+        )
+
+        hl = PI07HighLevelPlannerConfig(attention_implementation="sdpa")
+        assert hl.vlm_config.attention_implementation == "sdpa"
+
+        ll = PI07LowLevelPlannerConfig(attention_implementation="sdpa")
+        assert ll.vlm_config.attention_implementation == "sdpa"
+
+    def test_post_init_preserves_explicit_vlm_config_when_policy_default(self):
+        """Direct overrides via --policy.vlm_config.* must survive when the
+        policy-level field is at its default ('eager' / False)."""
+        from opentau.policies.pi07.high_level_planner.configuration_pi07_high_level import (
+            PI07HighLevelPlannerConfig,
+        )
+
+        cfg = PI07HighLevelPlannerConfig(
+            vlm_config=Gemma3WithExpertConfig(
+                attention_implementation="sdpa",
+                gradient_checkpointing=True,
+                discrete_action_vocab_size=2048,
+            )
+        )
+        # Policy-level fields stay at their defaults; vlm_config keeps its
+        # explicit values (the __post_init__ plumbing is gated on the
+        # policy-level field being NON-default).
+        assert cfg.attention_implementation == "eager"
+        assert cfg.gradient_checkpointing is False
+        assert cfg.vlm_config.attention_implementation == "sdpa"
+        assert cfg.vlm_config.gradient_checkpointing is True


### PR DESCRIPTION
## What this does

Backports the pi05 PR #182 / pi06 PR #214 attention + checkpointing knobs to the **pi07 engine** (`src/opentau/policies/pi07/gemma3_with_expert.py`) and **both planner policies** (high-level + low-level). `pi07_paligemma` is intentionally untouched.

**Engine** — `pi07/gemma3_with_expert.py`:
- `attention_implementation` now accepts `"sdpa"`; `"fa2"` warns and falls back to eager (was: `NotImplementedError`).
- New `sdpa_attention_forward` dispatches via `F.scaled_dot_product_attention` with optional `scale=` for Gemma 3's `query_pre_attn_scalar`.
- The interleaved per-layer body is extracted into `_run_layer` (bit-identical to the original inlined loop) so it can be the unit of `torch.utils.checkpoint.checkpoint(use_reentrant=False)` when `config.gradient_checkpointing=True`.
- Hoists the lazy `past_key_values={}` initialization out of the loop so checkpoint recompute is idempotent (saved-tensor hooks would otherwise see a different argument identity on the second pass).

**High-level + low-level configs**:
- High-level (`PI07HighLevelPlannerConfig`): new `gradient_checkpointing` field.
- Low-level (`PI07LowLevelPlannerConfig`): the existing `gradient_checkpointing` field now applies to **both** the SpaceTimeSiglip video encoder *and* the engine (combined semantics, mirrors PR #214's "one flag per policy" pattern). Behavior change for existing low-level users with the flag set: they additionally get engine ckpt — strictly safer numerically (extra recompute, identical training math), saves more memory than they currently get. Documented in the docstring.
- Both: `__post_init__` plumbs policy-level `attention_implementation` and `gradient_checkpointing` into `vlm_config` so a single `--policy.attention_implementation` / `--policy.gradient_checkpointing` CLI override reaches the engine. The previously-dead policy-level `attention_implementation` field is now wired up.
- Direct `--policy.vlm_config.*` overrides still work when the policy-level field is at its default (the plumbing is gated on the policy-level field being non-default).

`train.py:255` ZeRO-3/FSDP guard keys off `cfg.policy.gradient_checkpointing` — policy-agnostic, so pi07 inherits it automatically once the field exists at the policy level.

Defaults stay `attention_implementation="eager"` and `gradient_checkpointing=False` — matches PRs #182/#214's opt-in rollout.

## How it was tested

### CPU equivalence (added in `tests/policies/test_pi07_cpu.py`)

11 new tests across 5 classes:

- `TestGemma3WithExpertConfig` (3): bad/sdpa/fa2 validation.
- `TestPi07AttentionDispatcher` (3): dispatcher routing for each implementation; verifies fa2 falls back to eager (no `NotImplementedError`).
- `TestPi07SdpaEquivalence` (1): eager vs sdpa within atol/rtol 1e-4 in fp32. **Drives both streams** (`inputs_embeds=[hidden_backbone, hidden_expert]` with `adarms_cond=[None, cond]`) so the `q_concat`/`k_concat`/`v_concat` cross-stream concat path is the actual codepath under test — pi06 PR #214 only covered backbone-only.
- `TestPi07GradCkptEquivalence` (1): grad-ckpt forward bit-identical (atol/rtol 1e-6) in train mode, dropout=0, both streams. Pins that `_run_layer` extraction is bit-identical to the inlined loop body.
- `TestPi07ConfigPlumbing` (3): `__post_init__` propagation invariants — `gradient_checkpointing=True` and `attention_implementation="sdpa"` on the policy reach `vlm_config`, and direct `vlm_config` overrides survive when policy-level fields are at default.

```bash
uv run pytest -m "not gpu" tests/policies/test_pi07_cpu.py -v
# 60 passed (49 existing pi07 CPU tests + 11 new)

uv run pytest -m "not gpu" -n auto tests/policies tests/configs --ignore=tests/policies/test_pi07_paligemma_low_level_planner.py
# 194 passed, 2 skipped — no regressions in adjacent policies/configs.
```

### GPU verification (mlbox, RTX 5090 32 GB)

Pi07 GPU pytest subset on the new branch:
```bash
uv run pytest -m "gpu" -n 0 tests/policies/test_pi07_cpu.py tests/policies/test_pi07_high_level_planner.py tests/policies/test_pi07_low_level_planner.py tests/policies/test_pi07_video_encoder_cpu.py -v
# 7 passed, 49 deselected — all 7 pi07 GPU integration tests still pass with the refactored engine.
```

Ad-hoc GPU smoke (4-layer tiny config so it fits with budget for a forward + backward) verifies the actual SDPA + grad-ckpt code paths end-to-end on real CUDA + bf16:
- **eager vs sdpa** in eval mode: `max-abs-diff backbone=1.80e-01 expert=3.91e-03` (within bf16 reassociation noise; the unit tests assert tighter tolerances in fp32).
- **sdpa + grad-ckpt** in train mode: forward + backward complete without OOM, gradients flow on 99/143 trainable parameters (the 44 without grads are da_head/discrete_action_embedding/vision tower paths that the synthetic batch does not exercise — expected).

## How to checkout & try? (for the reviewer)

CPU equivalence:
```bash
uv run pytest -m "not gpu" tests/policies/test_pi07_cpu.py -v
```

GPU pytest subset:
```bash
uv run pytest -m "gpu" -n 0 tests/policies/test_pi07_cpu.py tests/policies/test_pi07_high_level_planner.py tests/policies/test_pi07_low_level_planner.py
```

GPU smoke training (single rank, ~10 steps; pick whichever lerobot dataset you have cached):

```bash
uv run python -m opentau.scripts.train \
  --policy.type=pi07_low_level \
  --policy.gradient_checkpointing=true \
  --policy.attention_implementation=sdpa \
  --batch_size=1 \
  --steps=10 \
  --dataset.repo_id=lerobot/<cached-dataset> \
  --output_dir=/tmp/pi07_low_level_smoke \
  --wandb.enable=false

uv run python -m opentau.scripts.train \
  --policy.type=pi07_high_level \
  --policy.gradient_checkpointing=true \
  --policy.attention_implementation=sdpa \
  --batch_size=1 \
  --steps=10 \
  --dataset.repo_id=lerobot/<cached-dataset> \
  --output_dir=/tmp/pi07_high_level_smoke \
  --wandb.enable=false
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [x] My PR includes policy-related changes.
  - [x] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.