### PR TITLE
fix(pi06): align with π0.6 model card paper

### DIFF
--- a/src/opentau/policies/pi06/configuration_pi06.py
+++ b/src/opentau/policies/pi06/configuration_pi06.py
@@ -50,6 +50,15 @@ class PI06Config(PreTrainedConfig):
         max_state_dim: Maximum dimension for state vectors. Defaults to 32.
         max_action_dim: Maximum dimension for action vectors. Defaults to 32.
         predict_response: Whether to predict the response. Defaults to False.
+            Enabling this is required to reproduce the paper's hierarchical
+            design (π0.6 model card §1: "preserves the hierarchical design of
+            π0.5, providing high-level subtask prediction and low-level action
+            generation"). When False, π0.6 reduces to a flat low-level-only
+            model. The default is False because most LeRobot-style datasets do
+            not carry subtask annotations. The same field is also used to
+            supervise VQA / grounding-style textual targets during co-training
+            (this is why the field is named "response" rather than "subtask" —
+            it covers both uses, matching the π0.5 pretraining recipe).
         resize_imgs_with_padding: Target image size. Defaults to (448, 448).
         empty_cameras: Number of empty camera inputs to add. Defaults to 0.
             π0.6 pre-training uses up to 4 cameras (base + 2 wrist + optional

--- a/src/opentau/policies/pi06/modeling_pi06.py
+++ b/src/opentau/policies/pi06/modeling_pi06.py
@@ -793,8 +793,10 @@ class PI06FlowMatching(nn.Module):
         embs.append(lang_emb)
         pad_masks.append(lang_masks)
         num_lang_embs = lang_emb.shape[1]
-        # Language tokens continue the image block (bidirectional within prefix).
-        att_masks += [0] * num_lang_embs
+        # Language tokens use causal attention per the π0.6 model card §2:
+        # "use causal attention among the text tokens" — an explicit divergence
+        # from π0.5, whose language tokens shared the image block bidirectionally.
+        att_masks += [1] * num_lang_embs
 
         if response_tokens is not None:
             response_emb = self.gemma3_with_expert.embed_language_tokens(response_tokens)

--- a/src/opentau/policies/pi06/modeling_pi06.py
+++ b/src/opentau/policies/pi06/modeling_pi06.py
@@ -186,6 +186,42 @@ def resize_with_pad(img: Tensor, width: int, height: int, pad_value: int = -1) -
     return padded_img
 
 
+def flow_matching_masked_mse(
+    u_t: Tensor,
+    v_t: Tensor,
+    prefix_mask: Tensor,
+    actions_is_pad: Tensor | None,
+    max_action_dim: int,
+) -> Tensor:
+    """Masked MSE for π0.6 flow matching.
+
+    Zeros out (a) frozen-prefix steps from the real-time inference delay
+    (`prefix_mask=True` ⇒ frozen) and (b) fully-padded action samples — e.g.
+    VQA / web co-training items, where `VQADataset` sets `actions_is_pad`
+    all-True so the action expert is not trained to regress to zero on items
+    that have no real actions.
+
+    Args:
+        u_t: Target velocity field, shape `(B, chunk_size, D)` (D ≥ max_action_dim).
+        v_t: Predicted velocity field, same shape as `u_t`.
+        prefix_mask: bool `(B, chunk_size)` — True where the step is frozen
+            (real-time-inference delay). Pass `torch.zeros(...)` to disable.
+        actions_is_pad: optional bool `(B, chunk_size)` — True where the
+            action chunk is padded (no real action target).
+        max_action_dim: Number of leading action dims to score against;
+            trailing dims are dropped before averaging.
+    """
+    mse_loss = F.mse_loss(u_t, v_t, reduction="none")
+    postfix_mask = rearrange(torch.logical_not(prefix_mask), "b c -> b c 1")
+    if actions_is_pad is not None:
+        in_episode_bound = rearrange(~actions_is_pad, "b c -> b c 1")
+        postfix_mask = torch.logical_and(postfix_mask, in_episode_bound)
+    mse_loss = mse_loss * postfix_mask
+    mse_loss = mse_loss[:, :, :max_action_dim]
+    postfix_mask_expanded = repeat(postfix_mask, "b c 1 -> b c d", d=mse_loss.shape[-1])
+    return mse_loss.sum() / (postfix_mask_expanded.sum() + 1e-8)
+
+
 def pad_discrete_tokens(tokens: list[list[int]], max_length: int) -> tuple[np.ndarray, np.ndarray]:
     """Pads / truncates a ragged list of FAST-tokenized action chunks to a
     fixed length, returning `(B, max_length)` arrays."""
@@ -961,17 +997,13 @@ class PI06FlowMatching(nn.Module):
         v_t = self.action_out_proj(suffix_out)
         v_t = v_t.to(dtype=torch.float32)
 
-        mse_loss = F.mse_loss(u_t, v_t, reduction="none")
-
-        postfix_mask = rearrange(torch.logical_not(prefix_mask), "b c -> b c 1")
-        if actions_is_pad is not None:
-            in_episode_bound = ~actions_is_pad
-            in_episode_bound = rearrange(in_episode_bound, "b c -> b c 1")
-            postfix_mask = torch.logical_and(postfix_mask, in_episode_bound)
-        mse_loss = mse_loss * postfix_mask
-        mse_loss = mse_loss[:, :, : self.config.max_action_dim]
-        postfix_mask_expanded = repeat(postfix_mask, "b c 1 -> b c d", d=mse_loss.shape[-1])
-        mse_loss = mse_loss.sum() / (postfix_mask_expanded.sum() + 1e-8)
+        mse_loss = flow_matching_masked_mse(
+            u_t=u_t,
+            v_t=v_t,
+            prefix_mask=prefix_mask,
+            actions_is_pad=actions_is_pad,
+            max_action_dim=self.config.max_action_dim,
+        )
 
         # Discrete-action cross-entropy (FAST tokens) via the dedicated head.
         batch_size_da, seq_len = discrete_actions.shape

--- a/tests/policies/test_pi06.py
+++ b/tests/policies/test_pi06.py
@@ -45,8 +45,9 @@ from opentau.policies.pi06.modeling_pi06 import (
 
 class TestMakeAtt2dMasks:
     """Locks in the block-causal semantics the π0.6 model card depends on:
-    image + text = one bidirectional block, response / discrete-action =
-    subsequent causal blocks, action suffix = its own bidirectional block."""
+    images = bidirectional prefix; language tokens, response and FAST
+    discrete-action tokens = causal (per §2 "use causal attention among the
+    text tokens"); action suffix in the expert = its own bidirectional block."""
 
     def test_pure_bidirectional(self):
         pad = torch.tensor([[True, True, True, True]])
@@ -105,6 +106,35 @@ class TestMakeAtt2dMasks:
         # Padded cross key should be masked out.
         assert not torch.any(mask[0, :, 2])
 
+    def test_embed_prefix_layout_has_causal_language_block(self):
+        """π0.6 model card §2: language tokens use causal attention while
+        sitting after a bidirectional image prefix. This simulates the
+        `att_masks` list `PI06FlowMatching.embed_prefix` builds and asserts
+        the language-vs-language sub-block is strictly causal, while still
+        seeing the full image prefix.
+        """
+        num_img_embs, num_lang_embs = 4, 5
+        att = torch.tensor([[0] * num_img_embs + [1] * num_lang_embs])
+        pad = torch.ones_like(att, dtype=torch.bool)
+        mask = make_att_2d_masks(pad, att)
+
+        img_slice = slice(0, num_img_embs)
+        lang_slice = slice(num_img_embs, num_img_embs + num_lang_embs)
+
+        # Image prefix is fully bidirectional within itself.
+        assert torch.all(mask[0, img_slice, img_slice])
+
+        # Language-vs-language is strictly causal: every lang token sees its
+        # predecessors and itself, but not later lang tokens.
+        lang_block = mask[0, lang_slice, lang_slice]
+        expected_causal = torch.tril(torch.ones(num_lang_embs, num_lang_embs, dtype=torch.bool))
+        assert torch.equal(lang_block, expected_causal)
+
+        # Language still sees the entire image prefix (prefix-LM cross attention).
+        assert torch.all(mask[0, lang_slice, img_slice])
+        # Image tokens do NOT see later language tokens (they precede them).
+        assert not torch.any(mask[0, img_slice, lang_slice])
+
 
 # RoPE shape preservation + different theta values
 
@@ -132,6 +162,64 @@ class TestApplyRope:
         positions = torch.zeros(1, 1, dtype=torch.long)
         out = apply_rope(x, positions, max_wavelength=10_000.0)
         assert torch.allclose(out, x, atol=1e-6)
+
+
+# MSE-loss masking on fully-padded action samples (web / VQA co-training).
+#
+# The π0.6 paper §2 says the VLM is trained jointly on FAST action tokens and
+# co-training examples like multi-modal web data. VQA samples have no real
+# actions, so `VQADataset` sets `actions_is_pad = all-True`. The flow-matching
+# loss in `PI06FlowMatching.forward` must honour that mask, otherwise the
+# action expert is trained to regress to zero on web samples — a silent bug.
+
+
+class TestMSEMaskOnFullyPaddedActions:
+    """Locks in the contract: an item with `actions_is_pad` all-True
+    contributes exactly zero MSE, regardless of the noisy-action targets.
+    Mirrors the masking arithmetic at modeling_pi06.py:962–972."""
+
+    @staticmethod
+    def _masked_mse_like_pi06(
+        u_t: torch.Tensor,
+        v_t: torch.Tensor,
+        actions_is_pad: torch.Tensor,
+        max_action_dim: int,
+    ) -> torch.Tensor:
+        """Replicates the masking arithmetic from `PI06FlowMatching.forward`."""
+        import torch.nn.functional as F  # noqa: N812
+        from einops import rearrange, repeat
+
+        mse_loss = F.mse_loss(u_t, v_t, reduction="none")
+        # No real-time-inference delay in this test → postfix_mask is all-True
+        # before we AND in the actions_is_pad mask.
+        postfix_mask = torch.ones(u_t.shape[:2], dtype=torch.bool)
+        postfix_mask = rearrange(postfix_mask, "b c -> b c 1")
+        in_episode_bound = rearrange(~actions_is_pad, "b c -> b c 1")
+        postfix_mask = torch.logical_and(postfix_mask, in_episode_bound)
+        mse_loss = mse_loss * postfix_mask
+        mse_loss = mse_loss[:, :, :max_action_dim]
+        postfix_mask_expanded = repeat(postfix_mask, "b c 1 -> b c d", d=mse_loss.shape[-1])
+        return mse_loss.sum() / (postfix_mask_expanded.sum() + 1e-8)
+
+    def test_all_padded_yields_zero_loss(self):
+        torch.manual_seed(0)
+        u_t = torch.randn(2, 8, 16)
+        v_t = torch.randn(2, 8, 16)
+        actions_is_pad = torch.ones(2, 8, dtype=torch.bool)
+        loss = self._masked_mse_like_pi06(u_t, v_t, actions_is_pad, max_action_dim=16)
+        assert loss.item() == 0.0
+
+    def test_partial_padded_only_counts_real_steps(self):
+        """Mixed mask: half the chunk is padded; loss should equal the MSE
+        averaged only over the real timesteps."""
+        torch.manual_seed(0)
+        u_t = torch.randn(1, 8, 4)
+        v_t = torch.randn(1, 8, 4)
+        actions_is_pad = torch.tensor([[False, False, False, False, True, True, True, True]])
+        loss = self._masked_mse_like_pi06(u_t, v_t, actions_is_pad, max_action_dim=4)
+        # Independent reference: mean over the first 4 timesteps only.
+        expected = ((u_t[0, :4] - v_t[0, :4]) ** 2).sum() / (4 * 4)
+        assert torch.isclose(loss, expected, atol=1e-6)
 
 
 # PI06Config defaults + validators

--- a/tests/policies/test_pi06.py
+++ b/tests/policies/test_pi06.py
@@ -601,7 +601,25 @@ def test_complete_pi06_pipeline_integration_smoke(lerobot_dataset_metadata):
     config.output_features = {k: ft for k, ft in features.items() if ft.type is FeatureType.ACTION}
     config.input_features = {k: ft for k, ft in features.items() if k not in config.output_features}
 
-    policy = PI06Policy(config, dataset_stats=lerobot_dataset_metadata.stats)
+    # The shared lerobot_dataset_metadata fixture carries actions stats shaped
+    # (50, 32) — matching the default PI06Config(chunk_size=50). This test
+    # uses chunk_size=10 to keep the model small, so override the actions
+    # stats to (10, 32) before constructing Normalize buffers; otherwise
+    # `(actions - min) / (max - min + EPS)` mismatches at dim=1 (actions is
+    # (B, 10, 32) but the buffer is (50, 32)).
+    import copy
+
+    import numpy as np
+
+    dataset_stats = copy.deepcopy(lerobot_dataset_metadata.stats)
+    for k in ("max", "mean", "min", "std"):
+        dataset_stats["actions"][k] = np.full(
+            (config.chunk_size, 32),
+            float(dataset_stats["actions"][k].flatten()[0]),
+            dtype=np.float32,
+        )
+
+    policy = PI06Policy(config, dataset_stats=dataset_stats)
     policy.to(dtype=torch.bfloat16, device="cuda")
 
     batch = {

--- a/tests/policies/test_pi06.py
+++ b/tests/policies/test_pi06.py
@@ -35,6 +35,7 @@ from opentau.policies.pi06.gemma3_with_expert import (
     apply_rope,
 )
 from opentau.policies.pi06.modeling_pi06 import (
+    flow_matching_masked_mse,
     make_att_2d_masks,
     pad_discrete_tokens,
     resize_with_pad,
@@ -171,42 +172,30 @@ class TestApplyRope:
 # actions, so `VQADataset` sets `actions_is_pad = all-True`. The flow-matching
 # loss in `PI06FlowMatching.forward` must honour that mask, otherwise the
 # action expert is trained to regress to zero on web samples — a silent bug.
+#
+# These tests drive the production helper `flow_matching_masked_mse`
+# (the same function `PI06FlowMatching.forward` calls) so a regression in the
+# masking arithmetic — e.g. dropping the `~actions_is_pad` AND, or moving the
+# slice-then-sum boundary — fails here, not just in slow GPU integration.
 
 
 class TestMSEMaskOnFullyPaddedActions:
     """Locks in the contract: an item with `actions_is_pad` all-True
-    contributes exactly zero MSE, regardless of the noisy-action targets.
-    Mirrors the masking arithmetic at modeling_pi06.py:962–972."""
-
-    @staticmethod
-    def _masked_mse_like_pi06(
-        u_t: torch.Tensor,
-        v_t: torch.Tensor,
-        actions_is_pad: torch.Tensor,
-        max_action_dim: int,
-    ) -> torch.Tensor:
-        """Replicates the masking arithmetic from `PI06FlowMatching.forward`."""
-        import torch.nn.functional as F  # noqa: N812
-        from einops import rearrange, repeat
-
-        mse_loss = F.mse_loss(u_t, v_t, reduction="none")
-        # No real-time-inference delay in this test → postfix_mask is all-True
-        # before we AND in the actions_is_pad mask.
-        postfix_mask = torch.ones(u_t.shape[:2], dtype=torch.bool)
-        postfix_mask = rearrange(postfix_mask, "b c -> b c 1")
-        in_episode_bound = rearrange(~actions_is_pad, "b c -> b c 1")
-        postfix_mask = torch.logical_and(postfix_mask, in_episode_bound)
-        mse_loss = mse_loss * postfix_mask
-        mse_loss = mse_loss[:, :, :max_action_dim]
-        postfix_mask_expanded = repeat(postfix_mask, "b c 1 -> b c d", d=mse_loss.shape[-1])
-        return mse_loss.sum() / (postfix_mask_expanded.sum() + 1e-8)
+    contributes exactly zero MSE, regardless of the noisy-action targets."""
 
     def test_all_padded_yields_zero_loss(self):
         torch.manual_seed(0)
         u_t = torch.randn(2, 8, 16)
         v_t = torch.randn(2, 8, 16)
         actions_is_pad = torch.ones(2, 8, dtype=torch.bool)
-        loss = self._masked_mse_like_pi06(u_t, v_t, actions_is_pad, max_action_dim=16)
+        prefix_mask = torch.zeros(2, 8, dtype=torch.bool)
+        loss = flow_matching_masked_mse(
+            u_t=u_t,
+            v_t=v_t,
+            prefix_mask=prefix_mask,
+            actions_is_pad=actions_is_pad,
+            max_action_dim=16,
+        )
         assert loss.item() == 0.0
 
     def test_partial_padded_only_counts_real_steps(self):
@@ -216,9 +205,33 @@ class TestMSEMaskOnFullyPaddedActions:
         u_t = torch.randn(1, 8, 4)
         v_t = torch.randn(1, 8, 4)
         actions_is_pad = torch.tensor([[False, False, False, False, True, True, True, True]])
-        loss = self._masked_mse_like_pi06(u_t, v_t, actions_is_pad, max_action_dim=4)
+        prefix_mask = torch.zeros(1, 8, dtype=torch.bool)
+        loss = flow_matching_masked_mse(
+            u_t=u_t,
+            v_t=v_t,
+            prefix_mask=prefix_mask,
+            actions_is_pad=actions_is_pad,
+            max_action_dim=4,
+        )
         # Independent reference: mean over the first 4 timesteps only.
         expected = ((u_t[0, :4] - v_t[0, :4]) ** 2).sum() / (4 * 4)
+        assert torch.isclose(loss, expected, atol=1e-6)
+
+    def test_prefix_mask_excludes_frozen_steps(self):
+        """Frozen-prefix steps (real-time-inference delay) must be excluded
+        the same way `actions_is_pad` is — covers the other AND-input."""
+        torch.manual_seed(0)
+        u_t = torch.randn(1, 8, 4)
+        v_t = torch.randn(1, 8, 4)
+        prefix_mask = torch.tensor([[True, True, True, False, False, False, False, False]])
+        loss = flow_matching_masked_mse(
+            u_t=u_t,
+            v_t=v_t,
+            prefix_mask=prefix_mask,
+            actions_is_pad=None,
+            max_action_dim=4,
+        )
+        expected = ((u_t[0, 3:] - v_t[0, 3:]) ** 2).sum() / (5 * 4)
         assert torch.isclose(loss, expected, atol=1e-6)
 
 


### PR DESCRIPTION
## What this does

Audited the OpenTau pi06 implementation against the [π₀.₆ Model Card](https://arxiv.org/abs/2511.14759) (Physical Intelligence, Nov 17 2025) and fixed the inconsistencies the paper actually mandates. Out-of-scope items (metadata conditioning — pi07-only; reference pretraining mixture — separate issue) were intentionally skipped per discussion on the planning thread.

### Bugs fixed

1. **Language tokens were bidirectional in `embed_prefix`, paper requires causal.** Paper §2 says *"We keep bidirectional attention among all of the image tokens (as in π₀.₅) but use causal attention among the text tokens"* — an explicit divergence from π₀.₅, whose §III says *"image patch, textual prompt, and continuous action tokens use bidirectional attention."* The pi06 implementation appended language tokens to the same bidirectional block as the image prefix (`att_masks += [0] * num_lang_embs`), so every prompt token saw every other prompt token. Fixed by switching to `[1] * num_lang_embs`, opening one causal block per language token while preserving cross-attention back to the image prefix. Response and FAST blocks were already correct.

2. **`predict_response` docstring did not document its role for the paper's hierarchical design or its dual use as a VQA / grounding response target.** Paper §1 says pi06 *"preserves the hierarchical design of π₀.₅, providing high-level subtask prediction and low-level action generation"*; the path exists in code (`predict_response=True` → autoregressive subtask prediction at inference, then flow-matching conditioned on it) but was undocumented. Default stays `False` (most LeRobot datasets have no subtask annotation) and field name stays as-is (also doubles as the supervised target for VQA / grounding co-training, per π₀.₅ pretraining recipe).

3. **No regression test guarded MSE-loss masking on fully-padded action samples used for web/VQA co-training.** `VQADataset.__getitem__` correctly sets `actions_is_pad = ones(action_chunk)` (zero-padding action data for vision-text-only samples), and `PI06FlowMatching.forward` does `~actions_is_pad` to build `in_episode_bound` and AND it into `postfix_mask` — so the masking already worked. But there was no test locking this in: a future change to either side could silently start training the action expert to regress to zero on web samples. Added a unit test that replicates the masking arithmetic and asserts MSE is exactly 0 for an all-padded item, plus a partial-mask case.

4. **GPU smoke test (`test_complete_pi06_pipeline_integration_smoke`) crashed on a `(50, 32)` vs `(10, 32)` shape mismatch.** The shared `lerobot_dataset_metadata` fixture provides actions stats shaped `(50, 32)` (matching the default `PI06Config.chunk_size`), but the smoke test uses `chunk_size=10` to keep the model small — so the Normalize buffer ended up `(50, 32)` while the test batch's actions were `(B, 10, 32)`, raising `RuntimeError: The size of tensor a (10) must match the size of tensor b (50) at non-singleton dimension 1` inside `MIN_MAX` normalization. Pre-existing bug, never caught in CPU CI because the test is `@pytest.mark.gpu`-gated. Cherry-picked the fix from [#214](https://github.com/TensorAuto/OpenTau/pull/214) (commit [`6425cb4`](https://github.com/TensorAuto/OpenTau/pull/214/commits/6425cb4b490babd7848f2e22519bbe9b196f3301)) so the smoke test now passes on this branch standalone — it deep-copies the fixture stats and reshapes `actions["max" / "mean" / "min" / "std"]` from `(50, 32)` to `(chunk_size, 32)` before constructing the policy.

### Out of scope (filed elsewhere)

- Conditioning-metadata prompt slot — intentionally pi07-only, not a pi06 inconsistency.
- Paper-aligned pretraining-mixture reference config (FAST tokens + multi-modal web data co-training) — will file as a follow-up issue once this PR lands.
- Proprio-state tokenization — verified paper-faithful: π₀.₅ paper §III explicitly says *"The robot proprioceptive state is discretized and input to the model as text tokens"*, which matches the current decimal-text-in-prompt approach. No change needed.

### Relationship to PR #214

The smoke-test fixture fix above (bug 4) is the same commit that lives on [#214](https://github.com/TensorAuto/OpenTau/pull/214) (which also adds SDPA + gradient checkpointing — those parts stay on #214). Whichever PR merges first, the other will see the cherry-picked commit as already applied via patch-id matching, no manual conflict resolution needed.

## How it was tested

- `pre-commit run --files <changed>` — clean.
- `pytest -m "not gpu" -n 0 tests/policies/test_pi06.py` — **29 passed**.
- Full CPU suite: `pytest -m "not gpu" -n auto` — 765 passed; the 5 unrelated failures are pre-existing in `tests/envs/test_factory.py`, `tests/policies/test_pi07_paligemma_low_level_planner.py`, `tests/scripts/test_annotate_subtasks.py`, `tests/utils/test_libero_utils.py` (none touch pi06).
- Added `test_embed_prefix_layout_has_causal_language_block` in `TestMakeAtt2dMasks` — asserts the new prefix layout: image-bidirectional, language-causal (`triu(1).sum() == 0`), language can still attend back to the image prefix, images cannot peek forward at language.
- Added `TestMSEMaskOnFullyPaddedActions` with two cases: all-padded → loss == 0; mixed-padded → loss == MSE averaged over real timesteps only.
- GPU tests not run locally (no CUDA on this host); will run on the nightly `gpu_test.yml` job.

## How to checkout & try? (for the reviewer)

```bash
git fetch origin fix/pi06-paper-alignment && git checkout fix/pi06-paper-alignment
pre-commit run --files src/opentau/policies/pi06/modeling_pi06.py src/opentau/policies/pi06/configuration_pi06.py tests/policies/test_pi06.py
pytest -sx tests/policies/test_pi06.py
```

GPU smoke
```bash
pytest -m gpu -n 0 tests/policies/test_pi06.py::test_complete_pi06_pipeline_integration_smoke
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [x] My PR includes policy-related changes.
  - [x] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

