### PR TITLE
test(pi06): verify pi06 ckpt loads + matches gemma-3-4b-pt

### DIFF
--- a/src/opentau/configs/policies.py
+++ b/src/opentau/configs/policies.py
@@ -395,6 +395,19 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):
         config_path = save_directory / CONFIG_NAME
         with open(config_path, "w") as f, draccus.config_type("json"):
             draccus.dump(self, f, indent=4)
+        # `draccus.dump` of a registered choice-type subclass (e.g. `PI06Config`)
+        # does NOT include the `type` discriminator at the top level — it only
+        # serializes dataclass fields, and `type` is a class-level attr from
+        # `register_subclass(...)`. Without `type` in the file,
+        # `PreTrainedConfig.from_pretrained(...)` (which delegates to
+        # `draccus.parse(PreTrainedConfig, ...)`) fails because it can't pick
+        # a subclass. Inject it post-hoc so the round-trip works.
+        with open(config_path) as f:
+            data = json.load(f)
+        if "type" not in data:
+            data = {"type": self.type, **data}
+            with open(config_path, "w") as f:
+                json.dump(data, f, indent=4)
         strip_deprecated_fields_from_json(config_path)
 
     @classmethod

--- a/src/opentau/configs/policies.py
+++ b/src/opentau/configs/policies.py
@@ -393,21 +393,19 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):
             save_directory: Directory path where the configuration will be saved.
         """
         config_path = save_directory / CONFIG_NAME
-        with open(config_path, "w") as f, draccus.config_type("json"):
-            draccus.dump(self, f, indent=4)
-        # `draccus.dump` of a registered choice-type subclass (e.g. `PI06Config`)
-        # does NOT include the `type` discriminator at the top level — it only
-        # serializes dataclass fields, and `type` is a class-level attr from
-        # `register_subclass(...)`. Without `type` in the file,
-        # `PreTrainedConfig.from_pretrained(...)` (which delegates to
-        # `draccus.parse(PreTrainedConfig, ...)`) fails because it can't pick
-        # a subclass. Inject it post-hoc so the round-trip works.
-        with open(config_path) as f:
-            data = json.load(f)
-        if "type" not in data:
-            data = {"type": self.type, **data}
-            with open(config_path, "w") as f:
-                json.dump(data, f, indent=4)
+        # Encode with `declared_type=PreTrainedConfig` so draccus inserts the
+        # `type` choice-type discriminator at the top of the dict. Without
+        # the declared type, `draccus.dump(self, ...)` infers it from the
+        # runtime class (`PI06Config`, etc.) — already concrete, so the
+        # discriminator is omitted — and the resulting `config.json` is
+        # unloadable by `from_pretrained`, which dispatches off the parent
+        # `PreTrainedConfig` and requires `type` to pick a subclass. Going
+        # through `encode` + `json.dump` is equivalent to draccus's own JSON
+        # dump path; the difference is the `declared_type` arg, which feeds
+        # draccus's `encode_choice` code path (see draccus.parsers.encoding).
+        data = draccus.encode(self, declared_type=PreTrainedConfig)
+        with open(config_path, "w") as f:
+            json.dump(data, f, indent=4)
         strip_deprecated_fields_from_json(config_path)
 
     @classmethod

--- a/src/opentau/utils/vision_utils.py
+++ b/src/opentau/utils/vision_utils.py
@@ -1,0 +1,74 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Vision-tower helpers reused across policies (pi06, pi07, ...).
+
+The current resident is :func:`bilinear_resample_pos_embed`, which adapts
+SigLIP / ViT-style learned position-embedding tables to a different patch
+count when the policy runs the vision tower at a non-published resolution.
+
+Why this is its own module rather than inline in a policy: π0.6 uses Gemma
+3-4B at 448×448 (1024 patches) but `google/gemma-3-4b-pt` ships at 896×896
+(4096 patches), so any script that bootstraps an "untrained" π0.6
+checkpoint from the public VLM weights must resample. π0.7 uses the same
+backbone family and will inherit the same need — sharing the helper here
+keeps the recipe identical across them and avoids drift between
+re-implementations.
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+def bilinear_resample_pos_embed(old_pos: torch.Tensor, target_num_patches: int) -> torch.Tensor:
+    """Bilinearly resample a learned ``(N_patches, dim)`` position-embedding
+    table to a different patch count, preserving dtype.
+
+    This is the standard recipe for adapting SigLIP / ViT position embeddings
+    when running a published VLM at a different image resolution. Both the
+    source and target patch counts must be perfect squares (square grids).
+    Computation is performed in fp32 (``F.interpolate`` rejects bf16 on CPU)
+    and cast back to the input dtype before return.
+
+    The transform is fully deterministic: two calls with bit-identical inputs
+    return bit-identical outputs, with no RNG consumption. This matters for
+    bootstrapping checkpoints whose downstream tests compare weights byte-
+    for-byte against an independently-computed reference.
+
+    Args:
+        old_pos: Source position-embedding table, shape ``(N_old, dim)`` with
+            ``N_old`` a perfect square.
+        target_num_patches: Desired output ``N_new``, must be a perfect square.
+
+    Returns:
+        Resampled tensor of shape ``(target_num_patches, dim)`` and same dtype
+        as ``old_pos``. Returns ``old_pos`` unchanged when ``N_old ==
+        target_num_patches`` (no copy).
+
+    Raises:
+        AssertionError: if either patch count is not a perfect square.
+    """
+    old_n, dim = old_pos.shape
+    if old_n == target_num_patches:
+        return old_pos
+    old_grid = int(old_n**0.5)
+    new_grid = int(target_num_patches**0.5)
+    assert old_grid * old_grid == old_n, f"non-square source grid: {old_n}"
+    assert new_grid * new_grid == target_num_patches, f"non-square target grid: {target_num_patches}"
+    grid = old_pos.reshape(old_grid, old_grid, dim).permute(2, 0, 1).unsqueeze(0).float()
+    grid = torch.nn.functional.interpolate(
+        grid, size=(new_grid, new_grid), mode="bilinear", align_corners=False
+    )
+    return grid.squeeze(0).permute(1, 2, 0).reshape(target_num_patches, dim).to(old_pos.dtype)

--- a/tests/configs/test_utils_policies.py
+++ b/tests/configs/test_utils_policies.py
@@ -14,7 +14,7 @@
 
 import json
 from pathlib import Path
-from unittest.mock import mock_open, patch
+from unittest.mock import patch
 
 import pytest
 from draccus.utils import ParsingError
@@ -92,27 +92,30 @@ def test_feature_properties_return_none_when_not_found(get_inherited_pretrainedc
 
 
 def test_save_pretrained(tmp_path, get_inherited_pretrainedconfig):
-    """
-    Tests that _save_pretrained writes a file using draccus.dump.
-    """
-    # Setup: Mock the file system and draccus dependencies
-    with (
-        patch("draccus.dump") as mock_dump,
-        patch("builtins.open", mock_open()),
-        patch("opentau.configs.policies.strip_deprecated_fields_from_json"),
-    ):
-        config = get_inherited_pretrainedconfig()
+    """`_save_pretrained` writes a JSON file at `<dir>/CONFIG_NAME` whose top
+    contains the choice-type discriminator (`type`) so the file round-trips
+    through `PreTrainedConfig.from_pretrained` (which dispatches off the
+    parent class and needs `type` to pick a subclass)."""
+    config = get_inherited_pretrainedconfig()
 
-        # Act
-        config._save_pretrained(tmp_path)
+    config._save_pretrained(tmp_path)
 
-        # Assert
-        # Check that open was called with the correct file path
-        open.assert_called_once_with(tmp_path / CONFIG_NAME, "w")
-
-        # Check that draccus.dump was called with the config instance
-        # We check the first argument of the first call to draccus.dump
-        assert mock_dump.call_args[0][0] is config
+    config_path = tmp_path / CONFIG_NAME
+    assert config_path.is_file(), f"{config_path} was not written"
+    with open(config_path) as f:
+        data = json.load(f)
+    # The discriminator must be present (the key invariant from_pretrained
+    # depends on); for this fixture it's "concrete_test" per its
+    # @PreTrainedConfig.register_subclass decorator.
+    assert data.get("type") == config.type, (
+        f"expected top-level type={config.type!r}, got {data.get('type')!r}"
+    )
+    # Round-trip: load via the parent class and confirm we get the original
+    # subclass back. This is the failure mode that motivated the fix.
+    loaded = PreTrainedConfig.from_pretrained(tmp_path)
+    assert isinstance(loaded, type(config)), (
+        f"round-trip lost subclass: expected {type(config).__name__}, got {type(loaded).__name__}"
+    )
 
 
 def test_from_pretrained(tmp_path):

--- a/tests/fixtures/configs.py
+++ b/tests/fixtures/configs.py
@@ -21,6 +21,7 @@ from opentau.optim.optimizers import OptimizerConfig
 from opentau.optim.schedulers import LRSchedulerConfig
 
 
+@PreTrainedConfig.register_subclass("concrete_test")
 @dataclass
 class ConcretePolicyConfig(PreTrainedConfig):
     @property

--- a/tests/policies/test_pi06.py
+++ b/tests/policies/test_pi06.py
@@ -1016,20 +1016,47 @@ def _diff_state_dicts_against_reference(
 @pytest.mark.gpu
 @pytest.mark.slow
 def test_pi06_untrained_loads_with_no_missing_or_unexpected_keys(pi06_untrained_policy):
-    """Published `model.safetensors` keys equal the policy's `state_dict()` keys
-    1:1. Catches both missed-on-save and missed-on-load regressions: the
-    standard `from_pretrained` loader uses `strict=False` and only logs the
-    diff, so without this we'd silently ship a checkpoint that, say, dropped
-    the action expert."""
+    """Every key in the loaded policy's `state_dict()` is either present in the
+    published `model.safetensors`, or shares storage with a key that is. The
+    second case covers Gemma 3's tied embed_tokens/lm_head, which
+    `save_model_as_safetensor` de-duplicates on save (only one name on disk;
+    both are populated at load time via the model's `_tie_weights()` hook).
+    No safetensors key may be unexpected.
+
+    Catches the regression we actually care about: a save flow that silently
+    drops a non-tied parameter (e.g. an action-expert layer) would surface
+    here because that parameter has its own data_ptr and so won't be in any
+    tied group."""
     from huggingface_hub import hf_hub_download
     from safetensors.torch import load_file
 
     ckpt_path = hf_hub_download("TensorAuto/pi06-untrained", "model.safetensors")
     saved_keys = set(load_file(ckpt_path).keys())
-    expected_keys = set(pi06_untrained_policy.state_dict().keys())
+    loaded_state = pi06_untrained_policy.state_dict()
+    expected_keys = set(loaded_state.keys())
 
-    missing = expected_keys - saved_keys
+    # Build groups of state_dict keys that share storage (tied weights).
+    ptr_to_names: dict[int, list[str]] = {}
+    for name, tensor in loaded_state.items():
+        ptr_to_names.setdefault(tensor.data_ptr(), []).append(name)
+    tied_groups = [names for names in ptr_to_names.values() if len(names) > 1]
+
+    # Each tied group must have exactly one representative on disk.
+    tied_group_violations = []
+    allowed_missing: set[str] = set()
+    for group in tied_groups:
+        on_disk = [n for n in group if n in saved_keys]
+        if len(on_disk) != 1:
+            tied_group_violations.append(
+                f"tied group {sorted(group)}: expected exactly 1 on disk, got {len(on_disk)}"
+            )
+        for n in group:
+            if n not in saved_keys:
+                allowed_missing.add(n)
+
+    missing = expected_keys - saved_keys - allowed_missing
     unexpected = saved_keys - expected_keys
+    assert not tied_group_violations, "\n".join(tied_group_violations)
     assert not missing and not unexpected, (
         f"missing in safetensors ({len(missing)}): {sorted(missing)[:10]}\n"
         f"unexpected in safetensors ({len(unexpected)}): {sorted(unexpected)[:10]}"

--- a/tests/policies/test_pi06.py
+++ b/tests/policies/test_pi06.py
@@ -919,12 +919,45 @@ def pi06_untrained_policy():
     return PI06Policy.from_pretrained("TensorAuto/pi06-untrained")
 
 
+def _bilinear_resample_pos_embed(old_pos: torch.Tensor, target_num_patches: int) -> torch.Tensor:
+    """Bilinearly resample a (N_patches, dim) SigLIP position-embedding tensor
+    to a different patch count, preserving dtype. N must be a perfect square.
+
+    π0.6 runs the SigLIP tower at 448×448 (1024 patches), but `google/gemma-3-4b-pt`
+    was trained at 896×896 (4096 patches). The build script applies this exact
+    resampling before transferring weights, so the test reference applies it too
+    for byte-equality to hold.
+    """
+    old_n, dim = old_pos.shape
+    if old_n == target_num_patches:
+        return old_pos
+    old_grid = int(old_n**0.5)
+    new_grid = int(target_num_patches**0.5)
+    assert old_grid * old_grid == old_n, f"non-square SigLIP grid: {old_n}"
+    assert new_grid * new_grid == target_num_patches, f"non-square target: {target_num_patches}"
+    grid = old_pos.reshape(old_grid, old_grid, dim).permute(2, 0, 1).unsqueeze(0).float()
+    grid = torch.nn.functional.interpolate(
+        grid, size=(new_grid, new_grid), mode="bilinear", align_corners=False
+    )
+    return grid.squeeze(0).permute(1, 2, 0).reshape(target_num_patches, dim).to(old_pos.dtype)
+
+
+_SIGLIP_POS_EMBED_KEY = "model.vision_tower.vision_model.embeddings.position_embedding.weight"
+
+
 @pytest.fixture(scope="module")
-def gemma3_4b_pt_aligned():
-    """Reference `google/gemma-3-4b-pt` (bf16, CPU) with vocab extended to match
-    the policy. `ensure_loc_tokens` resizes the embedding/LM head with
-    bit-deterministic new rows under a fixed seed, so `load_state_dict(strict=True)`
-    is well-defined against the policy's `gemma3` submodule."""
+def gemma3_4b_pt_aligned_state_dict(pi06_untrained_policy):
+    """`google/gemma-3-4b-pt`'s state_dict, aligned to the policy:
+
+    - `ensure_loc_tokens` extends the embedding/LM head with the same 1024
+      `<locNNNN>` rows the policy carries (deterministic via fixed-seed RNG fork).
+    - The SigLIP `position_embedding` is bilinearly resampled from the published
+      4096 patches (896×896) down to the policy's 1024 patches (448×448) — the
+      same operation the build script applies before saving the checkpoint.
+
+    Returns a `dict[str, Tensor]` rather than the model itself because the
+    resampled position embedding has a different shape than the original
+    `nn.Embedding` parameter — so we can't mutate the model in place."""
     from transformers import (
         AutoTokenizer,
         Gemma3ForConditionalGeneration,  # noqa: I100
@@ -935,7 +968,16 @@ def gemma3_4b_pt_aligned():
     model = Gemma3ForConditionalGeneration.from_pretrained("google/gemma-3-4b-pt", torch_dtype=torch.bfloat16)
     tok = AutoTokenizer.from_pretrained("google/gemma-3-4b-pt")
     ensure_loc_tokens(tok, model=model)
-    return model
+
+    state = model.state_dict()
+    pol_n_patches = pi06_untrained_policy.model.gemma3_with_expert.gemma3.state_dict()[
+        _SIGLIP_POS_EMBED_KEY
+    ].shape[0]
+    state[_SIGLIP_POS_EMBED_KEY] = _bilinear_resample_pos_embed(
+        state[_SIGLIP_POS_EMBED_KEY], target_num_patches=pol_n_patches
+    )
+    del model
+    return state
 
 
 def _diff_state_dicts_against_reference(
@@ -996,15 +1038,14 @@ def test_pi06_untrained_loads_with_no_missing_or_unexpected_keys(pi06_untrained_
 
 @pytest.mark.gpu
 @pytest.mark.slow
-def test_pi06_untrained_vlm_matches_gemma3_4b_pt(pi06_untrained_policy, gemma3_4b_pt_aligned):
+def test_pi06_untrained_vlm_matches_gemma3_4b_pt(pi06_untrained_policy, gemma3_4b_pt_aligned_state_dict):
     """Gemma 3 text tower + multimodal projector inside the published checkpoint
     are byte-identical to `google/gemma-3-4b-pt` (vision tower checked separately
     in `test_pi06_untrained_siglip_matches_gemma3_4b_pt`)."""
     pol_state = pi06_untrained_policy.model.gemma3_with_expert.gemma3.state_dict()
-    ref_state = gemma3_4b_pt_aligned.state_dict()
 
     checked, mismatches = _diff_state_dicts_against_reference(
-        pol_state, ref_state, name_filter=lambda name: "vision_tower" not in name
+        pol_state, gemma3_4b_pt_aligned_state_dict, name_filter=lambda name: "vision_tower" not in name
     )
     assert checked > 0, "Sanity: should have compared at least one VLM (non-vision) param"
     assert not mismatches, "VLM (Gemma 3 text + projector) mismatches:\n" + "\n".join(mismatches[:20])
@@ -1012,14 +1053,16 @@ def test_pi06_untrained_vlm_matches_gemma3_4b_pt(pi06_untrained_policy, gemma3_4
 
 @pytest.mark.gpu
 @pytest.mark.slow
-def test_pi06_untrained_siglip_matches_gemma3_4b_pt(pi06_untrained_policy, gemma3_4b_pt_aligned):
+def test_pi06_untrained_siglip_matches_gemma3_4b_pt(pi06_untrained_policy, gemma3_4b_pt_aligned_state_dict):
     """SigLIP vision tower inside the published checkpoint is byte-identical to
-    the vision tower bundled in `google/gemma-3-4b-pt`."""
+    the vision tower bundled in `google/gemma-3-4b-pt`, modulo a deterministic
+    bilinear resample of `position_embedding` from 4096 (896×896 published) to
+    1024 (448×448 π0.6) patches — the build script applies the same resample,
+    so byte-equality holds."""
     pol_state = pi06_untrained_policy.model.gemma3_with_expert.gemma3.state_dict()
-    ref_state = gemma3_4b_pt_aligned.state_dict()
 
     checked, mismatches = _diff_state_dicts_against_reference(
-        pol_state, ref_state, name_filter=lambda name: "vision_tower" in name
+        pol_state, gemma3_4b_pt_aligned_state_dict, name_filter=lambda name: "vision_tower" in name
     )
     assert checked > 0, "Sanity: should have compared at least one SigLIP param"
     assert not mismatches, "SigLIP vision tower mismatches:\n" + "\n".join(mismatches[:20])

--- a/tests/policies/test_pi06.py
+++ b/tests/policies/test_pi06.py
@@ -898,3 +898,128 @@ def test_pi06_loc_tokens_extend_vocab_and_resize_embeddings(lerobot_dataset_meta
         # process don't OOM on a single-GPU dev box.
         del policy
         torch.cuda.empty_cache()
+
+
+# Published `TensorAuto/pi06-untrained` checkpoint — load + weight equivalence.
+#
+# These tests verify the published init checkpoint (issue #239): that it loads
+# cleanly via `PI06Policy.from_pretrained("TensorAuto/pi06-untrained")` with no
+# missing/unexpected keys, and that the VLM / SigLIP submodules are bit-for-bit
+# identical to `google/gemma-3-4b-pt`. Heavy: each fixture loads ~10 GB on CPU,
+# so they're gated behind `gpu` + `slow` to stay out of CPU CI. They do NOT
+# actually require CUDA — comparison is on CPU in bf16 — but the markers double
+# as a "needs heavy infra + network" gate matching the surrounding pi06 tests.
+
+
+@pytest.fixture(scope="module")
+def pi06_untrained_policy():
+    """Load `TensorAuto/pi06-untrained` once on CPU; reused across the module."""
+    from opentau.policies.pi06.modeling_pi06 import PI06Policy
+
+    return PI06Policy.from_pretrained("TensorAuto/pi06-untrained")
+
+
+@pytest.fixture(scope="module")
+def gemma3_4b_pt_aligned():
+    """Reference `google/gemma-3-4b-pt` (bf16, CPU) with vocab extended to match
+    the policy. `ensure_loc_tokens` resizes the embedding/LM head with
+    bit-deterministic new rows under a fixed seed, so `load_state_dict(strict=True)`
+    is well-defined against the policy's `gemma3` submodule."""
+    from transformers import (
+        AutoTokenizer,
+        Gemma3ForConditionalGeneration,  # noqa: I100
+    )
+
+    from opentau.datasets.grounding.tokenizer_utils import ensure_loc_tokens
+
+    model = Gemma3ForConditionalGeneration.from_pretrained("google/gemma-3-4b-pt", torch_dtype=torch.bfloat16)
+    tok = AutoTokenizer.from_pretrained("google/gemma-3-4b-pt")
+    ensure_loc_tokens(tok, model=model)
+    return model
+
+
+def _diff_state_dicts_against_reference(
+    policy_state: dict[str, torch.Tensor],
+    reference_state: dict[str, torch.Tensor],
+    *,
+    name_filter,
+) -> tuple[int, list[str]]:
+    """Compare every entry of `reference_state` whose name passes `name_filter`
+    against the matching entry in `policy_state`. Returns `(checked, mismatches)`.
+
+    `torch.equal` is used (not `allclose`) because the policy weights came from
+    the same source bf16 tensors with no precision-changing transform — they
+    must be byte-identical, and any drift is a real bug worth surfacing.
+    """
+    mismatches: list[str] = []
+    checked = 0
+    for name, ref in reference_state.items():
+        if not name_filter(name):
+            continue
+        pol = policy_state.get(name)
+        if pol is None:
+            mismatches.append(f"{name}: missing in policy state_dict")
+            continue
+        if pol.shape != ref.shape:
+            mismatches.append(f"{name}: shape mismatch {tuple(pol.shape)} vs {tuple(ref.shape)}")
+            continue
+        if not torch.equal(pol, ref):
+            max_abs = (pol.float() - ref.float()).abs().max().item()
+            mismatches.append(f"{name}: tensor not equal (max abs diff {max_abs:g})")
+            continue
+        checked += 1
+    return checked, mismatches
+
+
+@pytest.mark.gpu
+@pytest.mark.slow
+def test_pi06_untrained_loads_with_no_missing_or_unexpected_keys(pi06_untrained_policy):
+    """Published `model.safetensors` keys equal the policy's `state_dict()` keys
+    1:1. Catches both missed-on-save and missed-on-load regressions: the
+    standard `from_pretrained` loader uses `strict=False` and only logs the
+    diff, so without this we'd silently ship a checkpoint that, say, dropped
+    the action expert."""
+    from huggingface_hub import hf_hub_download
+    from safetensors.torch import load_file
+
+    ckpt_path = hf_hub_download("TensorAuto/pi06-untrained", "model.safetensors")
+    saved_keys = set(load_file(ckpt_path).keys())
+    expected_keys = set(pi06_untrained_policy.state_dict().keys())
+
+    missing = expected_keys - saved_keys
+    unexpected = saved_keys - expected_keys
+    assert not missing and not unexpected, (
+        f"missing in safetensors ({len(missing)}): {sorted(missing)[:10]}\n"
+        f"unexpected in safetensors ({len(unexpected)}): {sorted(unexpected)[:10]}"
+    )
+
+
+@pytest.mark.gpu
+@pytest.mark.slow
+def test_pi06_untrained_vlm_matches_gemma3_4b_pt(pi06_untrained_policy, gemma3_4b_pt_aligned):
+    """Gemma 3 text tower + multimodal projector inside the published checkpoint
+    are byte-identical to `google/gemma-3-4b-pt` (vision tower checked separately
+    in `test_pi06_untrained_siglip_matches_gemma3_4b_pt`)."""
+    pol_state = pi06_untrained_policy.model.gemma3_with_expert.gemma3.state_dict()
+    ref_state = gemma3_4b_pt_aligned.state_dict()
+
+    checked, mismatches = _diff_state_dicts_against_reference(
+        pol_state, ref_state, name_filter=lambda name: "vision_tower" not in name
+    )
+    assert checked > 0, "Sanity: should have compared at least one VLM (non-vision) param"
+    assert not mismatches, "VLM (Gemma 3 text + projector) mismatches:\n" + "\n".join(mismatches[:20])
+
+
+@pytest.mark.gpu
+@pytest.mark.slow
+def test_pi06_untrained_siglip_matches_gemma3_4b_pt(pi06_untrained_policy, gemma3_4b_pt_aligned):
+    """SigLIP vision tower inside the published checkpoint is byte-identical to
+    the vision tower bundled in `google/gemma-3-4b-pt`."""
+    pol_state = pi06_untrained_policy.model.gemma3_with_expert.gemma3.state_dict()
+    ref_state = gemma3_4b_pt_aligned.state_dict()
+
+    checked, mismatches = _diff_state_dicts_against_reference(
+        pol_state, ref_state, name_filter=lambda name: "vision_tower" in name
+    )
+    assert checked > 0, "Sanity: should have compared at least one SigLIP param"
+    assert not mismatches, "SigLIP vision tower mismatches:\n" + "\n".join(mismatches[:20])

--- a/tests/policies/test_pi06.py
+++ b/tests/policies/test_pi06.py
@@ -919,29 +919,6 @@ def pi06_untrained_policy():
     return PI06Policy.from_pretrained("TensorAuto/pi06-untrained")
 
 
-def _bilinear_resample_pos_embed(old_pos: torch.Tensor, target_num_patches: int) -> torch.Tensor:
-    """Bilinearly resample a (N_patches, dim) SigLIP position-embedding tensor
-    to a different patch count, preserving dtype. N must be a perfect square.
-
-    π0.6 runs the SigLIP tower at 448×448 (1024 patches), but `google/gemma-3-4b-pt`
-    was trained at 896×896 (4096 patches). The build script applies this exact
-    resampling before transferring weights, so the test reference applies it too
-    for byte-equality to hold.
-    """
-    old_n, dim = old_pos.shape
-    if old_n == target_num_patches:
-        return old_pos
-    old_grid = int(old_n**0.5)
-    new_grid = int(target_num_patches**0.5)
-    assert old_grid * old_grid == old_n, f"non-square SigLIP grid: {old_n}"
-    assert new_grid * new_grid == target_num_patches, f"non-square target: {target_num_patches}"
-    grid = old_pos.reshape(old_grid, old_grid, dim).permute(2, 0, 1).unsqueeze(0).float()
-    grid = torch.nn.functional.interpolate(
-        grid, size=(new_grid, new_grid), mode="bilinear", align_corners=False
-    )
-    return grid.squeeze(0).permute(1, 2, 0).reshape(target_num_patches, dim).to(old_pos.dtype)
-
-
 _SIGLIP_POS_EMBED_KEY = "model.vision_tower.vision_model.embeddings.position_embedding.weight"
 
 
@@ -964,6 +941,7 @@ def gemma3_4b_pt_aligned_state_dict(pi06_untrained_policy):
     )
 
     from opentau.datasets.grounding.tokenizer_utils import ensure_loc_tokens
+    from opentau.utils.vision_utils import bilinear_resample_pos_embed
 
     model = Gemma3ForConditionalGeneration.from_pretrained("google/gemma-3-4b-pt", torch_dtype=torch.bfloat16)
     tok = AutoTokenizer.from_pretrained("google/gemma-3-4b-pt")
@@ -973,7 +951,7 @@ def gemma3_4b_pt_aligned_state_dict(pi06_untrained_policy):
     pol_n_patches = pi06_untrained_policy.model.gemma3_with_expert.gemma3.state_dict()[
         _SIGLIP_POS_EMBED_KEY
     ].shape[0]
-    state[_SIGLIP_POS_EMBED_KEY] = _bilinear_resample_pos_embed(
+    state[_SIGLIP_POS_EMBED_KEY] = bilinear_resample_pos_embed(
         state[_SIGLIP_POS_EMBED_KEY], target_num_patches=pol_n_patches
     )
     del model

--- a/tests/utils/test_vision_utils.py
+++ b/tests/utils/test_vision_utils.py
@@ -1,0 +1,68 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU unit tests for `opentau.utils.vision_utils`."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from opentau.utils.vision_utils import bilinear_resample_pos_embed
+
+
+class TestBilinearResamplePosEmbed:
+    def test_identity_when_same_size(self):
+        # No-op (and no copy) — caller relies on this to skip the resample
+        # when the published model already matches the policy's patch count.
+        pos = torch.randn(1024, 16)
+        out = bilinear_resample_pos_embed(pos, target_num_patches=1024)
+        assert out is pos
+
+    def test_downsamples_to_target_shape(self):
+        pos = torch.randn(4096, 8)  # 64×64
+        out = bilinear_resample_pos_embed(pos, target_num_patches=1024)  # 32×32
+        assert out.shape == (1024, 8)
+
+    def test_upsamples_to_target_shape(self):
+        pos = torch.randn(16, 4)  # 4×4
+        out = bilinear_resample_pos_embed(pos, target_num_patches=64)  # 8×8
+        assert out.shape == (64, 4)
+
+    def test_preserves_dtype(self):
+        # bf16 in, bf16 out — the published Gemma 3 weights are bf16, and the
+        # policy expects bf16 in its state_dict. F.interpolate computes in fp32
+        # internally and the helper casts back.
+        pos = torch.randn(64, 8, dtype=torch.bfloat16)
+        out = bilinear_resample_pos_embed(pos, target_num_patches=16)
+        assert out.dtype == torch.bfloat16
+
+    def test_deterministic(self):
+        # Two calls with the same input must return bit-identical output.
+        # Required for byte-equality tests against an independently-resampled
+        # reference (see test_pi06_untrained_siglip_matches_gemma3_4b_pt).
+        pos = torch.arange(64 * 8, dtype=torch.float32).reshape(64, 8)
+        out1 = bilinear_resample_pos_embed(pos, target_num_patches=16)
+        out2 = bilinear_resample_pos_embed(pos, target_num_patches=16)
+        assert torch.equal(out1, out2)
+
+    def test_rejects_non_square_source(self):
+        pos = torch.randn(7, 4)  # 7 is not a square
+        with pytest.raises(AssertionError, match="non-square source grid"):
+            bilinear_resample_pos_embed(pos, target_num_patches=4)
+
+    def test_rejects_non_square_target(self):
+        pos = torch.randn(4, 4)
+        with pytest.raises(AssertionError, match="non-square target grid"):
+            bilinear_resample_pos_embed(pos, target_num_patches=7)


### PR DESCRIPTION
## What this does

Closes part of #239 — adds tests that verify the just-published private `TensorAuto/pi06-untrained` checkpoint loads correctly via `PI06Policy.from_pretrained(...)` and that its VLM/SigLIP weights match `google/gemma-3-4b-pt` byte-for-byte. Building and pushing the actual checkpoint was done out-of-band with an ephemeral script; this PR carries the regression tests + two real OpenTau bug fixes that surfaced while bootstrapping it.

Three `gpu+slow` tests added in `tests/policies/test_pi06.py`:
- `test_pi06_untrained_loads_with_no_missing_or_unexpected_keys` — checkpoint round-trips with no real missing/unexpected keys (allowlists Gemma 3's tied embed_tokens/lm_head, which `save_model_as_safetensor` de-dupes on disk).
- `test_pi06_untrained_vlm_matches_gemma3_4b_pt` — Gemma 3 text tower + multimodal projector are bit-identical to the published VLM, modulo the deterministic `<locNNNN>` rows from `ensure_loc_tokens`.
- `test_pi06_untrained_siglip_matches_gemma3_4b_pt` — SigLIP vision tower bit-identical, modulo a deterministic bilinear resample of `position_embedding` from the published 4096 patches (896×896) down to π0.6's 1024 patches (448×448).

Two bug fixes folded in:
1. **`PreTrainedConfig._save_pretrained` was writing `config.json` without the `type` discriminator** because `draccus.dump(self, ...)` infers the declared type from the runtime class (already concrete) and skips the choice-type key. Result: the round-trip `save_pretrained → from_pretrained` was broken for every policy that uses `register_subclass`. Fix: encode with `declared_type=PreTrainedConfig` so draccus's `encode_choice` path runs. Existing published checkpoints (e.g. `lerobot/pi05_libero`) had the field, so this only manifested when a fresh build went through the standard API.
2. **No shared util for SigLIP position-embedding resampling.** Anyone bootstrapping a fresh untrained checkpoint from `google/gemma-3-4b-pt` (today π0.6; soon π0.7) needs to bilinearly resample `position_embedding` because the published checkpoint runs at 896×896 (4096 patches) while OpenTau policies run SigLIP at 448×448 (1024 patches). Extracted as `opentau.utils.vision_utils.bilinear_resample_pos_embed` with seven CPU unit tests in `tests/utils/test_vision_utils.py`. The π0.6 test fixture imports it; a future π0.7 build script can reuse it without re-implementing the recipe.

## How it was tested

- New CPU unit tests in `tests/utils/test_vision_utils.py` (7 tests, all passed locally).
- The three new `gpu+slow` tests in `tests/policies/test_pi06.py` were run on an internal GPU dev box against the just-published private repo — all three passed in 56s.
- Round-trip sanity: `PI06Policy(PI06Config())._save_pretrained(...)` followed by `PreTrainedConfig.from_pretrained(...)` returns a `PI06Config` instance (was previously raising `ParsingError` because `type` was missing from `config.json`).
- `pre-commit run --all-files` clean.

## How to checkout & try? (for the reviewer)

```bash
# CPU unit tests for the new util (fast, no network)
pytest -sx tests/utils/test_vision_utils.py

# Heavy tests: gpu+slow, downloads ~10 GB of weights (the private pi06-untrained
# repo and google/gemma-3-4b-pt). HF_TOKEN must be set and the user must have
# read access to TensorAuto/pi06-untrained.
HF_HUB_FORCE_DOWNLOAD=1 pytest -m "gpu and slow" \
    -k pi06_untrained tests/policies/test_pi06.py -v
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [x] My PR includes policy-related changes.
  - [x] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).