### PR TITLE
ci: gate workflows on org membership + allow claude[bot]

### DIFF
--- a/.github/workflows/check-pr-checklist.yml
+++ b/.github/workflows/check-pr-checklist.yml
@@ -23,6 +23,12 @@ permissions:
 
 jobs:
   check-checklist:
+    # Only validate checklists on PRs from trusted accounts. Outsider PRs
+    # require maintainer approval to run any workflow; the maintainer reads
+    # the PR body manually before approving.
+    if: >-
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+      || github.event.pull_request.user.login == 'claude[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Validate Checklist

--- a/.github/workflows/claude-implement-fixes.yml
+++ b/.github/workflows/claude-implement-fixes.yml
@@ -35,21 +35,37 @@ concurrency:
 
 jobs:
   implement:
+    # Trust gate per event source: only org owners/members/collaborators (or
+    # claude[bot]) may trigger `@claude fix`. This workflow has
+    # `contents: write` + bypassPermissions, so the blast radius for a wrong
+    # allow is high. The body-match `@claude fix` and the
+    # pull_request_review-late-gate (in the `Gate on @claude fix presence`
+    # step) are unchanged. The previous `user.type != 'Bot'` checks are
+    # subsumed by the positive author_association allowlist.
     if: >-
       (
         github.event_name == 'issue_comment'
         && github.event.issue.pull_request != null
         && contains(github.event.comment.body, '@claude fix')
-        && github.event.comment.user.type != 'Bot'
+        && (
+          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+          || github.event.comment.user.login == 'claude[bot]'
+        )
       )
       || (
         github.event_name == 'pull_request_review_comment'
         && contains(github.event.comment.body, '@claude fix')
-        && github.event.comment.user.type != 'Bot'
+        && (
+          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+          || github.event.comment.user.login == 'claude[bot]'
+        )
       )
       || (
         github.event_name == 'pull_request_review'
-        && github.event.review.user.type != 'Bot'
+        && (
+          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)
+          || github.event.review.user.login == 'claude[bot]'
+        )
       )
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -99,6 +115,9 @@ jobs:
         if: steps.gate.outputs.should_run == 'true'
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Match the bot allowlist in the job-level `if:` above. Never `*` on
+          # a public repo (per the action's docs warning).
+          allowed_bots: "claude[bot]"
           claude_args: |
             --model ${{ vars.CLAUDE_MODEL || 'claude-opus-4-7[1m]' }}
             --permission-mode bypassPermissions

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -31,13 +31,22 @@ permissions:
 
 jobs:
   review:
-    # Skip on `synchronize` when the pusher is a Claude bot — otherwise the
-    # implement-fixes workflow's pushes would re-trigger us in a loop and we'd
-    # end up reviewing our own fixes. Always run on `opened` (auto-reviewing a
-    # Claude-opened PR is the whole point of this workflow).
+    # Two gates AND'd together:
+    #   (1) Trust gate — only org owners/members/collaborators or claude[bot]
+    #       (which opens `chore(claude): learn from #N` PRs). author_association
+    #       is NONE for bots, so the login OR is required.
+    #   (2) Loop gate — on `synchronize` triggered by claude[bot] pushing a
+    #       fix commit (from claude-implement-fixes.yml), skip; otherwise we'd
+    #       review our own fixes ad infinitum. `opened` always passes.
     if: >-
-      github.event.action == 'opened'
-      || !contains(github.event.sender.login, 'claude')
+      (
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+        || github.event.pull_request.user.login == 'claude[bot]'
+      )
+      && (
+        github.event.action == 'opened'
+        || github.event.sender.login != 'claude[bot]'
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -49,6 +58,9 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Match the bot allowlist in the job-level `if:` above. Never `*` on
+          # a public repo (per the action's docs warning).
+          allowed_bots: "claude[bot]"
           claude_args: |
             --model ${{ vars.CLAUDE_MODEL || 'claude-opus-4-7[1m]' }}
             --permission-mode bypassPermissions

--- a/.github/workflows/cpu_test.yml
+++ b/.github/workflows/cpu_test.yml
@@ -37,6 +37,13 @@ env:
 
 jobs:
   cpu-tests:
+    # Block PRs from non-org accounts to keep fork code off our runners.
+    # `push` and `workflow_dispatch` already require write access, so the
+    # short-circuit lets them through unchanged.
+    if: >-
+      github.event_name != 'pull_request'
+      || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+      || github.event.pull_request.user.login == 'claude[bot]'
     name: CPU Tests
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/extract-claude-lessons.yml
+++ b/.github/workflows/extract-claude-lessons.yml
@@ -25,14 +25,23 @@ permissions:
 
 jobs:
   extract-lessons:
-    # Gate on the head branch name, not user.login: in this repo Claude Code
-    # pushes to a `claude/*` branch and a human opens the PR, so the PR's
-    # `user.login` never contains 'claude'. The branch prefix is the reliable
-    # signal that Claude touched the PR.
+    # Four AND'd gates:
+    #   (1) PR was merged.
+    #   (2) Head branch is `claude/*` (Claude Code touched it). Per #212,
+    #       this is the reliable signal even when a human opens the PR.
+    #   (3) Title isn't already a learn-from-N PR (avoid recursion).
+    #   (4) Trust: PR opener is org owner/member/collaborator OR claude[bot].
+    #       Defense-in-depth against an outside collaborator naming their
+    #       fork branch `claude/...` and getting a merge through.
+    #       author_association is NONE for bots, so the login OR is required.
     if: >-
       github.event.pull_request.merged == true
       && startsWith(github.event.pull_request.head.ref, 'claude/')
       && !startsWith(github.event.pull_request.title, 'chore(claude): learn from')
+      && (
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+        || github.event.pull_request.user.login == 'claude[bot]'
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -42,6 +51,9 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Match the bot allowlist in the job-level `if:` above. Never `*` on
+          # a public repo (per the action's docs warning).
+          allowed_bots: "claude[bot]"
           claude_args: |
             --model ${{ vars.CLAUDE_MODEL || 'claude-opus-4-7[1m]' }}
             --permission-mode bypassPermissions

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -23,6 +23,13 @@ permissions:
 
 jobs:
   pre-commit:
+    # Block PRs from non-org accounts to keep fork code off our runners.
+    # `push` already requires write access, so the short-circuit lets it
+    # through unchanged.
+    if: >-
+      github.event_name != 'pull_request'
+      || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+      || github.event.pull_request.user.login == 'claude[bot]'
     name: Pre-commit Hooks
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## What this does

Two coupled changes to `.github/workflows/`:

**1. Fixes the `review` job failure on #243.** The `claude-pr-review.yml` workflow on PR #243 (`chore(claude): learn from #242`, opened by `claude[bot]`) failed at the `anthropics/claude-code-action@v1` step with `Workflow initiated by non-human actor: claude (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.` The action's `allowed_bots` input defaults to `""` and rejects bot triggers. Fix: pass `allowed_bots: "claude[bot]"` on every claude-code-action step in the three Claude workflows.

**2. Restricts CI triggers to org members + claude[bot].** Previously any outside contributor could trigger CI by opening a PR or commenting `@claude fix`. For Claude workflows that meant burning Anthropic API credits with attacker-controlled prompts under `--permission-mode bypassPermissions`; for `cpu_test.yml` / `pre-commit.yml` it meant executing fork code on our runners. Six workflows now gate on `github.<event>.<x>.author_association ∈ {OWNER, MEMBER, COLLABORATOR}` OR login `== 'claude[bot]'` (the bot account that opens our `chore(claude): learn from #N` PRs). `push` and `workflow_dispatch` events are short-circuited through (already require write access).

Files touched (all `.github/workflows/`):
- `claude-pr-review.yml` — trust gate + loop guard tightened to exact `claude[bot]` match + `allowed_bots: "claude[bot]"`.
- `claude-implement-fixes.yml` — trust gate per event source (`issue_comment`, `pull_request_review_comment`, `pull_request_review`); old `user.type != 'Bot'` checks dropped (subsumed) + `allowed_bots: "claude[bot]"`.
- `extract-claude-lessons.yml` — defense-in-depth trust check appended to existing branch-name gate + `allowed_bots: "claude[bot]"`.
- `cpu_test.yml`, `pre-commit.yml` — job-level `if:` gating PR events only.
- `check-pr-checklist.yml` — job-level `if:` gating PR events.

Out of scope: `gpu_test.yml`, `regression_test.yml`, `build-docker-images.yml` (schedule + workflow_dispatch only), `publish-pypi.yml` (tag push only). Bot allowlist is `claude[bot]` only — no `dependabot[bot]`, no `*` (public-repo risk per the action's docs).

## How it was tested

- `pre-commit run --files .github/workflows/*.yml` — passes (yaml-lint, zizmor GitHub Actions security scanner, gitleaks, typos).
- Trace-through verification of the `if:` predicates against each event payload's `author_association` / `user.login` paths (paths confirmed against existing usages in the same files).
- Loop-guard scenario walked: `opened` short-circuits true (auto-review of claude[bot]-opened PRs); `synchronize` from `claude[bot]` push evaluates `sender.login != 'claude[bot]'` to false → skipped.
- Live verification (after merge) per the plan's verification checklist:
  1. Next `chore(claude): learn from #N` PR auto-review must succeed (no more "Add bot to allowed_bots list" error).
  2. Outsider PR must show all four PR-event workflows as skipped.
  3. Member `@claude fix` must trigger `claude-implement-fixes.yml`; outsider `@claude fix` must not.

## How to checkout & try? (for the reviewer)

```bash
git fetch origin claude/fix-ci-restrict-access-jjYFO
git checkout claude/fix-ci-restrict-access-jjYFO
git diff main -- .github/workflows/
```

Inspect each workflow's job-level `if:` and the `allowed_bots:` line on each `anthropics/claude-code-action@v1` step.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SgQq7eAmFdLKwRVqPqFQCf)_