### PR TITLE
ci: remove concurrency group from cpu_test workflow

### DIFF
--- a/.github/workflows/cpu_test.yml
+++ b/.github/workflows/cpu_test.yml
@@ -22,10 +22,6 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: cpu-test-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: true
-
 env:
   GIT_LFS_SKIP_SMUDGE: "1"
   GIT_CLEAN_FLAGS: "-ffdx -e .venv/"


### PR DESCRIPTION
## What this does
Removes the `concurrency` block from `.github/workflows/cpu_test.yml`. With `cancel-in-progress: true`, every superseded run on a PR was reported as a failed status check, making PRs look red even when the underlying tests would have passed on a fresh run.

## How it was tested
No code paths changed — workflow-config-only edit. Verified the YAML still parses by running pre-commit (`check yaml`, `zizmor`, etc. all pass). CI on this PR will exercise the new behavior end-to-end.

## How to checkout & try? (for the reviewer)
```bash
git fetch origin claude/remove-ci-concurrency-group-M1XFL
git checkout claude/remove-ci-concurrency-group-M1XFL
git diff main -- .github/workflows/cpu_test.yml
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).


---
_Generated by [Claude Code](https://claude.ai/code/session_017EHj3GSR73JvBYXiRhdFcS)_