### PR TITLE
ci: review [claude-fix] commits; bar bots from triggering @claude fix

### DIFF
--- a/.github/workflows/claude-implement-fixes.yml
+++ b/.github/workflows/claude-implement-fixes.yml
@@ -35,37 +35,31 @@ concurrency:
 
 jobs:
   implement:
-    # Trust gate per event source: only org owners/members/collaborators (or
-    # claude[bot]) may trigger `@claude fix`. This workflow has
-    # `contents: write` + bypassPermissions, so the blast radius for a wrong
-    # allow is high. The body-match `@claude fix` and the
-    # pull_request_review-late-gate (in the `Gate on @claude fix presence`
-    # step) are unchanged. The previous `user.type != 'Bot'` checks are
-    # subsumed by the positive author_association allowlist.
+    # Trust gate per event source: only humans (user.type == 'User') with
+    # OWNER/MEMBER/COLLABORATOR association on this repo may trigger
+    # `@claude fix`. Bots — including claude[bot] — are NOT permitted to
+    # trigger; this also closes the only realistic review→fix loop, since a
+    # `@claude fix` string in a claude[bot] review summary can no longer fire
+    # this workflow. This workflow holds `contents: write` + bypassPermissions,
+    # so the blast radius for a wrong allow is high.
     if: >-
       (
         github.event_name == 'issue_comment'
         && github.event.issue.pull_request != null
+        && github.event.comment.user.type == 'User'
         && contains(github.event.comment.body, '@claude fix')
-        && (
-          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
-          || github.event.comment.user.login == 'claude[bot]'
-        )
+        && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
       )
       || (
         github.event_name == 'pull_request_review_comment'
+        && github.event.comment.user.type == 'User'
         && contains(github.event.comment.body, '@claude fix')
-        && (
-          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
-          || github.event.comment.user.login == 'claude[bot]'
-        )
+        && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
       )
       || (
         github.event_name == 'pull_request_review'
-        && (
-          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)
-          || github.event.review.user.login == 'claude[bot]'
-        )
+        && github.event.review.user.type == 'User'
+        && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)
       )
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -115,8 +109,11 @@ jobs:
         if: steps.gate.outputs.should_run == 'true'
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          # Match the bot allowlist in the job-level `if:` above. Never `*` on
-          # a public repo (per the action's docs warning).
+          # No bot can TRIGGER this workflow (per the job-level `if:` above).
+          # `allowed_bots` here governs which bot-authored comments the agent
+          # treats as trusted input while resolving feedback — claude[bot]
+          # review summaries remain trustworthy in that role. Never `*` on a
+          # public repo (per the action's docs warning).
           allowed_bots: "claude[bot]"
           claude_args: |
             --model ${{ vars.CLAUDE_MODEL || 'claude-opus-4-7[1m]' }}

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -31,22 +31,20 @@ permissions:
 
 jobs:
   review:
-    # Two gates AND'd together:
-    #   (1) Trust gate — only org owners/members/collaborators or claude[bot]
-    #       (which opens `chore(claude): learn from #N` PRs). author_association
-    #       is NONE for bots, so the login OR is required.
-    #   (2) Loop gate — on `synchronize` triggered by claude[bot] pushing a
-    #       fix commit (from claude-implement-fixes.yml), skip; otherwise we'd
-    #       review our own fixes ad infinitum. `opened` always passes.
+    # Trust gate — only org owners/members/collaborators or claude[bot]
+    # (which opens `chore(claude): learn from #N` PRs). author_association
+    # is NONE for bots, so the login OR is required.
+    #
+    # Note: we deliberately DO NOT skip when github.event.sender is claude[bot].
+    # Each review invocation is a fresh claude-code-action session, so reviewing
+    # a `[claude-fix]` commit is just a normal review with no shared context —
+    # and that fresh-eyes pass is exactly what we want on bot-authored fixes.
+    # The previously-feared review→fix loop requires a review comment to
+    # contain the literal `@claude fix`; the prompt template below never emits
+    # that string, so the loop is not reachable in practice.
     if: >-
-      (
-        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
-        || github.event.pull_request.user.login == 'claude[bot]'
-      )
-      && (
-        github.event.action == 'opened'
-        || github.event.sender.login != 'claude[bot]'
-      )
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+      || github.event.pull_request.user.login == 'claude[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
## What this does

Two coordinated changes to the Claude bot workflows that tighten their trust gates:

1. **`claude-pr-review.yml`** — drop the loop gate that skipped review on `synchronize` events triggered by `claude[bot]`. From now on, when `claude-implement-fixes.yml` pushes a `[claude-fix]` commit to a PR, Claude PR Review runs against that commit and posts a fresh-eyes summary instead of being silently skipped. Each review run is a brand-new `claude-code-action` session with no shared state, so reviewing a bot-authored fix is just a normal review by an independent reviewer.

2. **`claude-implement-fixes.yml`** — bar bots from triggering `@claude fix` at all. Drop the `|| user.login == 'claude[bot]'` clauses from every event branch and require `user.type == 'User'`. The `OWNER`/`MEMBER`/`COLLABORATOR` author_association allowlist is unchanged.

Together: every `[claude-fix]` commit gets reviewed, **and** no fix run can be initiated by a bot. Change #2 is what makes change #1 safe by construction — the previously-feared review→fix loop required a review comment by `claude[bot]` containing the literal string `@claude fix` to fire the fix workflow, and after change #2 that path is closed regardless of what the review prompt happens to emit.

### claude-pr-review.yml — drop the loop gate

Before:
```yaml
if: >-
  (
    contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
    || github.event.pull_request.user.login == 'claude[bot]'
  )
  && (
    github.event.action == 'opened'
    || github.event.sender.login != 'claude[bot]'
  )
```

After:
```yaml
if: >-
  contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
  || github.event.pull_request.user.login == 'claude[bot]'
```

Only the loop gate is removed; the trust gate is unchanged. `concurrency.cancel-in-progress: true` still kills a stale review when a newer push arrives, so back-to-back fixes don't pile up parallel reviews.

### claude-implement-fixes.yml — bots cannot trigger

For each of the three event branches (`issue_comment`, `pull_request_review_comment`, `pull_request_review`):

- Remove `|| user.login == 'claude[bot]'`.
- Add `github.event.<comment|review>.user.type == 'User'` as defense-in-depth against any `Bot` / `Mannequin` / GitHub App that might somehow earn `MEMBER`/`COLLABORATOR` association.
- Updated the comment block above the `if:` and the `allowed_bots` comment to reflect that no bot can trigger any longer. The `allowed_bots: "claude[bot]"` value on `claude-code-action` is **kept** — that field controls which bot-authored comments the agent treats as trusted *input* while resolving feedback (so `claude[bot]` review summaries remain readable), not who can trigger.

Per maintainer feedback, this PR does **not** add a per-actor `gh api repos/{repo}/collaborators/{login}/permission` write-access verification step. The `OWNER`/`MEMBER`/`COLLABORATOR` allowlist is treated as the right floor.

### Effect on each event path

claude-pr-review.yml:
- `pull_request.opened` by member → reviews. **Unchanged.**
- `pull_request.synchronize` by member → reviews. **Unchanged.**
- `pull_request.synchronize` by `claude[bot]` pushing a `[claude-fix]` commit → **now reviews** (was skipped). This is the goal.
- `pull_request.opened` by `claude[bot]` (the lessons-extraction PRs) → reviews. **Unchanged.**

claude-implement-fixes.yml:
- Outside contributor with `@claude fix` → rejected at job `if:` (association `NONE` / `CONTRIBUTOR`). **Unchanged.**
- Org member or repo collaborator with `@claude fix` → fires. **Unchanged.**
- `claude[bot]` posting `@claude fix` (e.g. inside a review summary) → rejected (`User` type fails for `Bot`, and the bot OR is gone). **Newly rejected** — closes the loop hazard.
- Any `Bot` / `Mannequin` / GitHub App that earned `MEMBER` association → rejected by the `user.type == 'User'` check. **Newly rejected** (defense-in-depth).

## How it was tested

- `uvx pre-commit run --files .github/workflows/claude-pr-review.yml .github/workflows/claude-implement-fixes.yml` — all hooks pass on both files (including `zizmor`, `check yaml`, `typos`, `gitleaks`).
- Logic walk-through against every event path each workflow listens for, with PR #250's actual events as the worked example for the review-skip fix.
- No code paths touched, so no unit tests apply. `cpu_test.yml` still runs on this PR.

## How to checkout & try? (for the reviewer)

```bash
git fetch origin && git checkout claude/investigate-ci-skip-WOH2L
git diff main -- .github/workflows/claude-pr-review.yml .github/workflows/claude-implement-fixes.yml
```

To observe the new behavior end-to-end after merge: open any PR, leave a `@claude fix` comment from your account, and confirm (a) the resulting `[claude-fix]` push triggers a Claude PR Review run that posts a summary (instead of being marked `skipped`), and (b) `claude[bot]` posting a `@claude fix` string in any of its own comments does **not** trigger the fix workflow.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.
