### PR TITLE
ci: restrict @claude fix to humans with repo write access

### DIFF
--- a/.github/workflows/claude-implement-fixes.yml
+++ b/.github/workflows/claude-implement-fixes.yml
@@ -35,37 +35,33 @@ concurrency:
 
 jobs:
   implement:
-    # Trust gate per event source: only org owners/members/collaborators (or
-    # claude[bot]) may trigger `@claude fix`. This workflow has
-    # `contents: write` + bypassPermissions, so the blast radius for a wrong
-    # allow is high. The body-match `@claude fix` and the
-    # pull_request_review-late-gate (in the `Gate on @claude fix presence`
-    # step) are unchanged. The previous `user.type != 'Bot'` checks are
-    # subsumed by the positive author_association allowlist.
+    # Trust gate per event source: only humans (user.type == 'User') with
+    # MEMBER/OWNER/COLLABORATOR association may trigger `@claude fix`. The
+    # author_association allowlist is a cheap pre-filter — it does NOT prove
+    # write access (a MEMBER may be an org member with no team binding, and a
+    # COLLABORATOR may have read/triage). The `Verify actor has write access`
+    # step below makes the actual write/admin check via the collaborators API
+    # before any privileged work runs. This workflow holds `contents: write`
+    # + bypassPermissions, so the blast radius for a wrong allow is high;
+    # bots (including claude[bot]) are NOT permitted to trigger.
     if: >-
       (
         github.event_name == 'issue_comment'
         && github.event.issue.pull_request != null
+        && github.event.comment.user.type == 'User'
         && contains(github.event.comment.body, '@claude fix')
-        && (
-          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
-          || github.event.comment.user.login == 'claude[bot]'
-        )
+        && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
       )
       || (
         github.event_name == 'pull_request_review_comment'
+        && github.event.comment.user.type == 'User'
         && contains(github.event.comment.body, '@claude fix')
-        && (
-          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
-          || github.event.comment.user.login == 'claude[bot]'
-        )
+        && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
       )
       || (
         github.event_name == 'pull_request_review'
-        && (
-          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)
-          || github.event.review.user.login == 'claude[bot]'
-        )
+        && github.event.review.user.type == 'User'
+        && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)
       )
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -75,6 +71,28 @@ jobs:
       issues: write
       id-token: write  # claude-code-action does an OIDC handshake at startup
     steps:
+      # The job-level if: filters by author_association (cheap, no API call),
+      # but MEMBER/COLLABORATOR do not strictly imply write permission. This
+      # step asserts that github.actor actually has admin or write on this
+      # repo before any privileged step runs.
+      - name: Verify actor has write access
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+          PERM=$(gh api "repos/${REPO}/collaborators/${ACTOR}/permission" --jq '.permission')
+          case "$PERM" in
+            admin|write)
+              echo "actor ${ACTOR} has '${PERM}' permission — proceeding"
+              ;;
+            *)
+              echo "::error::actor ${ACTOR} permission is '${PERM}'; require admin or write"
+              exit 1
+              ;;
+          esac
+
       # For pull_request_review.submitted, scan the review's line comments
       # (which the event payload does not include) for the trigger phrase.
       # If absent, exit before paying for a Claude run. For comment events,
@@ -115,8 +133,11 @@ jobs:
         if: steps.gate.outputs.should_run == 'true'
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          # Match the bot allowlist in the job-level `if:` above. Never `*` on
-          # a public repo (per the action's docs warning).
+          # The job-level `if:` no longer trusts any bot to TRIGGER this
+          # workflow. `allowed_bots` here governs which bot-authored comments
+          # the agent reads as trusted input while resolving feedback —
+          # claude[bot] review summaries are still trustworthy in that role.
+          # Never `*` on a public repo (per the action's docs warning).
           allowed_bots: "claude[bot]"
           claude_args: |
             --model ${{ vars.CLAUDE_MODEL || 'claude-opus-4-7[1m]' }}


### PR DESCRIPTION
## What this does

Tightens the trigger gate on `.github/workflows/claude-implement-fixes.yml` so only **real humans with `admin` or `write` access on this repo** can fire `@claude fix`. The workflow holds `contents: write` + `bypassPermissions` and runs an unattended Claude session that pushes back to the PR branch — that's the correct floor for who's allowed to invoke it.

### What was loose before

For each of the three trigger events (`issue_comment.created`, `pull_request_review_comment.created`, `pull_request_review.submitted`) the job-level `if:` was:

```yaml
contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), <author_association>)
|| <user.login> == 'claude[bot]'
```

Two gaps vs. "humans with write access":

1. **Bots could trigger.** The `|| user.login == 'claude[bot]'` clauses meant a comment from `claude[bot]` containing `@claude fix` (e.g. its own review summary) would fire the workflow.
2. **`MEMBER` / `COLLABORATOR` does not imply write.** `MEMBER` is "in the org that owns the repo" — an org member with no team binding has read on public repos. `COLLABORATOR` is anyone invited at any level (read / triage / write / maintain / admin). `author_association` cannot prove write; only `GET /repos/{owner}/{repo}/collaborators/{login}/permission` can.

### What changed

Three layered checks, applied uniformly to all three event branches:

1. **Drop the bot OR.** `|| user.login == 'claude[bot]'` removed from every event branch.
2. **Require `user.type == 'User'`.** Cheap field check that excludes bots/apps before any API call. Even if a bot somehow gets `MEMBER`/`COLLABORATOR` association, this rejects it.
3. **Add `Verify actor has write access` step.** Calls `gh api repos/${{ github.repository }}/collaborators/${ACTOR}/permission --jq .permission`. Exits non-zero unless the result is `admin` or `write`. Runs before `Gate on @claude fix presence`, so a wrong allow exits before the Claude session ever starts.

`author_association` allowlist is preserved as a cheap pre-filter (avoids burning an API request on every drive-by external commenter), and the body-match for `@claude fix` is unchanged.

The `allowed_bots: "claude[bot]"` setting on `claude-code-action` is **kept** with an updated comment — that field controls which bot-authored comments the agent treats as trusted input *while resolving feedback*, not who can trigger. `claude[bot]` review summaries are still legitimate input in that role; `claude[bot]` just cannot start a fix run.

### Effect on each trigger path

- Outside contributor with `@claude fix` → rejected at job `if:` (association `NONE` / `CONTRIBUTOR`). **Unchanged.**
- Org member with read-only access → passes job `if:` (`MEMBER` association, `User` type), but `Verify actor has write access` exits with permission `read`. **Newly rejected.**
- Repo collaborator with `triage` or `read` permission → same as above, rejected at the verify step. **Newly rejected.**
- Repo collaborator with `write` or `admin` permission → passes both gates. **Unchanged.**
- `claude[bot]` posting `@claude fix` (e.g. inside a review summary) → rejected at job `if:` (`User` type fails for `Bot`, and the bot OR is gone). **Newly rejected** — closes the loop hazard called out in #251.
- Any `Bot`/`Mannequin`/GitHub App that earned `MEMBER` association → rejected by the `user.type == 'User'` check. **Newly rejected** (defense-in-depth).

## How it was tested

- `uvx pre-commit run --files .github/workflows/claude-implement-fixes.yml` — all hooks pass, including `zizmor` (GH Actions security linter) and `check yaml`.
- Logic walk-through (above) against each event branch and each user class.
- The `gh api repos/{repo}/collaborators/{login}/permission` endpoint requires only the "Metadata: read" permission that the default `GITHUB_TOKEN` already carries on this repo, so no permission bump in `permissions:` was needed.
- End-to-end behavior is observable post-merge: a normal write-access member's `@claude fix` comment still fires; any other actor's `@claude fix` is now ignored or fails with an explicit `::error::actor X permission is 'read'; require admin or write` annotation.

## How to checkout & try? (for the reviewer)

```bash
git fetch origin && git checkout ci/claude-fix-write-access-only
git diff main -- .github/workflows/claude-implement-fixes.yml
```

To exercise it after merge: drop a comment containing `@claude fix` from your own account on any open PR and confirm the workflow runs as expected. To exercise the negative path safely, ask a triage-only collaborator (or temporarily downgrade your own permission on a fork) to comment `@claude fix` and verify the run fails at `Verify actor has write access` with the expected error annotation.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.


---
_Generated by [Claude Code](https://claude.ai/code/session_011aCyxu1YjKCYyBgWPbBgs6)_