### PR TITLE
fix(pi05_mem): mask padded history; preserve current state token; emit at inference

### DIFF
--- a/src/opentau/policies/pi05_mem/modeling_pi05.py
+++ b/src/opentau/policies/pi05_mem/modeling_pi05.py
@@ -418,8 +418,12 @@ class PI05MemPolicy(PreTrainedPolicy):
 
         Appends the single-frame observation from ``batch`` to internal deque
         buffers, then assembles a batch with ``n_obs_steps`` evenly-spaced
-        frames (interval = ``history_interval``).  Early in an episode, missing
-        history slots are zero-padded.
+        frames (interval = ``history_interval``). Early in an episode the
+        buffer is partially filled, so some slots are zero-padded; the
+        returned ``"obs_history_is_pad"`` (B, T) bool tensor flags those
+        slots ``True`` so the model can mask them out of attention. Once the
+        buffer is full (typically a handful of steps in), the mask is all
+        ``False`` and the encoder uses the real history.
 
         Expected batch keys:
             - ``"state"``: (B, D) current proprioceptive state.
@@ -427,8 +431,9 @@ class PI05MemPolicy(PreTrainedPolicy):
             - ``"prompt"``: list[str] language instructions (passed through unchanged).
             - Any other metadata keys are forwarded unchanged.
 
-        Returns a new dict with ``"state"`` expanded to (B, T, D) and image keys
-        expanded to (B, T, C, H, W), where T = ``n_obs_steps``.
+        Returns a new dict with ``"state"`` expanded to (B, T, D), image keys
+        expanded to (B, T, C, H, W), and a new ``"obs_history_is_pad"`` (B, T)
+        bool tensor (``True`` = padded). T = ``n_obs_steps``.
         """
         n_hist: int = self.config.n_obs_steps
         interval = self.config.history_interval or 1
@@ -452,6 +457,8 @@ class PI05MemPolicy(PreTrainedPolicy):
         # sample n_hist frames at the configured interval
         buf_len = len(self._state_buffer)
         missing = buf_maxlen - buf_len  # how many slots are still empty
+        bsize = batch["state"].shape[0]
+        device = batch["state"].device
 
         # Pass through all non-image, non-state keys (e.g. "prompt" and other metadata).
         temporal_batch = {key: v for key, v in batch.items() if key not in img_keys and key != "state"}
@@ -476,6 +483,21 @@ class PI05MemPolicy(PreTrainedPolicy):
                 else:
                     cam_frames.append(self._obs_buffers[key][idx])
             temporal_batch[key] = torch.stack(cam_frames, dim=1)  # (B, T, C, H, W)
+
+        # Same `idx < 0` decision as the loops above: a slot is padded iff the
+        # buffer didn't have an entry to fill it. The pattern is identical
+        # for state and every camera (they share the same buffer length), so
+        # we emit one (B, T) mask. Broadcast across batch — every sample sees
+        # the same padding pattern at any given step. Without this, the
+        # encoder's None-fallback masks ALL history at inference (including
+        # genuine mid-episode frames once the buffer is full); with it, only
+        # the actually-padded start-of-episode slots get masked.
+        pad_pattern = torch.tensor(
+            [i * interval - missing < 0 for i in range(n_hist)],
+            dtype=torch.bool,
+            device=device,
+        )
+        temporal_batch["obs_history_is_pad"] = pad_pattern.unsqueeze(0).expand(bsize, n_hist)
 
         return temporal_batch
 
@@ -524,7 +546,12 @@ class PI05MemPolicy(PreTrainedPolicy):
 
         batch = self.normalize_inputs(batch)
 
-        videos, vid_masks = self.prepare_videos(batch)
+        # `_build_history_batch` (called from `select_action` upstream) emits
+        # this; it's None when the caller skipped that step (e.g. n_obs_steps
+        # is 1, or sample_actions is invoked directly without the buffer).
+        obs_history_is_pad = batch.get("obs_history_is_pad")
+
+        videos, vid_masks = self.prepare_videos(batch, obs_history_is_pad=obs_history_is_pad)
         lang_tokens, lang_masks = self.prepare_language(batch)
         state = self.prepare_state(batch)
 
@@ -565,6 +592,7 @@ class PI05MemPolicy(PreTrainedPolicy):
             action_prefix,
             delay,
             noise=noise,
+            obs_history_is_pad=obs_history_is_pad,
         )
 
         action_feature = self.config.action_feature
@@ -824,7 +852,7 @@ class PI05MemFlowMatching(nn.Module):
         time = time_beta * 0.999 + 0.001
         return time
 
-    def embed_video(self, video: Tensor) -> Tensor:
+    def embed_video(self, video: Tensor, obs_history_is_pad: Tensor | None = None) -> Tensor:
         """Encode a video through the space-time SigLIP video encoder.
 
         The encoder applies standard SigLIP spatial attention on every layer
@@ -834,11 +862,18 @@ class PI05MemFlowMatching(nn.Module):
 
         Args:
             video: (B, T, C, H, W) pixel values in [0, 1].
+            obs_history_is_pad: Optional ``(B, T)`` bool mask — ``True`` for
+                padded history frames. Threaded into the SpaceTime SigLIP
+                encoder so temporal attention blocks padded frames (pixel-
+                zeroing alone is insufficient — the patch embedding bias and
+                temporal PE for ``t < T-1`` are non-zero, so zero pixels
+                still produce non-zero hidden states the current frame would
+                otherwise attend to).
 
         Returns:
             (B, num_video_tokens, vlm_hidden_size) current-frame tokens.
         """
-        return self.video_encoder(video)
+        return self.video_encoder(video, obs_history_is_pad=obs_history_is_pad)
 
     def embed_prefix(
         self,
@@ -876,7 +911,7 @@ class PI05MemFlowMatching(nn.Module):
         bsize = lang_tokens.shape[0]
 
         for vid, vid_mask in zip(videos, vid_masks, strict=False):
-            vid_emb = self.embed_video(vid)  # (B, num_video_tokens, vlm_hidden)
+            vid_emb = self.embed_video(vid, obs_history_is_pad=obs_history_is_pad)
             vid_emb = vid_emb.to(dtype=_preferred_dtype())
 
             num_vid_embs = vid_emb.shape[1]
@@ -902,9 +937,19 @@ class PI05MemFlowMatching(nn.Module):
         state_emb = self.state_proj(state.to(dtype=_preferred_dtype()))
         num_state_tokens = state_emb.shape[1]  # T
         if obs_history_is_pad is not None:
-            state_mask = ~obs_history_is_pad  # True = real, False = padded
+            state_mask = ~obs_history_is_pad  # (B, T) — `~` allocates a fresh tensor
         else:
-            state_mask = torch.ones(bsize, num_state_tokens, dtype=torch.bool, device=state.device)
+            # Absent → assume all history is padded; only current step is real.
+            state_mask = torch.zeros(bsize, num_state_tokens, dtype=torch.bool, device=state.device)
+        # Current step (t = T-1) is ALWAYS real even when the dataset's
+        # history_state_drop_prob augmentation flips obs_history_is_pad to
+        # all-True. Without this override the policy would condition on no
+        # state at all, since attention to the current state token would be
+        # masked out — defeating the purpose of preserving the current frame.
+        # Both branches above produce fresh tensors (`~` allocates;
+        # `torch.zeros` allocates), so the `[:, -1] = True` write below does
+        # not reach the caller's `obs_history_is_pad`.
+        state_mask[:, -1] = True
 
         embs.append(state_emb)
         pad_masks.append(state_mask)
@@ -1107,8 +1152,19 @@ class PI05MemFlowMatching(nn.Module):
         action_prefix: Tensor,
         delay: Tensor,
         noise: Tensor | None = None,
+        obs_history_is_pad: Tensor | None = None,
     ) -> Tensor:
-        """Do a full inference forward and compute the action."""
+        """Do a full inference forward and compute the action.
+
+        Args:
+            obs_history_is_pad: Optional ``(B, T)`` bool mask flagging padded
+                history slots (``True`` = padded). Emitted by
+                ``PI05MemPolicy._build_history_batch`` so the encoder can use
+                real mid-episode history while still masking out the
+                start-of-episode zero-fill. ``None`` falls back to "all
+                history padded except current" via ``embed_prefix`` and the
+                encoder's None-fallback.
+        """
         bsize = lang_tokens.shape[0]
         device = lang_tokens.device
 
@@ -1117,7 +1173,12 @@ class PI05MemFlowMatching(nn.Module):
             noise = self.sample_noise(actions_shape, device)
 
         prefix_embs, prefix_pad_masks, prefix_att_masks = self.embed_prefix(
-            videos, vid_masks, lang_tokens, lang_masks, state
+            videos,
+            vid_masks,
+            lang_tokens,
+            lang_masks,
+            state,
+            obs_history_is_pad=obs_history_is_pad,
         )
         prefix_att_2d_masks = make_att_2d_masks(prefix_pad_masks, prefix_att_masks)
         prefix_position_ids = torch.cumsum(prefix_pad_masks, dim=1) - 1

--- a/src/opentau/policies/pi05_mem/video_encoder.py
+++ b/src/opentau/policies/pi05_mem/video_encoder.py
@@ -130,8 +130,16 @@ class _TemporalSelfAttention(nn.Module):
     def attn(self) -> SiglipAttention:
         return self._attn_ref[0]
 
-    def forward(self, hidden_states: Tensor) -> Tensor:
-        """hidden_states: (B*N, T, D) -> (B*N, T, D)."""
+    def forward(self, hidden_states: Tensor, temporal_attn_mask: Tensor | None = None) -> Tensor:
+        """hidden_states: (B*N, T, D) -> (B*N, T, D).
+
+        Args:
+            hidden_states: ``(B*N, T, D)`` hidden states reshaped for temporal
+                attention (one sequence per spatial patch position).
+            temporal_attn_mask: Optional ``(B*N, 1, T, T)`` additive float mask.
+                ``0.0`` = attend, ``-inf`` = block. When ``None``, falls back to
+                the standard causal lower-triangular mask via ``is_causal=True``.
+        """
         attn = self.attn
         bn, t, d = hidden_states.shape
         num_heads = attn.num_heads
@@ -141,11 +149,19 @@ class _TemporalSelfAttention(nn.Module):
         k = attn.k_proj(hidden_states).view(bn, t, num_heads, head_dim).transpose(1, 2)
         v = attn.v_proj(hidden_states).view(bn, t, num_heads, head_dim).transpose(1, 2)
 
-        # is_causal=True -> lower-triangular mask, each position attends to
-        # itself and earlier positions (our convention: t=T-1 is current).
-        out = F.scaled_dot_product_attention(
-            q, k, v, attn_mask=None, is_causal=True, dropout_p=0.0, scale=attn.scale
-        )
+        if temporal_attn_mask is not None:
+            # Caller-supplied mask already encodes both causal AND padded-history
+            # blocking; do NOT also set is_causal=True (SDPA disallows combining
+            # the two).
+            out = F.scaled_dot_product_attention(
+                q, k, v, attn_mask=temporal_attn_mask, is_causal=False, dropout_p=0.0, scale=attn.scale
+            )
+        else:
+            # is_causal=True -> lower-triangular mask, each position attends to
+            # itself and earlier positions (our convention: t=T-1 is current).
+            out = F.scaled_dot_product_attention(
+                q, k, v, attn_mask=None, is_causal=True, dropout_p=0.0, scale=attn.scale
+            )
         out = out.transpose(1, 2).reshape(bn, t, d)
         return attn.out_proj(out)
 
@@ -262,11 +278,20 @@ class SpaceTimeEncoderLayerWrapper(nn.Module):
         hidden_states: Tensor,
         attention_mask: Optional[Tensor] = None,
         output_attentions: bool = False,
+        temporal_attn_mask: Tensor | None = None,
     ) -> tuple[Tensor, ...]:
         """hidden_states: (B*T, N, D) -> tuple starting with (B*T, N, D).
 
-        Signature matches ``SiglipEncoderLayer.forward`` so ``SiglipEncoder``
-        can dispatch unchanged.
+        Signature extends ``SiglipEncoderLayer.forward`` with an extra
+        ``temporal_attn_mask`` kwarg. Vanilla ``SiglipEncoderLayer`` instances
+        never receive it: ``SpaceTimeSiglipVideoEncoder.forward`` dispatches
+        it only to ``SpaceTimeEncoderLayerWrapper`` instances via an
+        ``isinstance`` check, bypassing ``SiglipEncoder.forward`` entirely.
+
+        Args:
+            temporal_attn_mask: Optional ``(B*N, 1, T, T)`` additive float mask
+                for temporal attention. ``0.0`` = attend, ``-inf`` = block.
+                When ``None``, the standard causal mask is used.
         """
         t = self.num_frames
         bt, n, d = hidden_states.shape
@@ -301,7 +326,7 @@ class SpaceTimeEncoderLayerWrapper(nn.Module):
 
         t_in = rearrange(x_pe, "b t n d -> (b n) t d")
         t_norm = self.layer_norm1(t_in)
-        t_out = self._temporal_attn(t_norm)
+        t_out = self._temporal_attn(t_norm, temporal_attn_mask=temporal_attn_mask)
         # Residual on the pre-PE hidden (not on x_pe): PE is a transient
         # positional signal, not a feature perturbation to carry forward.
         t_res = rearrange(x, "b t n d -> (b n) t d") + t_out
@@ -397,13 +422,80 @@ class SpaceTimeSiglipVideoEncoder(nn.Module):
     def multi_modal_projector(self) -> PaliGemmaMultiModalProjector:
         return self._multi_modal_projector_ref[0]
 
-    def forward(self, video: Tensor) -> Tensor:
+    @staticmethod
+    def _build_temporal_attn_mask(
+        obs_history_is_pad: Tensor,
+        num_patches: int,
+        dtype: torch.dtype,
+    ) -> Tensor:
+        """Build a causal temporal attention mask that blocks padded frames.
+
+        Pure pixel-level zeroing of padded frames is not enough — the SigLIP
+        patch embedding has a learned bias and the temporal positional
+        embedding ``e(t)`` is non-zero for ``t < T-1``, so padded "zero" frames
+        still produce non-zero hidden states that the current frame would
+        attend to. This mask blocks attention to padded keys at the SDPA call.
+
+        Args:
+            obs_history_is_pad: ``(B, T)`` bool — ``True`` for padded steps.
+            num_patches: ``N``, number of spatial patches per frame (the
+                video encoder runs one temporal sequence per patch position,
+                so each patch row of the (B*N) batch reuses the same mask).
+            dtype: Float dtype matching the hidden states (additive mask gets
+                added to attention scores; mismatched dtypes force upcasts).
+
+        Returns:
+            ``(B*N, 1, T, T)`` additive float mask where ``0.0`` = attend and
+            ``-inf`` = block. Row ``i`` can attend to column ``j`` iff
+            ``j <= i`` (causal) **and** ``obs_history_is_pad[:, j]`` is
+            ``False``. The current frame (``j = T-1``) is always attendable
+            even if the caller set ``obs_history_is_pad[:, -1] = True`` —
+            losing the current frame would defeat the encoder.
+        """
+        b, t = obs_history_is_pad.shape
+        device = obs_history_is_pad.device
+
+        # Causal: position i attends to j <= i.
+        causal = torch.tril(torch.ones(t, t, dtype=torch.bool, device=device))  # (T, T)
+
+        # Key-side visibility: True where frame j is real (not padded).
+        # Force the last frame always attendable as a defensive fallback —
+        # callers (e.g. the dataset's history_state_drop_prob augmentation)
+        # set obs_history_is_pad to all-True; without this override, the
+        # current frame would have no key to attend to and produce NaNs.
+        # `~obs_history_is_pad` allocates a fresh tensor, so the in-place
+        # write below does not reach the caller's `obs_history_is_pad`.
+        key_valid = ~obs_history_is_pad  # (B, T)
+        key_valid[:, -1] = True
+
+        # Combined: (B, T_query, T_key)
+        mask_bool = causal.unsqueeze(0) & key_valid.unsqueeze(1)  # (B, T, T)
+
+        # Bool → additive float: True → 0.0, False → -inf.
+        float_mask = torch.zeros(b, t, t, dtype=dtype, device=device)
+        float_mask.masked_fill_(~mask_bool, float("-inf"))
+
+        # Expand for the (B*N) flattened-patch batch dimension:
+        #   (B, T, T) → (B, 1, T, T) → repeat_interleave(N) → (B*N, 1, T, T)
+        float_mask = float_mask.unsqueeze(1)  # (B, 1, T, T)
+        float_mask = float_mask.repeat_interleave(num_patches, dim=0)  # (B*N, 1, T, T)
+
+        return float_mask
+
+    def forward(self, video: Tensor, obs_history_is_pad: Tensor | None = None) -> Tensor:
         """Encode a video clip and return the current-frame tokens.
 
         Args:
             video: ``(B, T, C, H, W)`` pixel values in ``[0, 1]``, with
                 ``T == num_frames``, ``C == 3``, and spatial size matching
                 the SigLIP config (224x224 by default).
+            obs_history_is_pad: Optional ``(B, T)`` bool mask where ``True``
+                marks padded history frames. Padded frames are blocked in
+                the temporal attention so the current frame cannot read
+                contaminated hidden states from them. When ``None`` and
+                ``T > 1``, falls back to "only the current frame is real"
+                (matches inference-time semantics where
+                ``_build_history_batch`` doesn't populate this mask).
 
         Returns:
             ``(B, num_video_tokens, vlm_hidden_size)`` current-frame tokens,
@@ -428,20 +520,54 @@ class SpaceTimeSiglipVideoEncoder(nn.Module):
         # Patch embedding + learned spatial position embedding.
         hidden = self.vision_tower.vision_model.embeddings(flat)
 
+        # Build temporal attention mask. Skipped at T=1 because the wrapper's
+        # T=1 short-circuit bypasses temporal attention entirely.
+        temporal_attn_mask: Tensor | None = None
+        if t > 1:
+            if obs_history_is_pad is not None:
+                temporal_attn_mask = self._build_temporal_attn_mask(
+                    obs_history_is_pad, self.num_video_tokens, hidden.dtype
+                )
+            else:
+                # Inference fallback: select_action -> _build_history_batch
+                # zero-pads missing slots but does NOT emit obs_history_is_pad.
+                # Treat all history as padded so the current frame's
+                # representation is uncontaminated by the zero-pixel
+                # placeholders.
+                fallback_pad = torch.ones(b, t, dtype=torch.bool, device=hidden.device)
+                fallback_pad[:, -1] = False
+                temporal_attn_mask = self._build_temporal_attn_mask(
+                    fallback_pad, self.num_video_tokens, hidden.dtype
+                )
+
         # Encoder stack: standard spatial layers + wrapped every-Nth layer
         # with temporal attention. SpaceTimeEncoderLayerWrapper matches the
         # SiglipEncoderLayer signature, so we drive the loop manually here
         # (instead of calling SiglipEncoder.forward) so we can wrap each
         # layer in torch.utils.checkpoint.checkpoint when the flag is set —
         # the same explicit pattern PaliGemmaWithExpertModel uses.
+        # ``temporal_attn_mask`` is passed only to spacetime-wrapped layers
+        # (vanilla layers don't accept it). Under gradient checkpointing it
+        # MUST go in as a positional arg — torch.utils.checkpoint.checkpoint
+        # with use_reentrant=False does not forward kwargs to the wrapped
+        # function.
         use_ckpt = self.gradient_checkpointing and self.training
         for layer in self.vision_tower.vision_model.encoder.layers:
+            is_spacetime = isinstance(layer, SpaceTimeEncoderLayerWrapper)
             if use_ckpt:
-                layer_outputs = torch.utils.checkpoint.checkpoint(
-                    layer, hidden, None, False, use_reentrant=False
-                )
+                if is_spacetime:
+                    layer_outputs = torch.utils.checkpoint.checkpoint(
+                        layer, hidden, None, False, temporal_attn_mask, use_reentrant=False
+                    )
+                else:
+                    layer_outputs = torch.utils.checkpoint.checkpoint(
+                        layer, hidden, None, False, use_reentrant=False
+                    )
             else:
-                layer_outputs = layer(hidden, None, False)
+                if is_spacetime:
+                    layer_outputs = layer(hidden, None, False, temporal_attn_mask=temporal_attn_mask)
+                else:
+                    layer_outputs = layer(hidden, None, False)
             hidden = layer_outputs[0]
 
         hidden = self.vision_tower.vision_model.post_layernorm(hidden)

--- a/tests/policies/test_pi05_mem.py
+++ b/tests/policies/test_pi05_mem.py
@@ -574,3 +574,391 @@ class TestSpaceTimeSiglipVideoEncoder:
             out_st = enc_st(video)
 
         torch.testing.assert_close(out_st, out_no_st, rtol=1e-5, atol=1e-5)
+
+
+# Padded-history attention masking. Pixel-zeroing of padded frames is not
+# enough — the SigLIP patch embedding has a learned bias and the temporal
+# positional embedding e(t) is non-zero for t < T-1, so padded "zero" frames
+# still produce non-zero hidden states the current frame would otherwise
+# attend to. The encoder must build an attention mask blocking padded keys.
+
+
+class TestTemporalAttentionMaskBlocksPaddedHistory:
+    @staticmethod
+    def _make_encoder(num_frames: int = 4, spacetime_stride: int = 4):
+        helper = TestSpaceTimeSiglipVideoEncoder()
+        return helper._make_encoder(num_frames=num_frames, spacetime_stride=spacetime_stride)
+
+    def test_current_frame_invariant_to_padded_history(self):
+        """Gold-standard: with the first three frames marked padded and an
+        identical current frame at ``[:, -1]``, the encoder output must NOT
+        depend on the pixel values of those padded frames. Pre-fix code
+        reads contaminated hidden states from padded frames through the
+        temporal attention path and the two outputs diverge.
+        """
+        torch.manual_seed(0)
+        encoder = self._make_encoder(num_frames=4, spacetime_stride=4).eval()
+
+        current = torch.rand(1, 1, 3, 224, 224)
+        vid_a = torch.cat([torch.rand(1, 3, 3, 224, 224), current], dim=1)
+        vid_b = torch.cat([torch.zeros(1, 3, 3, 224, 224), current], dim=1)
+
+        obs_history_is_pad = torch.tensor([[True, True, True, False]])
+        with torch.no_grad():
+            out_a = encoder(vid_a, obs_history_is_pad=obs_history_is_pad)
+            out_b = encoder(vid_b, obs_history_is_pad=obs_history_is_pad)
+
+        torch.testing.assert_close(out_a, out_b, rtol=1e-5, atol=1e-5)
+
+    def test_inference_fallback_blocks_all_history(self):
+        """``obs_history_is_pad=None`` triggers the inference fallback that
+        treats every history slot as padded; pins the property that
+        ``select_action`` (which never emitted ``obs_history_is_pad`` before
+        this fix) does not let zero-pixel placeholders contaminate the
+        current frame.
+        """
+        torch.manual_seed(1)
+        encoder = self._make_encoder(num_frames=4, spacetime_stride=4).eval()
+
+        current = torch.rand(1, 1, 3, 224, 224)
+        vid_a = torch.cat([torch.rand(1, 3, 3, 224, 224), current], dim=1)
+        vid_b = torch.cat([torch.zeros(1, 3, 3, 224, 224), current], dim=1)
+
+        with torch.no_grad():
+            out_a = encoder(vid_a)  # obs_history_is_pad defaults to None
+            out_b = encoder(vid_b)
+
+        torch.testing.assert_close(out_a, out_b, rtol=1e-5, atol=1e-5)
+
+    def test_temporal_mask_shape_and_values(self):
+        """Exercise ``_build_temporal_attn_mask`` directly. Documents the
+        contract: causal lower-triangular AND key-side ``~obs_history_is_pad``
+        with current-frame override; (B*N, 1, T, T) shape; additive 0/-inf.
+        """
+        from opentau.policies.pi05_mem.video_encoder import SpaceTimeSiglipVideoEncoder
+
+        obs_history_is_pad = torch.tensor([[True, False, False]])
+        mask = SpaceTimeSiglipVideoEncoder._build_temporal_attn_mask(
+            obs_history_is_pad, num_patches=4, dtype=torch.float32
+        )
+
+        # Shape: B=1, N=4, T=3 -> (B*N, 1, T, T) = (4, 1, 3, 3).
+        assert mask.shape == (4, 1, 3, 3)
+        assert mask.dtype == torch.float32
+
+        # All N rows for batch 0 share the same (T, T) submatrix.
+        m = mask[0, 0]  # (3, 3)
+
+        # Row 0: query=frame0 (padded query, but causal allows j=0 only;
+        # since frame 0 is padded its key is blocked -> -inf). The
+        # current-frame override only forces key j=T-1 real, not j=0.
+        assert m[0, 0] == float("-inf"), "padded frame 0 key should be blocked"
+        # Row 1: query=frame1 attends to {0 (padded -> -inf), 1 (real -> 0)}.
+        assert m[1, 0] == float("-inf")
+        assert m[1, 1] == 0.0
+        # Row 2: query=current attends to {0 (padded -> -inf), 1 (real -> 0),
+        # 2 (current, always real -> 0)}.
+        assert m[2, 0] == float("-inf")
+        assert m[2, 1] == 0.0
+        assert m[2, 2] == 0.0
+
+        # Upper triangular off-diagonals are blocked (causal).
+        assert m[0, 1] == float("-inf")
+        assert m[0, 2] == float("-inf")
+        assert m[1, 2] == float("-inf")
+
+        # Patch rows for the same batch are identical.
+        for n in range(1, 4):
+            torch.testing.assert_close(mask[n, 0], mask[0, 0])
+
+    def test_current_frame_override_when_pad_includes_current(self):
+        """Defensive: even if a caller passes ``obs_history_is_pad`` with the
+        current step (T-1) marked padded — as the dataset's
+        ``history_state_drop_prob`` augmentation does — the mask must keep
+        the current frame attendable, otherwise the current query has no
+        valid key and softmax produces NaNs.
+        """
+        from opentau.policies.pi05_mem.video_encoder import SpaceTimeSiglipVideoEncoder
+
+        all_padded = torch.tensor([[True, True, True, True]])
+        mask = SpaceTimeSiglipVideoEncoder._build_temporal_attn_mask(
+            all_padded, num_patches=1, dtype=torch.float32
+        )
+        m = mask[0, 0]
+        assert m[3, 3] == 0.0, "current frame must remain self-attendable"
+
+    def test_pad_tensor_not_mutated(self):
+        """The mask helper must not mutate the caller's ``obs_history_is_pad``
+        tensor (it is also consumed downstream as the state mask in
+        ``embed_prefix``).
+        """
+        from opentau.policies.pi05_mem.video_encoder import SpaceTimeSiglipVideoEncoder
+
+        all_padded = torch.tensor([[True, True, True, True]])
+        snapshot = all_padded.clone()
+        SpaceTimeSiglipVideoEncoder._build_temporal_attn_mask(all_padded, num_patches=1, dtype=torch.float32)
+        torch.testing.assert_close(all_padded, snapshot)
+
+
+# State mask: current step (t = T-1) must always be marked real, even when
+# obs_history_is_pad sets it to True (e.g. dataset's history_state_drop_prob
+# augmentation flips the entire tensor to all-True). Without the override the
+# policy is conditioned on no state at all when that augmentation fires.
+
+
+def _make_embed_prefix_stub():
+    """Construct a partial PI05MemFlowMatching that exposes only the attrs
+    ``embed_prefix`` reads — no PaliGemma init, just enough for the layout
+    paths exercised by the state-mask tests.
+    """
+    import types
+
+    from opentau.policies.pi05_mem.modeling_pi05 import PI05MemFlowMatching
+
+    hidden = 4
+    n_video_tokens = 3
+    fm = PI05MemFlowMatching.__new__(PI05MemFlowMatching)
+
+    class _FakePaligemma:
+        def embed_language_tokens(self, tokens):
+            return torch.zeros((*tokens.shape, hidden), dtype=torch.float32)
+
+        def embed_discrete_actions(self, da):
+            return torch.zeros((*da.shape, hidden), dtype=torch.float32)
+
+    fm.paligemma_with_expert = _FakePaligemma()
+    fm.state_proj = lambda state: torch.zeros(state.shape[0], state.shape[1], hidden, dtype=torch.float32)
+    fm.embed_video = lambda video, obs_history_is_pad=None: torch.zeros(
+        video.shape[0], n_video_tokens, hidden, dtype=torch.float32
+    )
+    fm.config = types.SimpleNamespace(discrete_action_max_length=2)
+    return fm
+
+
+def _embed_prefix_default_inputs(*, batch_size: int = 2, prompt_len: int = 3, t_state: int = 1):
+    return {
+        "videos": [torch.zeros(batch_size, t_state, 3, 4, 4)],
+        "vid_masks": [torch.ones(batch_size, dtype=torch.bool)],
+        "lang_tokens": torch.zeros(batch_size, prompt_len, dtype=torch.long),
+        "lang_masks": torch.ones(batch_size, prompt_len, dtype=torch.bool),
+        "state": torch.zeros(batch_size, t_state, 7),
+    }
+
+
+def _state_slice_indices(prompt_len: int, n_video_tokens: int, t_state: int) -> slice:
+    """Layout: videos(n_video_tokens) + lang(prompt_len) + state(t_state)."""
+    state_lo = n_video_tokens + prompt_len
+    return slice(state_lo, state_lo + t_state)
+
+
+class TestStateMaskCurrentStepAlwaysReal:
+    """Pin the post-fix invariant: state_mask[:, -1] is True regardless of
+    obs_history_is_pad. (Bug B from the audit; ported from pi07 / PR #205.)
+    """
+
+    def test_state_mask_current_step_real_when_all_history_padded(self):
+        """``obs_history_is_pad = ones(B, T)`` (the
+        ``history_state_drop_prob=1.0`` case) MUST still leave the current
+        state token (index T-1) marked real, otherwise attention to it is
+        masked out and the policy conditions on no state at all.
+        """
+        from opentau.policies.pi05_mem.modeling_pi05 import PI05MemFlowMatching
+
+        fake = _make_embed_prefix_stub()
+        bsize = 2
+        t_state = 4
+        kwargs = _embed_prefix_default_inputs(batch_size=bsize, t_state=t_state)
+        kwargs["obs_history_is_pad"] = torch.ones(bsize, t_state, dtype=torch.bool)
+
+        _, pad_masks, _ = PI05MemFlowMatching.embed_prefix(fake, **kwargs)
+
+        state_slice = _state_slice_indices(prompt_len=3, n_video_tokens=3, t_state=t_state)
+        state_mask = pad_masks[:, state_slice]
+        assert state_mask.shape == (bsize, t_state)
+
+        for i in range(bsize):
+            assert state_mask[i, -1].item() is True, (
+                f"sample {i}: current state token (T-1) is masked out — the "
+                f"history_state_drop_prob augmentation would condition on no "
+                f"state at all. state_mask = {state_mask[i].tolist()}"
+            )
+        assert (~state_mask[:, :-1]).all().item() is True
+
+    def test_state_mask_none_branch_assumes_history_padded_keeps_current_real(self):
+        """``obs_history_is_pad = None`` means the caller didn't tell us
+        which slots are real. Post-fix: assume all history is padded so the
+        encoder cannot attend to garbage history slots — but the current
+        step is still real.
+        """
+        from opentau.policies.pi05_mem.modeling_pi05 import PI05MemFlowMatching
+
+        fake = _make_embed_prefix_stub()
+        bsize = 2
+        t_state = 4
+        kwargs = _embed_prefix_default_inputs(batch_size=bsize, t_state=t_state)
+        kwargs["obs_history_is_pad"] = None
+
+        _, pad_masks, _ = PI05MemFlowMatching.embed_prefix(fake, **kwargs)
+
+        state_slice = _state_slice_indices(prompt_len=3, n_video_tokens=3, t_state=t_state)
+        state_mask = pad_masks[:, state_slice]
+        assert state_mask.shape == (bsize, t_state)
+
+        for i in range(bsize):
+            assert state_mask[i, -1].item() is True
+            assert (~state_mask[i, :-1]).all().item() is True
+
+    def test_state_mask_partial_history_pad_preserves_current(self):
+        """Mixed pad pattern (typical of natural episode-boundary padding):
+        some history slots padded, current step real -> state_mask matches
+        ``~obs_history_is_pad`` exactly, with the override a no-op since the
+        current bit was already True.
+        """
+        from opentau.policies.pi05_mem.modeling_pi05 import PI05MemFlowMatching
+
+        fake = _make_embed_prefix_stub()
+        bsize = 2
+        t_state = 4
+        kwargs = _embed_prefix_default_inputs(batch_size=bsize, t_state=t_state)
+        kwargs["obs_history_is_pad"] = torch.tensor([[True, True, False, False], [True, False, False, False]])
+
+        _, pad_masks, _ = PI05MemFlowMatching.embed_prefix(fake, **kwargs)
+
+        state_slice = _state_slice_indices(prompt_len=3, n_video_tokens=3, t_state=t_state)
+        state_mask = pad_masks[:, state_slice]
+        torch.testing.assert_close(
+            state_mask,
+            torch.tensor([[False, False, True, True], [False, True, True, True]]),
+        )
+
+    def test_state_mask_does_not_mutate_obs_history_is_pad(self):
+        """The override path must not mutate the caller's
+        ``obs_history_is_pad`` (it is also threaded into ``embed_video``
+        for the temporal attention mask — mutating it there would cause
+        cross-call corruption).
+        """
+        from opentau.policies.pi05_mem.modeling_pi05 import PI05MemFlowMatching
+
+        fake = _make_embed_prefix_stub()
+        bsize = 1
+        t_state = 4
+        kwargs = _embed_prefix_default_inputs(batch_size=bsize, t_state=t_state)
+        original_pad = torch.ones(bsize, t_state, dtype=torch.bool)
+        kwargs["obs_history_is_pad"] = original_pad
+        snapshot = original_pad.clone()
+
+        PI05MemFlowMatching.embed_prefix(fake, **kwargs)
+
+        torch.testing.assert_close(original_pad, snapshot)
+
+
+# `_build_history_batch` emits ``obs_history_is_pad`` so the encoder can use
+# real mid-episode history while still masking start-of-episode zero-fill.
+# Without this emit, the encoder's None-fallback masks ALL history at
+# inference (mid-episode regression flagged in pi07's PR #253 review and
+# inherited from pi05_mem's original design).
+
+
+class TestBuildHistoryBatchEmitsObsHistoryIsPad:
+    @staticmethod
+    def _make_policy_stub(*, n_obs_steps: int, history_interval: int, image_keys: list[str]):
+        """Construct a partial PI05MemPolicy that exposes only the attrs
+        ``_build_history_batch`` reads.
+        """
+        import types
+
+        from opentau.policies.pi05_mem.modeling_pi05 import PI05MemPolicy
+
+        policy = PI05MemPolicy.__new__(PI05MemPolicy)
+        buf_size = (n_obs_steps - 1) * history_interval + 1
+        policy.config = types.SimpleNamespace(
+            n_obs_steps=n_obs_steps,
+            history_interval=history_interval,
+            obs_buffer_size=buf_size,
+            image_features=dict.fromkeys(image_keys),
+        )
+        policy._state_buffer = None
+        policy._obs_buffers = None
+        return policy
+
+    def _make_batch(self, image_keys: list[str], state_dim: int = 4) -> dict:
+        return {
+            "state": torch.zeros(1, state_dim),
+            **{k: torch.zeros(1, 3, 8, 8) for k in image_keys},
+        }
+
+    def test_first_step_marks_all_but_current_padded(self):
+        """At episode start, only the very first observation is in the
+        buffer; every other slot in the requested history was zero-filled.
+        Mask should be ``[True, ..., True, False]`` — the canonical case
+        the Bug A fix protects against contamination from.
+        """
+        policy = self._make_policy_stub(n_obs_steps=4, history_interval=1, image_keys=["camera0"])
+        out = policy._build_history_batch(self._make_batch(["camera0"]))
+
+        assert "obs_history_is_pad" in out
+        assert out["obs_history_is_pad"].shape == (1, 4)
+        assert out["obs_history_is_pad"].dtype == torch.bool
+        assert out["obs_history_is_pad"].tolist() == [[True, True, True, False]]
+
+    def test_buffer_full_emits_all_false(self):
+        """Once the buffer is full (after ``obs_buffer_size`` calls), every
+        slot maps to a real observation — mask is all-False. This is the
+        mid-episode case the previous behavior regressed: with no emit, the
+        encoder masked these real frames out via the None-fallback.
+        """
+        policy = self._make_policy_stub(n_obs_steps=4, history_interval=2, image_keys=["camera0"])
+        # obs_buffer_size = (4-1)*2 + 1 = 7. Need 7 calls to fill.
+        batch = self._make_batch(["camera0"])
+        for _ in range(7):
+            out = policy._build_history_batch(batch)
+        assert out["obs_history_is_pad"].tolist() == [[False, False, False, False]]
+
+    def test_partial_fill_marks_only_unfilled_slots(self):
+        """After ``k < obs_buffer_size`` calls, the leading slots are still
+        virtual past-steps. With ``n_obs_steps=4, history_interval=2``
+        (buffer_size=7), after 4 calls the deque has 4 entries -> ``missing
+        = 3`` -> slots with ``i*interval - 3 < 0`` are padded: i=0 -> -3 (T),
+        i=1 -> -1 (T), i=2 -> 1 (F), i=3 -> 3 (F). Mask = [T, T, F, F].
+        """
+        policy = self._make_policy_stub(n_obs_steps=4, history_interval=2, image_keys=["camera0"])
+        batch = self._make_batch(["camera0"])
+        for _ in range(4):
+            out = policy._build_history_batch(batch)
+        assert out["obs_history_is_pad"].tolist() == [[True, True, False, False]]
+
+    def test_mask_is_broadcast_over_batch(self):
+        """The buffer is shared across batch elements, so the (B, T) mask is
+        the same across the batch dim. Verify by emitting from a B=3 batch.
+        """
+        policy = self._make_policy_stub(n_obs_steps=4, history_interval=1, image_keys=["camera0"])
+        batch = {
+            "state": torch.zeros(3, 4),
+            "camera0": torch.zeros(3, 3, 8, 8),
+        }
+        out = policy._build_history_batch(batch)
+
+        assert out["obs_history_is_pad"].shape == (3, 4)
+        assert torch.all(out["obs_history_is_pad"] == out["obs_history_is_pad"][0:1])
+
+    def test_state_and_camera_padding_match_emitted_mask(self):
+        """The emitted mask must agree slot-for-slot with the actual
+        zero-padding pattern of state and camera tensors.
+        """
+        policy = self._make_policy_stub(n_obs_steps=3, history_interval=1, image_keys=["camera0"])
+        batch = {
+            "state": torch.full((1, 4), 7.0),
+            "camera0": torch.full((1, 3, 8, 8), 5.0),
+        }
+        out = policy._build_history_batch(batch)
+        # After one call: missing = 2; mask = [True, True, False].
+        is_pad = out["obs_history_is_pad"][0]  # (T,)
+        state = out["state"][0]  # (T, D)
+        cam = out["camera0"][0]  # (T, C, H, W)
+        for t, padded in enumerate(is_pad.tolist()):
+            if padded:
+                assert torch.all(state[t] == 0.0), f"state[{t}] not zero-filled"
+                assert torch.all(cam[t] == 0.0), f"camera[{t}] not zero-filled"
+            else:
+                assert torch.all(state[t] == 7.0), f"state[{t}] zero-filled but mask says real"
+                assert torch.all(cam[t] == 5.0), f"camera[{t}] zero-filled but mask says real"


### PR DESCRIPTION
## What this does

Ports the same three padded-history fixes recently applied to `pi07` ([#253](https://github.com/TensorAuto/OpenTau/pull/253)) and to `pi07_paligemma` ([#205](https://github.com/TensorAuto/OpenTau/pull/205)) into `pi05_mem` — the original SpaceTime SigLIP home, where all three bugs originated. Audited against the same five-criterion list; only the bug fixes applied.

**Bug A — SpaceTimeSigLIP temporal attention did not mask padded history frames.** Pixel-zeroing alone is insufficient because the SigLIP patch embedding has a learned bias and the temporal positional embedding `e(t)` is non-zero for `t < T-1`, so padded "zero" frames produced non-zero hidden states the current frame attended to. Threaded `obs_history_is_pad` through `embed_video` → `SpaceTimeSiglipVideoEncoder.forward`; a new `_build_temporal_attn_mask` helper produces a `(B*N, 1, T, T)` additive float mask combining causal lower-triangular with key-side `~obs_history_is_pad`. Inference fallback when the mask is absent and `T > 1`: treats all history as padded so the current frame is uncontaminated by zero placeholders from `_build_history_batch`.

**Bug B — `state_mask` masked the current state token whenever `obs_history_is_pad[:, -1] = True`.** The dataset's `history_state_drop_prob` augmentation flips the entire `obs_history_is_pad` tensor to all-True while zeroing the state, so the policy was being conditioned on no state at all. Added an unconditional `state_mask[:, -1] = True` override after both branches; switched the absent-mask branch from `ones` to `zeros` so the encoder cannot attend to garbage history slots without a real signal.

**Mid-episode fix — `_build_history_batch` now emits `obs_history_is_pad`** based on the same `idx < 0` decision the state/camera loops already make. Threaded through `PI05MemPolicy.sample_actions` → `PI05MemFlowMatching.sample_actions` → `embed_prefix`. Without this emit, the encoder's `None`-fallback masks ALL history at inference (even genuine mid-episode frames once the buffer fills); with it, only the truly-padded start-of-episode slots get masked. The `None`-fallback and `embed_prefix`'s zeros-then-current branch are kept as defensive defaults for callers that bypass `_build_history_batch`.

Audit of the other two criteria from the original review:

3. **Subgoal images encoded with the same video encoder weights** — N/A. `pi05_mem` has no subgoal concept (no `prepare_subgoal*`, no subgoal in `embed_prefix`). The "no second set of weights" property is already satisfied by [modeling_pi05.py:801-803](src/opentau/policies/pi05_mem/modeling_pi05.py:801) constructing the encoder with `vision_tower=self.paligemma_with_expert.paligemma.vision_tower` held by reference.
4. **Inference prompt construction matches training** — already satisfied. `embed_prefix` is just `videos + lang + state + (training-only: discrete_actions)`. No optional response/subgoal/metadata blocks → no conditional layout to keep in sync. Training and inference are byte-equivalent on the shared prefix already.

## How it was tested

New regression tests in `tests/policies/test_pi05_mem.py`:

- `TestTemporalAttentionMaskBlocksPaddedHistory` — current-frame output is invariant to padded-history pixel values; inference fallback works with `obs_history_is_pad=None`; mask shape and per-cell values pinned; current-frame override defends the all-padded edge case; helper does not mutate the caller's tensor.
- `TestStateMaskCurrentStepAlwaysReal` — current state token stays real when `obs_history_is_pad` is all-True or `None` or partial-pad; helper does not mutate the caller's `obs_history_is_pad`.
- `TestBuildHistoryBatchEmitsObsHistoryIsPad` — pins shape, the first-step `[T, T, T, F]` pattern, the buffer-full all-False pattern, the partial-fill mid-episode pattern, batch broadcasting, and slot-by-slot agreement with the actual zero-fill of state and camera tensors.

Verification run:

- `pre-commit run --all-files` — all hooks pass.
- `pytest -m "not gpu" -n auto tests/policies/` — 184 passed, 2 skipped (CPU subset; the new pi05_mem tests land in this subset).
- `pytest -m "gpu" -n 0 tests/policies/test_pi05_mem.py tests/policies/test_pi05_mem_gpu.py` — 6/6 pass on a CUDA host (forward shape/dtype, single-frame invariance, gradient freeze/unfreeze, causality smoke, end-to-end policy).
- Determinism: ran a tiny `PI05MemPolicy.forward` twice with the same `torch.manual_seed`/CUDA seed and pre-sampled noise+time; MSE and CE losses are bit-identical (`torch.equal`, not just `allclose`). Per CLAUDE.md hard rule for `modeling_*.py` touches.

## How to checkout & try? (for the reviewer)

```bash
git fetch origin claude/pi05-mem-padded-history && git checkout claude/pi05-mem-padded-history
pre-commit run --all-files
pytest -m "not gpu" -n auto tests/policies/test_pi05_mem.py
# GPU host:
pytest -m "gpu" -n 0 tests/policies/test_pi05_mem.py tests/policies/test_pi05_mem_gpu.py
```

To see the bug-A regression directly (current-frame invariance under padded history):

```bash
pytest -sx tests/policies/test_pi05_mem.py::TestTemporalAttentionMaskBlocksPaddedHistory::test_current_frame_invariant_to_padded_history
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [x] My PR includes policy-related changes.
  - [x] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).