### PR TITLE
feat(annotate_subtasks): add Gemini Robotics-ER 1.6 as a model option

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ dependencies = [
     "openai>=2.16.0",
     "python-dotenv>=1.2.1",
     "anthropic>=0.55.0",
+    "google-genai>=1.0.0",
 ]
 
 [project.scripts]

--- a/src/opentau/scripts/annotate_subtasks.py
+++ b/src/opentau/scripts/annotate_subtasks.py
@@ -22,8 +22,10 @@ For every episode the script:
    recordings).
 2. Resizes each sampled frame to ``--target-width`` pixels wide (JPEG,
    default 640 px) to reduce image token cost.
-3. Sends all sampled frames together with their timestamps to
-   ``claude-opus-4-7`` and asks it to identify subtask transition times.
+3. Sends all sampled frames together with their timestamps to the configured
+   model (Anthropic ``claude-opus-4-7`` by default; Google
+   ``gemini-robotics-er-1.6-preview`` is also supported via ``--model``) and
+   asks it to identify subtask transition times.
 4. Saves the returned ``[{"time": float, "subtask": str}, ...]`` list as a
    per-episode JSON at ``{root}/subtasks/episode_{episode_index:06d}.json``.
 5. Updates ``meta/info.json`` with a ``subtask_path`` field (required by
@@ -86,6 +88,8 @@ import anthropic
 import av
 import pyarrow as pa
 import pyarrow.parquet as pq
+from google import genai
+from google.genai import types as genai_types
 from huggingface_hub import snapshot_download
 from PIL import Image
 from tqdm import tqdm
@@ -151,7 +155,8 @@ def _to_b64_jpeg(img: Image.Image, quality: int = 85) -> str:
 # Anthropic Messages API rejects requests with more than 100 images per content
 # array, so any episode longer than (MAX_FRAMES_PER_REQUEST / sample_fps) seconds
 # would otherwise fail mid-run. Above this cap we uniformly subsample the captured
-# frames; the effective sampling rate drops accordingly.
+# frames; the effective sampling rate drops accordingly. Gemini accepts more
+# images per request but the same cap keeps cost/latency bounded for both.
 MAX_FRAMES_PER_REQUEST = 100
 
 
@@ -236,6 +241,12 @@ def _coerce_subtasks(parsed: list, raw_text: str = "") -> list[dict]:
     return subtasks
 
 
+def _is_gemini_model(model: str) -> bool:
+    """Route ``gemini-*`` and ``robotics-er-*`` model IDs to the Google API."""
+    name = model.lower()
+    return name.startswith("gemini") or name.startswith("robotics-er")
+
+
 def _call_claude(
     client: anthropic.Anthropic,
     model: str,
@@ -279,6 +290,62 @@ def _call_claude(
     return _coerce_subtasks(parsed, raw_text)
 
 
+def _call_gemini(
+    client: genai.Client,
+    model: str,
+    task_description: str,
+    frames: list[Image.Image],
+    timestamps: list[float],
+    sample_fps: float,
+) -> list[dict]:
+    """Send sampled frames to a Gemini model and parse the subtask boundary JSON.
+
+    Used for the Gemini Robotics-ER family (e.g. ``gemini-robotics-er-1.6-preview``)
+    as well as general Gemini multimodal models.
+    """
+    contents: list = []
+    for ts, img in zip(timestamps, frames, strict=False):
+        contents.append(f"t={ts:.1f}s:")
+        buf = io.BytesIO()
+        img.save(buf, format="JPEG", quality=85)
+        contents.append(genai_types.Part.from_bytes(data=buf.getvalue(), mime_type="image/jpeg"))
+
+    contents.append(_USER_TEMPLATE.format(task=task_description, fps=sample_fps))
+
+    response = client.models.generate_content(
+        model=model,
+        contents=contents,
+        config=genai_types.GenerateContentConfig(
+            system_instruction=_SYSTEM_PROMPT_TEMPLATE.format(fps=sample_fps),
+            max_output_tokens=1024,
+            response_mime_type="application/json",
+        ),
+    )
+
+    raw_text = (response.text or "").strip()
+    if not raw_text:
+        raise ValueError(f"Gemini response had no text (finish_reason={response.candidates}).")
+
+    parsed = _parse_json_response(raw_text)
+    return _coerce_subtasks(parsed, raw_text)
+
+
+def _annotate_subtasks(
+    client: anthropic.Anthropic | genai.Client,
+    model: str,
+    task_description: str,
+    frames: list[Image.Image],
+    timestamps: list[float],
+    sample_fps: float,
+) -> list[dict]:
+    """Dispatch to the Anthropic or Gemini call path based on model name."""
+    if _is_gemini_model(model):
+        assert isinstance(client, genai.Client)
+        return _call_gemini(client, model, task_description, frames, timestamps, sample_fps)
+    assert isinstance(client, anthropic.Anthropic)
+    return _call_claude(client, model, task_description, frames, timestamps, sample_fps)
+
+
 # ---------------------------------------------------------------------------
 # Per-episode annotation
 # ---------------------------------------------------------------------------
@@ -297,7 +364,7 @@ def _subtask_path(root: Path, template: str, ep_index: int) -> Path:
 
 
 def _annotate_episode(
-    client: anthropic.Anthropic,
+    client: anthropic.Anthropic | genai.Client,
     model: str,
     root: Path,
     info: dict,
@@ -345,7 +412,7 @@ def _annotate_episode(
             max_frames,
         )
 
-    subtasks = _call_claude(client, model, task_description, frames, timestamps, sample_fps)
+    subtasks = _annotate_subtasks(client, model, task_description, frames, timestamps, sample_fps)
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
     with open(out_path, "w") as f:
@@ -421,7 +488,7 @@ def _update_parquet_response(root: Path, info: dict, ep_index: int, ep_info: dic
 
 
 def _process_dataset(
-    client: anthropic.Anthropic,
+    client: anthropic.Anthropic | genai.Client,
     root: Path,
     model: str,
     sample_fps: float,
@@ -584,7 +651,12 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     p.add_argument(
         "--model",
         default="claude-opus-4-7",
-        help="Anthropic model ID to use (default: claude-opus-4-7).",
+        help=(
+            "Model ID to use. Anthropic models (e.g. 'claude-opus-4-7', the default) "
+            "go through ANTHROPIC_API_KEY; model IDs starting with 'gemini' or "
+            "'robotics-er' (e.g. 'gemini-robotics-er-1.6-preview') go through "
+            "GEMINI_API_KEY via google-genai."
+        ),
     )
     p.add_argument(
         "--write-response-column",
@@ -605,7 +677,9 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=8,
         help=(
             "Number of automatic retries for the Anthropic SDK on 429/5xx responses; "
-            "the SDK applies exponential backoff between attempts (default: 8)."
+            "the SDK applies exponential backoff between attempts (default: 8). "
+            "Ignored when using a Gemini model — google-genai's retry policy is "
+            "configured via its own client options."
         ),
     )
     p.add_argument(
@@ -648,15 +722,22 @@ def main(argv: list[str] | None = None) -> None:
 
     args = _parse_args(argv)
 
-    api_key = os.environ.get("ANTHROPIC_API_KEY")
-    if not api_key:
-        logger.error("ANTHROPIC_API_KEY is not set in the environment.")
-        sys.exit(1)
-
-    # max_retries triggers anthropic-sdk-python's built-in exponential backoff for
-    # 429 rate-limit responses (and 5xx). Default is 2; bump it so a long batch
-    # job does not give up after a transient burst on rate-limited tiers.
-    client = anthropic.Anthropic(api_key=api_key, max_retries=args.max_api_retries)
+    client: anthropic.Anthropic | genai.Client
+    if _is_gemini_model(args.model):
+        api_key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
+        if not api_key:
+            logger.error("GEMINI_API_KEY (or GOOGLE_API_KEY) is not set in the environment.")
+            sys.exit(1)
+        client = genai.Client(api_key=api_key)
+    else:
+        api_key = os.environ.get("ANTHROPIC_API_KEY")
+        if not api_key:
+            logger.error("ANTHROPIC_API_KEY is not set in the environment.")
+            sys.exit(1)
+        # max_retries triggers anthropic-sdk-python's built-in exponential backoff for
+        # 429 rate-limit responses (and 5xx). Default is 2; bump it so a long batch
+        # job does not give up after a transient burst on rate-limited tiers.
+        client = anthropic.Anthropic(api_key=api_key, max_retries=args.max_api_retries)
     datasets = _load_datasets_from_config(args.config_path)
 
     if not datasets:

--- a/src/opentau/scripts/annotate_subtasks.py
+++ b/src/opentau/scripts/annotate_subtasks.py
@@ -13,9 +13,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Annotate each episode in a dataset mixture with subtask labels using Claude.
+"""Annotate each episode in a dataset mixture with subtask labels using a VLM.
 
-For every episode the script:
+Supports both Anthropic Claude (default) and Google Gemini — including the
+Gemini Robotics-ER family — as the annotator. For every episode the script:
 
 1. Samples ``--sample-fps`` frames per second from the first available video
    track (default 1 fps, giving a 30-50x reduction from typical 30-50 fps
@@ -146,10 +147,14 @@ def _resize(img: Image.Image, target_width: int) -> Image.Image:
     return img.resize((target_width, new_h), Image.LANCZOS)
 
 
-def _to_b64_jpeg(img: Image.Image, quality: int = 85) -> str:
+def _to_jpeg_bytes(img: Image.Image, quality: int = 85) -> bytes:
     buf = io.BytesIO()
     img.save(buf, format="JPEG", quality=quality)
-    return base64.standard_b64encode(buf.getvalue()).decode("ascii")
+    return buf.getvalue()
+
+
+def _to_b64_jpeg(img: Image.Image, quality: int = 85) -> str:
+    return base64.standard_b64encode(_to_jpeg_bytes(img, quality=quality)).decode("ascii")
 
 
 # Anthropic Messages API rejects requests with more than 100 images per content
@@ -170,7 +175,8 @@ def _extract_sampled_frames(
 
     If the number of frames sampled at ``sample_fps`` exceeds ``max_frames``,
     the captured frames are uniformly subsampled down to ``max_frames`` so the
-    request stays within the Anthropic Messages API's 100-image limit.
+    request stays within the Anthropic Messages API's 100-image limit (Gemini
+    accepts more, but the same cap keeps cost/latency bounded for both).
     """
     with av.open(str(video_path)) as container:
         stream = container.streams.video[0]
@@ -235,7 +241,7 @@ def _coerce_subtasks(parsed: list, raw_text: str = "") -> list[dict]:
         except (TypeError, ValueError):
             continue
     if not subtasks:
-        raise ValueError(f"Claude response had no valid subtask entries: {raw_text!r}")
+        raise ValueError(f"Model response had no valid subtask entries: {raw_text!r}")
     if subtasks[0]["time"] != 0.0:
         subtasks.insert(0, {"time": 0.0, "subtask": subtasks[0]["subtask"]})
     return subtasks
@@ -306,9 +312,7 @@ def _call_gemini(
     contents: list = []
     for ts, img in zip(timestamps, frames, strict=False):
         contents.append(f"t={ts:.1f}s:")
-        buf = io.BytesIO()
-        img.save(buf, format="JPEG", quality=85)
-        contents.append(genai_types.Part.from_bytes(data=buf.getvalue(), mime_type="image/jpeg"))
+        contents.append(genai_types.Part.from_bytes(data=_to_jpeg_bytes(img), mime_type="image/jpeg"))
 
     contents.append(_USER_TEMPLATE.format(task=task_description, fps=sample_fps))
 
@@ -324,7 +328,8 @@ def _call_gemini(
 
     raw_text = (response.text or "").strip()
     if not raw_text:
-        raise ValueError(f"Gemini response had no text (finish_reason={response.candidates}).")
+        finish_reason = response.candidates[0].finish_reason if response.candidates else None
+        raise ValueError(f"Gemini response had no text (finish_reason={finish_reason}).")
 
     parsed = _parse_json_response(raw_text)
     return _coerce_subtasks(parsed, raw_text)
@@ -609,7 +614,11 @@ def _load_datasets_from_config(config_path: Path) -> list[dict]:
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     p = argparse.ArgumentParser(
-        description="Annotate every episode in a dataset mixture with subtask labels using Claude.",
+        description=(
+            "Annotate every episode in a dataset mixture with subtask labels using a VLM "
+            "(Anthropic Claude by default; Google Gemini / Gemini Robotics-ER also supported "
+            "via --model)."
+        ),
         epilog=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -630,10 +639,11 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         type=int,
         default=MAX_FRAMES_PER_REQUEST,
         help=(
-            "Hard cap on frames per Claude request. Long clips are uniformly subsampled "
+            "Hard cap on frames per model request. Long clips are uniformly subsampled "
             f"down to this many frames. The Anthropic Messages API rejects requests with "
-            f"more than 100 images, so do not raise above {MAX_FRAMES_PER_REQUEST} "
-            f"(default: {MAX_FRAMES_PER_REQUEST})."
+            f"more than 100 images, so do not raise above {MAX_FRAMES_PER_REQUEST} when "
+            f"using Claude; Gemini tolerates more, but the same cap keeps cost/latency "
+            f"bounded (default: {MAX_FRAMES_PER_REQUEST})."
         ),
     )
     p.add_argument(

--- a/tests/scripts/test_annotate_subtasks.py
+++ b/tests/scripts/test_annotate_subtasks.py
@@ -14,9 +14,19 @@
 
 from __future__ import annotations
 
-import pytest
+from unittest.mock import MagicMock, patch
 
-from opentau.scripts.annotate_subtasks import _coerce_subtasks, _parse_json_response
+import anthropic
+import pytest
+from google import genai
+
+from opentau.scripts import annotate_subtasks
+from opentau.scripts.annotate_subtasks import (
+    _annotate_subtasks,
+    _coerce_subtasks,
+    _is_gemini_model,
+    _parse_json_response,
+)
 
 
 class TestParseJsonResponse:
@@ -108,3 +118,96 @@ class TestCoerceSubtasks:
         entries = [{"time": 0.0, "subtask": "first"}, {"time": 1.0, "subtask": "second"}]
         out = _coerce_subtasks(entries)
         assert out == entries
+
+    def test_error_message_is_provider_agnostic(self):
+        # _coerce_subtasks is reached from both Claude and Gemini paths, so its
+        # error message must not single out a single provider.
+        with pytest.raises(ValueError, match=r"^Model response had no valid subtask entries"):
+            _coerce_subtasks([])
+
+
+class TestIsGeminiModel:
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "gemini-1.5-pro",
+            "gemini-2.0-flash",
+            "gemini-robotics-er-1.6-preview",
+            "Gemini-Pro",
+            "GEMINI-1.5",
+            "robotics-er-1.6",
+            "Robotics-ER-1.6-preview",
+        ],
+    )
+    def test_routes_to_gemini(self, model):
+        assert _is_gemini_model(model) is True
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "claude-opus-4-7",
+            "claude-sonnet-4-6",
+            "Claude-Haiku-4-5",
+            "gpt-4o",
+            "",
+        ],
+    )
+    def test_does_not_route_to_gemini(self, model):
+        assert _is_gemini_model(model) is False
+
+
+class TestAnnotateSubtasksDispatch:
+    """Verify the dispatcher routes each model to the right backend with the right client.
+
+    The runtime ``isinstance`` asserts in ``_annotate_subtasks`` would only catch
+    a misrouted call when annotation actually runs — these tests pin the contract.
+    """
+
+    def _make_inputs(self):
+        return {
+            "task_description": "pick up the cup",
+            "frames": [],
+            "timestamps": [],
+            "sample_fps": 1.0,
+        }
+
+    def test_claude_model_calls_claude_with_anthropic_client(self):
+        anthropic_client = MagicMock(spec=anthropic.Anthropic)
+        expected = [{"time": 0.0, "subtask": "ok"}]
+        with (
+            patch.object(annotate_subtasks, "_call_claude", return_value=expected) as call_claude,
+            patch.object(annotate_subtasks, "_call_gemini") as call_gemini,
+        ):
+            out = _annotate_subtasks(anthropic_client, "claude-opus-4-7", **self._make_inputs())
+        assert out == expected
+        call_claude.assert_called_once()
+        call_gemini.assert_not_called()
+        # The dispatcher must hand the Anthropic client through unchanged.
+        assert call_claude.call_args.args[0] is anthropic_client
+
+    @pytest.mark.parametrize("model", ["gemini-robotics-er-1.6-preview", "robotics-er-1.6"])
+    def test_gemini_model_calls_gemini_with_genai_client(self, model):
+        gemini_client = MagicMock(spec=genai.Client)
+        expected = [{"time": 0.0, "subtask": "ok"}]
+        with (
+            patch.object(annotate_subtasks, "_call_gemini", return_value=expected) as call_gemini,
+            patch.object(annotate_subtasks, "_call_claude") as call_claude,
+        ):
+            out = _annotate_subtasks(gemini_client, model, **self._make_inputs())
+        assert out == expected
+        call_gemini.assert_called_once()
+        call_claude.assert_not_called()
+        assert call_gemini.call_args.args[0] is gemini_client
+
+    def test_gemini_model_with_anthropic_client_trips_assert(self):
+        # Mirror the failure mode the reviewer flagged: a future Vertex-style
+        # ``models/gemini-...`` ID would currently fall through to the Claude
+        # branch; verify the isinstance assert catches a client/model mismatch.
+        anthropic_client = MagicMock(spec=anthropic.Anthropic)
+        with pytest.raises(AssertionError):
+            _annotate_subtasks(anthropic_client, "gemini-1.5-pro", **self._make_inputs())
+
+    def test_claude_model_with_genai_client_trips_assert(self):
+        gemini_client = MagicMock(spec=genai.Client)
+        with pytest.raises(AssertionError):
+            _annotate_subtasks(gemini_client, "claude-opus-4-7", **self._make_inputs())

--- a/uv.lock
+++ b/uv.lock
@@ -477,6 +477,46 @@ toml = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "47.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy' or (extra == 'extra-7-opentau-libero' and extra == 'extra-7-opentau-urdf')" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/b2/7ffa7fe8207a8c42147ffe70c3e360b228160c1d85dc3faff16aaa3244c0/cryptography-47.0.0.tar.gz", hash = "sha256:9f8e55fe4e63613a5e1cc5819030f27b97742d720203a087802ce4ce9ceb52bb", size = 830863, upload-time = "2026-04-24T19:54:57.056Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/98/40dfe932134bdcae4f6ab5927c87488754bf9eb79297d7e0070b78dd58e9/cryptography-47.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:160ad728f128972d362e714054f6ba0067cab7fb350c5202a9ae8ae4ce3ef1a0", size = 7912214, upload-time = "2026-04-24T19:53:03.864Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c6/2733531243fba725f58611b918056b277692f1033373dcc8bd01af1c05d4/cryptography-47.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b9a8943e359b7615db1a3ba587994618e094ff3d6fa5a390c73d079ce18b3973", size = 4644617, upload-time = "2026-04-24T19:53:06.909Z" },
+    { url = "https://files.pythonhosted.org/packages/00/e3/b27be1a670a9b87f855d211cf0e1174a5d721216b7616bd52d8581d912ed/cryptography-47.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f5c15764f261394b22aef6b00252f5195f46f2ca300bec57149474e2538b31f8", size = 4668186, upload-time = "2026-04-24T19:53:09.053Z" },
+    { url = "https://files.pythonhosted.org/packages/81/b9/8443cfe5d17d482d348cee7048acf502bb89a51b6382f06240fd290d4ca3/cryptography-47.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9c59ab0e0fa3a180a5a9c59f3a5abe3ef90d474bc56d7fadfbe80359491b615b", size = 4651244, upload-time = "2026-04-24T19:53:11.217Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/5e/13ed0cdd0eb88ba159d6dd5ebfece8cb901dbcf1ae5ac4072e28b55d3153/cryptography-47.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:34b4358b925a5ea3e14384ca781a2c0ef7ac219b57bb9eacc4457078e2b19f92", size = 5252906, upload-time = "2026-04-24T19:53:13.532Z" },
+    { url = "https://files.pythonhosted.org/packages/64/16/ed058e1df0f33d440217cd120d41d5dda9dd215a80b8187f68483185af82/cryptography-47.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0024b87d47ae2399165a6bfb20d24888881eeab83ae2566d62467c5ff0030ce7", size = 4701842, upload-time = "2026-04-24T19:53:15.618Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3d30986b30fdbd9e969abbdf8ba00ed0618615144341faeb57f395a084fe/cryptography-47.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:1e47422b5557bb82d3fff997e8d92cff4e28b9789576984f08c248d2b3535d93", size = 4289313, upload-time = "2026-04-24T19:53:17.755Z" },
+    { url = "https://files.pythonhosted.org/packages/df/fd/32db38e3ad0cb331f0691cb4c7a8a6f176f679124dee746b3af6633db4d9/cryptography-47.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:6f29f36582e6151d9686235e586dd35bb67491f024767d10b842e520dc6a07ac", size = 4650964, upload-time = "2026-04-24T19:53:20.062Z" },
+    { url = "https://files.pythonhosted.org/packages/86/53/5395d944dfd48cb1f67917f533c609c34347185ef15eb4308024c876f274/cryptography-47.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:a9b761f012a943b7de0e828843c5688d0de94a0578d44d6c85a1bae32f87791f", size = 5207817, upload-time = "2026-04-24T19:53:22.498Z" },
+    { url = "https://files.pythonhosted.org/packages/34/4f/e5711b28e1901f7d480a2b1b688b645aa4c77c73f10731ed17e7f7db3f0d/cryptography-47.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:4e1de79e047e25d6e9f8cea71c86b4a53aced64134f0f003bbcbf3655fd172c8", size = 4701544, upload-time = "2026-04-24T19:53:24.356Z" },
+    { url = "https://files.pythonhosted.org/packages/22/22/c8ddc25de3010fc8da447648f5a092c40e7a8fadf01dd6d255d9c0b9373d/cryptography-47.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ef6b3634087f18d2155b1e8ce264e5345a753da2c5fa9815e7d41315c90f8318", size = 4783536, upload-time = "2026-04-24T19:53:26.665Z" },
+    { url = "https://files.pythonhosted.org/packages/66/b6/d4a68f4ea999c6d89e8498579cba1c5fcba4276284de7773b17e4fa69293/cryptography-47.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:11dbb9f50a0f1bb9757b3d8c27c1101780efb8f0bdecfb12439c22a74d64c001", size = 4926106, upload-time = "2026-04-24T19:53:28.686Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ed/5f524db1fade9c013aa618e1c99c6ed05e8ffc9ceee6cda22fed22dda3f4/cryptography-47.0.0-cp311-abi3-win32.whl", hash = "sha256:7fda2f02c9015db3f42bb8a22324a454516ed10a8c29ca6ece6cdbb5efe2a203", size = 3258581, upload-time = "2026-04-24T19:53:31.058Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/dc/1b901990b174786569029f67542b3edf72ac068b6c3c8683c17e6a2f5363/cryptography-47.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:f5c3296dab66202f1b18a91fa266be93d6aa0c2806ea3d67762c69f60adc71aa", size = 3775309, upload-time = "2026-04-24T19:53:33.054Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/34/a4fae8ae7c3bc227460c9ae43f56abf1b911da0ec29e0ebac53bb0a4b6b7/cryptography-47.0.0-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:14432c8a9bcb37009784f9594a62fae211a2ae9543e96c92b2a8e4c3cd5cd0c4", size = 7904072, upload-time = "2026-04-24T19:54:06.411Z" },
+    { url = "https://files.pythonhosted.org/packages/01/64/d7b1e54fdb69f22d24a64bb3e88dc718b31c7fb10ef0b9691a3cf7eeea6e/cryptography-47.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:07efe86201817e7d3c18781ca9770bc0db04e1e48c994be384e4602bc38f8f27", size = 4635767, upload-time = "2026-04-24T19:54:08.519Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/7b/cca826391fb2a94efdcdfe4631eb69306ee1cff0b22f664a412c90713877/cryptography-47.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b45761c6ec22b7c726d6a829558777e32d0f1c8be7c3f3480f9c912d5ee8a10", size = 4654350, upload-time = "2026-04-24T19:54:10.795Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/65/4b57bcc823f42a991627c51c2f68c9fd6eb1393c1756aac876cba2accae2/cryptography-47.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:edd4da498015da5b9f26d38d3bfc2e90257bfa9cbed1f6767c282a0025ae649b", size = 4643394, upload-time = "2026-04-24T19:54:13.275Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c4/2c5fbeea70adbbca2bbae865e1d605d6a4a7f8dbd9d33eaf69645087f06c/cryptography-47.0.0-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9af828c0d5a65c70ec729cd7495a4bf1a67ecb66417b8f02ff125ab8a6326a74", size = 5225777, upload-time = "2026-04-24T19:54:15.18Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/b8/ac57107ef32749d2b244e36069bb688792a363aaaa3acc9e3cf84c130315/cryptography-47.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:256d07c78a04d6b276f5df935a9923275f53bd1522f214447fdf365494e2d515", size = 4688771, upload-time = "2026-04-24T19:54:17.835Z" },
+    { url = "https://files.pythonhosted.org/packages/56/fc/9f1de22ff8be99d991f240a46863c52d475404c408886c5a38d2b5c3bb26/cryptography-47.0.0-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:5d0e362ff51041b0c0d219cc7d6924d7b8996f57ce5712bdcef71eb3c65a59cc", size = 4270753, upload-time = "2026-04-24T19:54:19.963Z" },
+    { url = "https://files.pythonhosted.org/packages/00/68/d70c852797aa68e8e48d12e5a87170c43f67bb4a59403627259dd57d15de/cryptography-47.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:1581aef4219f7ca2849d0250edaa3866212fb74bf5667284f46aa92f9e65c1ca", size = 4642911, upload-time = "2026-04-24T19:54:21.818Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/51/661cbee74f594c5d97ff82d34f10d5551c085ca4668645f4606ebd22bd5d/cryptography-47.0.0-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:a49a3eb5341b9503fa3000a9a0db033161db90d47285291f53c2a9d2cd1b7f76", size = 5181411, upload-time = "2026-04-24T19:54:24.376Z" },
+    { url = "https://files.pythonhosted.org/packages/94/87/f2b6c374a82cf076cfa1416992ac8e8ec94d79facc37aec87c1a5cb72352/cryptography-47.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2207a498b03275d0051589e326b79d4cf59985c99031b05bb292ac52631c37fe", size = 4688262, upload-time = "2026-04-24T19:54:26.946Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e2/8b7462f4acf21ec509616f0245018bb197194ab0b65c2ea21a0bdd53c0eb/cryptography-47.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7a02675e2fabd0c0fc04c868b8781863cbf1967691543c22f5470500ff840b31", size = 4775506, upload-time = "2026-04-24T19:54:28.926Z" },
+    { url = "https://files.pythonhosted.org/packages/70/75/158e494e4c08dc05e039da5bb48553826bd26c23930cf8d3cd5f21fa8921/cryptography-47.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:80887c5cbd1774683cb126f0ab4184567f080071d5acf62205acb354b4b753b7", size = 4912060, upload-time = "2026-04-24T19:54:30.869Z" },
+    { url = "https://files.pythonhosted.org/packages/06/bd/0a9d3edbf5eadbac926d7b9b3cd0c4be584eeeae4a003d24d9eda4affbbd/cryptography-47.0.0-cp38-abi3-win32.whl", hash = "sha256:ed67ea4e0cfb5faa5bc7ecb6e2b8838f3807a03758eec239d6c21c8769355310", size = 3248487, upload-time = "2026-04-24T19:54:33.494Z" },
+    { url = "https://files.pythonhosted.org/packages/60/80/5681af756d0da3a599b7bdb586fac5a1540f1bcefd2717a20e611ddade45/cryptography-47.0.0-cp38-abi3-win_amd64.whl", hash = "sha256:835d2d7f47cdc53b3224e90810fb1d36ca94ea29cc1801fb4c1bc43876735769", size = 3755737, upload-time = "2026-04-24T19:54:35.408Z" },
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "12.9.4"
 source = { registry = "https://pypi.org/simple" }
@@ -925,6 +965,45 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/93/977b9e679e356871d428ae7a1139ec767dd5177bed58a6344b4d2199e00f/glfw-2.10.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:cca5158d62189e08792b1ae54f92307a282921a0e7783315b467e21b0a381c88", size = 243480, upload-time = "2026-03-10T17:21:30.538Z" },
     { url = "https://files.pythonhosted.org/packages/f9/bd/cea9569c8f2188b0a104472951420434a3e1f5cf26f5836ef9d7227a1a30/glfw-2.10.0-py2.py3-none-win32.whl", hash = "sha256:5e024509989740e8e7b86cc4aab508195495f79879072b0e1f68bd036a2916ad", size = 552641, upload-time = "2026-03-10T17:21:32.653Z" },
     { url = "https://files.pythonhosted.org/packages/cc/9b/4366ad3e1c0688146c70aa6143584d6a8d88583b9390f106250e25a3d5cd/glfw-2.10.0-py2.py3-none-win_amd64.whl", hash = "sha256:7f787ee8645781f10e8800438ce4357ab38c573ffb191aba380c1e72eba6311c", size = 559423, upload-time = "2026-03-10T17:21:34.766Z" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.50.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/18/238d7021d151bdab868f23433817b027dd759135202f4dfce0670d1230ca/google_auth-2.50.0.tar.gz", hash = "sha256:f35eafb191195328e8ce10a7883970877e7aeb49c2bfaa54aa0e394316d353d0", size = 336523, upload-time = "2026-04-30T21:19:29.659Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/cf/4880c2137c14280b2f59975cdf12cc442bc0ae1f9ea473a26eaa0c146786/google_auth-2.50.0-py3-none-any.whl", hash = "sha256:04382175e28b94f49694977f0a792688b59a668def1499e9d8de996dc9ce5b15", size = 246495, upload-time = "2026-04-30T21:19:27.664Z" },
+]
+
+[package.optional-dependencies]
+requests = [
+    { name = "requests" },
+]
+
+[[package]]
+name = "google-genai"
+version = "1.74.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "google-auth", extra = ["requests"] },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "sniffio" },
+    { name = "tenacity" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/c8/4a8f1de0a3268d526a345b8c74456b3e1e6ffd200982626326cf7ca83e5b/google_genai-1.74.0.tar.gz", hash = "sha256:c4c473cebdeb6e5adbb0639326de66a3a85a2209e0d32de7d66bf05c698abae8", size = 536772, upload-time = "2026-04-29T22:16:35.881Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/2b/539c328b66f7bfef2df869371a1789361228e5a7694ba02a642608367b46/google_genai-1.74.0-py3-none-any.whl", hash = "sha256:87d0b311c67d4b2a0ca741e9fc6891330c29defae81d46d8db41079aa1a3d80a", size = 790433, upload-time = "2026-04-29T22:16:33.979Z" },
 ]
 
 [[package]]
@@ -2331,6 +2410,7 @@ dependencies = [
     { name = "einops" },
     { name = "flask" },
     { name = "gdown" },
+    { name = "google-genai" },
     { name = "grpcio" },
     { name = "grpcio-tools" },
     { name = "gymnasium", extra = ["other"] },
@@ -2432,6 +2512,7 @@ requires-dist = [
     { name = "flask", specifier = ">=3.0.3" },
     { name = "future", marker = "extra == 'libero'", specifier = "==0.18.2" },
     { name = "gdown", specifier = ">=5.1.0" },
+    { name = "google-genai", specifier = ">=1.0.0" },
     { name = "grpcio", specifier = ">=1.60.0" },
     { name = "grpcio-tools", specifier = ">=1.60.0" },
     { name = "gym", marker = "extra == 'libero'", specifier = ">=0.25,<0.27" },
@@ -2711,6 +2792,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/95/f37b6a252fdbf247a67a78fb3f61a529fe0600e304c4d07741763d3522b1/pyarrow-23.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:1675c374570d8b91ea6d4edd4608fa55951acd44e0c31bd146e091b4005de24f", size = 48157777, upload-time = "2026-01-18T16:14:12.483Z" },
     { url = "https://files.pythonhosted.org/packages/ab/ab/fb94923108c9c6415dab677cf1f066d3307798eafc03f9a65ab4abc61056/pyarrow-23.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:247374428fde4f668f138b04031a7e7077ba5fa0b5b1722fdf89a017bf0b7ee0", size = 50580441, upload-time = "2026-01-18T16:14:20.187Z" },
     { url = "https://files.pythonhosted.org/packages/ae/78/897ba6337b517fc8e914891e1bd918da1c4eb8e936a553e95862e67b80f6/pyarrow-23.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:de53b1bd3b88a2ee93c9af412c903e57e738c083be4f6392288294513cd8b2c1", size = 27530028, upload-time = "2026-01-18T16:14:27.353Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]
@@ -3618,6 +3720,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
 name = "tensorboard"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4000,6 +4111,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c2/62/a7c072fbfefb2980a00f99ca994279cb9ecf310cb2e6b2a4d2a28fe192b3/wcwidth-0.5.3.tar.gz", hash = "sha256:53123b7af053c74e9fe2e92ac810301f6139e64379031f7124574212fb3b4091", size = 157587, upload-time = "2026-01-31T03:52:10.92Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3c/c1/d73f12f8cdb1891334a2ccf7389eed244d3941e74d80dd220badb937f3fb/wcwidth-0.5.3-py3-none-any.whl", hash = "sha256:d584eff31cd4753e1e5ff6c12e1edfdb324c995713f75d26c29807bb84bf649e", size = 92981, upload-time = "2026-01-31T03:52:09.14Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/74/221f58decd852f4b59cc3354cccaf87e8ef695fede361d03dc9a7396573b/websockets-16.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:04cdd5d2d1dacbad0a7bf36ccbcd3ccd5a30ee188f2560b7a62a30d14107b31a", size = 177343, upload-time = "2026-01-10T09:22:21.28Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0f/22ef6107ee52ab7f0b710d55d36f5a5d3ef19e8a205541a6d7ffa7994e5a/websockets-16.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:8ff32bb86522a9e5e31439a58addbb0166f0204d64066fb955265c4e214160f0", size = 175021, upload-time = "2026-01-10T09:22:22.696Z" },
+    { url = "https://files.pythonhosted.org/packages/10/40/904a4cb30d9b61c0e278899bf36342e9b0208eb3c470324a9ecbaac2a30f/websockets-16.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:583b7c42688636f930688d712885cf1531326ee05effd982028212ccc13e5957", size = 175320, upload-time = "2026-01-10T09:22:23.94Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/2f/4b3ca7e106bc608744b1cdae041e005e446124bebb037b18799c2d356864/websockets-16.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7d837379b647c0c4c2355c2499723f82f1635fd2c26510e1f587d89bc2199e72", size = 183815, upload-time = "2026-01-10T09:22:25.469Z" },
+    { url = "https://files.pythonhosted.org/packages/86/26/d40eaa2a46d4302becec8d15b0fc5e45bdde05191e7628405a19cf491ccd/websockets-16.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df57afc692e517a85e65b72e165356ed1df12386ecb879ad5693be08fac65dde", size = 185054, upload-time = "2026-01-10T09:22:27.101Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ba/6500a0efc94f7373ee8fefa8c271acdfd4dca8bd49a90d4be7ccabfc397e/websockets-16.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:2b9f1e0d69bc60a4a87349d50c09a037a2607918746f07de04df9e43252c77a3", size = 184565, upload-time = "2026-01-10T09:22:28.293Z" },
+    { url = "https://files.pythonhosted.org/packages/04/b4/96bf2cee7c8d8102389374a2616200574f5f01128d1082f44102140344cc/websockets-16.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:335c23addf3d5e6a8633f9f8eda77efad001671e80b95c491dd0924587ece0b3", size = 183848, upload-time = "2026-01-10T09:22:30.394Z" },
+    { url = "https://files.pythonhosted.org/packages/02/8e/81f40fb00fd125357814e8c3025738fc4ffc3da4b6b4a4472a82ba304b41/websockets-16.0-cp310-cp310-win32.whl", hash = "sha256:37b31c1623c6605e4c00d466c9d633f9b812ea430c11c8a278774a1fde1acfa9", size = 178249, upload-time = "2026-01-10T09:22:32.083Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/5f/7e40efe8df57db9b91c88a43690ac66f7b7aa73a11aa6a66b927e44f26fa/websockets-16.0-cp310-cp310-win_amd64.whl", hash = "sha256:8e1dab317b6e77424356e11e99a432b7cb2f3ec8c5ab4dabbcee6add48f72b35", size = 178685, upload-time = "2026-01-10T09:22:33.345Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What this does

Adds Google's Gemini family — including [Gemini Robotics-ER 1.6](https://ai.google.dev/gemini-api/docs/pricing#gemini-robotics-er) — as a `--model` option for `src/opentau/scripts/annotate_subtasks.py`. Anthropic remains the default; the script dispatches to google-genai when the model ID starts with `gemini` or `robotics-er`.

- New `_call_gemini` mirrors `_call_claude`: interleaves `t=…s:` text with JPEG `Part.from_bytes(...)`, system prompt as `system_instruction`, asks for `application/json`.
- `_annotate_subtasks` dispatches by model name; `main()` picks the right client/key (`GEMINI_API_KEY` or `GOOGLE_API_KEY` for Gemini, `ANTHROPIC_API_KEY` otherwise).
- Adds `google-genai>=1.0.0` to `pyproject.toml` and refreshes `uv.lock`.
- `--max-api-retries` continues to apply to the Anthropic client; the Gemini SDK uses its own retry policy.

🗃️ Feature

## How it was tested

- `uv sync --extra dev` and module import + dispatcher smoke test:
  ```
  _is_gemini_model('gemini-robotics-er-1.6-preview') = True
  _is_gemini_model('robotics-er-1.6')               = True
  _is_gemini_model('claude-opus-4-7')               = False
  ```
- `--help` renders cleanly with the updated `--model` description.
- `uv run pre-commit run --files pyproject.toml uv.lock src/opentau/scripts/annotate_subtasks.py` — all hooks pass (ruff, ruff-format, pyupgrade, bandit, …).
- End-to-end annotation against the live Gemini API was not exercised here — needs a valid `GEMINI_API_KEY` and a dataset on disk.

## How to checkout & try? (for the reviewer)

```bash
git checkout feat/annotate-subtasks-gemini-er
uv sync --extra dev

# Anthropic (unchanged default)
ANTHROPIC_API_KEY=... python src/opentau/scripts/annotate_subtasks.py \
    --config-path configs/examples/train_mixture_config.json \
    --max-episodes-per-dataset 1

# Gemini Robotics-ER 1.6
GEMINI_API_KEY=... python src/opentau/scripts/annotate_subtasks.py \
    --config-path configs/examples/train_mixture_config.json \
    --model gemini-robotics-er-1.6-preview \
    --max-episodes-per-dataset 1
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)