### PR TITLE
feat(datasets): add tolerance_s and skip_timestamp_check config knobs

### DIFF
--- a/src/opentau/configs/default.py
+++ b/src/opentau/configs/default.py
@@ -79,6 +79,20 @@ class DatasetConfig:
             metadata field. When provided (including the empty string), takes
             precedence over the value loaded from ``meta/info.json``. ``None``
             (default) leaves the loaded value untouched.
+        tolerance_s: Optional per-dataset override for the timestamp-sync
+            tolerance (in seconds) passed to ``LeRobotDataset``'s load-time
+            ``check_timestamps_sync`` call. ``None`` (default) inherits the
+            mixture-wide ``DatasetMixtureConfig.tolerance_s`` value. Set this
+            to a larger value (e.g. ``1e-3``) when a single dataset in the
+            mixture has slightly off-fps timestamps but you don't want to
+            loosen the check for the others. Must be ``>= 0`` when set.
+        skip_timestamp_check: Optional per-dataset override that bypasses the
+            load-time ``check_timestamps_sync`` call entirely. ``None``
+            (default) inherits the mixture-wide
+            ``DatasetMixtureConfig.skip_timestamp_check``. ``True`` skips the
+            check (a warning is logged); ``False`` forces the check on for this
+            dataset even if the mixture default is ``True``. Does not affect
+            the record-time check inside ``add_episode``.
 
     Raises:
         ValueError: If both or neither of `repo_id` and `vqa` are set, or
@@ -105,6 +119,13 @@ class DatasetConfig:
     # written through to `dataset.meta.info[...]` after the dataset is built.
     robot_type: str | None = None
     control_mode: str | None = None
+
+    # Per-dataset overrides for the load-time timestamp-sync check. `None`
+    # inherits from `DatasetMixtureConfig.{tolerance_s, skip_timestamp_check}`.
+    # A non-None value here wins over the mixture default for this dataset
+    # only — useful when one dataset in a mixture has off-fps timestamps.
+    tolerance_s: float | None = None
+    skip_timestamp_check: bool | None = None
 
     # DEPRECATED. Set `val_split_ratio` on `DatasetMixtureConfig` instead — the
     # mixture-level value is the single source of truth and is applied uniformly
@@ -196,6 +217,20 @@ class DatasetMixtureConfig:
             must have a non-empty ``control_mode`` after the optional
             ``DatasetConfig.control_mode`` override has been applied. Defaults
             to ``False`` (empty / missing values are allowed).
+        tolerance_s: Mixture-wide default tolerance (in seconds) for the
+            load-time ``check_timestamps_sync`` call inside
+            ``LeRobotDataset.__init__``. Each dataset's frame-to-frame
+            timestamp spacing must lie within ``1/fps +/- tolerance_s`` or the
+            check raises. Defaults to ``1e-4``. A per-dataset
+            ``DatasetConfig.tolerance_s`` overrides this value when set. Must
+            be ``>= 0``.
+        skip_timestamp_check: If True, bypass the load-time
+            ``check_timestamps_sync`` call for every dataset in the mixture
+            (a warning is logged per dataset). Useful as a debug knob when
+            the timing data is known-bad but you still want the mixture to
+            load. Defaults to ``False``. A per-dataset
+            ``DatasetConfig.skip_timestamp_check`` overrides this value when
+            set. Does not affect the record-time check inside ``add_episode``.
 
     Note:
         Dropout rolls use the default torch RNG. PyTorch DataLoader workers
@@ -251,6 +286,13 @@ class DatasetMixtureConfig:
     require_non_empty_robot_type: bool = False
     require_non_empty_control_mode: bool = False
 
+    # Mixture-wide defaults for the load-time timestamp-sync check. Each
+    # dataset can override these via `DatasetConfig.{tolerance_s,
+    # skip_timestamp_check}`. The default tolerance matches
+    # `LeRobotDataset.__init__`'s historical default.
+    tolerance_s: float = 1e-4
+    skip_timestamp_check: bool = False
+
     def __post_init__(self):
         """Validate dataset mixture configuration."""
         if self.weights is not None and len(self.datasets) != len(self.weights):
@@ -267,6 +309,15 @@ class DatasetMixtureConfig:
             )
         if self.val_split_ratio < 0 or self.val_split_ratio > 1:
             raise ValueError(f"`val_split_ratio` must be between 0 and 1, got {self.val_split_ratio}.")
+        if self.tolerance_s < 0:
+            raise ValueError(f"`tolerance_s` must be >= 0, got {self.tolerance_s}.")
+        for dataset_cfg in self.datasets:
+            if dataset_cfg.tolerance_s is not None and dataset_cfg.tolerance_s < 0:
+                identifier = dataset_cfg.repo_id or dataset_cfg.vqa or "<unidentified dataset>"
+                raise ValueError(
+                    f"`DatasetConfig.tolerance_s` must be >= 0 (or None to inherit), "
+                    f"got {dataset_cfg.tolerance_s} for {identifier}."
+                )
         if self.n_obs_history is not None and (
             not isinstance(self.n_obs_history, int) or self.n_obs_history < 1
         ):

--- a/src/opentau/configs/default.py
+++ b/src/opentau/configs/default.py
@@ -86,6 +86,10 @@ class DatasetConfig:
             to a larger value (e.g. ``1e-3``) when a single dataset in the
             mixture has slightly off-fps timestamps but you don't want to
             loosen the check for the others. Must be ``>= 0`` when set.
+            This also applies to frames decoded from video files: the same
+            value is used as the per-frame match tolerance in
+            ``query_video_frames_*``, so loosening it widens the
+            video-frame match window as well.
         skip_timestamp_check: Optional per-dataset override that bypasses the
             load-time ``check_timestamps_sync`` call entirely. ``None``
             (default) inherits the mixture-wide
@@ -142,6 +146,12 @@ class DatasetConfig:
         """Validate dataset configuration and register custom mappings if provided."""
         if (self.repo_id is None) == (self.vqa is None):
             raise ValueError("Exactly one of `repo_id` or `vqa` for Dataset config should be set.")
+
+        if self.tolerance_s is not None and self.tolerance_s < 0:
+            raise ValueError(
+                f"`DatasetConfig.tolerance_s` must be >= 0 (or None to inherit), "
+                f"got {self.tolerance_s} for {self.repo_id or self.vqa}."
+            )
 
         # If data_features_name_mapping is provided, upsert it into the global DATA_FEATURES_NAME_MAPPING
         if self.data_features_name_mapping is not None:
@@ -223,7 +233,10 @@ class DatasetMixtureConfig:
             timestamp spacing must lie within ``1/fps +/- tolerance_s`` or the
             check raises. Defaults to ``1e-4``. A per-dataset
             ``DatasetConfig.tolerance_s`` overrides this value when set. Must
-            be ``>= 0``.
+            be ``>= 0``. This also applies to frames decoded from video
+            files: the same value is used as the per-frame match tolerance
+            in ``query_video_frames_*``, so loosening it widens the
+            video-frame match window as well.
         skip_timestamp_check: If True, bypass the load-time
             ``check_timestamps_sync`` call for every dataset in the mixture
             (a warning is logged per dataset). Useful as a debug knob when
@@ -311,13 +324,6 @@ class DatasetMixtureConfig:
             raise ValueError(f"`val_split_ratio` must be between 0 and 1, got {self.val_split_ratio}.")
         if self.tolerance_s < 0:
             raise ValueError(f"`tolerance_s` must be >= 0, got {self.tolerance_s}.")
-        for dataset_cfg in self.datasets:
-            if dataset_cfg.tolerance_s is not None and dataset_cfg.tolerance_s < 0:
-                identifier = dataset_cfg.repo_id or dataset_cfg.vqa or "<unidentified dataset>"
-                raise ValueError(
-                    f"`DatasetConfig.tolerance_s` must be >= 0 (or None to inherit), "
-                    f"got {dataset_cfg.tolerance_s} for {identifier}."
-                )
         if self.n_obs_history is not None and (
             not isinstance(self.n_obs_history, int) or self.n_obs_history < 1
         ):

--- a/src/opentau/datasets/factory.py
+++ b/src/opentau/datasets/factory.py
@@ -205,6 +205,16 @@ def make_dataset(
         # once `__init__` emits the warning the suppression is a no-op.
         if cfg.control_mode is not None:
             suppress_control_mode_warning(cfg.repo_id)
+        # Per-dataset values win over the mixture-wide default; `None` means
+        # "inherit". See `DatasetConfig` / `DatasetMixtureConfig` docstrings.
+        effective_tolerance = (
+            cfg.tolerance_s if cfg.tolerance_s is not None else train_cfg.dataset_mixture.tolerance_s
+        )
+        effective_skip = (
+            cfg.skip_timestamp_check
+            if cfg.skip_timestamp_check is not None
+            else train_cfg.dataset_mixture.skip_timestamp_check
+        )
         dataset = LeRobotDataset(
             train_cfg,
             cfg.repo_id,
@@ -214,12 +224,14 @@ def make_dataset(
             delta_timestamps_std=dt_std,
             delta_timestamps_lower=dt_lower,
             delta_timestamps_upper=dt_upper,
+            tolerance_s=effective_tolerance,
             image_transforms=image_transforms,
             revision=cfg.revision,
             video_backend=cfg.video_backend,
             image_resample_strategy=train_cfg.dataset_mixture.image_resample_strategy,
             vector_resample_strategy=train_cfg.dataset_mixture.vector_resample_strategy,
             return_advantage_input=return_advantage_input,
+            skip_timestamp_check=effective_skip,
         )
     else:
         raise ValueError("Exactly one of `cfg.vqa` and `cfg.repo_id` should be provided.")

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -1092,6 +1092,7 @@ class LeRobotDataset(BaseDataset):
         vector_resample_strategy: str = "nearest",
         standardize: bool = True,
         return_advantage_input: bool = False,
+        skip_timestamp_check: bool = False,
     ):
         """Initialize LeRobotDataset.
 
@@ -1215,6 +1216,12 @@ class LeRobotDataset(BaseDataset):
                 Defaults to 'nearest'.
             standardize (bool, Optional): Flag to enable standardization in `__getitem__`. Defaults to True.
             return_advantage_input (bool, Optional): Flag to return advantage inputs ("success", "episode_end_idx", "current_idx", "last_step", "episode_index", "timestamp", ). Defaults to False. Ignored if standardize is False.
+            skip_timestamp_check (bool, Optional): If True, bypass the load-time
+                ``check_timestamps_sync`` call (a warning is logged). Frame-to-frame
+                spacing is NOT verified against ``1/fps``; downstream
+                ``delta_timestamps`` lookups may sample unintended frames. Defaults
+                to False. Does not affect the record-time check inside
+                ``add_episode``.
         """
         super().__init__(cfg)
         self.cfg = cfg
@@ -1229,6 +1236,7 @@ class LeRobotDataset(BaseDataset):
         )
         self.episodes = episodes
         self.tolerance_s = tolerance_s
+        self.skip_timestamp_check = skip_timestamp_check
         self.revision = revision if revision else CODEBASE_VERSION
         self.video_backend = video_backend if video_backend else get_safe_default_codec()
 
@@ -1337,12 +1345,20 @@ class LeRobotDataset(BaseDataset):
 
         # Check timestamps
         # If transform is set, with_transform will decode all columns of a row before returning the desired column(s).
-        no_transform_ds = self.hf_dataset.with_transform(None).with_format("numpy")
-        logging.info("Checking timestamps synchronization...")
-        timestamps = np.asarray(no_transform_ds["timestamp"], dtype=np.float32)
-        episode_indices = np.asarray(no_transform_ds["episode_index"], dtype=np.int64)
-        ep_data_index_np = {k: t.numpy() for k, t in self.episode_data_index.items()}
-        check_timestamps_sync(timestamps, episode_indices, ep_data_index_np, self.fps, self.tolerance_s)
+        if self.skip_timestamp_check:
+            logging.warning(
+                "Skipping timestamp sync check for %s (skip_timestamp_check=True). "
+                "Frame-to-frame spacing is NOT verified against 1/fps; downstream "
+                "delta_timestamps lookups may sample unintended frames.",
+                self.repo_id,
+            )
+        else:
+            no_transform_ds = self.hf_dataset.with_transform(None).with_format("numpy")
+            logging.info("Checking timestamps synchronization...")
+            timestamps = np.asarray(no_transform_ds["timestamp"], dtype=np.float32)
+            episode_indices = np.asarray(no_transform_ds["episode_index"], dtype=np.int64)
+            ep_data_index_np = {k: t.numpy() for k, t in self.episode_data_index.items()}
+            check_timestamps_sync(timestamps, episode_indices, ep_data_index_np, self.fps, self.tolerance_s)
 
         # Per-episode caches used by the optional-key emission path. Populated
         # from meta/episodes.jsonl annotations when present, else filled with

--- a/tests/configs/test_default.py
+++ b/tests/configs/test_default.py
@@ -136,6 +136,35 @@ def test_val_split_ratio_warns_when_child_overrides():
     )
 
 
+def test_dataset_mixture_config_tolerance_defaults():
+    """Mixture-level timestamp-sync defaults match the historical `LeRobotDataset` behavior."""
+    cfg = DatasetMixtureConfig()
+    assert cfg.tolerance_s == 1e-4
+    assert cfg.skip_timestamp_check is False
+
+
+def test_dataset_config_tolerance_defaults():
+    """Per-dataset timestamp-sync overrides default to None (inherit from mixture)."""
+    cfg = DatasetConfig(repo_id="foo/bar")
+    assert cfg.tolerance_s is None
+    assert cfg.skip_timestamp_check is None
+
+
+def test_invalid_negative_mixture_tolerance_raises():
+    """Mixture-level `tolerance_s` must be non-negative."""
+    with pytest.raises(ValueError, match=r"`tolerance_s` must be >= 0, got -1\.0"):
+        DatasetMixtureConfig(tolerance_s=-1.0)
+
+
+def test_invalid_negative_per_dataset_tolerance_raises():
+    """Per-dataset `tolerance_s` must be non-negative when set."""
+    with pytest.raises(
+        ValueError,
+        match=r"`DatasetConfig\.tolerance_s` must be >= 0 \(or None to inherit\), got -0\.5",
+    ):
+        DatasetMixtureConfig(datasets=[DatasetConfig(repo_id="foo/bar", tolerance_s=-0.5)])
+
+
 class TestDatasetConfigDataMapping:
     """Test class for DatasetConfig data mapping functionality."""
 

--- a/tests/configs/test_default.py
+++ b/tests/configs/test_default.py
@@ -165,6 +165,15 @@ def test_invalid_negative_per_dataset_tolerance_raises():
         DatasetMixtureConfig(datasets=[DatasetConfig(repo_id="foo/bar", tolerance_s=-0.5)])
 
 
+def test_invalid_negative_bare_dataset_tolerance_raises():
+    """Bare `DatasetConfig` must validate `tolerance_s` without going through a mixture."""
+    with pytest.raises(
+        ValueError,
+        match=r"`DatasetConfig\.tolerance_s` must be >= 0 \(or None to inherit\), got -1\.0 for foo/bar",
+    ):
+        DatasetConfig(repo_id="foo/bar", tolerance_s=-1.0)
+
+
 class TestDatasetConfigDataMapping:
     """Test class for DatasetConfig data mapping functionality."""
 

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -19,7 +19,7 @@ import logging
 import re
 from copy import deepcopy
 from importlib import import_module
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
@@ -413,6 +413,129 @@ def test_do_not_use_imagenet_stats(dataset_config, train_pipeline_config, repo_i
     item = dataset[0]
 
     check_standard_data_format(item, delta_timestamps_params, dataset, train_pipeline_config)
+
+
+def test_skip_timestamp_check_bypasses_load_check(tmp_path, lerobot_dataset_factory):
+    """`skip_timestamp_check=True` must suppress the load-time `check_timestamps_sync` call."""
+    with patch("opentau.datasets.lerobot_dataset.check_timestamps_sync") as mock_check:
+        dataset = lerobot_dataset_factory(
+            root=tmp_path / "skip_check_test",
+            skip_timestamp_check=True,
+        )
+
+    assert dataset.skip_timestamp_check is True
+    # Only the load path is exercised here (no save_episode), so the call
+    # count reflects whether the load-time gate was honored.
+    assert mock_check.call_count == 0
+
+
+def test_default_runs_load_check(tmp_path, lerobot_dataset_factory):
+    """Without the flag, the load-time `check_timestamps_sync` runs exactly once."""
+    with patch("opentau.datasets.lerobot_dataset.check_timestamps_sync") as mock_check:
+        dataset = lerobot_dataset_factory(root=tmp_path / "default_check_test")
+
+    assert dataset.skip_timestamp_check is False
+    assert mock_check.call_count == 1
+
+
+def _register_mapping(repo_id):
+    """Temporarily install an empty entry into DATA_FEATURES_NAME_MAPPING.
+
+    `factory.resolve_delta_timestamps` does a hard dict lookup on the mapping;
+    callers that mock out `LeRobotDatasetMetadata` still need an entry to exist
+    or they get a `KeyError`. Returns a no-arg cleanup callable.
+    """
+    from opentau.datasets.standard_data_format_mapping import DATA_FEATURES_NAME_MAPPING
+
+    sentinel = object()
+    original = DATA_FEATURES_NAME_MAPPING.get(repo_id, sentinel)
+    DATA_FEATURES_NAME_MAPPING[repo_id] = {}
+
+    def _cleanup():
+        if original is sentinel:
+            DATA_FEATURES_NAME_MAPPING.pop(repo_id, None)
+        else:
+            DATA_FEATURES_NAME_MAPPING[repo_id] = original
+
+    return _cleanup
+
+
+def test_make_dataset_per_dataset_overrides_win(train_pipeline_config):
+    """When set, `DatasetConfig.{tolerance_s,skip_timestamp_check}` win over mixture defaults."""
+    dataset_cfg = train_pipeline_config.dataset_mixture.datasets[0]
+    cleanup = _register_mapping(dataset_cfg.repo_id)
+    try:
+        dataset_cfg.tolerance_s = 2e-3
+        dataset_cfg.skip_timestamp_check = True
+        train_pipeline_config.dataset_mixture.tolerance_s = 5e-4
+        train_pipeline_config.dataset_mixture.skip_timestamp_check = False
+
+        with (
+            patch("opentau.datasets.factory.LeRobotDatasetMetadata") as mock_meta_cls,
+            patch("opentau.datasets.factory.LeRobotDataset") as mock_ds_cls,
+        ):
+            mock_meta_cls.return_value = MagicMock(features=[])
+            mock_ds_cls.return_value = MagicMock(meta=MagicMock(info={}, stats={}, camera_keys=[]))
+
+            make_dataset(dataset_cfg, train_pipeline_config)
+
+        kwargs = mock_ds_cls.call_args.kwargs
+        assert kwargs["tolerance_s"] == 2e-3
+        assert kwargs["skip_timestamp_check"] is True
+    finally:
+        cleanup()
+
+
+def test_make_dataset_inherits_mixture_defaults(train_pipeline_config):
+    """When per-dataset overrides are None, the mixture-wide defaults flow through."""
+    dataset_cfg = train_pipeline_config.dataset_mixture.datasets[0]
+    cleanup = _register_mapping(dataset_cfg.repo_id)
+    try:
+        # Per-dataset values left at None (the dataclass default).
+        assert dataset_cfg.tolerance_s is None
+        assert dataset_cfg.skip_timestamp_check is None
+        train_pipeline_config.dataset_mixture.tolerance_s = 7e-3
+        train_pipeline_config.dataset_mixture.skip_timestamp_check = True
+
+        with (
+            patch("opentau.datasets.factory.LeRobotDatasetMetadata") as mock_meta_cls,
+            patch("opentau.datasets.factory.LeRobotDataset") as mock_ds_cls,
+        ):
+            mock_meta_cls.return_value = MagicMock(features=[])
+            mock_ds_cls.return_value = MagicMock(meta=MagicMock(info={}, stats={}, camera_keys=[]))
+
+            make_dataset(dataset_cfg, train_pipeline_config)
+
+        kwargs = mock_ds_cls.call_args.kwargs
+        assert kwargs["tolerance_s"] == 7e-3
+        assert kwargs["skip_timestamp_check"] is True
+    finally:
+        cleanup()
+
+
+def test_make_dataset_per_dataset_skip_false_overrides_mixture_true(train_pipeline_config):
+    """`DatasetConfig.skip_timestamp_check=False` must force the check on for one
+    dataset even when the mixture default opts to skip — the override is true
+    bidirectional, not a "set-only-when-True" sentinel.
+    """
+    dataset_cfg = train_pipeline_config.dataset_mixture.datasets[0]
+    cleanup = _register_mapping(dataset_cfg.repo_id)
+    try:
+        dataset_cfg.skip_timestamp_check = False
+        train_pipeline_config.dataset_mixture.skip_timestamp_check = True
+
+        with (
+            patch("opentau.datasets.factory.LeRobotDatasetMetadata") as mock_meta_cls,
+            patch("opentau.datasets.factory.LeRobotDataset") as mock_ds_cls,
+        ):
+            mock_meta_cls.return_value = MagicMock(features=[])
+            mock_ds_cls.return_value = MagicMock(meta=MagicMock(info={}, stats={}, camera_keys=[]))
+
+            make_dataset(dataset_cfg, train_pipeline_config)
+
+        assert mock_ds_cls.call_args.kwargs["skip_timestamp_check"] is False
+    finally:
+        cleanup()
 
 
 # TODO(aliberts): Move to more appropriate location


### PR DESCRIPTION
## What this does

Exposes `LeRobotDataset`'s timestamp-sync tolerance through `DatasetConfig` / `DatasetMixtureConfig` and adds an explicit skip flag, so users can configure or bypass the load-time `check_timestamps_sync` call from a `TrainPipelineConfig` JSON. Previously the tolerance was hardcoded to `1e-4` with no escape hatch outside of `scripts/visualize_dataset.py`.

**New fields:**

| Field | Mixture-level default | Per-dataset override |
|---|---|---|
| `tolerance_s` | `DatasetMixtureConfig.tolerance_s: float = 1e-4` | `DatasetConfig.tolerance_s: float \| None = None` |
| `skip_timestamp_check` | `DatasetMixtureConfig.skip_timestamp_check: bool = False` | `DatasetConfig.skip_timestamp_check: bool \| None = None` |

Per-dataset values win over the mixture default when set; `None` means inherit. The skip only bypasses the load-time call in `LeRobotDataset.__init__`; the record-time call inside `add_episode` is intentionally **not** gated — bad timestamps in fresh recordings indicate a real capture bug, not tolerable drift.

Useful when one dataset in a mixture has slightly off-fps timestamps (override per-dataset to loosen for just that one) or as a debug knob to skip the check entirely while investigating timing data.

## How it was tested

- Added 4 config-level tests in `tests/configs/test_default.py`: defaults at both levels, validation rejects negative `tolerance_s` at both levels.
- Added 5 factory/dataset-level tests in `tests/datasets/test_datasets.py`: skip bypasses the load check, default runs it once, per-dataset overrides win over mixture defaults in both directions (true override, not set-when-True), mixture defaults flow through when per-dataset is `None`.
- `pre-commit run --all-files` (focused on modified files): all hooks pass.
- `pytest -m "not gpu" -n auto tests/configs/test_default.py tests/datasets/test_datasets.py`: 64 passed.
- Full CPU suite (`pytest -m "not gpu" -n auto`): 959 passed, 13 skipped, no regressions. (One pre-existing `test_libero_utils.py::test_libero2torch` failure due to missing local LIBERO benchmark data — unrelated to this PR.)

## How to checkout & try? (for the reviewer)

Run the focused tests:
```bash
pytest -sx tests/configs/test_default.py -k "tolerance"
pytest -sx tests/datasets/test_datasets.py -k "timestamp_check or tolerance"
```

Or exercise via a smoke-config CLI override:
```bash
opentau-train \
    --accelerate-config configs/examples/accelerate_ddp_config.yaml \
    --config_path=configs/examples/pi05_training_config.json \
    --dataset_mixture.skip_timestamp_check=true \
    --steps=2
```

Per-dataset override in JSON / CLI:
```bash
opentau-train ... \
    --dataset_mixture.datasets.0.tolerance_s=1e-3 \
    --dataset_mixture.datasets.0.skip_timestamp_check=true
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).