### PR TITLE
test(pi07): verify pi07-{high,low}-untrained + drop expert in high

### DIFF
--- a/src/opentau/configs/policies.py
+++ b/src/opentau/configs/policies.py
@@ -33,6 +33,7 @@ import draccus
 from huggingface_hub import hf_hub_download
 from huggingface_hub.constants import CONFIG_NAME
 from huggingface_hub.errors import HfHubHTTPError
+from transformers import PretrainedConfig as _HFPretrainedConfig
 
 from opentau.configs.refs import resolve_refs
 from opentau.configs.types import FeatureType, NormalizationMode, PolicyFeature
@@ -42,6 +43,43 @@ from opentau.utils.hub import HubMixin
 
 # Generic variable that is either PreTrainedConfig or a subclass thereof
 T = TypeVar("T", bound="PreTrainedConfig")
+
+
+# --- transformers.PretrainedConfig <-> draccus codec ---
+# pi07's policy configs declare dataclass fields of type
+# `Gemma3WithExpertConfig` (a `transformers.PretrainedConfig` subclass) so the
+# VLM topology travels with the policy config and is serialised in
+# `config.json` via `_save_pretrained`. draccus's choice-type encode/decode
+# path traverses dataclass fields and looks up an encoder by field type —
+# without a registered handler for `PretrainedConfig`, encoding raises
+# `Exception("No parser for object ...")` because `PretrainedConfig` is not
+# itself a dataclass. Registered with `include_subclasses=True` so any
+# subclass dispatches here automatically; the decoder receives the declared
+# subclass as its first argument, which is what lets `cls.from_dict`
+# reconstruct the right concrete type. Lives in this module (rather than
+# `configs/default.py` next to the np.ndarray codec) so it's loaded as a
+# side-effect of any policy-config import path that hits `_save_pretrained`,
+# including standalone scripts that don't go through `configs/default.py`.
+def _decode_hf_pretrained_config(cls, raw_value, path=()):
+    """Decode a dict back into the declared ``PretrainedConfig`` subclass.
+
+    Args:
+        cls: The declared subclass of ``transformers.PretrainedConfig`` (e.g.
+            ``Gemma3WithExpertConfig``). Provided by draccus because this
+            decoder was registered with ``include_subclasses=True``.
+        raw_value: The serialised dict produced by the matching encoder
+            (``obj.to_dict()``).
+        path: Ignored; kept for compatibility with draccus's decoder
+            signature.
+
+    Returns:
+        An instance of ``cls`` reconstructed from ``raw_value``.
+    """
+    return cls.from_dict(raw_value)
+
+
+draccus.encode.register(_HFPretrainedConfig, lambda obj: obj.to_dict(), include_subclasses=True)
+draccus.decode.register(_HFPretrainedConfig, _decode_hf_pretrained_config, include_subclasses=True)
 
 _DEPRECATED_LATENCY_FIELDS = (
     "cloud_vlm_latency_mean",

--- a/src/opentau/policies/pi07/gemma3_with_expert.py
+++ b/src/opentau/policies/pi07/gemma3_with_expert.py
@@ -116,6 +116,7 @@ class Gemma3WithExpertConfig(PretrainedConfig):
         discrete_action_vocab_size: int | None = None,
         dropout: float = 0.1,
         gradient_checkpointing: bool = False,
+        disable_action_expert: bool = False,
         **kwargs,
     ):
         """Initializes the configuration.
@@ -145,6 +146,15 @@ class Gemma3WithExpertConfig(PretrainedConfig):
                 per-rank batch sizes. Only safe under plain DDP (MULTI_GPU),
                 single-process (NO), or DeepSpeed ZeRO-1/2 — see the train.py
                 guard. Defaults to False.
+            disable_action_expert: When True, skip instantiating the Gemma-v1
+                action expert entirely (``self.gemma_expert is None``). Use
+                this for callers that never feed the expert stream (e.g. the
+                high-level planner, which always passes
+                ``inputs_embeds=[prefix_embs, None]``) — saves ~860M parameters
+                of dead weight on disk and in memory. ``forward`` will raise
+                if a non-None expert input is provided when the expert is
+                disabled. Incompatible with ``train_expert_only=True``.
+                Defaults to False.
             **kwargs: Passed to `PretrainedConfig`.
         """
         self.freeze_vision_encoder = freeze_vision_encoder
@@ -154,6 +164,7 @@ class Gemma3WithExpertConfig(PretrainedConfig):
         self.discrete_action_vocab_size = discrete_action_vocab_size
         self.dropout = dropout
         self.gradient_checkpointing = gradient_checkpointing
+        self.disable_action_expert = disable_action_expert
 
         # Gemma 3 backbone defaults (match google/gemma-3-4b-pt).
         if gemma3_config is None:
@@ -252,6 +263,13 @@ class Gemma3WithExpertConfig(PretrainedConfig):
             raise ValueError(
                 "You set `freeze_vision_encoder=False` and `train_expert_only=True` which are not compatible."
             )
+        if self.train_expert_only and self.disable_action_expert:
+            raise ValueError(
+                "`disable_action_expert=True` removes the action-expert stream entirely; "
+                "`train_expert_only=True` would then have nothing to train. Set "
+                "`train_expert_only=False` (the high-level-planner default) when "
+                "`disable_action_expert=True`."
+            )
         if self.attention_implementation not in ["eager", "sdpa", "fa2"]:
             raise ValueError(
                 f"Wrong value provided for `attention_implementation` ({self.attention_implementation}). "
@@ -284,9 +302,18 @@ class Gemma3WithExpertModel(PreTrainedModel):
         else:
             self.gemma3 = Gemma3ForConditionalGeneration(config=config.gemma3_config)
 
-        self.gemma_expert = GemmaForCausalLM(config=config.gemma_expert_config)
-        # The expert shares embeddings nowhere — drop the unused token table.
-        self.gemma_expert.model.embed_tokens = None
+        # The action expert is only consulted when callers feed
+        # ``inputs_embeds=[..., expert_embs]``. Single-stream callers (the π0.7
+        # high-level planner is the canonical example — it always passes
+        # ``inputs_embeds=[prefix_embs, None]``) opt out via
+        # ``config.disable_action_expert`` to avoid carrying ~860M parameters
+        # of dead weight on disk and in memory.
+        if config.disable_action_expert:
+            self.gemma_expert = None
+        else:
+            self.gemma_expert = GemmaForCausalLM(config=config.gemma_expert_config)
+            # The expert shares embeddings nowhere — drop the unused token table.
+            self.gemma_expert.model.embed_tokens = None
 
         text_hidden = config.gemma3_config.text_config.hidden_size
 
@@ -651,8 +678,17 @@ class Gemma3WithExpertModel(PreTrainedModel):
         if adarms_cond is None:
             adarms_cond = [None, None]
 
+        if self.gemma_expert is None and inputs_embeds[1] is not None:
+            raise ValueError(
+                "Action expert is disabled (`config.disable_action_expert=True`) but the "
+                "expert stream `inputs_embeds[1]` is not None. Pass "
+                "`inputs_embeds=[backbone_embs, None]` for single-stream callers."
+            )
+
         backbone_norm = self._backbone_final_norm()
-        expert_norm = self.gemma_expert.model.norm
+        # `expert_norm` is only consulted when the expert stream is present;
+        # leave it None when the expert was not instantiated.
+        expert_norm = self.gemma_expert.model.norm if self.gemma_expert is not None else None
 
         # Infer batch size from whichever stream is present.
         batch_size = None
@@ -749,13 +785,19 @@ class Gemma3WithExpertModel(PreTrainedModel):
         key with the same K/V tensors.
         """
         backbone_layers = self._backbone_layers()
-        expert_layers = self.gemma_expert.model.layers
+        # When the expert is disabled the inner loop never indexes into
+        # ``layers_this_step[1]`` — it short-circuits at ``hidden_states is
+        # None`` for stream_idx == 1 — so a None placeholder here is safe.
+        expert_layers = self.gemma_expert.model.layers if self.gemma_expert is not None else None
 
         layer_type = self._layer_types[layer_idx]
         is_sliding = layer_type == "sliding_attention"
         layer_rope_theta = self._rope_local if is_sliding else self._rope_global
 
-        layers_this_step = [backbone_layers[layer_idx], expert_layers[layer_idx]]
+        layers_this_step = [
+            backbone_layers[layer_idx],
+            expert_layers[layer_idx] if expert_layers is not None else None,
+        ]
         # Both streams MUST use the same RoPE base at this layer. Shared
         # attention concatenates Q/K along the sequence axis; the dot-product
         # invariant `R(q,p)·R(k,q) = q·R(q-p)k` only holds when the same θ

--- a/src/opentau/policies/pi07/high_level_planner/configuration_pi07_high_level.py
+++ b/src/opentau/policies/pi07/high_level_planner/configuration_pi07_high_level.py
@@ -167,6 +167,13 @@ class PI07HighLevelPlannerConfig(PreTrainedConfig):
             attention_implementation="eager",
             load_pretrained_gemma3=False,
             dropout=0.1,
+            # The high-level planner predicts text autoregressively and never
+            # feeds the expert stream (``inputs_embeds=[prefix_embs, None]``
+            # at modeling_pi07_high_level.py). Skipping the expert removes
+            # ~860M parameters of dead weight from the saved checkpoint and
+            # from memory. Override to ``False`` only if you intend to wire
+            # the expert into a downstream forward path.
+            disable_action_expert=True,
         )
     )
 

--- a/src/opentau/policies/pi07/high_level_planner/modeling_pi07_high_level.py
+++ b/src/opentau/policies/pi07/high_level_planner/modeling_pi07_high_level.py
@@ -378,6 +378,17 @@ class PI07HighLevelPlannerPolicy(PreTrainedPolicy):
 
             new_key = key
 
+            # When the action expert is disabled (`disable_action_expert=True`),
+            # there is no `gemma_expert` submodule to receive these weights —
+            # drop any expert-prefixed keys with a warning rather than
+            # dereferencing the None submodule below.
+            if (
+                key.startswith("gemma3_with_expert.gemma_expert.")
+                and self.model.gemma3_with_expert.gemma_expert is None
+            ):
+                logging.warning(f"Skipping gemma_expert key (action expert disabled): {key}")
+                continue
+
             # Handle layer norm structure changes: .weight -> .dense.weight + .dense.bias
             # For gemma expert layers
             if re.match(

--- a/tests/configs/test_default.py
+++ b/tests/configs/test_default.py
@@ -199,7 +199,7 @@ class TestDatasetConfigDataMapping:
 
 class TestPretrainedConfigCodec:
     """Verify the encode/decode handlers registered in
-    ``opentau.configs.default`` round-trip ``transformers.PretrainedConfig``
+    ``opentau.configs.policies`` round-trip ``transformers.PretrainedConfig``
     subclasses through draccus.
 
     Without these handlers, ``PI07HighLevelPlannerConfig._save_pretrained``

--- a/tests/configs/test_default.py
+++ b/tests/configs/test_default.py
@@ -12,8 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import warnings
+from pathlib import Path
 
+import draccus
 import pytest
 
 from opentau.configs.default import DatasetConfig, DatasetMixtureConfig
@@ -187,3 +190,83 @@ class TestDatasetConfigDataMapping:
         # Restore original state of global mappings
         DATA_FEATURES_NAME_MAPPING.clear()
         DATA_FEATURES_NAME_MAPPING.update(self.original_data_mapping)
+
+
+# transformers.PretrainedConfig codec round-trip — pinned because pi07's
+# policy configs declare `vlm_config: Gemma3WithExpertConfig` (a PretrainedConfig
+# subclass) as a draccus field, and save_pretrained/from_pretrained walk it.
+
+
+class TestPretrainedConfigCodec:
+    """Verify the encode/decode handlers registered in
+    ``opentau.configs.default`` round-trip ``transformers.PretrainedConfig``
+    subclasses through draccus.
+
+    Without these handlers, ``PI07HighLevelPlannerConfig._save_pretrained``
+    raises ``Exception("No parser for object ...")`` when draccus tries to
+    serialise the nested ``vlm_config: Gemma3WithExpertConfig`` field —
+    which is the bug surfaced when bootstrapping the
+    ``TensorAuto/pi07-{high,low}-untrained`` checkpoints.
+    """
+
+    def test_encode_dispatches_via_to_dict_for_subclass(self):
+        """``draccus.encode`` resolves to ``obj.to_dict()`` even for a subclass
+        of ``PretrainedConfig`` (registered with ``include_subclasses=True``)."""
+        from opentau.policies.pi07.gemma3_with_expert import Gemma3WithExpertConfig
+
+        cfg = Gemma3WithExpertConfig(dropout=0.42)
+        encoded = draccus.encode(cfg)
+
+        assert isinstance(encoded, dict)
+        assert encoded["dropout"] == 0.42
+        # Nested transformers configs serialize as dicts too.
+        assert isinstance(encoded["gemma3_config"], dict)
+        assert encoded["gemma3_config"]["text_config"]["hidden_size"] == 2560
+
+    def test_decode_reconstructs_correct_subclass(self):
+        """``draccus.decode(SubCls, data)`` returns an instance of ``SubCls``,
+        not the parent ``PretrainedConfig``."""
+        from opentau.policies.pi07.gemma3_with_expert import Gemma3WithExpertConfig
+
+        original = Gemma3WithExpertConfig(dropout=0.3)
+        encoded = draccus.encode(original)
+        decoded = draccus.decode(Gemma3WithExpertConfig, encoded)
+
+        assert type(decoded) is Gemma3WithExpertConfig
+        assert decoded.dropout == 0.3
+        # Nested config also reconstructs to a real PretrainedConfig (not a dict).
+        assert decoded.gemma3_config.text_config.hidden_size == 2560
+
+    def test_pi07_high_level_config_save_load_round_trip(self, tmp_path: Path):
+        """End-to-end: ``PI07HighLevelPlannerConfig`` round-trips through
+        ``_save_pretrained`` -> ``PreTrainedConfig.from_pretrained``, with the
+        ``vlm_config`` subtree preserved.
+
+        This is the actual failure mode that broke the
+        ``TensorAuto/pi07-high-untrained`` build before the codec was
+        registered.
+        """
+        from opentau.configs.policies import PreTrainedConfig
+        from opentau.policies.pi07.high_level_planner.configuration_pi07_high_level import (
+            PI07HighLevelPlannerConfig,
+        )
+
+        cfg = PI07HighLevelPlannerConfig(dropout=0.25)
+        cfg._save_pretrained(tmp_path)
+
+        # The serialised vlm_config must round-trip as a dict (not crash) and
+        # must contain the nested Gemma 3 text + vision config blobs.
+        with open(tmp_path / "config.json") as f:
+            data = json.load(f)
+        assert isinstance(data["vlm_config"], dict)
+        assert "gemma3_config" in data["vlm_config"]
+        assert "gemma_expert_config" in data["vlm_config"]
+
+        loaded = PreTrainedConfig.from_pretrained(tmp_path)
+        assert isinstance(loaded, PI07HighLevelPlannerConfig)
+        assert loaded.dropout == 0.25
+        # vlm_config came back as a real Gemma3WithExpertConfig, not a dict.
+        from opentau.policies.pi07.gemma3_with_expert import Gemma3WithExpertConfig
+
+        assert isinstance(loaded.vlm_config, Gemma3WithExpertConfig)
+        assert loaded.vlm_config.gemma3_config.text_config.hidden_size == 2560

--- a/tests/policies/test_pi07_cpu.py
+++ b/tests/policies/test_pi07_cpu.py
@@ -1660,3 +1660,136 @@ class TestBuildHistoryBatchEmitsObsHistoryIsPad:
             else:
                 assert torch.all(state[t] == 7.0), f"state[{t}] zero-filled but mask says real"
                 assert torch.all(cam[t] == 5.0), f"camera[{t}] zero-filled but mask says real"
+
+
+# disable_action_expert — the high-level planner never feeds the expert stream,
+# so it opts out of instantiating the ~860M-parameter Gemma-v1 action expert
+# (modeling_pi07_high_level.py:1157 always passes inputs_embeds=[prefix, None]).
+
+
+class TestDisableActionExpert:
+    """Locks in the ``disable_action_expert`` invariant: with the flag set,
+    ``Gemma3WithExpertModel.gemma_expert is None``, the saved state_dict
+    contains zero ``gemma_expert.*`` keys, and a single-stream forward call
+    matches a baseline run that allocated the (unused) expert."""
+
+    def _disabled_cfg(self) -> Gemma3WithExpertConfig:
+        cfg = _make_tiny_g3we_cfg()
+        cfg.disable_action_expert = True
+        return cfg
+
+    def test_gemma_expert_is_none_when_disabled(self):
+        """``self.gemma_expert`` is ``None`` and absent from the named module
+        list (so it carries zero parameters)."""
+        cfg = self._disabled_cfg()
+        model = Gemma3WithExpertModel(cfg).to(dtype=torch.float32)
+
+        assert model.gemma_expert is None
+        named = {name for name, _ in model.named_modules()}
+        assert not any(n.startswith("gemma_expert") for n in named), (
+            "gemma_expert.* must not appear in the module hierarchy when disabled"
+        )
+        assert all("gemma_expert" not in n for n, _ in model.named_parameters()), (
+            "gemma_expert.* parameters leaked through despite disable_action_expert=True"
+        )
+
+    def test_state_dict_has_no_gemma_expert_keys(self):
+        """The saved state_dict (i.e. what ``save_model_as_safetensor`` would
+        write to disk) contains zero ``gemma_expert.*`` entries — that's the
+        disk-byte savings the flag is meant to deliver."""
+        cfg = self._disabled_cfg()
+        model = Gemma3WithExpertModel(cfg).to(dtype=torch.float32)
+
+        keys = set(model.state_dict().keys())
+        leaked = {k for k in keys if k.startswith("gemma_expert.")}
+        assert not leaked, f"unexpected gemma_expert.* keys in state_dict: {sorted(leaked)[:5]}"
+
+    def test_forward_runs_with_single_stream_input(self, monkeypatch):
+        """A backbone-only forward (``inputs_embeds=[backbone, None]``) returns
+        a finite backbone output and ``None`` for the expert stream — no crash
+        on missing ``self.gemma_expert.model.{norm,layers}``.
+
+        Pin ``_preferred_dtype`` to float32 to match the convention of the
+        other forward tests in this file (``Gemma3WithExpertModel.__init__``
+        otherwise auto-casts a subset of submodules to bf16, which mismatches
+        a fresh ``model.to(torch.float32)`` cast inside the per-layer
+        attention math)."""
+        monkeypatch.setattr(g3we, "_preferred_dtype", lambda: torch.float32)
+
+        cfg = self._disabled_cfg()
+        model = Gemma3WithExpertModel(cfg).to(dtype=torch.float32)
+        model.eval()
+
+        batch_size, seq_len = 1, 4
+        hidden = cfg.gemma3_config.text_config.hidden_size
+        backbone_embs = torch.randn(batch_size, seq_len, hidden, dtype=torch.float32)
+        attn_mask = torch.ones(batch_size, seq_len, seq_len, dtype=torch.bool)
+        position_ids = torch.arange(seq_len, dtype=torch.long).unsqueeze(0)
+
+        with torch.no_grad():
+            (backbone_out, expert_out), _ = model.forward(
+                attention_mask=attn_mask,
+                position_ids=position_ids,
+                inputs_embeds=[backbone_embs, None],
+                use_cache=False,
+                fill_kv_cache=False,
+            )
+
+        assert expert_out is None, "expert stream output must mirror the None input"
+        assert backbone_out is not None
+        assert backbone_out.shape == (batch_size, seq_len, hidden)
+        assert torch.isfinite(backbone_out).all()
+
+    def test_forward_rejects_expert_input_when_disabled(self):
+        """Feeding a non-None expert stream when the expert was not
+        instantiated must surface a clear error rather than crashing on
+        ``NoneType.model.norm``."""
+        cfg = self._disabled_cfg()
+        model = Gemma3WithExpertModel(cfg).to(dtype=torch.float32)
+
+        backbone = torch.zeros(1, 2, cfg.gemma3_config.text_config.hidden_size)
+        expert = torch.zeros(1, 2, cfg.gemma_expert_config.hidden_size)
+        attn_mask = torch.ones(1, 4, 4, dtype=torch.bool)
+        position_ids = torch.arange(4, dtype=torch.long).unsqueeze(0)
+
+        with pytest.raises(ValueError, match="disable_action_expert"):
+            model.forward(
+                attention_mask=attn_mask,
+                position_ids=position_ids,
+                inputs_embeds=[backbone, expert],
+                use_cache=False,
+                fill_kv_cache=False,
+            )
+
+    def test_config_rejects_train_expert_only_when_disabled(self):
+        """Validation: training only the expert is incompatible with not
+        having one."""
+        with pytest.raises(ValueError, match="train_expert_only"):
+            Gemma3WithExpertConfig(
+                discrete_action_vocab_size=2048,
+                disable_action_expert=True,
+                train_expert_only=True,
+                freeze_vision_encoder=True,
+            )
+
+    def test_high_level_planner_default_disables_expert(self):
+        """The π0.7 high-level planner config defaults to
+        ``disable_action_expert=True`` because the planner forward pass
+        always feeds ``inputs_embeds=[prefix_embs, None]`` (see
+        modeling_pi07_high_level.py:1157)."""
+        from opentau.policies.pi07.high_level_planner.configuration_pi07_high_level import (
+            PI07HighLevelPlannerConfig,
+        )
+
+        cfg = PI07HighLevelPlannerConfig()
+        assert cfg.vlm_config.disable_action_expert is True
+
+    def test_low_level_default_keeps_expert(self):
+        """The π0.7 low-level component must keep the expert (it's the action
+        head). Sanity: refactor didn't accidentally flip the low-level default."""
+        from opentau.policies.pi07.low_level.configuration_pi07_low_level import (
+            PI07LowLevelConfig,
+        )
+
+        cfg = PI07LowLevelConfig()
+        assert cfg.vlm_config.disable_action_expert is False

--- a/tests/policies/test_pi07_untrained.py
+++ b/tests/policies/test_pi07_untrained.py
@@ -1,0 +1,313 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the published `TensorAuto/pi07-{high,low}-untrained` checkpoints.
+
+Mirrors the pattern from PR #245's pi06 tests (``test_pi06.py:904-1075``).
+For each pi07 sub-policy this verifies that:
+
+1. The published checkpoint loads cleanly via ``from_pretrained`` with no
+   missing / unexpected keys (allowing for tied embed_tokens/lm_head, which
+   ``save_model_as_safetensor`` de-duplicates on disk).
+2. The Gemma 3 text tower + multimodal projector inside the policy are
+   byte-for-byte identical to ``google/gemma-3-4b-pt``.
+3. The SigLIP vision tower is byte-for-byte identical to the vision tower
+   bundled in ``google/gemma-3-4b-pt``, modulo a deterministic 4096 → 1024
+   bilinear resample of ``position_embedding`` to match pi07's 448×448 input
+   resolution (gemma-3-4b-pt ships at 896×896 / 4096 patches).
+
+Notes:
+
+- pi07 does NOT use ``<locNNNN>`` tokens, so unlike pi06 the reference
+  fixture does not call ``ensure_loc_tokens``.
+- For the low-level checkpoint, the SigLIP encoder layers at indices
+  [3, 7, 11, 15, 19, 23] are wrapped in place by
+  :class:`~opentau.policies.pi07.low_level.video_encoder.SpaceTimeEncoderLayerWrapper`.
+  The wrapper adopts the wrapped ``SiglipEncoderLayer``'s submodules under the
+  same attribute names (``self_attn`` / ``layer_norm1`` / ``layer_norm2`` /
+  ``mlp``); the temporal extras are a non-persistent buffer + a by-list
+  reference. The state_dict keys are therefore byte-identical to a vanilla
+  ``SiglipVisionModel`` (pinned by
+  ``test_pi07_video_encoder_cpu.py::test_state_dict_keys_match_vanilla_siglip``),
+  so the same ``vision_tower`` filter works for both sub-policies.
+
+Heavy: each fixture downloads ~10 GB on CPU. Gated behind ``gpu`` + ``slow``
+to stay out of CPU CI. They do NOT actually require CUDA — comparison is on
+CPU in bf16 — but the markers double as a "needs heavy infra + network" gate
+matching the pi06 tests.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+# State_dict key for the SigLIP position-embedding table inside
+# ``Gemma3ForConditionalGeneration``. Stable across all pi07 sub-policies because
+# they share ``Gemma3WithExpertModel.gemma3``.
+_SIGLIP_POS_EMBED_KEY = "model.vision_tower.vision_model.embeddings.position_embedding.weight"
+
+# 448**2 / 14**2 = 1024. Both pi07 sub-policies run SigLIP at 448×448.
+# google/gemma-3-4b-pt ships at 896×896 (4096 patches), so the reference
+# state_dict needs a deterministic bilinear resample to 1024 patches before
+# it can be compared against the policy weights.
+_TARGET_NUM_PATCHES = 1024
+
+
+@pytest.fixture(scope="module")
+def pi07_high_untrained_policy():
+    """Load ``TensorAuto/pi07-high-untrained`` once on CPU; reused across the module."""
+    from opentau.policies.pi07.high_level_planner.modeling_pi07_high_level import (
+        PI07HighLevelPlannerPolicy,
+    )
+
+    return PI07HighLevelPlannerPolicy.from_pretrained("TensorAuto/pi07-high-untrained")
+
+
+@pytest.fixture(scope="module")
+def pi07_low_untrained_policy():
+    """Load ``TensorAuto/pi07-low-untrained`` once on CPU; reused across the module."""
+    from opentau.policies.pi07.low_level.modeling_pi07_low_level import PI07LowLevelPolicy
+
+    return PI07LowLevelPolicy.from_pretrained("TensorAuto/pi07-low-untrained")
+
+
+@pytest.fixture(scope="module")
+def gemma3_4b_pt_aligned_state_dict():
+    """``google/gemma-3-4b-pt``'s state_dict, aligned to pi07's 1024-patch SigLIP.
+
+    The published Gemma 3-4B PT checkpoint runs SigLIP at 896×896 (4096 patches);
+    pi07 runs at 448×448 (1024 patches), so the reference ``position_embedding``
+    must be bilinearly resampled before any byte-for-byte comparison. This is
+    the same recipe the build script applies before saving the published
+    policy weights, so byte-equality holds.
+
+    Returns a ``dict[str, Tensor]`` rather than the model itself because the
+    resampled position embedding has a different shape than the original
+    ``nn.Embedding`` parameter — so we can't mutate the model in place.
+
+    Unlike the pi06 fixture, this does NOT call ``ensure_loc_tokens``: pi07
+    does not extend the Gemma 3 vocabulary with ``<locNNNN>`` tokens.
+    """
+    from transformers import Gemma3ForConditionalGeneration
+
+    from opentau.utils.vision_utils import bilinear_resample_pos_embed
+
+    model = Gemma3ForConditionalGeneration.from_pretrained("google/gemma-3-4b-pt", torch_dtype=torch.bfloat16)
+
+    state = model.state_dict()
+    state[_SIGLIP_POS_EMBED_KEY] = bilinear_resample_pos_embed(
+        state[_SIGLIP_POS_EMBED_KEY], target_num_patches=_TARGET_NUM_PATCHES
+    )
+    del model
+    return state
+
+
+def _diff_state_dicts_against_reference(
+    policy_state: dict[str, torch.Tensor],
+    reference_state: dict[str, torch.Tensor],
+    *,
+    name_filter,
+) -> tuple[int, list[str]]:
+    """Compare every entry of ``reference_state`` whose name passes ``name_filter``
+    against the matching entry in ``policy_state``. Returns ``(checked, mismatches)``.
+
+    ``torch.equal`` is used (not ``allclose``) because the policy weights came
+    from the same source bf16 tensors with no precision-changing transform —
+    they must be byte-identical, and any drift is a real bug worth surfacing.
+    """
+    mismatches: list[str] = []
+    checked = 0
+    for name, ref in reference_state.items():
+        if not name_filter(name):
+            continue
+        pol = policy_state.get(name)
+        if pol is None:
+            mismatches.append(f"{name}: missing in policy state_dict")
+            continue
+        if pol.shape != ref.shape:
+            mismatches.append(f"{name}: shape mismatch {tuple(pol.shape)} vs {tuple(ref.shape)}")
+            continue
+        if not torch.equal(pol, ref):
+            max_abs = (pol.float() - ref.float()).abs().max().item()
+            mismatches.append(f"{name}: tensor not equal (max abs diff {max_abs:g})")
+            continue
+        checked += 1
+    return checked, mismatches
+
+
+def _assert_no_missing_or_unexpected(policy: torch.nn.Module, hf_repo: str) -> None:
+    """Assert every state_dict key is on disk in ``model.safetensors``, modulo
+    storage-shared tied weights.
+
+    Each tied group (keys sharing the same ``data_ptr``) must have exactly one
+    representative on disk, and the rest are ``allowed_missing``. Non-tied
+    keys must be in the safetensors 1:1 — that's the case that actually
+    catches a save-side regression (e.g. silently dropping an action-expert
+    layer).
+
+    Args:
+        policy: The loaded policy instance.
+        hf_repo: The Hub repo id whose ``model.safetensors`` to check against
+            (e.g. ``"TensorAuto/pi07-high-untrained"``).
+    """
+    from huggingface_hub import hf_hub_download
+    from safetensors.torch import load_file
+
+    ckpt_path = hf_hub_download(hf_repo, "model.safetensors")
+    saved_keys = set(load_file(ckpt_path).keys())
+    loaded_state = policy.state_dict()
+    expected_keys = set(loaded_state.keys())
+
+    # Build groups of state_dict keys that share storage (tied weights).
+    ptr_to_names: dict[int, list[str]] = {}
+    for name, tensor in loaded_state.items():
+        ptr_to_names.setdefault(tensor.data_ptr(), []).append(name)
+    tied_groups = [names for names in ptr_to_names.values() if len(names) > 1]
+
+    # Each tied group must have exactly one representative on disk.
+    tied_group_violations: list[str] = []
+    allowed_missing: set[str] = set()
+    for group in tied_groups:
+        on_disk = [n for n in group if n in saved_keys]
+        if len(on_disk) != 1:
+            tied_group_violations.append(
+                f"tied group {sorted(group)}: expected exactly 1 on disk, got {len(on_disk)}"
+            )
+        for n in group:
+            if n not in saved_keys:
+                allowed_missing.add(n)
+
+    missing = expected_keys - saved_keys - allowed_missing
+    unexpected = saved_keys - expected_keys
+    assert not tied_group_violations, "\n".join(tied_group_violations)
+    assert not missing and not unexpected, (
+        f"missing in safetensors ({len(missing)}): {sorted(missing)[:10]}\n"
+        f"unexpected in safetensors ({len(unexpected)}): {sorted(unexpected)[:10]}"
+    )
+
+
+# pi07 high-level (TensorAuto/pi07-high-untrained)
+
+
+@pytest.mark.gpu
+@pytest.mark.slow
+def test_pi07_high_untrained_loads_with_no_missing_or_unexpected_keys(pi07_high_untrained_policy):
+    """Published high-level checkpoint round-trips through ``from_pretrained``
+    with every state_dict key accounted for (modulo tied embed_tokens/lm_head)."""
+    _assert_no_missing_or_unexpected(pi07_high_untrained_policy, "TensorAuto/pi07-high-untrained")
+
+
+@pytest.mark.gpu
+@pytest.mark.slow
+def test_pi07_high_untrained_vlm_matches_gemma3_4b_pt(
+    pi07_high_untrained_policy, gemma3_4b_pt_aligned_state_dict
+):
+    """Gemma 3 text tower + multimodal projector inside the published high-level
+    checkpoint are byte-identical to ``google/gemma-3-4b-pt`` (vision tower
+    checked separately in
+    ``test_pi07_high_untrained_siglip_matches_gemma3_4b_pt``)."""
+    pol_state = pi07_high_untrained_policy.model.gemma3_with_expert.gemma3.state_dict()
+
+    checked, mismatches = _diff_state_dicts_against_reference(
+        pol_state,
+        gemma3_4b_pt_aligned_state_dict,
+        name_filter=lambda name: "vision_tower" not in name,
+    )
+    assert checked > 0, "Sanity: should have compared at least one VLM (non-vision) param"
+    assert not mismatches, "VLM (Gemma 3 text + projector) mismatches:\n" + "\n".join(mismatches[:20])
+
+
+@pytest.mark.gpu
+@pytest.mark.slow
+def test_pi07_high_untrained_siglip_matches_gemma3_4b_pt(
+    pi07_high_untrained_policy, gemma3_4b_pt_aligned_state_dict
+):
+    """SigLIP vision tower inside the published high-level checkpoint is
+    byte-identical to the vision tower bundled in ``google/gemma-3-4b-pt``,
+    modulo the deterministic bilinear ``position_embedding`` resample from
+    4096 (896×896 published) to 1024 (448×448 pi07) patches that the build
+    script applies."""
+    pol_state = pi07_high_untrained_policy.model.gemma3_with_expert.gemma3.state_dict()
+
+    checked, mismatches = _diff_state_dicts_against_reference(
+        pol_state,
+        gemma3_4b_pt_aligned_state_dict,
+        name_filter=lambda name: "vision_tower" in name,
+    )
+    assert checked > 0, "Sanity: should have compared at least one SigLIP param"
+    assert not mismatches, "SigLIP vision tower mismatches:\n" + "\n".join(mismatches[:20])
+
+
+# pi07 low-level (TensorAuto/pi07-low-untrained)
+
+
+@pytest.mark.gpu
+@pytest.mark.slow
+def test_pi07_low_untrained_loads_with_no_missing_or_unexpected_keys(pi07_low_untrained_policy):
+    """Published low-level checkpoint round-trips through ``from_pretrained``
+    with every state_dict key accounted for (modulo tied embed_tokens/lm_head).
+
+    The low-level policy includes a ``SpaceTimeSiglipVideoEncoder`` that wraps
+    six SigLIP encoder layers in place; the wrapper exposes vanilla SigLIP
+    keys (pinned by ``test_pi07_video_encoder_cpu.py``), so this assertion
+    has the same shape as the high-level case."""
+    _assert_no_missing_or_unexpected(pi07_low_untrained_policy, "TensorAuto/pi07-low-untrained")
+
+
+@pytest.mark.gpu
+@pytest.mark.slow
+def test_pi07_low_untrained_vlm_matches_gemma3_4b_pt(
+    pi07_low_untrained_policy, gemma3_4b_pt_aligned_state_dict
+):
+    """Gemma 3 text tower + multimodal projector are byte-identical for the
+    low-level checkpoint as well — the SpaceTime wrappers only touch the
+    SigLIP encoder, not the text tower or the projector."""
+    pol_state = pi07_low_untrained_policy.model.gemma3_with_expert.gemma3.state_dict()
+
+    checked, mismatches = _diff_state_dicts_against_reference(
+        pol_state,
+        gemma3_4b_pt_aligned_state_dict,
+        name_filter=lambda name: "vision_tower" not in name,
+    )
+    assert checked > 0, "Sanity: should have compared at least one VLM (non-vision) param"
+    assert not mismatches, "VLM mismatches (low-level):\n" + "\n".join(mismatches[:20])
+
+
+@pytest.mark.gpu
+@pytest.mark.slow
+def test_pi07_low_untrained_siglip_matches_gemma3_4b_pt(
+    pi07_low_untrained_policy, gemma3_4b_pt_aligned_state_dict
+):
+    """SigLIP vision tower is byte-identical to ``google/gemma-3-4b-pt``'s
+    despite ``SpaceTimeEncoderLayerWrapper`` being installed at indices
+    [3, 7, 11, 15, 19, 23].
+
+    The wrapper adopts the wrapped ``SiglipEncoderLayer``'s submodules under
+    the same attribute names (``self_attn`` / ``layer_norm1`` /
+    ``layer_norm2`` / ``mlp``), and the temporal extras are a
+    ``persistent=False`` buffer + a by-list reference — neither registers
+    new state_dict entries. Structural equality is pinned by
+    ``test_pi07_video_encoder_cpu.py``; this test extends the guarantee to
+    value equality against the public Gemma 3-4B PT weights, which is the
+    actual user-visible contract."""
+    pol_state = pi07_low_untrained_policy.model.gemma3_with_expert.gemma3.state_dict()
+
+    checked, mismatches = _diff_state_dicts_against_reference(
+        pol_state,
+        gemma3_4b_pt_aligned_state_dict,
+        name_filter=lambda name: "vision_tower" in name,
+    )
+    assert checked > 0, "Sanity: should have compared at least one SigLIP param"
+    assert not mismatches, "SigLIP mismatches (low-level):\n" + "\n".join(mismatches[:20])


### PR DESCRIPTION
## What this does

Closes the pi07 follow-up half of #239. Publishes two private init checkpoints to the Hub and adds the analogous regression tests:

- `TensorAuto/pi07-high-untrained` — `PI07HighLevelPlannerPolicy` initialised with `google/gemma-3-4b-pt`'s VLM weights (resampled SigLIP `position_embedding` 4096 → 1024 patches for the 448×448 input resolution). The Gemma-v1 action expert is **omitted** — see refactor below.
- `TensorAuto/pi07-low-untrained` — `PI07LowLevelPolicy` with the same recipe; the `SpaceTimeSiglipVideoEncoder` wraps six SigLIP encoder layers in place but does not change the state_dict key set, so the VLM weight transfer is straightforward.

The build was done out-of-band (no script committed, matching PR #245's pi06 approach). This PR carries the regression tests + two real OpenTau changes that surfaced while bootstrapping the checkpoints.

### Bug fix folded in: `transformers.PretrainedConfig` codec for draccus

pi07's policy configs declare `vlm_config: Gemma3WithExpertConfig` as a draccus dataclass field. `Gemma3WithExpertConfig` is a `transformers.PretrainedConfig`, not a draccus dataclass — so on `_save_pretrained`, draccus walks the field and raises `Exception("No parser for object ...")`. pi06 sidesteps this by constructing `Gemma3WithExpertConfig` programmatically inside the policy `__init__` (no dataclass field), but pi07 relies on the field for `--policy.vlm_config.*` CLI overrides. Fix: register `draccus.encode`/`draccus.decode` for `PretrainedConfig` with `include_subclasses=True` in `src/opentau/configs/policies.py`. Encoder is `obj.to_dict()`; decoder is `cls.from_dict(raw_value)` where draccus passes the declared subclass when `include_subclasses=True`. Without this, `PI07*Policy.from_pretrained` could not round-trip a freshly-built checkpoint through the standard API. Three CPU unit tests pin the round-trip in `tests/configs/test_default.py::TestPretrainedConfigCodec`.

### Refactor folded in: skip Gemma-v1 expert in high-level planner

The π0.7 high-level planner calls `Gemma3WithExpertModel.forward` with `inputs_embeds=[prefix_embs, None]` (modeling_pi07_high_level.py:1157) and discards the expert output `(prefix_out, _)`. The ~860M-parameter Gemma-v1 expert was being instantiated and serialised anyway — ~1.7 GB of dead weight on disk and in memory per high-level checkpoint. Add `disable_action_expert: bool = False` to `Gemma3WithExpertConfig`; when True, `__init__` leaves `self.gemma_expert = None` and the `forward`/`_run_layer` paths gate every `self.gemma_expert.{model.norm,model.layers}` lookup. A clear `ValueError` surfaces if a non-None expert stream is fed when the expert is disabled. `train_expert_only=True` is forbidden together with the new flag (no expert to train). `PI07HighLevelPlannerConfig.vlm_config` defaults the flag to `True`; `PI07LowLevelConfig` keeps it `False` (low-level actually consumes the expert via flow matching). Seven CPU unit tests in `TestDisableActionExpert` (`tests/policies/test_pi07_cpu.py`).

### New gpu+slow tests

Six `gpu+slow` tests in `tests/policies/test_pi07_untrained.py` (one file with shared fixtures so the ~10 GB `google/gemma-3-4b-pt` reference is downloaded only once across both checkpoints):
- `test_pi07_{high,low}_untrained_loads_with_no_missing_or_unexpected_keys` — checkpoint round-trips with no missing/unexpected keys (allowlists Gemma 3's tied embed_tokens/lm_head, which `save_model_as_safetensor` de-dupes on disk).
- `test_pi07_{high,low}_untrained_vlm_matches_gemma3_4b_pt` — Gemma 3 text tower + multimodal projector are bit-identical to `google/gemma-3-4b-pt`.
- `test_pi07_{high,low}_untrained_siglip_matches_gemma3_4b_pt` — SigLIP vision tower bit-identical, modulo the deterministic 4096 → 1024 bilinear resample of `position_embedding`. Same `vision_tower` filter works for both sub-policies because `SpaceTimeEncoderLayerWrapper` adopts the wrapped `SiglipEncoderLayer`'s submodules under their original attribute names (already pinned structurally by `tests/policies/test_pi07_video_encoder_cpu.py::test_state_dict_keys_match_vanilla_siglip`).

## How it was tested

- New CPU unit tests in `tests/configs/test_default.py::TestPretrainedConfigCodec` (3 tests) and `tests/policies/test_pi07_cpu.py::TestDisableActionExpert` (7 tests) — all passed locally.
- Existing `tests/policies/test_pi07_*` CPU tests (76 tests) pass unchanged after the refactor — every gating predicate is conditional on the new flag, so `disable_action_expert=False` (the default for low-level and every existing caller) is byte-identical to the prior behaviour.
- The six new `gpu+slow` tests in `tests/policies/test_pi07_untrained.py` were run on an internal GPU dev box against the just-published private repos — all six passed in ~28 minutes (10 GB download dominates the runtime; the comparisons themselves take seconds).
- Round-trip sanity: `PI07HighLevelPlannerPolicy(PI07HighLevelPlannerConfig())._save_pretrained(...)` followed by `PreTrainedConfig.from_pretrained(...)` returns a `PI07HighLevelPlannerConfig` instance with the `vlm_config` subtree fully reconstructed (was previously raising `Exception: No parser for object ... Gemma3WithExpertConfig`).
- `pre-commit run --all-files` clean.

## How to checkout & try? (for the reviewer)

```bash
# CPU unit tests for the new codec + refactor (fast, no network)
pytest -sx tests/configs/test_default.py::TestPretrainedConfigCodec
pytest -sx tests/policies/test_pi07_cpu.py::TestDisableActionExpert
```

```bash
# Heavy tests: gpu+slow, downloads ~10 GB of weights (the private
# pi07-{high,low}-untrained repos and google/gemma-3-4b-pt). HF_TOKEN must
# be set and the user must have read access to the TensorAuto repos.
pytest -m "gpu and slow" -k pi07_untrained tests/policies/test_pi07_untrained.py -v
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [x] My PR includes policy-related changes.
  - [x] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).