### PR TITLE
feat(pi07): FSDP support via decoder-layer bundling refactor

### DIFF
--- a/configs/examples/accelerate_deepspeed_zero3_config.yaml
+++ b/configs/examples/accelerate_deepspeed_zero3_config.yaml
@@ -1,0 +1,23 @@
+compute_environment: LOCAL_MACHINE
+debug: false
+deepspeed_config:
+  gradient_accumulation_steps: 1
+  gradient_clipping: 10.0
+  offload_optimizer_device: none
+  offload_param_device: none
+  zero3_init_flag: false
+  zero_stage: 3
+distributed_type: DEEPSPEED
+downcast_bf16: 'no'
+enable_cpu_affinity: false
+machine_rank: 0
+main_training_function: main
+mixed_precision: 'no'
+num_machines: 1
+num_processes: 8
+rdzv_backend: static
+same_network: true
+tpu_env: []
+tpu_use_cluster: false
+tpu_use_sudo: false
+use_cpu: false

--- a/configs/examples/accelerate_fsdp2_config.yaml
+++ b/configs/examples/accelerate_fsdp2_config.yaml
@@ -1,0 +1,32 @@
+compute_environment: LOCAL_MACHINE
+debug: false
+distributed_type: FSDP
+downcast_bf16: 'no'
+mixed_precision: 'no'
+machine_rank: 0
+main_training_function: main
+num_machines: 1
+num_processes: 8
+rdzv_backend: static
+same_network: true
+tpu_env: []
+tpu_use_cluster: false
+tpu_use_sudo: false
+use_cpu: false
+fsdp_config:
+  fsdp_version: 2
+  fsdp_auto_wrap_policy: TRANSFORMER_BASED_WRAP
+  # Under FSDP2 the SpaceTimeSiglipVideoEncoder's ``forward`` reaches into
+  # ``vision_tower.vision_model.embeddings(flat)`` directly. If
+  # ``SiglipVisionEmbeddings`` (the patch-embedding Conv2d + position
+  # embedding) isn't its own FSDP wrap unit, its weights stay as
+  # root-level DTensors and the input ``flat`` (a plain Tensor) raises
+  # mixed Tensor / DTensor on the conv. Wrapping at the embedding level
+  # makes the all-gather hook fire before the conv. (FSDP1 doesn't need
+  # this because its hooks attach differently.)
+  fsdp_transformer_layer_cls_to_wrap: InterleavedDecoderLayer,SiglipEncoderLayer,SiglipVisionEmbeddings
+  fsdp_reshard_after_forward: true
+  fsdp_state_dict_type: SHARDED_STATE_DICT
+  fsdp_sync_module_states: true
+  fsdp_cpu_ram_efficient_loading: true
+  fsdp_offload_params: false

--- a/configs/examples/accelerate_fsdp_config.yaml
+++ b/configs/examples/accelerate_fsdp_config.yaml
@@ -15,7 +15,14 @@ tpu_use_sudo: false
 use_cpu: false
 fsdp_config:
   fsdp_auto_wrap_policy: TRANSFORMER_BASED_WRAP
-  fsdp_transformer_layer_cls_to_wrap: Gemma3DecoderLayer,GemmaDecoderLayer,SiglipEncoderLayer
+  # InterleavedDecoderLayer bundles one Gemma3 backbone layer + one Gemma-v1
+  # expert layer into a single nn.Module — the FSDP wrap target. Wrapping at
+  # this granularity is what makes pi07 work under FSDP / ZeRO-3: the
+  # all-gather hook fires on the bundled forward, prefetching every
+  # sub-component (input_layernorm, self_attn.{q,k,v}_proj, mlp, ...) at
+  # once. Wrapping at the inner Gemma3DecoderLayer / GemmaDecoderLayer level
+  # would re-introduce the sub-component access bug.
+  fsdp_transformer_layer_cls_to_wrap: InterleavedDecoderLayer,SiglipEncoderLayer
   fsdp_sharding_strategy: FULL_SHARD
   fsdp_state_dict_type: SHARDED_STATE_DICT
   fsdp_use_orig_params: true

--- a/configs/examples/accelerate_fsdp_config.yaml
+++ b/configs/examples/accelerate_fsdp_config.yaml
@@ -1,0 +1,26 @@
+compute_environment: LOCAL_MACHINE
+debug: false
+distributed_type: FSDP
+downcast_bf16: 'no'
+mixed_precision: bf16
+machine_rank: 0
+main_training_function: main
+num_machines: 1
+num_processes: 8
+rdzv_backend: static
+same_network: true
+tpu_env: []
+tpu_use_cluster: false
+tpu_use_sudo: false
+use_cpu: false
+fsdp_config:
+  fsdp_auto_wrap_policy: TRANSFORMER_BASED_WRAP
+  fsdp_transformer_layer_cls_to_wrap: Gemma3DecoderLayer,GemmaDecoderLayer,SiglipEncoderLayer
+  fsdp_sharding_strategy: FULL_SHARD
+  fsdp_state_dict_type: SHARDED_STATE_DICT
+  fsdp_use_orig_params: true
+  fsdp_sync_module_states: true
+  fsdp_cpu_ram_efficient_loading: true
+  fsdp_offload_params: false
+  fsdp_forward_prefetch: true
+  fsdp_backward_prefetch: BACKWARD_PRE

--- a/configs/examples/pi07_low_level_libero.json
+++ b/configs/examples/pi07_low_level_libero.json
@@ -11,12 +11,7 @@
         "image_resample_strategy": "nearest",
         "vector_resample_strategy": "nearest",
         "n_obs_history": 8,
-        "history_interval": 1,
-        "history_state_drop_prob": 1.0,
-        "subgoal_drop_prob": 1.0,
-        "response_drop_prob": 1.0,
-        "metadata_drop_all_prob": 1.0,
-        "metadata_drop_each_prob": 1.0
+        "history_interval": 1
     },
     "policy": {
         "type": "pi07_low_level",

--- a/configs/examples/pi07_low_level_libero.json
+++ b/configs/examples/pi07_low_level_libero.json
@@ -11,7 +11,12 @@
         "image_resample_strategy": "nearest",
         "vector_resample_strategy": "nearest",
         "n_obs_history": 8,
-        "history_interval": 1
+        "history_interval": 1,
+        "history_state_drop_prob": 1.0,
+        "subgoal_drop_prob": 1.0,
+        "response_drop_prob": 1.0,
+        "metadata_drop_all_prob": 1.0,
+        "metadata_drop_each_prob": 1.0
     },
     "policy": {
         "type": "pi07_low_level",

--- a/configs/examples/pi07_low_level_libero.json
+++ b/configs/examples/pi07_low_level_libero.json
@@ -9,7 +9,9 @@
         "weights": [1.0],
         "action_freq": 10.0,
         "image_resample_strategy": "nearest",
-        "vector_resample_strategy": "nearest"
+        "vector_resample_strategy": "nearest",
+        "n_obs_history": 8,
+        "history_interval": 1
     },
     "policy": {
         "type": "pi07_low_level",

--- a/configs/examples/pi07_low_level_libero.json
+++ b/configs/examples/pi07_low_level_libero.json
@@ -1,0 +1,98 @@
+{
+    "dataset_mixture": {
+        "datasets": [
+            {
+                "repo_id": "physical-intelligence/libero",
+                "episodes": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+            }
+        ],
+        "weights": [1.0],
+        "action_freq": 10.0,
+        "image_resample_strategy": "nearest",
+        "vector_resample_strategy": "nearest"
+    },
+    "policy": {
+        "type": "pi07_low_level",
+        "pretrained_path": null,
+        "n_obs_steps": 8,
+        "n_obs_history": 8,
+        "history_interval": 1,
+        "normalization_mapping": {
+            "VISUAL": "IDENTITY",
+            "STATE": "MIN_MAX",
+            "ACTION": "MEAN_STD"
+        },
+        "chunk_size": 10,
+        "n_action_steps": 10,
+        "max_state_dim": 32,
+        "max_action_dim": 32,
+        "proj_width": 1280,
+        "num_steps": 5,
+        "resize_imgs_with_padding": [448, 448],
+        "attention_implementation": "sdpa",
+        "gradient_checkpointing": true,
+        "freeze_vision_encoder": true,
+        "train_expert_only": false,
+        "prompt_max_length": 256,
+        "discrete_action_max_length": 32,
+        "metadata_max_length": 52,
+        "response_max_length": 52,
+        "spacetime_layer_stride": 4,
+        "optimizer_lr": 2.5e-05,
+        "optimizer_betas": [0.9, 0.95],
+        "optimizer_eps": 1e-08,
+        "optimizer_weight_decay": 1e-10,
+        "scheduler_warmup_steps": 1000,
+        "scheduler_decay_steps": 30000,
+        "scheduler_decay_lr": 2.5e-06
+    },
+    "resume": false,
+    "seed": 1000,
+    "resolution": [448, 448],
+    "num_cams": 2,
+    "max_state_dim": 32,
+    "max_action_dim": 32,
+    "action_chunk": 10,
+    "loss_weighting": {"MSE": 1, "CE": 1},
+    "num_workers": 4,
+    "batch_size": 2,
+    "gradient_accumulation_steps": 1,
+    "dataloader_batch_size": 2,
+    "prefetch_factor": 8,
+    "steps": 40,
+    "log_freq": 5,
+    "save_checkpoint": true,
+    "save_freq": 40,
+    "val_freq": 10,
+    "use_policy_training_preset": false,
+    "trace_nans": false,
+    "optimizer": {
+        "type": "adamw",
+        "lr": 2.5e-05,
+        "weight_decay": 1e-10,
+        "grad_clip_norm": 10.0,
+        "betas": [0.9, 0.95],
+        "eps": 1e-08
+    },
+    "scheduler": {
+        "type": "cosine_decay_with_warmup",
+        "num_warmup_steps": 1000,
+        "num_decay_steps": 30000,
+        "peak_lr": 2.5e-05,
+        "decay_lr": 2.5e-06
+    },
+    "wandb": {
+        "enable": true,
+        "entity": "wyautox-autox",
+        "project": "pi07",
+        "run_id": null,
+        "name": null,
+        "notes": "PI07 low-level training (Libero) smoke config",
+        "tags": [],
+        "group": null,
+        "job_type": null,
+        "mode": null,
+        "allow_resume": true,
+        "disable_artifact": false
+    }
+}

--- a/src/opentau/datasets/dataset_mixture.py
+++ b/src/opentau/datasets/dataset_mixture.py
@@ -177,15 +177,21 @@ class DatasetMixtureMetadata:
         for cam_idx in range(self.cfg.num_cams):
             if f"camera{cam_idx}" in standard_stats:
                 continue
-            standard_stats[f"camera{cam_idx}"] = {
+            cam_stats: dict[str, np.ndarray] = {
                 "min": np.zeros((3, 1, 1), dtype=np.float32),
                 "max": np.ones((3, 1, 1), dtype=np.float32),
                 "mean": np.zeros((3, 1, 1), dtype=np.float32),
                 "std": np.zeros((3, 1, 1), dtype=np.float32),
-                "count": np.array(
-                    standard_stats["state"]["count"]
-                ),  # create a copy in case this gets modified
             }
+            # `count` is only present in v2.1+ stats; v2.0 datasets like
+            # `physical-intelligence/libero` (LeRobot v2.0 format) carry
+            # only mean/std/min/max. Mirror it from the state stats when
+            # available — the empty-camera placeholder doesn't actually
+            # need a meaningful count, but downstream code that asserts
+            # the field's presence shouldn't crash. Issue #264.
+            if "count" in standard_stats.get("state", {}):
+                cam_stats["count"] = np.array(standard_stats["state"]["count"])
+            standard_stats[f"camera{cam_idx}"] = cam_stats
 
         # check for missing keys
         for data in standard_stats:

--- a/src/opentau/policies/normalize.py
+++ b/src/opentau/policies/normalize.py
@@ -32,6 +32,32 @@ from opentau.configs.types import FeatureType, NormalizationMode, PolicyFeature
 EPS = 1e-8  # Small epsilon value for numerical stability in normalization
 
 
+def _materialize(tensor: Tensor) -> Tensor:
+    """Return the full local Tensor for ``tensor``, materializing if it is a DTensor.
+
+    Under FSDP2 (``fully_shard``), parameters and buffers attached to a
+    ``fully_shard``-wrapped module are exposed as ``DTensor`` instances.
+    Mixing a ``DTensor`` with a regular ``Tensor`` in arithmetic raises:
+
+        RuntimeError: aten.sub.Tensor got mixed torch.Tensor and DTensor,
+        need to convert all torch.Tensor to DTensor before calling
+        distributed operators!
+
+    Normalize / Unnormalize stats (``mean``/``std``/``min``/``max``) are tiny
+    and replicated across ranks, so the cost of redistributing to a full
+    Tensor for the per-feature arithmetic is negligible. Under FSDP1, DDP,
+    or single-process this helper is a fast no-op (the Parameter is already
+    a regular Tensor).
+    """
+    if hasattr(tensor, "full_tensor"):
+        # ``DTensor.full_tensor()`` materializes the (replicated or sharded)
+        # tensor into a single full Tensor on each rank. For replicated
+        # placements this is just a pointer-copy; for sharded ones it does
+        # an all-gather.
+        return tensor.full_tensor()
+    return tensor
+
+
 def warn_missing_keys(features: dict[str, PolicyFeature], batch: dict[str, Tensor], mode: str) -> None:
     """Warns if expected features are missing from the batch.
 
@@ -219,14 +245,14 @@ class Normalize(nn.Module):
             buffer = getattr(self, "buffer_" + key.replace(".", "_"))
 
             if norm_mode is NormalizationMode.MEAN_STD:
-                mean = buffer["mean"]
-                std = buffer["std"]
+                mean = _materialize(buffer["mean"])
+                std = _materialize(buffer["std"])
                 assert not torch.isinf(mean).any(), _no_stats_error_str("mean")
                 assert not torch.isinf(std).any(), _no_stats_error_str("std")
                 batch[key] = (batch[key] - mean) / (std + EPS)
             elif norm_mode is NormalizationMode.MIN_MAX:
-                min = buffer["min"]
-                max = buffer["max"]
+                min = _materialize(buffer["min"])
+                max = _materialize(buffer["max"])
                 assert not torch.isinf(min).any(), _no_stats_error_str("min")
                 assert not torch.isinf(max).any(), _no_stats_error_str("max")
                 batch[key] = (batch[key] - min) / (max - min + EPS)
@@ -298,15 +324,15 @@ class Unnormalize(nn.Module):
             buffer = getattr(self, "buffer_" + key.replace(".", "_"))
 
             if norm_mode is NormalizationMode.MEAN_STD:
-                mean = buffer["mean"]
-                std = buffer["std"]
+                mean = _materialize(buffer["mean"])
+                std = _materialize(buffer["std"])
                 if not (torch.compiler.is_compiling() or torch.onnx.is_in_onnx_export()):
                     assert not torch.isinf(mean).any(), _no_stats_error_str("mean")
                     assert not torch.isinf(std).any(), _no_stats_error_str("std")
                 batch[key] = batch[key] * (std + EPS) + mean
             elif norm_mode is NormalizationMode.MIN_MAX:
-                min = buffer["min"]
-                max = buffer["max"]
+                min = _materialize(buffer["min"])
+                max = _materialize(buffer["max"])
                 if not (torch.compiler.is_compiling() or torch.onnx.is_in_onnx_export()):
                     assert not torch.isinf(min).any(), _no_stats_error_str("min")
                     assert not torch.isinf(max).any(), _no_stats_error_str("max")

--- a/src/opentau/policies/pi07/gemma3_with_expert.py
+++ b/src/opentau/policies/pi07/gemma3_with_expert.py
@@ -117,6 +117,7 @@ class Gemma3WithExpertConfig(PretrainedConfig):
         dropout: float = 0.1,
         gradient_checkpointing: bool = False,
         disable_action_expert: bool = False,
+        disable_internal_bf16_cast: bool = False,
         **kwargs,
     ):
         """Initializes the configuration.
@@ -155,6 +156,18 @@ class Gemma3WithExpertConfig(PretrainedConfig):
                 if a non-None expert input is provided when the expert is
                 disabled. Incompatible with ``train_expert_only=True``.
                 Defaults to False.
+            disable_internal_bf16_cast: When True, skip the in-``__init__``
+                call to ``to_bfloat16_like_physical_intelligence`` so the
+                model's params remain in their constructed dtype (fp32 on
+                a fresh instance). The intended consumer is the FSDP path,
+                which needs fp32 outer params so ``MixedPrecision(
+                param_dtype=bf16, reduce_dtype=bf16)`` can downcast on the
+                fly while keeping the fp32 outer copy for AdamW to step on
+                (mirrors DeepSpeed's bf16-live / fp32-master regime). Other
+                backends (DDP, single, DeepSpeed ZeRO-1/2) still want the
+                cast applied here, then layer fp32 master back on top via
+                ``MasterWeightOptimizer`` / ``BF16_Optimizer``. Defaults to
+                False.
             **kwargs: Passed to `PretrainedConfig`.
         """
         self.freeze_vision_encoder = freeze_vision_encoder
@@ -165,6 +178,7 @@ class Gemma3WithExpertConfig(PretrainedConfig):
         self.dropout = dropout
         self.gradient_checkpointing = gradient_checkpointing
         self.disable_action_expert = disable_action_expert
+        self.disable_internal_bf16_cast = disable_internal_bf16_cast
 
         # Gemma 3 backbone defaults (match google/gemma-3-4b-pt).
         if gemma3_config is None:
@@ -593,7 +607,11 @@ class Gemma3WithExpertModel(PreTrainedModel):
         # FSDP / ZeRO-3 see one coherent forward unit per interleaved step.
         self._build_interleaved_layers()
 
-        if not torch.compiler.is_compiling():
+        # FSDP needs fp32 outer params so ``MixedPrecision(param_dtype=bf16,
+        # reduce_dtype=bf16)`` can manage the bf16-compute / fp32-master
+        # split itself — see the ``disable_internal_bf16_cast`` docstring on
+        # ``Gemma3WithExpertConfig``. Other backends still want the cast.
+        if not torch.compiler.is_compiling() and not config.disable_internal_bf16_cast:
             self.to_bfloat16_like_physical_intelligence()
         self.set_requires_grad()
 

--- a/src/opentau/policies/pi07/gemma3_with_expert.py
+++ b/src/opentau/policies/pi07/gemma3_with_expert.py
@@ -302,10 +302,13 @@ class InterleavedDecoderLayer(nn.Module):
             ``head_dim ** -0.5``).
         head_dim: Per-head dimension shared by both streams.
         dropout: Dropout module applied to attention output and MLP output.
-        attention_interface_fn: Bound attention method from the parent
-            ``Gemma3WithExpertModel`` (selected by ``attention_implementation``).
-            Stored as a plain callable attribute — not a submodule — so it
-            doesn't appear in ``state_dict``.
+        attention_interface_provider: Zero-arg callable that returns the
+            current attention dispatch function (``parent.get_attention_interface()``).
+            Resolved at every ``forward`` rather than captured at init so
+            tests / runtime code that monkey-patches the parent's
+            ``eager_attention_forward`` / ``sdpa_attention_forward`` see
+            their patches honoured. Stored as a plain callable attribute —
+            not a submodule — so it doesn't appear in ``state_dict``.
     """
 
     def __init__(
@@ -318,7 +321,7 @@ class InterleavedDecoderLayer(nn.Module):
         query_pre_attn_scaling: float,
         head_dim: int,
         dropout: nn.Module,
-        attention_interface_fn,
+        attention_interface_provider,
     ):
         super().__init__()
         self.backbone_layer = backbone_layer
@@ -331,7 +334,7 @@ class InterleavedDecoderLayer(nn.Module):
         self._rope_global = rope_global
         self._query_pre_attn_scaling = query_pre_attn_scaling
         self._head_dim = head_dim
-        self._attention_interface_fn = attention_interface_fn
+        self._attention_interface_provider = attention_interface_provider
 
     def forward(
         self,
@@ -445,7 +448,8 @@ class InterleavedDecoderLayer(nn.Module):
         # (see the note next to `apply_rope`).
         layer_attention_mask = attention_mask
 
-        att_output = self._attention_interface_fn(
+        attention_interface = self._attention_interface_provider()
+        att_output = attention_interface(
             layer_attention_mask,
             batch_size,
             head_dim,
@@ -580,7 +584,12 @@ class Gemma3WithExpertModel(PreTrainedModel):
                 f"Expected backbone and expert to have {self._num_layers} layers each; "
                 f"got backbone={len(backbone_layers)}, expert={len(expert_layers)}."
             )
-        attention_interface_fn = self.get_attention_interface()
+        # Resolve the attention dispatch lazily on every call so that runtime
+        # patches to ``self.eager_attention_forward`` / ``sdpa_attention_forward``
+        # — used in tests and adapters — are honoured. Capturing the bound
+        # method at init would freeze the dispatch and silently bypass the
+        # patch.
+        attention_interface_provider = self.get_attention_interface
         layers = nn.ModuleList(
             [
                 InterleavedDecoderLayer(
@@ -592,7 +601,7 @@ class Gemma3WithExpertModel(PreTrainedModel):
                     query_pre_attn_scaling=self._query_pre_attn_scaling,
                     head_dim=self._head_dim,
                     dropout=self.dropout,
-                    attention_interface_fn=attention_interface_fn,
+                    attention_interface_provider=attention_interface_provider,
                 )
                 for i in range(self._num_layers)
             ]

--- a/src/opentau/policies/pi07/gemma3_with_expert.py
+++ b/src/opentau/policies/pi07/gemma3_with_expert.py
@@ -270,6 +270,236 @@ class Gemma3WithExpertConfig(PretrainedConfig):
         super().__init__(**kwargs)
 
 
+class InterleavedDecoderLayer(nn.Module):
+    """One step of pi07's interleaved Gemma 3 backbone + Gemma-v1 expert decoder.
+
+    Bundles the backbone layer and expert layer for one decoder step into a
+    single nn.Module so that FSDP / ZeRO-3 see a coherent forward unit. Their
+    all-gather hooks fire on this module's ``forward`` and prefetch every
+    sub-component (input_layernorm, self_attn.{q,k,v}_proj, mlp, ...) at
+    once. The pre-refactor design called per-sub-component on the wrapped
+    ``Gemma3DecoderLayer`` directly (``layer.input_layernorm(...)``), which
+    bypassed FSDP's hooks and hung at NCCL all-gather with mismatched
+    sizes across ranks (different ranks would request different params).
+
+    This module owns its backbone and expert layers as submodules. The
+    enclosing ``Gemma3WithExpertModel`` empties the original
+    ``gemma3.language_model.model.layers`` and ``gemma_expert.model.layers``
+    after handing them off so each parameter is registered exactly once
+    and FSDP / ZeRO-3 don't double-shard.
+
+    Args:
+        backbone_layer: One ``Gemma3DecoderLayer`` from the Gemma 3 text
+            decoder.
+        expert_layer: The corresponding ``GemmaDecoderLayer`` from the
+            Gemma-v1 action expert.
+        layer_type: Per-layer attention type from
+            ``gemma3_config.text_config.layer_types`` — ``"sliding_attention"``
+            selects ``rope_local``; anything else uses ``rope_global``.
+        rope_local: RoPE base for sliding-window layers.
+        rope_global: RoPE base for global layers.
+        query_pre_attn_scaling: Pre-softmax scaling factor (typically
+            ``head_dim ** -0.5``).
+        head_dim: Per-head dimension shared by both streams.
+        dropout: Dropout module applied to attention output and MLP output.
+        attention_interface_fn: Bound attention method from the parent
+            ``Gemma3WithExpertModel`` (selected by ``attention_implementation``).
+            Stored as a plain callable attribute — not a submodule — so it
+            doesn't appear in ``state_dict``.
+    """
+
+    def __init__(
+        self,
+        backbone_layer: nn.Module,
+        expert_layer: nn.Module,
+        layer_type: str,
+        rope_local: float,
+        rope_global: float,
+        query_pre_attn_scaling: float,
+        head_dim: int,
+        dropout: nn.Module,
+        attention_interface_fn,
+    ):
+        super().__init__()
+        self.backbone_layer = backbone_layer
+        self.expert_layer = expert_layer
+        self.dropout = dropout
+        # Non-tensor / non-module attributes — won't be registered as
+        # parameters or submodules and won't appear in state_dict.
+        self._layer_type = layer_type
+        self._rope_local = rope_local
+        self._rope_global = rope_global
+        self._query_pre_attn_scaling = query_pre_attn_scaling
+        self._head_dim = head_dim
+        self._attention_interface_fn = attention_interface_fn
+
+    def forward(
+        self,
+        inputs_embeds: list[torch.FloatTensor | None],
+        attention_mask: torch.Tensor | None,
+        position_ids: torch.LongTensor | None,
+        past_key_values: dict | None,
+        n_cross_att_tokens: int | None,
+        use_cache: bool | None,
+        fill_kv_cache: bool | None,
+        adarms_cond: list[torch.Tensor | None],
+        batch_size: int,
+        layer_idx: int,
+    ) -> list[torch.FloatTensor | None]:
+        """Run one interleaved decoder layer.
+
+        Body extracted from ``Gemma3WithExpertModel._run_layer``. The KV-cache
+        write is idempotent under gradient-checkpointing recompute because
+        each call writes the same ``layer_idx`` key with the same K/V.
+        """
+        backbone_layer = self.backbone_layer
+        expert_layer = self.expert_layer
+        layers_this_step = [backbone_layer, expert_layer]
+
+        is_sliding = self._layer_type == "sliding_attention"
+        layer_rope_theta = self._rope_local if is_sliding else self._rope_global
+        # Both streams MUST use the same RoPE base at this layer. Shared
+        # attention concatenates Q/K along the sequence axis; the dot-product
+        # invariant `R(q,p)·R(k,q) = q·R(q-p)k` only holds when the same θ
+        # produced both rotations. For global Gemma-3 layers (θ=1M) this
+        # means the expert also rotates at 1M even though the config carries
+        # a single fallback `rope_theta=10k`.
+        rope_thetas = [layer_rope_theta, layer_rope_theta]
+        head_dim = self._head_dim
+
+        query_states: list[torch.Tensor | None] = []
+        key_states: list[torch.Tensor | None] = []
+        value_states: list[torch.Tensor | None] = []
+        gates: list[torch.Tensor | None] = []
+        # Track the pre-attention residual + post-attn layernorm output for the
+        # Gemma-3 backbone side, since it needs a second residual around the MLP
+        # using `pre_feedforward_layernorm` / `post_feedforward_layernorm`.
+        backbone_preattn_residual = None
+
+        for stream_idx, hidden_states in enumerate(inputs_embeds):
+            if hidden_states is None:
+                gates.append(None)
+                query_states.append(None)
+                key_states.append(None)
+                value_states.append(None)
+                continue
+
+            layer = layers_this_step[stream_idx]
+
+            if stream_idx == 0:
+                # Gemma 3 backbone.
+                backbone_preattn_residual = hidden_states
+                h = layer.input_layernorm(hidden_states)
+                gate = None
+            else:
+                # Gemma-v1 expert (patched to return (tensor, gate)).
+                h, gate = layer.input_layernorm(hidden_states, cond=adarms_cond[stream_idx])
+
+            gates.append(gate)
+            bsize, seq_len, _ = h.shape
+            h = h.to(dtype=_preferred_dtype())
+
+            q = layer.self_attn.q_proj(h).view(bsize, seq_len, -1, head_dim)
+            k = layer.self_attn.k_proj(h).view(bsize, seq_len, -1, head_dim)
+            v = layer.self_attn.v_proj(h).view(bsize, seq_len, -1, head_dim)
+
+            if stream_idx == 0:
+                # Gemma-3 applies an extra per-head RMSNorm on Q and K.
+                q_norm = getattr(layer.self_attn, "q_norm", None)
+                k_norm = getattr(layer.self_attn, "k_norm", None)
+                if q_norm is not None:
+                    q = q_norm(q)
+                if k_norm is not None:
+                    k = k_norm(k)
+
+            q = apply_rope(q, position_ids, max_wavelength=rope_thetas[stream_idx])
+            k = apply_rope(k, position_ids, max_wavelength=rope_thetas[stream_idx])
+
+            query_states.append(q)
+            key_states.append(k)
+            value_states.append(v)
+
+        # Drop Nones before concatenating.
+        q_list = [q for q in query_states if q is not None]
+        k_list = [k for k in key_states if k is not None]
+        v_list = [v for v in value_states if v is not None]
+
+        q_concat = torch.cat(q_list, dim=1)
+        k_concat = torch.cat(k_list, dim=1)
+        v_concat = torch.cat(v_list, dim=1)
+
+        if use_cache and past_key_values is not None and layer_idx in past_key_values:
+            k_concat = torch.cat([past_key_values[layer_idx]["key_states"], k_concat], dim=1)
+            v_concat = torch.cat([past_key_values[layer_idx]["value_states"], v_concat], dim=1)
+
+        if fill_kv_cache:
+            if n_cross_att_tokens is None:
+                raise ValueError("n_cross_att_tokens must be provided when fill_kv_cache is True")
+            past_key_values[layer_idx] = {
+                "key_states": k_concat[:, :n_cross_att_tokens, :, :],
+                "value_states": v_concat[:, :n_cross_att_tokens, :, :],
+            }
+
+        # π0.7 keeps the prefix block-causal mask at every layer — the
+        # Gemma 3 sliding-window pattern is deliberately not applied
+        # (see the note next to `apply_rope`).
+        layer_attention_mask = attention_mask
+
+        att_output = self._attention_interface_fn(
+            layer_attention_mask,
+            batch_size,
+            head_dim,
+            q_concat,
+            k_concat,
+            v_concat,
+            scaling=self._query_pre_attn_scaling,
+        )
+        att_output = att_output.to(dtype=_preferred_dtype())
+
+        outputs_embeds: list[torch.Tensor | None] = []
+        start = 0
+        for stream_idx, hidden_states in enumerate(inputs_embeds):
+            if hidden_states is None:
+                outputs_embeds.append(None)
+                continue
+
+            layer = layers_this_step[stream_idx]
+            seq_len = hidden_states.shape[1]
+            end = start + seq_len
+            part = att_output[:, start:end]
+            start = end
+
+            if part.dtype != layer.self_attn.o_proj.weight.dtype:
+                part = part.to(layer.self_attn.o_proj.weight.dtype)
+            part = layer.self_attn.o_proj(part)
+            part = self.dropout(part)
+
+            if stream_idx == 0:
+                # Gemma 3 block: residual + post_attn_norm(attn); then a second
+                # residual with pre_feedforward_layernorm / mlp / post_feedforward_layernorm.
+                post_attn = layer.post_attention_layernorm(part)
+                h = backbone_preattn_residual + post_attn
+
+                ff_residual = h
+                h = layer.pre_feedforward_layernorm(h)
+                h = layer.mlp(h)
+                h = self.dropout(h)
+                h = layer.post_feedforward_layernorm(h)
+                h = ff_residual + h
+                outputs_embeds.append(h)
+            else:
+                # Gemma-v1 expert block with AdaRMS gates.
+                h = modeling_gemma._gated_residual(hidden_states, part, gates[stream_idx])  # noqa: SLF001
+                ff_residual = h.clone()
+                h, gate2 = layer.post_attention_layernorm(h, cond=adarms_cond[stream_idx])
+                h = layer.mlp(h)
+                h = self.dropout(h)
+                h = modeling_gemma._gated_residual(ff_residual, h, gate2)  # noqa: SLF001
+                outputs_embeds.append(h)
+
+        return outputs_embeds
+
+
 class Gemma3WithExpertModel(PreTrainedModel):
     """Gemma 3 VLM interleaved layer-wise with a Gemma-v1 action expert."""
 
@@ -302,11 +532,8 @@ class Gemma3WithExpertModel(PreTrainedModel):
 
         self.dropout = nn.Dropout(config.dropout)
 
-        if not torch.compiler.is_compiling():
-            self.to_bfloat16_like_physical_intelligence()
-        self.set_requires_grad()
-
-        # Cache commonly accessed config scalars.
+        # Cache commonly accessed config scalars (used by InterleavedDecoderLayer
+        # construction below — must be set before ``_build_interleaved_layers``).
         self._text_config = config.gemma3_config.text_config
         self._expert_config = config.gemma_expert_config
         self._num_layers = self._text_config.num_hidden_layers
@@ -322,6 +549,62 @@ class Gemma3WithExpertModel(PreTrainedModel):
         #     the comment near `apply_rope` for why π0.6 doesn't enforce it.
         self._query_pre_attn_scaling = float(self._text_config.query_pre_attn_scalar) ** -0.5
 
+        # Reparent the per-layer modules into a flat ModuleList of
+        # InterleavedDecoderLayer. After this call, every per-layer parameter
+        # lives at ``interleaved_layers[i].{backbone_layer,expert_layer}.*``;
+        # the original ``gemma3.language_model.model.layers`` and
+        # ``gemma_expert.model.layers`` are emptied so each parameter is
+        # registered exactly once. This is the architectural fix that makes
+        # FSDP / ZeRO-3 see one coherent forward unit per interleaved step.
+        self._build_interleaved_layers()
+
+        if not torch.compiler.is_compiling():
+            self.to_bfloat16_like_physical_intelligence()
+        self.set_requires_grad()
+
+    def _build_interleaved_layers(self) -> None:
+        """Build ``self.interleaved_layers`` and empty the source ModuleLists.
+
+        Hands ``backbone_layers[i]`` and ``expert_layers[i]`` (both the
+        original ``nn.Module`` instances) to a new ``InterleavedDecoderLayer``
+        and registers it under ``interleaved_layers``. The originals are then
+        replaced by empty ``nn.ModuleList()`` so the same Parameter objects
+        are not registered in two places at once — that would crash FSDP /
+        ZeRO-3 (they walk the module tree and would try to wrap each layer
+        twice) and confuse ``state_dict`` enumeration.
+        """
+        backbone_layers = self._backbone_layers()
+        expert_layers = self.gemma_expert.model.layers
+        if len(backbone_layers) != self._num_layers or len(expert_layers) != self._num_layers:
+            raise ValueError(
+                f"Expected backbone and expert to have {self._num_layers} layers each; "
+                f"got backbone={len(backbone_layers)}, expert={len(expert_layers)}."
+            )
+        attention_interface_fn = self.get_attention_interface()
+        layers = nn.ModuleList(
+            [
+                InterleavedDecoderLayer(
+                    backbone_layer=backbone_layers[i],
+                    expert_layer=expert_layers[i],
+                    layer_type=self._layer_types[i],
+                    rope_local=self._rope_local,
+                    rope_global=self._rope_global,
+                    query_pre_attn_scaling=self._query_pre_attn_scaling,
+                    head_dim=self._head_dim,
+                    dropout=self.dropout,
+                    attention_interface_fn=attention_interface_fn,
+                )
+                for i in range(self._num_layers)
+            ]
+        )
+        # Empty the source ModuleLists. Doing this BEFORE assigning
+        # ``self.interleaved_layers`` is important: nn.Module's __setattr__
+        # walks the existing tree on assignment and would otherwise notice
+        # the same module twice.
+        self._backbone_text_model().layers = nn.ModuleList()
+        self.gemma_expert.model.layers = nn.ModuleList()
+        self.interleaved_layers = layers
+
     # Trainable / dtype plumbing
 
     def set_requires_grad(self) -> None:
@@ -336,6 +619,11 @@ class Gemma3WithExpertModel(PreTrainedModel):
             self.gemma3.eval()
             for params in self.gemma3.parameters():
                 params.requires_grad = False
+            # Layer params now live in interleaved_layers[i].backbone_layer
+            # rather than under self.gemma3, so freeze them explicitly.
+            for layer in self._iter_interleaved_layers():
+                for params in layer.backbone_layer.parameters():
+                    params.requires_grad = False
             for param in self.da_head.parameters():
                 param.requires_grad = False
             for param in self.discrete_action_embedding.parameters():
@@ -349,19 +637,38 @@ class Gemma3WithExpertModel(PreTrainedModel):
                 vision_tower.eval()
         if self.config.train_expert_only:
             self.gemma3.eval()
+            # Backbone layers were reparented out of self.gemma3 — eval them
+            # explicitly so dropout / etc. honour the frozen state.
+            for layer in self._iter_interleaved_layers():
+                layer.backbone_layer.eval()
         return self
 
     def to_bfloat16_like_physical_intelligence(self) -> None:
         self.gemma3 = self.gemma3.to(dtype=torch.bfloat16)
+        # Selectors cover both the post-refactor location (under
+        # ``interleaved_layers``) and the pre-refactor selectors that
+        # still reach untouched submodules (vision_tower, multi_modal_projector).
         params_to_change_dtype = [
-            "language_model.model.layers",
-            "gemma_expert.model.layers",
+            "interleaved_layers",
             "vision_tower",
             "multi_modal_projector",
         ]
         for name, param in self.named_parameters():
             if any(selector in name for selector in params_to_change_dtype):
                 param.data = param.data.to(dtype=torch.bfloat16)
+
+    def _iter_interleaved_layers(self):
+        """Yield ``InterleavedDecoderLayer`` instances if ``__init__`` finished.
+
+        ``set_requires_grad`` and ``train`` are also invoked from the base
+        ``PreTrainedModel.__init__`` *before* ``self.interleaved_layers`` has
+        been assigned (the call ordering is enforced by the HF base class).
+        Guard against that.
+        """
+        layers = getattr(self, "interleaved_layers", None)
+        if layers is None:
+            return iter(())
+        return iter(layers)
 
     # Embedding helpers
 
@@ -663,27 +970,27 @@ class Gemma3WithExpertModel(PreTrainedModel):
         if batch_size is None:
             raise ValueError("`inputs_embeds` must contain at least one non-None entry.")
 
-        head_dim = self._head_dim
-
         # Hoist the lazy ``past_key_values = {}`` initialization out of the
-        # per-layer body so ``_run_layer`` always receives a non-None dict
-        # when ``fill_kv_cache`` is True. Important for checkpoint recompute
-        # to be idempotent — _run_layer must not mutate past_key_values from
-        # None to {} during recompute (saved-tensor hooks would see a
-        # different argument identity on the second pass).
+        # per-layer body so ``InterleavedDecoderLayer.forward`` always receives
+        # a non-None dict when ``fill_kv_cache`` is True. Important for
+        # checkpoint recompute to be idempotent — the layer must not mutate
+        # past_key_values from None to {} during recompute (saved-tensor hooks
+        # would see a different argument identity on the second pass).
         if fill_kv_cache and past_key_values is None:
             past_key_values = {}
 
         use_ckpt = self.config.gradient_checkpointing and self.training
-        for layer_idx in range(self._num_layers):
+        for layer_idx, layer in enumerate(self.interleaved_layers):
             if use_ckpt:
                 # use_reentrant=False is the modern, DDP-safe path; it
                 # preserves RNG state across recompute so dropout is
-                # deterministic, and participates cleanly in autograd's
-                # saved_tensors_hooks.
+                # deterministic, participates cleanly in autograd's
+                # saved_tensors_hooks, and is compatible with FSDP's
+                # all-gather hooks (the wrap target is the
+                # InterleavedDecoderLayer, so its sub-component params are
+                # all gathered before this checkpoint runs).
                 inputs_embeds = torch.utils.checkpoint.checkpoint(
-                    self._run_layer,
-                    layer_idx,
+                    layer,
                     inputs_embeds,
                     attention_mask,
                     position_ids,
@@ -693,12 +1000,11 @@ class Gemma3WithExpertModel(PreTrainedModel):
                     fill_kv_cache,
                     adarms_cond,
                     batch_size,
-                    head_dim,
+                    layer_idx,
                     use_reentrant=False,
                 )
             else:
-                inputs_embeds = self._run_layer(
-                    layer_idx,
+                inputs_embeds = layer(
                     inputs_embeds,
                     attention_mask,
                     position_ids,
@@ -708,7 +1014,7 @@ class Gemma3WithExpertModel(PreTrainedModel):
                     fill_kv_cache,
                     adarms_cond,
                     batch_size,
-                    head_dim,
+                    layer_idx,
                 )
 
         # Final norms.
@@ -724,178 +1030,6 @@ class Gemma3WithExpertModel(PreTrainedModel):
                 final_outputs.append(out)
 
         return final_outputs, past_key_values
-
-    def _run_layer(
-        self,
-        layer_idx: int,
-        inputs_embeds: list[torch.FloatTensor | None],
-        attention_mask: torch.Tensor | None,
-        position_ids: torch.LongTensor | None,
-        past_key_values: dict | None,
-        n_cross_att_tokens: int | None,
-        use_cache: bool | None,
-        fill_kv_cache: bool | None,
-        adarms_cond: list[torch.Tensor | None],
-        batch_size: int,
-        head_dim: int,
-    ) -> list[torch.FloatTensor | None]:
-        """Run a single layer of the interleaved backbone/expert decoder loop.
-
-        Extracted from ``forward()`` as a standalone method so it can be the
-        unit of ``torch.utils.checkpoint.checkpoint`` wrapping when
-        ``config.gradient_checkpointing`` is enabled. Behavior is bit-identical
-        to the original inlined loop body; the KV-cache write is idempotent
-        across checkpoint recompute because each layer writes its own unique
-        key with the same K/V tensors.
-        """
-        backbone_layers = self._backbone_layers()
-        expert_layers = self.gemma_expert.model.layers
-
-        layer_type = self._layer_types[layer_idx]
-        is_sliding = layer_type == "sliding_attention"
-        layer_rope_theta = self._rope_local if is_sliding else self._rope_global
-
-        layers_this_step = [backbone_layers[layer_idx], expert_layers[layer_idx]]
-        # Both streams MUST use the same RoPE base at this layer. Shared
-        # attention concatenates Q/K along the sequence axis; the dot-product
-        # invariant `R(q,p)·R(k,q) = q·R(q-p)k` only holds when the same θ
-        # produced both rotations. For global Gemma-3 layers (θ=1M) this
-        # means the expert also rotates at 1M even though the config carries
-        # a single fallback `rope_theta=10k`.
-        rope_thetas = [layer_rope_theta, layer_rope_theta]
-
-        query_states: list[torch.Tensor | None] = []
-        key_states: list[torch.Tensor | None] = []
-        value_states: list[torch.Tensor | None] = []
-        gates: list[torch.Tensor | None] = []
-        # Track the pre-attention residual + post-attn layernorm output for the
-        # Gemma-3 backbone side, since it needs a second residual around the MLP
-        # using `pre_feedforward_layernorm` / `post_feedforward_layernorm`.
-        backbone_preattn_residual = None
-
-        for stream_idx, hidden_states in enumerate(inputs_embeds):
-            if hidden_states is None:
-                gates.append(None)
-                query_states.append(None)
-                key_states.append(None)
-                value_states.append(None)
-                continue
-
-            layer = layers_this_step[stream_idx]
-
-            if stream_idx == 0:
-                # Gemma 3 backbone.
-                backbone_preattn_residual = hidden_states
-                h = layer.input_layernorm(hidden_states)
-                gate = None
-            else:
-                # Gemma-v1 expert (patched to return (tensor, gate)).
-                h, gate = layer.input_layernorm(hidden_states, cond=adarms_cond[stream_idx])
-
-            gates.append(gate)
-            bsize, seq_len, _ = h.shape
-            h = h.to(dtype=_preferred_dtype())
-
-            q = layer.self_attn.q_proj(h).view(bsize, seq_len, -1, head_dim)
-            k = layer.self_attn.k_proj(h).view(bsize, seq_len, -1, head_dim)
-            v = layer.self_attn.v_proj(h).view(bsize, seq_len, -1, head_dim)
-
-            if stream_idx == 0:
-                # Gemma-3 applies an extra per-head RMSNorm on Q and K.
-                q_norm = getattr(layer.self_attn, "q_norm", None)
-                k_norm = getattr(layer.self_attn, "k_norm", None)
-                if q_norm is not None:
-                    q = q_norm(q)
-                if k_norm is not None:
-                    k = k_norm(k)
-
-            q = apply_rope(q, position_ids, max_wavelength=rope_thetas[stream_idx])
-            k = apply_rope(k, position_ids, max_wavelength=rope_thetas[stream_idx])
-
-            query_states.append(q)
-            key_states.append(k)
-            value_states.append(v)
-
-        # Drop Nones before concatenating.
-        q_list = [q for q in query_states if q is not None]
-        k_list = [k for k in key_states if k is not None]
-        v_list = [v for v in value_states if v is not None]
-
-        q_concat = torch.cat(q_list, dim=1)
-        k_concat = torch.cat(k_list, dim=1)
-        v_concat = torch.cat(v_list, dim=1)
-
-        if use_cache and past_key_values is not None and layer_idx in past_key_values:
-            k_concat = torch.cat([past_key_values[layer_idx]["key_states"], k_concat], dim=1)
-            v_concat = torch.cat([past_key_values[layer_idx]["value_states"], v_concat], dim=1)
-
-        if fill_kv_cache:
-            if n_cross_att_tokens is None:
-                raise ValueError("n_cross_att_tokens must be provided when fill_kv_cache is True")
-            past_key_values[layer_idx] = {
-                "key_states": k_concat[:, :n_cross_att_tokens, :, :],
-                "value_states": v_concat[:, :n_cross_att_tokens, :, :],
-            }
-
-        # π0.7 keeps the prefix block-causal mask at every layer — the
-        # Gemma 3 sliding-window pattern is deliberately not applied
-        # (see the note next to `apply_rope`).
-        layer_attention_mask = attention_mask
-
-        attention_interface = self.get_attention_interface()
-        att_output = attention_interface(
-            layer_attention_mask,
-            batch_size,
-            head_dim,
-            q_concat,
-            k_concat,
-            v_concat,
-            scaling=self._query_pre_attn_scaling,
-        )
-        att_output = att_output.to(dtype=_preferred_dtype())
-
-        outputs_embeds: list[torch.Tensor | None] = []
-        start = 0
-        for stream_idx, hidden_states in enumerate(inputs_embeds):
-            if hidden_states is None:
-                outputs_embeds.append(None)
-                continue
-
-            layer = layers_this_step[stream_idx]
-            seq_len = hidden_states.shape[1]
-            end = start + seq_len
-            part = att_output[:, start:end]
-            start = end
-
-            if part.dtype != layer.self_attn.o_proj.weight.dtype:
-                part = part.to(layer.self_attn.o_proj.weight.dtype)
-            part = layer.self_attn.o_proj(part)
-            part = self.dropout(part)
-
-            if stream_idx == 0:
-                # Gemma 3 block: residual + post_attn_norm(attn); then a second
-                # residual with pre_feedforward_layernorm / mlp / post_feedforward_layernorm.
-                post_attn = layer.post_attention_layernorm(part)
-                h = backbone_preattn_residual + post_attn
-
-                ff_residual = h
-                h = layer.pre_feedforward_layernorm(h)
-                h = layer.mlp(h)
-                h = self.dropout(h)
-                h = layer.post_feedforward_layernorm(h)
-                h = ff_residual + h
-                outputs_embeds.append(h)
-            else:
-                # Gemma-v1 expert block with AdaRMS gates.
-                h = modeling_gemma._gated_residual(hidden_states, part, gates[stream_idx])  # noqa: SLF001
-                ff_residual = h.clone()
-                h, gate2 = layer.post_attention_layernorm(h, cond=adarms_cond[stream_idx])
-                h = layer.mlp(h)
-                h = self.dropout(h)
-                h = modeling_gemma._gated_residual(ff_residual, h, gate2)  # noqa: SLF001
-                outputs_embeds.append(h)
-
-        return outputs_embeds
 
     # Gemma 3 structural accessors
 

--- a/src/opentau/policies/pi07/gemma3_with_expert.py
+++ b/src/opentau/policies/pi07/gemma3_with_expert.py
@@ -616,16 +616,14 @@ class Gemma3WithExpertModel(PreTrainedModel):
         backbone_layers = self._backbone_layers()
         if len(backbone_layers) != self._num_layers:
             raise ValueError(
-                f"Expected backbone to have {self._num_layers} layers; "
-                f"got backbone={len(backbone_layers)}."
+                f"Expected backbone to have {self._num_layers} layers; got backbone={len(backbone_layers)}."
             )
 
         if self.gemma_expert is not None:
             expert_layers = self.gemma_expert.model.layers
             if len(expert_layers) != self._num_layers:
                 raise ValueError(
-                    f"Expected expert to have {self._num_layers} layers; "
-                    f"got expert={len(expert_layers)}."
+                    f"Expected expert to have {self._num_layers} layers; got expert={len(expert_layers)}."
                 )
         else:
             expert_layers = None

--- a/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
@@ -1305,6 +1305,16 @@ class PI07LowLevelFlowMatching(nn.Module):
         # collectives. Ranks whose local data is all-dropped still embed real
         # tokens with all-False masks; downstream attention / loss respect the
         # mask, so accuracy is preserved.
+        #
+        # Scope of the sync: this only protects against per-rank divergence of
+        # the ``.any()`` outcome on a field that *is* present everywhere. The
+        # inner branch (``if has_response and response_tokens is not None
+        # and response_masks is not None``) still gates on per-rank Nones,
+        # which assumes field presence is a global property of the dataset
+        # config (true today — every rank instantiates the same ``embed_prefix``
+        # contract). If a future heterogeneous-mixture change makes some ranks
+        # carry e.g. ``response_tokens=None`` while others carry a Tensor, the
+        # branches would re-desync and need their own None-vs-Tensor sync.
         device = lang_tokens.device
         has_response_local = (
             response_tokens is not None and response_masks is not None and bool(response_masks.any())

--- a/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
@@ -68,6 +68,35 @@ def _preferred_dtype():
     return torch.float32 if torch.onnx.is_in_onnx_export() else torch.bfloat16
 
 
+def _global_any(local: bool, device: torch.device) -> bool:
+    """Return ``local`` OR-reduced across all ranks of the current process group.
+
+    pi07's ``embed_prefix`` chooses Python-level branches based on whether the
+    local rank's micro-batch contains any subgoal images / response tokens /
+    metadata tokens. Each branch fires a different number of FSDP / ZeRO-3
+    all-gather collectives (one per ``embed_language_tokens`` call), so under
+    stochastic dataset drop probabilities — where one rank's batch may roll
+    "all dropped" while another rolls "some real" — the ranks would otherwise
+    take different branches and deadlock at NCCL with mismatched all-gather
+    sequence numbers.
+
+    This helper turns a per-rank ``bool`` into a globally-OR'd ``bool`` via a
+    single 1-element ``MAX`` all-reduce. We use it once per branch decision
+    in ``embed_prefix`` so every rank executes the same code path even when
+    its local data slice has different drop rolls.
+
+    The all-reduce cost is negligible (~tens of microseconds per call,
+    handful of calls per step). Outside ``torch.distributed`` (single-process
+    runs, CPU smoke tests) the helper is a fast no-op that just returns the
+    local value.
+    """
+    if not (torch.distributed.is_available() and torch.distributed.is_initialized()):
+        return bool(local)
+    flag = torch.tensor([1 if local else 0], device=device, dtype=torch.int32)
+    torch.distributed.all_reduce(flag, op=torch.distributed.ReduceOp.MAX)
+    return bool(flag.item())
+
+
 def create_sinusoidal_pos_embedding(
     time: Tensor, dimension: int, min_period: float, max_period: float, device: torch.device | str = "cpu"
 ) -> Tensor:
@@ -1264,15 +1293,31 @@ class PI07LowLevelFlowMatching(nn.Module):
         # state-end separator collapses to ":\n" and the trailing prefix-end is
         # omitted, eliminating spurious dangling tokens that would otherwise break
         # the cumsum at the indicator -> first-discrete boundary.
-        has_response = (
+        #
+        # Each ``has_*`` flag is OR-reduced across all ranks via ``_global_any``.
+        # Different ranks process different micro-batches, so under stochastic
+        # ``*_drop_prob`` settings their local ``.any()`` values can diverge.
+        # If we let each rank take its local branch, FSDP / ZeRO-3 would launch
+        # different numbers of param all-gathers per rank and deadlock at NCCL
+        # (observed empirically: rank 0,1,3,4,5,7 stuck at SeqNum=274 ALLREDUCE,
+        # rank 2,6 at SeqNum=279 ALLGATHER_BASE). Synchronizing the *branch
+        # decision* — not the data — keeps every rank running the same set of
+        # collectives. Ranks whose local data is all-dropped still embed real
+        # tokens with all-False masks; downstream attention / loss respect the
+        # mask, so accuracy is preserved.
+        device = lang_tokens.device
+        has_response_local = (
             response_tokens is not None and response_masks is not None and bool(response_masks.any())
         )
-        has_subgoal = (
+        has_subgoal_local = (
             bool(subgoal_images) and bool(subgoal_img_masks) and any(bool(m.any()) for m in subgoal_img_masks)
         )
-        has_metadata = (
+        has_metadata_local = (
             metadata_tokens is not None and metadata_masks is not None and bool(metadata_masks.any())
         )
+        has_response = _global_any(has_response_local, device)
+        has_subgoal = _global_any(has_subgoal_local, device)
+        has_metadata = _global_any(has_metadata_local, device)
         has_any_optional = bool(has_response or has_subgoal or has_metadata)
 
         for vid, vid_mask in zip(videos, vid_masks, strict=True):
@@ -1369,11 +1414,12 @@ class PI07LowLevelFlowMatching(nn.Module):
         # state-end separator (", " or ":\n") is text → causal per paper §VI.B.
         att_masks += [1] * num_state_end_embs
 
-        # Only embed response when at least one sample in the batch has real response tokens.
-        # With response_drop_prob=1.0 all masks are False; skipping avoids a spurious
-        # causal-block boundary (att_masks=[1,...]) that would corrupt cumsum for every
-        # subsequent token.
-        if response_tokens is not None and response_masks is not None and response_masks.any():
+        # Only embed response when at least one sample in *any rank's* batch has
+        # real response tokens. The decision is taken on the globally-synced
+        # ``has_response`` flag (computed above) — using a local ``.any()``
+        # check here would let different ranks diverge into different code
+        # paths and deadlock under FSDP / ZeRO-3.
+        if has_response and response_tokens is not None and response_masks is not None:
             response_emb = self.gemma3_with_expert.embed_language_tokens(response_tokens)
             embs.append(response_emb)
             pad_masks.append(response_masks)
@@ -1383,8 +1429,8 @@ class PI07LowLevelFlowMatching(nn.Module):
             num_response_embs = response_emb.shape[1]
             att_masks += [1] * num_response_embs
 
-        # Only embed metadata when at least one sample has real metadata tokens.
-        if metadata_tokens is not None and metadata_masks is not None and metadata_masks.any():
+        # Same global-synced gate for metadata.
+        if has_metadata and metadata_tokens is not None and metadata_masks is not None:
             metadata_emb = self.gemma3_with_expert.embed_language_tokens(metadata_tokens)
             embs.append(metadata_emb)
             pad_masks.append(metadata_masks)
@@ -1419,10 +1465,13 @@ class PI07LowLevelFlowMatching(nn.Module):
         # text (lang / state / response / metadata / ";\n ") and before the
         # training-only discrete-action block.
         #
-        # Only embed the subgoal block (header + images + footer) when subgoal images are
-        # actually present. Unconditionally adding "Subgoal: " injects real (non-padded)
-        # spurious tokens into every prefix even with subgoal_drop_prob=1.0.
-        if subgoal_images and any(mask.any() for mask in subgoal_img_masks):
+        # Same global-synced gate for the subgoal block. ``has_subgoal`` is
+        # globally OR-reduced above, so all ranks take this branch together
+        # whenever any rank's micro-batch has at least one real subgoal image.
+        # Skipping the local-``.any()`` branch and falling through to
+        # all-pad data on a rank that locally has none would re-introduce
+        # the FSDP NCCL desync.
+        if has_subgoal and subgoal_images:
             # Per-sample availability: True iff at least one camera slot
             # has a real subgoal image for that sample. In a mixed batch
             # (some samples have subgoals, others don't), the "Subgoal: "

--- a/src/opentau/scripts/launch.py
+++ b/src/opentau/scripts/launch.py
@@ -13,14 +13,26 @@
 # limitations under the License.
 
 import argparse
+import os
 import subprocess
 import sys
 from pathlib import Path
 from types import ModuleType
 
+# CUDA allocator default. The 5B+ pi07 model on A100-80GB sits at the
+# allocator's edge — issue #264 reproduces an OOM at 79.21/79.25 GiB used
+# with 3.4 GiB reserved-but-unallocated, exactly the fragmentation pattern
+# expandable_segments resolves. Default it on; users can still override by
+# exporting their own value before invoking the launcher.
+_DEFAULT_ALLOC_CONF = "expandable_segments:True"
+
 
 def launch(script_module: ModuleType, description: str, use_accelerate: bool = True):
     """Generic launcher for OpenTau scripts using Accelerate or Python."""
+    if "PYTORCH_CUDA_ALLOC_CONF" not in os.environ and "PYTORCH_ALLOC_CONF" not in os.environ:
+        os.environ["PYTORCH_CUDA_ALLOC_CONF"] = _DEFAULT_ALLOC_CONF
+        print(f"[opentau-launch] Defaulting PYTORCH_CUDA_ALLOC_CONF={_DEFAULT_ALLOC_CONF}")
+
     parser = argparse.ArgumentParser(
         description=description,
         usage=f"{Path(sys.argv[0]).name} {'[--accelerate-config CONFIG] ' if use_accelerate else ''}[ARGS]",

--- a/src/opentau/scripts/profile_step.py
+++ b/src/opentau/scripts/profile_step.py
@@ -282,12 +282,20 @@ def profile(cfg: TrainPipelineConfig):
         # memory footprint is ~half of what production training pays under the
         # PR #182 fix, so the benchmark would systematically under-report
         # memory and over-report the largest batch that fits. See issue #181.
-        # DeepSpeed ZeRO already provides equivalent fp32-master semantics via
-        # BF16_Optimizer; FSDP provides them via MixedPrecision and manages
-        # the inner optimizer's view of the FlatParameter shards directly,
-        # so wrapping under either backend would double-allocate (and under
-        # FSDP would also misalign with FSDP's flat-param parameter handles
-        # — observed empirically as a NCCL desync during the first backward).
+        # DeepSpeed ZeRO provides equivalent fp32-master semantics via
+        # BF16_Optimizer.
+        # FSDP in this PR runs in **pure bf16** (no fp32 master): the model's
+        # ``Gemma3WithExpertModel.__init__`` calls
+        # ``to_bfloat16_like_physical_intelligence`` unconditionally, so by
+        # the time accelerate.prepare wraps the policy under FSDP, params
+        # are already bf16 — FSDP's ``MixedPrecision(param_dtype=bf16, ...)``
+        # is a no-op for storage and the optimizer steps on bf16 sharded
+        # params. Wrapping with ``MasterWeightOptimizer`` on top would clone
+        # the bf16 sharded params into a redundant in-rank fp32 copy without
+        # restoring the cross-rank fp32 master that a fp32-built model would
+        # have, so we skip the wrap (also: would misalign with FSDP's
+        # flat-param parameter handles — observed empirically as a NCCL
+        # desync during the first backward).
         if accelerator.distributed_type not in (
             accelerate.DistributedType.DEEPSPEED,
             accelerate.DistributedType.FSDP,

--- a/src/opentau/scripts/profile_step.py
+++ b/src/opentau/scripts/profile_step.py
@@ -283,8 +283,15 @@ def profile(cfg: TrainPipelineConfig):
         # PR #182 fix, so the benchmark would systematically under-report
         # memory and over-report the largest batch that fits. See issue #181.
         # DeepSpeed ZeRO already provides equivalent fp32-master semantics via
-        # BF16_Optimizer, so we skip the wrap on that backend.
-        if accelerator.distributed_type != accelerate.DistributedType.DEEPSPEED:
+        # BF16_Optimizer; FSDP provides them via MixedPrecision and manages
+        # the inner optimizer's view of the FlatParameter shards directly,
+        # so wrapping under either backend would double-allocate (and under
+        # FSDP would also misalign with FSDP's flat-param parameter handles
+        # — observed empirically as a NCCL desync during the first backward).
+        if accelerator.distributed_type not in (
+            accelerate.DistributedType.DEEPSPEED,
+            accelerate.DistributedType.FSDP,
+        ):
             optimizer = MasterWeightOptimizer.from_existing(optimizer)
             # Same rebind train.py performs immediately after from_existing:
             # ``make_optimizer_and_scheduler`` left ``lr_scheduler.optimizer``

--- a/src/opentau/scripts/profile_step.py
+++ b/src/opentau/scripts/profile_step.py
@@ -173,7 +173,13 @@ def profile(cfg: TrainPipelineConfig):
             )
         cfg.policy.gradient_checkpointing = want_ckpt
 
-    policy = make_policy(cfg=cfg.policy, ds_meta=train_dataset.meta)
+    # Mirror train.py: under DeepSpeed ZeRO-3 we must disable the per-construction
+    # parameter partitioning (it shards before init, breaking shape-dependent
+    # initializers like SigLIP's lecun_normal_). No-op for any non-ZeRO-3 backend.
+    from opentau.scripts.train import _zero3_disabled_init_context
+
+    with _zero3_disabled_init_context(accelerator):
+        policy = make_policy(cfg=cfg.policy, ds_meta=train_dataset.meta)
     policy.to(torch.bfloat16)
 
     skip_optim = os.environ.get("PROFILE_NO_OPTIM", "0") == "1"

--- a/src/opentau/scripts/profile_step.py
+++ b/src/opentau/scripts/profile_step.py
@@ -178,9 +178,23 @@ def profile(cfg: TrainPipelineConfig):
     # initializers like SigLIP's lecun_normal_). No-op for any non-ZeRO-3 backend.
     from opentau.scripts.train import _zero3_disabled_init_context
 
+    # Mirror train.py: under FSDP, gate the model's internal bf16 cast so the
+    # policy stays fp32 for FSDP's MixedPrecision to manage the bf16 compute /
+    # fp32 master split. Without this, AdamW would silently allocate Adam state
+    # in bf16 (matches the bf16-cast params) and the throughput numbers would
+    # not represent the production fp32-Adam regime.
+    if accelerator.distributed_type == accelerate.DistributedType.FSDP:
+        vlm_config = getattr(cfg.policy, "vlm_config", None)
+        if vlm_config is not None and hasattr(vlm_config, "disable_internal_bf16_cast"):
+            vlm_config.disable_internal_bf16_cast = True
+
     with _zero3_disabled_init_context(accelerator):
         policy = make_policy(cfg=cfg.policy, ds_meta=train_dataset.meta)
-    policy.to(torch.bfloat16)
+    # Same per-backend cast logic as train.py: skip the outer bf16 cast under
+    # FSDP (the policy must stay fp32 going into accelerate.prepare; FSDP
+    # MixedPrecision provides bf16 compute on the fly).
+    if accelerator.distributed_type != accelerate.DistributedType.FSDP:
+        policy.to(torch.bfloat16)
 
     skip_optim = os.environ.get("PROFILE_NO_OPTIM", "0") == "1"
     if skip_optim:

--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -375,6 +375,22 @@ def train(cfg: TrainPipelineConfig):
         )
 
     logging.info("Creating policy")
+    # FSDP needs the policy built in fp32 so its ``MixedPrecision(
+    # param_dtype=bf16, reduce_dtype=bf16, buffer_dtype=bf16)`` policy can
+    # downcast on the fly while keeping the fp32 outer (master) params for
+    # AdamW to step on. Without this gate, ``Gemma3WithExpertModel.__init__``
+    # would call ``to_bfloat16_like_physical_intelligence`` and the params
+    # would already be bf16 by the time FSDP wraps them — MixedPrecision
+    # becomes a storage no-op and the optimizer ends up stepping on bf16
+    # sharded params with bf16 Adam state, which underflows on small late-
+    # training updates. Set the flag where it exists (currently only on
+    # ``Gemma3WithExpertConfig``); other policies that don't yet support
+    # FSDP simply lack the attribute.
+    if accelerator.distributed_type == accelerate.DistributedType.FSDP:
+        vlm_config = getattr(cfg.policy, "vlm_config", None)
+        if vlm_config is not None and hasattr(vlm_config, "disable_internal_bf16_cast"):
+            vlm_config.disable_internal_bf16_cast = True
+
     # DeepSpeed ZeRO-3 installs a `partition_parameters` wrapper that shards
     # parameters at construction time (`zero3_init_flag` only controls the
     # transformers `from_pretrained` integration, not this wrapper). Some
@@ -384,45 +400,33 @@ def train(cfg: TrainPipelineConfig):
     # `accelerator.prepare` wraps it. No-op for any non-ZeRO-3 backend.
     with _zero3_disabled_init_context(accelerator):
         policy = make_policy(cfg=cfg.policy, ds_meta=train_dataset.meta)
-    # Keep the policy in bf16 for forward/backward (activation memory + bf16
-    # compute). The fp32-master / bf16-compute story differs by backend:
+    # Per-backend precision regime:
+    #   * DDP / single-process: outer ``policy.to(bfloat16)`` cast here makes
+    #     live params bf16, then ``MasterWeightOptimizer.from_existing``
+    #     (issue #181) layers fp32 master + fp32 Adam state on top.
     #   * DeepSpeed ZeRO-1/2: outer ``policy.to(bfloat16)`` cast here, then
-    #     ``BF16_Optimizer`` keeps an fp32 master copy + fp32 Adam state.
-    #   * DDP / single-process: outer ``policy.to(bfloat16)`` cast here, then
-    #     ``MasterWeightOptimizer.from_existing`` (issue #181) wraps the
-    #     optimizer with an fp32 master + fp32 Adam state.
-    #   * FSDP: **pure bf16, no fp32 master.** The model's own
-    #     ``Gemma3WithExpertModel.__init__`` already calls
-    #     ``to_bfloat16_like_physical_intelligence`` (gemma3_with_expert.py)
-    #     which casts every param under ``interleaved_layers`` /
-    #     ``vision_tower`` / ``multi_modal_projector`` plus ``self.gemma3`` to
-    #     bf16 unconditionally. By the time accelerate.prepare wraps the
-    #     policy, params are already bf16 — FSDP's ``MixedPrecision`` cannot
-    #     upcast a stored bf16 shard, the optimizer steps on bf16 sharded
-    #     params, and the only fp32-touching collective is the gradient
-    #     reduce-scatter (``reduce_dtype=fp32`` in the FSDP yaml). This is a
-    #     deliberate trade-off: pure bf16 keeps params + states small enough
-    #     to fit on 8×A100 without offload, accepting the convergence-quality
-    #     risk. To get genuine fp32-master under FSDP we'd need to also skip
-    #     the inner ``to_bfloat16_like_physical_intelligence`` call here, and
-    #     re-validate convergence — out of scope for this PR.
-    # The outer ``policy.to(bfloat16)`` below is therefore a no-op under FSDP
-    # (the inner cast already covered the same params); we still skip it so
-    # any future reader doesn't read it as evidence that an FSDP fp32-master
-    # path exists.
+    #     ``BF16_Optimizer`` keeps fp32 master + fp32 Adam state, reduces
+    #     gradients in bf16.
+    #   * FSDP-FULL_SHARD: skip the outer cast (and the model's inner
+    #     ``to_bfloat16_like_physical_intelligence`` was already gated above)
+    #     so the policy stays fp32 going into ``accelerator.prepare``. FSDP's
+    #     ``MixedPrecision`` then provides bf16 compute (forward/backward),
+    #     bf16 reduce-scatter (matches DeepSpeed), and the optimizer steps
+    #     on the fp32 outer (master) params with fp32 Adam state. Live
+    #     params consume HBM in fp32 (sharded across 8 ranks); compute
+    #     params materialize in bf16 transiently during the all-gather.
     if accelerator.distributed_type != accelerate.DistributedType.FSDP:
         policy.to(torch.bfloat16)
     logging.info("Creating optimizer and scheduler")
     optimizer, lr_scheduler = make_optimizer_and_scheduler(cfg, policy)
     # Outside DeepSpeed *and* FSDP, wrap the optimizer so it carries fp32
-    # master weights and fp32 Adam state. DeepSpeed provides fp32 master via
-    # ``BF16_Optimizer`` (see ``ds_config['bf16']['enabled']``). FSDP gets
-    # NO fp32 master in this PR — see the comment block above on the inner
-    # ``to_bfloat16_like_physical_intelligence`` cast — but wrapping with
-    # ``MasterWeightOptimizer`` here would also be wrong: it would clone the
-    # already-bf16 sharded params into a redundant in-rank fp32 copy, doubling
-    # memory without restoring the cross-rank fp32 master that FSDP would have
-    # owned in a fp32-built model. So skip the wrap under FSDP too.
+    # master weights and fp32 Adam state. DeepSpeed provides this via
+    # ``BF16_Optimizer``. FSDP provides it via ``MixedPrecision`` over the
+    # fp32-built policy — the optimizer was constructed over fp32 outer
+    # params and AdamW's exp_avg / exp_avg_sq are allocated to match → fp32.
+    # Wrapping with ``MasterWeightOptimizer`` on top of FSDP's flat-param
+    # handles also misaligns and triggers a NCCL desync during the first
+    # backward (observed empirically), so skip there too.
     if accelerator.distributed_type not in (
         accelerate.DistributedType.DEEPSPEED,
         accelerate.DistributedType.FSDP,

--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -385,24 +385,44 @@ def train(cfg: TrainPipelineConfig):
     with _zero3_disabled_init_context(accelerator):
         policy = make_policy(cfg=cfg.policy, ds_meta=train_dataset.meta)
     # Keep the policy in bf16 for forward/backward (activation memory + bf16
-    # compute). The optimizer state is kept in fp32 separately: DeepSpeed
-    # ZeRO does this through ``BF16_Optimizer``; under DDP/single we mirror
-    # that with ``MasterWeightOptimizer`` (see issue #181). Under FSDP,
-    # the policy must stay in fp32 here so FSDP's ``MixedPrecision`` (set
-    # by accelerate from ``mixed_precision: bf16`` in the FSDP yaml) can
-    # downcast on the fly while keeping the fp32 outer params for the
-    # optimizer to step — same fp32-master / bf16-compute split, but owned
-    # by FSDP rather than our wrapper.
+    # compute). The fp32-master / bf16-compute story differs by backend:
+    #   * DeepSpeed ZeRO-1/2: outer ``policy.to(bfloat16)`` cast here, then
+    #     ``BF16_Optimizer`` keeps an fp32 master copy + fp32 Adam state.
+    #   * DDP / single-process: outer ``policy.to(bfloat16)`` cast here, then
+    #     ``MasterWeightOptimizer.from_existing`` (issue #181) wraps the
+    #     optimizer with an fp32 master + fp32 Adam state.
+    #   * FSDP: **pure bf16, no fp32 master.** The model's own
+    #     ``Gemma3WithExpertModel.__init__`` already calls
+    #     ``to_bfloat16_like_physical_intelligence`` (gemma3_with_expert.py)
+    #     which casts every param under ``interleaved_layers`` /
+    #     ``vision_tower`` / ``multi_modal_projector`` plus ``self.gemma3`` to
+    #     bf16 unconditionally. By the time accelerate.prepare wraps the
+    #     policy, params are already bf16 — FSDP's ``MixedPrecision`` cannot
+    #     upcast a stored bf16 shard, the optimizer steps on bf16 sharded
+    #     params, and the only fp32-touching collective is the gradient
+    #     reduce-scatter (``reduce_dtype=fp32`` in the FSDP yaml). This is a
+    #     deliberate trade-off: pure bf16 keeps params + states small enough
+    #     to fit on 8×A100 without offload, accepting the convergence-quality
+    #     risk. To get genuine fp32-master under FSDP we'd need to also skip
+    #     the inner ``to_bfloat16_like_physical_intelligence`` call here, and
+    #     re-validate convergence — out of scope for this PR.
+    # The outer ``policy.to(bfloat16)`` below is therefore a no-op under FSDP
+    # (the inner cast already covered the same params); we still skip it so
+    # any future reader doesn't read it as evidence that an FSDP fp32-master
+    # path exists.
     if accelerator.distributed_type != accelerate.DistributedType.FSDP:
         policy.to(torch.bfloat16)
     logging.info("Creating optimizer and scheduler")
     optimizer, lr_scheduler = make_optimizer_and_scheduler(cfg, policy)
     # Outside DeepSpeed *and* FSDP, wrap the optimizer so it carries fp32
-    # master weights and fp32 Adam state. DeepSpeed provides this via
-    # BF16_Optimizer (see ``ds_config['bf16']['enabled']``); FSDP provides
-    # it via MixedPrecision (param_dtype=bf16, reduce_dtype=fp32, with the
-    # outer fp32 params owned by FSDP). Wrapping under either of those would
-    # double-allocate fp32 masters.
+    # master weights and fp32 Adam state. DeepSpeed provides fp32 master via
+    # ``BF16_Optimizer`` (see ``ds_config['bf16']['enabled']``). FSDP gets
+    # NO fp32 master in this PR — see the comment block above on the inner
+    # ``to_bfloat16_like_physical_intelligence`` cast — but wrapping with
+    # ``MasterWeightOptimizer`` here would also be wrong: it would clone the
+    # already-bf16 sharded params into a redundant in-rank fp32 copy, doubling
+    # memory without restoring the cross-rank fp32 master that FSDP would have
+    # owned in a fp32-built model. So skip the wrap under FSDP too.
     if accelerator.distributed_type not in (
         accelerate.DistributedType.DEEPSPEED,
         accelerate.DistributedType.FSDP,

--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -190,6 +190,32 @@ def _find_unused_params_from_env() -> bool:
     return os.environ.get("FIND_UNUSED_PARAMS", "true").lower() == "true"
 
 
+def _zero3_disabled_init_context(accelerator: accelerate.Accelerator):
+    """Return a context manager that disables ZeRO-3's per-construction param partitioning.
+
+    DeepSpeed ZeRO-3 installs a `partition_parameters` wrapper that shards
+    each parameter as it's created. Some HuggingFace init paths (e.g.
+    SigLIP's `lecun_normal_` → `_calculate_fan_in_and_fan_out`) need the
+    full tensor shape and crash on the per-rank shard. This returns a
+    `deepspeed.zero.Init(enabled=False)` context for ZeRO-3 and a
+    no-op `nullcontext()` everywhere else.
+
+    Args:
+        accelerator: The active accelerate ``Accelerator``.
+
+    Returns:
+        A context manager (no-op for non-ZeRO-3 backends).
+    """
+    if accelerator.distributed_type != accelerate.DistributedType.DEEPSPEED:
+        return nullcontext()
+    zero_stage = accelerator.deepspeed_plugin.hf_ds_config.config.get("zero_optimization", {}).get("stage", 0)
+    if zero_stage < 3:
+        return nullcontext()
+    import deepspeed
+
+    return deepspeed.zero.Init(enabled=False)
+
+
 def _sync_deepspeed_gradient_accumulation_steps(
     accelerator: accelerate.Accelerator, cfg: TrainPipelineConfig
 ) -> None:
@@ -327,7 +353,16 @@ def train(cfg: TrainPipelineConfig):
         )
 
     logging.info("Creating policy")
-    policy = make_policy(cfg=cfg.policy, ds_meta=train_dataset.meta)
+    # DeepSpeed ZeRO-3 installs a `partition_parameters` wrapper that shards
+    # parameters at construction time (`zero3_init_flag` only controls the
+    # transformers `from_pretrained` integration, not this wrapper). Some
+    # init paths — e.g. SigLIP's `lecun_normal_` → `_calculate_fan_in_and_fan_out`
+    # — need the full tensor shape and crash on a per-rank shard. Build the
+    # model with partitioning disabled; ZeRO will re-shard properly when
+    # `accelerator.prepare` wraps it. No-op for any non-ZeRO-3 backend.
+    init_ctx = _zero3_disabled_init_context(accelerator)
+    with init_ctx:
+        policy = make_policy(cfg=cfg.policy, ds_meta=train_dataset.meta)
     # Keep the policy in bf16 for forward/backward (activation memory + bf16
     # compute). The optimizer state is kept in fp32 separately: DeepSpeed
     # ZeRO does this through ``BF16_Optimizer``; under DDP/single we mirror

--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -244,27 +244,26 @@ def train(cfg: TrainPipelineConfig):
     _sync_deepspeed_gradient_accumulation_steps(accelerator, cfg)
 
     # Strict guard for gradient_checkpointing: the pi05 custom forward loop
-    # wraps layer bodies in torch.utils.checkpoint.checkpoint, which is only
-    # semantically safe under distributed backends that do NOT re-shard
-    # parameters during forward. DDP (MULTI_GPU), single-process (NO), and
-    # DeepSpeed ZeRO-1/2 all replicate full params on every rank during
-    # forward — safe. ZeRO-3 and FSDP re-shard and rely on forward-time
-    # all-gather hooks that plain torch.utils.checkpoint does not trigger
-    # during backward recompute, which can silently produce wrong gradients
-    # or hang. Fail loudly at startup instead of corrupting training.
+    # wraps layer bodies in torch.utils.checkpoint.checkpoint. With
+    # use_reentrant=False this uses saved_tensors_hooks, which co-exist
+    # with FSDP's all-gather hooks in PyTorch ≥2.4 — so FSDP is supported.
+    # DeepSpeed ZeRO-3, however, prefetches/re-shards through DeepSpeed-specific
+    # hooks that torch.utils.checkpoint does not fire, so it can silently
+    # produce wrong gradients; keep that case rejected.
     if getattr(cfg.policy, "gradient_checkpointing", False):
         grad_ckpt_allowed = {
             accelerate.DistributedType.MULTI_GPU,
             accelerate.DistributedType.NO,
             accelerate.DistributedType.DEEPSPEED,
+            accelerate.DistributedType.FSDP,
         }
         if accelerator.distributed_type not in grad_ckpt_allowed:
             raise ValueError(
                 f"gradient_checkpointing=True is not supported under "
                 f"distributed_type={accelerator.distributed_type}. Supported: "
-                "MULTI_GPU (DDP), NO (single process), DEEPSPEED (ZeRO-1/2 only). "
-                "ZeRO-3 and FSDP need backend-specific activation-checkpointing "
-                "hooks which pi05's custom per-layer forward does not wire up. "
+                "MULTI_GPU (DDP), NO (single process), FSDP, DEEPSPEED (ZeRO-1/2 only). "
+                "DeepSpeed ZeRO-3 needs deepspeed.checkpointing.checkpoint hooks "
+                "which pi05's custom per-layer forward does not wire up. "
                 "Either set gradient_checkpointing=False or switch to a "
                 "supported backend."
             )
@@ -278,7 +277,9 @@ def train(cfg: TrainPipelineConfig):
                     f"DeepSpeed ZeRO stage {zero_stage}. ZeRO-3 re-shards parameters "
                     "during forward and needs deepspeed.checkpointing.checkpoint "
                     "rather than torch.utils.checkpoint. Either set "
-                    "gradient_checkpointing=False or use zero_stage: 1 or 2."
+                    "gradient_checkpointing=False, use zero_stage: 1 or 2, or "
+                    "switch to FSDP (which has equivalent param sharding and "
+                    "is compatible with torch.utils.checkpoint)."
                 )
 
     logging.info(pformat(cfg.to_dict()))
@@ -329,15 +330,27 @@ def train(cfg: TrainPipelineConfig):
     policy = make_policy(cfg=cfg.policy, ds_meta=train_dataset.meta)
     # Keep the policy in bf16 for forward/backward (activation memory + bf16
     # compute). The optimizer state is kept in fp32 separately: DeepSpeed
-    # ZeRO does this through ``BF16_Optimizer``; under DDP/FSDP/single we
-    # mirror that with ``MasterWeightOptimizer`` (see issue #181).
-    policy.to(torch.bfloat16)
+    # ZeRO does this through ``BF16_Optimizer``; under DDP/single we mirror
+    # that with ``MasterWeightOptimizer`` (see issue #181). Under FSDP,
+    # the policy must stay in fp32 here so FSDP's ``MixedPrecision`` (set
+    # by accelerate from ``mixed_precision: bf16`` in the FSDP yaml) can
+    # downcast on the fly while keeping the fp32 outer params for the
+    # optimizer to step — same fp32-master / bf16-compute split, but owned
+    # by FSDP rather than our wrapper.
+    if accelerator.distributed_type != accelerate.DistributedType.FSDP:
+        policy.to(torch.bfloat16)
     logging.info("Creating optimizer and scheduler")
     optimizer, lr_scheduler = make_optimizer_and_scheduler(cfg, policy)
-    # Outside DeepSpeed, wrap the optimizer so it carries fp32 master weights
-    # and fp32 Adam state. DeepSpeed already provides this via BF16_Optimizer
-    # (see ``ds_config['bf16']['enabled']``), so we don't double-wrap there.
-    if accelerator.distributed_type != accelerate.DistributedType.DEEPSPEED:
+    # Outside DeepSpeed *and* FSDP, wrap the optimizer so it carries fp32
+    # master weights and fp32 Adam state. DeepSpeed provides this via
+    # BF16_Optimizer (see ``ds_config['bf16']['enabled']``); FSDP provides
+    # it via MixedPrecision (param_dtype=bf16, reduce_dtype=fp32, with the
+    # outer fp32 params owned by FSDP). Wrapping under either of those would
+    # double-allocate fp32 masters.
+    if accelerator.distributed_type not in (
+        accelerate.DistributedType.DEEPSPEED,
+        accelerate.DistributedType.FSDP,
+    ):
         optimizer = MasterWeightOptimizer.from_existing(optimizer)
         # ``make_optimizer_and_scheduler`` bound the LR scheduler to the
         # ORIGINAL ``torch.optim.AdamW`` (now discarded in favour of the

--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -20,7 +20,7 @@ import os
 
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
 from pprint import pformat
 from typing import Any
 
@@ -190,30 +190,52 @@ def _find_unused_params_from_env() -> bool:
     return os.environ.get("FIND_UNUSED_PARAMS", "true").lower() == "true"
 
 
+@contextmanager
 def _zero3_disabled_init_context(accelerator: accelerate.Accelerator):
-    """Return a context manager that disables ZeRO-3's per-construction param partitioning.
+    """Context manager that suppresses ZeRO-3 per-construction param partitioning.
 
-    DeepSpeed ZeRO-3 installs a `partition_parameters` wrapper that shards
-    each parameter as it's created. Some HuggingFace init paths (e.g.
-    SigLIP's `lecun_normal_` → `_calculate_fan_in_and_fan_out`) need the
-    full tensor shape and crash on the per-rank shard. This returns a
-    `deepspeed.zero.Init(enabled=False)` context for ZeRO-3 and a
-    no-op `nullcontext()` everywhere else.
+    Under DeepSpeed ZeRO-3, transformers' `is_deepspeed_zero3_enabled()` flag
+    routes module construction through DeepSpeed's `partition_parameters`
+    wrapper, which shards each parameter as it's created. Several init
+    paths in our model graph need the full tensor shape and crash on the
+    per-rank shard — concretely, transformers' SigLIP `_init_weights`
+    calls `lecun_normal_` → `_calculate_fan_in_and_fan_out`, which raises
+    on a 0-D shard.
+
+    The accelerate yaml field `zero3_init_flag: false` only controls
+    transformers' `from_pretrained` integration, NOT the partitioning
+    wrapper that fires on plain `__init__`. To suppress the wrapper for a
+    bounded section we have to unset the active `HfDeepSpeedConfig` directly.
+
+    On entry: if the active backend is DeepSpeed ZeRO-3, save and clear the
+    HF-side DeepSpeed config so `is_deepspeed_zero3_enabled()` returns False.
+    On exit: restore it. ZeRO-3 itself still partitions the params correctly
+    when `accelerator.prepare` later wraps the model.
 
     Args:
         accelerator: The active accelerate ``Accelerator``.
-
-    Returns:
-        A context manager (no-op for non-ZeRO-3 backends).
     """
     if accelerator.distributed_type != accelerate.DistributedType.DEEPSPEED:
-        return nullcontext()
+        yield
+        return
     zero_stage = accelerator.deepspeed_plugin.hf_ds_config.config.get("zero_optimization", {}).get("stage", 0)
     if zero_stage < 3:
-        return nullcontext()
-    import deepspeed
+        yield
+        return
 
-    return deepspeed.zero.Init(enabled=False)
+    from transformers.integrations.deepspeed import (
+        is_deepspeed_zero3_enabled,
+        set_hf_deepspeed_config,
+        unset_hf_deepspeed_config,
+    )
+
+    saved_hf_ds_config = accelerator.deepspeed_plugin.hf_ds_config if is_deepspeed_zero3_enabled() else None
+    try:
+        unset_hf_deepspeed_config()
+        yield
+    finally:
+        if saved_hf_ds_config is not None:
+            set_hf_deepspeed_config(saved_hf_ds_config)
 
 
 def _sync_deepspeed_gradient_accumulation_steps(
@@ -360,8 +382,7 @@ def train(cfg: TrainPipelineConfig):
     # — need the full tensor shape and crash on a per-rank shard. Build the
     # model with partitioning disabled; ZeRO will re-shard properly when
     # `accelerator.prepare` wraps it. No-op for any non-ZeRO-3 backend.
-    init_ctx = _zero3_disabled_init_context(accelerator)
-    with init_ctx:
+    with _zero3_disabled_init_context(accelerator):
         policy = make_policy(cfg=cfg.policy, ds_meta=train_dataset.meta)
     # Keep the policy in bf16 for forward/backward (activation memory + bf16
     # compute). The optimizer state is kept in fp32 separately: DeepSpeed

--- a/tests/policies/test_pi07_cpu.py
+++ b/tests/policies/test_pi07_cpu.py
@@ -1660,3 +1660,163 @@ class TestBuildHistoryBatchEmitsObsHistoryIsPad:
             else:
                 assert torch.all(state[t] == 7.0), f"state[{t}] zero-filled but mask says real"
                 assert torch.all(cam[t] == 5.0), f"camera[{t}] zero-filled but mask says real"
+
+
+# Tests pinning the architectural invariants of the InterleavedDecoderLayer
+# refactor (commit aaefa6e). These are the things that, if broken, would
+# silently re-introduce the FSDP / ZeRO-3 NCCL desync that the refactor fixes
+# but CPU runs would still produce plausible-looking forward outputs from.
+class TestInterleavedDecoderLayer:
+    def test_module_list_built_with_correct_count(self):
+        """One InterleavedDecoderLayer per text-config layer."""
+        cfg = _make_tiny_g3we_cfg()
+        model = Gemma3WithExpertModel(cfg).to(dtype=torch.float32)
+        assert hasattr(model, "interleaved_layers")
+        assert isinstance(model.interleaved_layers, torch.nn.ModuleList)
+        assert len(model.interleaved_layers) == cfg.gemma3_config.text_config.num_hidden_layers
+        assert all(isinstance(layer, g3we.InterleavedDecoderLayer) for layer in model.interleaved_layers)
+
+    def test_source_module_lists_are_emptied(self):
+        """The original ``language_model.layers`` and ``gemma_expert.model.layers``
+        must be empty after init — otherwise FSDP / ZeRO-3 walks the module
+        tree and tries to wrap each layer twice."""
+        cfg = _make_tiny_g3we_cfg()
+        model = Gemma3WithExpertModel(cfg).to(dtype=torch.float32)
+        backbone_text = model._backbone_text_model()
+        assert len(backbone_text.layers) == 0
+        assert len(model.gemma_expert.model.layers) == 0
+
+    def test_each_parameter_registered_exactly_once(self):
+        """No Parameter object should appear under multiple module paths.
+        Double-registration breaks FSDP's flat-param construction."""
+        cfg = _make_tiny_g3we_cfg()
+        model = Gemma3WithExpertModel(cfg).to(dtype=torch.float32)
+        seen: dict[int, str] = {}
+        for name, param in model.named_parameters():
+            pid = id(param)
+            if pid in seen:
+                pytest.fail(f"parameter object {pid} registered at both {seen[pid]} and {name}")
+            seen[pid] = name
+
+    def test_state_dict_layer_keys_under_interleaved_prefix(self):
+        """All per-layer params must serialise under the ``interleaved_layers``
+        prefix (NOT under ``gemma3.language_model.model.layers`` or
+        ``gemma_expert.model.layers``). This is the documented post-refactor
+        key namespace."""
+        cfg = _make_tiny_g3we_cfg()
+        model = Gemma3WithExpertModel(cfg).to(dtype=torch.float32)
+        state_keys = list(model.state_dict().keys())
+        # Per-layer attention / mlp / norm weights must exist under the new path.
+        backbone_layer_keys = [k for k in state_keys if k.startswith("interleaved_layers.0.backbone_layer.")]
+        expert_layer_keys = [k for k in state_keys if k.startswith("interleaved_layers.0.expert_layer.")]
+        assert backbone_layer_keys, "no backbone layer keys under interleaved_layers"
+        assert expert_layer_keys, "no expert layer keys under interleaved_layers"
+        # And NOT under the old paths.
+        for key in state_keys:
+            assert ".language_model.model.layers." not in key, f"stale key path: {key}"
+            assert ".language_model.layers." not in key, f"stale key path: {key}"
+            assert "gemma_expert.model.layers." not in key, f"stale key path: {key}"
+
+    def test_train_expert_only_freezes_backbone_layers(self):
+        """When ``train_expert_only=True`` the backbone layers (now living
+        under ``interleaved_layers[i].backbone_layer``) must be frozen.
+        Pre-refactor this was achieved by freezing ``self.gemma3.parameters()``;
+        after the refactor those layers are no longer reachable from
+        ``self.gemma3``."""
+        cfg = _make_tiny_g3we_cfg()
+        cfg.train_expert_only = True
+        model = Gemma3WithExpertModel(cfg).to(dtype=torch.float32)
+        for layer in model.interleaved_layers:
+            for name, param in layer.backbone_layer.named_parameters():
+                assert not param.requires_grad, (
+                    f"backbone param interleaved_layers.*.backbone_layer.{name} should be frozen"
+                )
+            # Expert layer params must remain trainable.
+            for name, param in layer.expert_layer.named_parameters():
+                assert param.requires_grad, (
+                    f"expert param interleaved_layers.*.expert_layer.{name} should be trainable"
+                )
+
+    def test_train_expert_only_eval_propagates_to_backbone_layers(self):
+        """``train(mode=True)`` with ``train_expert_only=True`` must also
+        flip the backbone layers under interleaved_layers to ``.training=False``
+        — they used to live under ``self.gemma3`` which the original ``train``
+        method walks."""
+        cfg = _make_tiny_g3we_cfg()
+        cfg.train_expert_only = True
+        model = Gemma3WithExpertModel(cfg).to(dtype=torch.float32)
+        model.train(True)
+        for layer in model.interleaved_layers:
+            assert not layer.backbone_layer.training, "backbone layer not in eval mode"
+            # Expert layer should be in training mode.
+            assert layer.expert_layer.training, "expert layer should be training"
+
+    def test_attention_dispatch_is_resolved_at_call_time(self, monkeypatch):
+        """The InterleavedDecoderLayer must look up the attention dispatch
+        via ``parent.get_attention_interface()`` per forward, NOT capture it
+        at init. Otherwise tests / runtime adapters that monkey-patch
+        ``self.eager_attention_forward`` (existing pattern, see
+        TestNoSlidingWindowEnforcement above) silently bypass the patch."""
+        monkeypatch.setattr(g3we, "_preferred_dtype", lambda: torch.float32)
+        cfg = _make_tiny_g3we_cfg()
+        model = Gemma3WithExpertModel(cfg).to(dtype=torch.float32)
+        real_eager = model.eager_attention_forward
+        calls: list[int] = []
+
+        def spy_eager(*args, **kwargs):
+            calls.append(1)
+            return real_eager(*args, **kwargs)
+
+        monkeypatch.setattr(model, "eager_attention_forward", spy_eager)
+
+        batch, seq_len = 1, 4
+        hidden = torch.randn(batch, seq_len, cfg.gemma3_config.text_config.hidden_size)
+        position_ids = torch.arange(seq_len)[None, :]
+        attention_mask = torch.tril(torch.ones(seq_len, seq_len, dtype=torch.bool))[None]
+        with torch.no_grad():
+            model.forward(
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                inputs_embeds=[hidden, None],
+            )
+        # One call per layer.
+        assert len(calls) == cfg.gemma3_config.text_config.num_hidden_layers
+
+    def test_forward_seeded_determinism(self, monkeypatch):
+        """Two seeded forwards through the refactored stack must produce
+        bit-identical outputs (no rank-dependent ordering, no captured-once
+        objects breaking re-entrancy)."""
+        # Same convention as TestNoSlidingWindowEnforcement above — pin
+        # ``_preferred_dtype`` to fp32 so the layer's intra-forward casts
+        # don't mix bf16 weights with fp32 inputs.
+        monkeypatch.setattr(g3we, "_preferred_dtype", lambda: torch.float32)
+        cfg = _make_tiny_g3we_cfg()
+
+        def _one_run() -> torch.Tensor:
+            torch.manual_seed(0)
+            model = Gemma3WithExpertModel(cfg).to(dtype=torch.float32)
+            model.eval()
+            torch.manual_seed(1)
+            batch, seq_len = 1, 4
+            hidden = torch.randn(batch, seq_len, cfg.gemma3_config.text_config.hidden_size)
+            position_ids = torch.arange(seq_len)[None, :]
+            attention_mask = torch.tril(torch.ones(seq_len, seq_len, dtype=torch.bool))[None]
+            with torch.no_grad():
+                outs, _ = model.forward(
+                    attention_mask=attention_mask,
+                    position_ids=position_ids,
+                    inputs_embeds=[hidden, None],
+                )
+            return outs[0].detach().clone()
+
+        out_a = _one_run()
+        out_b = _one_run()
+        assert torch.equal(out_a, out_b), "non-deterministic forward (refactor regression?)"
+
+    def test_attention_provider_not_in_state_dict(self):
+        """The cached attention dispatch provider must not leak into
+        ``state_dict`` (it's a callable, not a Parameter / Buffer / Module)."""
+        cfg = _make_tiny_g3we_cfg()
+        model = Gemma3WithExpertModel(cfg).to(dtype=torch.float32)
+        for key in model.state_dict():
+            assert "attention_interface" not in key, f"unexpected key: {key}"

--- a/tests/policies/test_pi07_cpu.py
+++ b/tests/policies/test_pi07_cpu.py
@@ -1953,3 +1953,39 @@ class TestDisableActionExpert:
 
         cfg = PI07LowLevelConfig()
         assert cfg.vlm_config.disable_action_expert is False
+
+
+class TestDisableInternalBf16Cast:
+    """Locks in that ``disable_internal_bf16_cast=True`` actually skips the
+    in-``__init__`` ``to_bfloat16_like_physical_intelligence`` call. The flag
+    exists because FSDP needs fp32 outer params for ``MixedPrecision`` to
+    own the bf16-compute / fp32-master split — if the model casts itself to
+    bf16 before FSDP wraps, FSDP can't upcast and the optimizer ends up
+    stepping on bf16 sharded params with bf16 Adam state."""
+
+    def test_default_keeps_bf16_cast_active(self):
+        """Default (False) preserves pre-flag behaviour: per-layer params
+        are bf16 after init (matches the on-device dtype DeepSpeed/DDP
+        expect when they layer fp32 master back on top)."""
+        cfg = _make_tiny_g3we_cfg()
+        assert cfg.disable_internal_bf16_cast is False
+        model = Gemma3WithExpertModel(cfg)  # do NOT post-cast — read the in-init dtype
+        # Sample a per-layer param that ``to_bfloat16_like_physical_intelligence``
+        # always touches (interleaved_layers selector).
+        sample = model.interleaved_layers[0].backbone_layer.input_layernorm.weight
+        assert sample.dtype == torch.bfloat16, f"expected bf16 after default in-init cast, got {sample.dtype}"
+
+    def test_flag_skips_bf16_cast(self):
+        """With the flag, the same per-layer param stays in its constructed
+        dtype (fp32 from the HF backbone defaults)."""
+        cfg = _make_tiny_g3we_cfg()
+        cfg.disable_internal_bf16_cast = True
+        model = Gemma3WithExpertModel(cfg)
+        sample = model.interleaved_layers[0].backbone_layer.input_layernorm.weight
+        assert sample.dtype == torch.float32, f"expected fp32 (cast skipped), got {sample.dtype}"
+        # Also covers the SigLIP vision tower and the MM projector — all of
+        # the selectors ``to_bfloat16_like_physical_intelligence`` walks.
+        for name, param in model.named_parameters():
+            assert param.dtype == torch.float32, (
+                f"param {name} unexpectedly {param.dtype} (expected fp32 with cast skipped)"
+            )


### PR DESCRIPTION
## What this does

Makes pi07 full-unfreeze training work under PyTorch FSDP-FULL_SHARD on 8×A100, with the same fp32-master / bf16-compute precision regime DeepSpeed uses — as a lower-overhead alternative to DeepSpeed ZeRO-2.

**200-step verified throughput (pi07 low-level, full unfreeze, sdpa+grad_ckpt, default stochastic drops):**

| Config | per-rank bs | step (ms) | samples/s | vs ZeRO-2 baseline |
| --- | ---: | ---: | ---: | ---: |
| ZeRO-2 baseline (no grad_ckpt, eager) | 6 | 3946 | 12.2 | 1.00× |
| **FSDP-FULL_SHARD, num_cams=1** | **12** | **6180** | **15.5** | **+1.27×** |
| **FSDP-FULL_SHARD, num_cams=4** (pre-training target) | **8** | **11038** | **5.8** | — (different cam count) |

**Precision regime — matches DeepSpeed ZeRO-1/2:**

| | DDP / single | DeepSpeed ZeRO-1/2 | **FSDP-FULL_SHARD (this PR)** |
| --- | --- | --- | --- |
| Live (compute) params | bf16 | bf16 | **bf16** (FSDP MixedPrecision downcast) |
| Master params | fp32 (`MasterWeightOptimizer`) | fp32 (`BF16_Optimizer`) | **fp32** (FSDP outer params) |
| Adam state | fp32 | fp32 | **fp32** (built over fp32 outer) |
| Gradient reduce-scatter | bf16 | bf16 | **bf16** (`reduce_dtype=bf16`) |

The fp32 master + fp32 Adam state is what protects late-training updates from bf16's 7-bit-mantissa underflow on small gradient magnitudes. Throughput cost vs the simpler bf16-everywhere regime is **<2%** (0.6% at cam=1, 1.7% at cam=4) — within step-time noise.

**The structural change:**

- **`InterleavedDecoderLayer(nn.Module)`** in `gemma3_with_expert.py` bundles one Gemma 3 backbone layer + one Gemma-v1 expert layer for one decoder step. `Gemma3WithExpertModel.__init__` reparents per-layer modules out of `gemma3.language_model.model.layers` / `gemma_expert.model.layers` into a flat `interleaved_layers` ModuleList, and empties the source ModuleLists so each Parameter is registered exactly once. The accelerate FSDP yaml wraps `InterleavedDecoderLayer` (instead of the inner `Gemma3DecoderLayer` / `GemmaDecoderLayer`) so the all-gather hook fires before the sub-component accesses inside `forward`. Without this refactor, both FSDP1 and ZeRO-3 either silently produce wrong gradients or hang at NCCL all-gather.
- **`Gemma3WithExpertConfig.disable_internal_bf16_cast`** (new) gates the in-`__init__` `to_bfloat16_like_physical_intelligence` call so the policy stays fp32 going into FSDP. train.py / profile_step.py set the flag whenever `accelerator.distributed_type == FSDP`. Other backends (DDP, ZeRO-1/2) keep the existing behavior. Without this gate, FSDP's `MixedPrecision` becomes a storage no-op (params already bf16) and AdamW silently allocates state in bf16.
- **`_zero3_disabled_init_context`** in `train.py` calls `unset_hf_deepspeed_config()` for the duration of `make_policy` so SigLIP's `lecun_normal_` (which needs the full tensor shape for fan-in/out) doesn't crash on a per-rank ZeRO-3 partition.
- **`_global_any` branch sync in `embed_prefix`** — every per-rank decision to enter an `if has_response / has_subgoal / has_metadata` branch is globally OR-reduced (1-element `MAX` all-reduce, no-op outside `torch.distributed`). Stochastic drops give different ranks different feature subsets; before the sync, ranks took different branches inside `embed_prefix`, which made FSDP issue a different number of all-gather collectives on different ranks and hung NCCL with mismatched SeqNum. The cleaner alternative — hoist the `embed_*` calls out of the `if`s entirely — is filed as a follow-up.
- **Step 0 wins** that always help, included here: `attention_implementation: "sdpa"`, `gradient_checkpointing: true`, `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` defaulted in the `opentau-train` launcher.
- **`dataset_mixture.py` `count`-key fix** (issue #264) — the empty-camera padding tolerated v2.0 stats that lack `count`. Unblocks `num_cams > actual_cams` benchmarks on libero.
- **CI fix** — the `InterleavedDecoderLayer` originally captured `model.get_attention_interface()` at init, which silently bypassed runtime patches to `model.eager_attention_forward` / `sdpa_attention_forward` (existing test pattern). Switched to a per-call lookup so monkey-patches still take effect.
- **`Normalize.forward` DTensor materialization** — first FSDP2 blocker. Tiny `_materialize(tensor)` helper calls `.full_tensor()` when the input is a DTensor, returns it as-is otherwise. No-op for FSDP1/DDP/single. Fast on these stats because their placement is "replicated" by default.

**Per-rank persistent memory under fp32-master (pi07, ~5.5B):**
- fp32 master params: 5.5B × 4 / 8 = ~2.75 GB
- fp32 Adam exp_avg + exp_avg_sq: ~5.5 GB
- bf16 grad buffer (post reduce-scatter): ~1.4 GB
- NCCL + cuDNN + allocator overhead: ~1–2 GB
- **~10–11 GB/rank persistent**, leaving ~70 GB on each 80 GB A100 for activations.

New files:
- `configs/examples/pi07_low_level_libero.json` — real-pi07 (Gemma 3) example (sdpa, grad_ckpt, default stochastic drops, 8 history frames).
- `configs/examples/accelerate_fsdp_config.yaml` — FSDP1 + FULL_SHARD (production).
- `configs/examples/accelerate_fsdp2_config.yaml` — FSDP2 (experimental — see commit `a20cd47` for status).
- `configs/examples/accelerate_deepspeed_zero3_config.yaml` — ZeRO-3 baseline.

## How it was tested

- **CPU pi07 suite** (`tests/policies/test_pi07_*.py`) all pass against the refactored model. The 9 `TestInterleavedDecoderLayer` tests pin: module count, source ModuleLists empty after init, every Parameter object registered exactly once, state-dict layer keys under the new `interleaved_layers.X.{backbone,expert}_layer.*` namespace, `train_expert_only=True` freeze paths, `train(mode=True)` eval propagation, attention dispatch resolved at call time (the CI regression), seeded-forward determinism, and that the cached attention-dispatch provider doesn't leak into state_dict. The 2 `TestDisableInternalBf16Cast` tests pin both directions of the new flag (default keeps the cast active; flag skips it and params stay fp32).
- **GPU pytest pi07** (`pytest -m gpu tests/policies/test_pi07_low_level.py tests/policies/test_pi07_high_level_planner.py`): 7 / 7 pass on 8×A100 in 2:11.
- **Byte-identical pre vs post-refactor**: built the pre-refactor model (main repo, OLD `_run_layer`) and the post-refactor model (this branch, `InterleavedDecoderLayer`) with the same seed and same input. Backbone and expert outputs are bit-equal (`max_abs_diff = 0`).
- **8×A100 profiling**: 200-step `profile_step.py` end-to-end at the two configurations above (cam=1 bs=12 and cam=4 bs=8). No NaNs / crashes / hangs at either.

Not yet run before merge:
- Optional: state_dict back-compat hook (existing pi07 checkpoints have `gemma3.language_model.model.layers.X.*` keys; reload onto the refactored model would miss layer params unless translated).
- pi07 high-level planner under FSDP — same `Gemma3WithExpertModel` so structurally compatible, but throughput benchmarking requires a libero subtask-annotated dataset.
- pi06 under FSDP — has its own copy of `gemma3_with_expert.py` without the refactor; FSDP fails at `accelerate.prepare` because the wrap target `InterleavedDecoderLayer` doesn't exist in pi06's namespace. Same architectural fix needs porting.
- FSDP2 end-to-end — `Normalize.forward` fix landed; `SiglipVisionEmbeddings` wrap helps; the third blocker (`video_encoder.py:346` direct sub-component access on the SpaceTime SigLIP) still requires the equivalent `nn.Module` bundling that `InterleavedDecoderLayer` does for the decoder. Documented inline in `accelerate_fsdp2_config.yaml`.

## How to checkout & try? (for the reviewer)

Pre-training target (cam=4 bs=8):

```bash
opentau-train \
    --accelerate-config configs/examples/accelerate_fsdp_config.yaml \
    --config_path configs/examples/pi07_low_level_libero.json \
    --batch_size 8 --dataloader_batch_size 8 --num_cams 4 --num_workers 8
```

Reproducing the cam=1 throughput headline:

```bash
PROFILE_STEPS=200 PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True \
    accelerate launch \
    --config_file configs/examples/accelerate_fsdp_config.yaml --num_processes=8 \
    src/opentau/scripts/profile_step.py \
    --config_path configs/examples/pi07_low_level_libero.json \
    --batch_size=12 --dataloader_batch_size=12 --num_cams=1 \
    --policy.freeze_vision_encoder=false --policy.train_expert_only=false \
    --policy.gradient_checkpointing=true --policy.attention_implementation=sdpa \
    --wandb.enable=false
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [x] My PR includes policy-related changes.
  - [x] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.
