### PR TITLE
Fixing SpaceTime attention block in siglip

### DIFF
--- a/src/opentau/policies/pi07/video_encoder.py
+++ b/src/opentau/policies/pi07/video_encoder.py
@@ -65,7 +65,6 @@ import torch.nn.functional as F  # noqa: N812
 from einops import rearrange
 from torch import Tensor, nn
 from transformers.models.siglip.modeling_siglip import (
-    SiglipAttention,
     SiglipEncoderLayer,
     SiglipVisionModel,
 )
@@ -83,7 +82,7 @@ def _build_temporal_sinusoidal_pe(
     embed_dim: int,
     *,
     min_period: float = 4e-3,
-    max_period: float = 4.0,
+    max_period: float = 40.0,
     dtype: torch.dtype = torch.float32,
     device: torch.device | str = "cpu",
 ) -> Tensor:
@@ -96,11 +95,27 @@ def _build_temporal_sinusoidal_pe(
     The zero-current-row condition lets a ``T=1`` forward pass match an
     un-modified SigLIP ViT exactly, which is required for single-frame
     invariance against ``PaliGemmaModel.get_image_features``.
+
+    The ``max_period`` floor governs the LONGEST sinusoidal period. To avoid
+    temporal aliasing (different timesteps mapping to nearly-identical
+    low-frequency rows), ``max_period`` should comfortably exceed the time
+    range ``T-1``. The default ``40.0`` covers up to ``T=20`` with the
+    longest sinusoid completing at most ``19 / 40 ≈ 0.48`` of a cycle —
+    every timestep in ``{-19, ..., 0}`` therefore gets a unique
+    low-frequency encoding. Callers needing ``T > 20`` should pass a larger
+    ``max_period`` explicitly (rule of thumb: ``2 * (T - 1)``).
     """
     if embed_dim % 2 != 0:
         raise ValueError(f"embed_dim ({embed_dim}) must be divisible by 2")
     if num_frames < 1:
         raise ValueError(f"num_frames ({num_frames}) must be >= 1")
+    if num_frames - 1 > max_period:
+        raise ValueError(
+            f"num_frames ({num_frames}) exceeds the no-alias range of max_period "
+            f"({max_period}); the lowest-frequency sinusoid would complete more than "
+            f"a full cycle over the time range, causing temporal aliasing. Pass "
+            f"max_period >= {2 * (num_frames - 1)} explicitly."
+        )
 
     # time[i] = i - (T-1) in {-(T-1), ..., -1, 0}; row T-1 has time = 0.
     time = torch.arange(num_frames, dtype=torch.float64, device=device) - (num_frames - 1)
@@ -115,99 +130,43 @@ def _build_temporal_sinusoidal_pe(
     return pe.to(dtype=dtype)
 
 
-class _TemporalSelfAttention(nn.Module):
-    """Parameter-free causal temporal self-attention.
-
-    Re-uses an existing ``SiglipAttention`` instance's
-    ``q_proj``/``k_proj``/``v_proj``/``out_proj`` linear layers, but applies
-    them over the ``T`` axis (for each fixed patch position) with a
-    standard lower-triangular causal mask (position ``i`` attends to
-    positions ``j <= i``; since ``t = T-1`` is the current frame, the current
-    frame attends to all past frames).
-
-    The referenced ``SiglipAttention`` is held in a list to keep ``nn.Module``
-    from re-registering its parameters under this module's path (which would
-    duplicate them in ``state_dict`` under both
-    ``base_layer.self_attn.*`` and ``_temporal_attn.attn.*``).
-    """
-
-    def __init__(self, attn: SiglipAttention):
-        super().__init__()
-        # Wrap in a list so nn.Module.__setattr__ does not treat ``attn``
-        # as a child submodule; the base layer already owns these params.
-        self._attn_ref: list[SiglipAttention] = [attn]
-
-    @property
-    def attn(self) -> SiglipAttention:
-        return self._attn_ref[0]
-
-    def forward(self, hidden_states: Tensor, temporal_attn_mask: Tensor | None = None) -> Tensor:
-        """hidden_states: (B*N, T, D) -> (B*N, T, D).
-
-        Args:
-            hidden_states: ``(B*N, T, D)`` hidden states reshaped for temporal
-                attention (one sequence per spatial patch position).
-            temporal_attn_mask: Optional ``(B*N, 1, T, T)`` additive float mask.
-                ``0.0`` = attend, ``-inf`` = block. When ``None``, falls back to
-                the standard causal lower-triangular mask via ``is_causal=True``.
-        """
-        attn = self.attn
-        bn, t, d = hidden_states.shape
-        num_heads = attn.num_heads
-        head_dim = attn.head_dim
-
-        q = attn.q_proj(hidden_states).view(bn, t, num_heads, head_dim).transpose(1, 2)
-        k = attn.k_proj(hidden_states).view(bn, t, num_heads, head_dim).transpose(1, 2)
-        v = attn.v_proj(hidden_states).view(bn, t, num_heads, head_dim).transpose(1, 2)
-
-        if temporal_attn_mask is not None:
-            # Caller-supplied mask already encodes both causal AND padded-history
-            # blocking; do NOT also set is_causal=True (SDPA disallows combining
-            # the two).
-            out = F.scaled_dot_product_attention(
-                q, k, v, attn_mask=temporal_attn_mask, is_causal=False, dropout_p=0.0, scale=attn.scale
-            )
-        else:
-            # is_causal=True -> lower-triangular mask, each position attends to
-            # itself and earlier positions (our convention: t=T-1 is current).
-            out = F.scaled_dot_product_attention(
-                q, k, v, attn_mask=None, is_causal=True, dropout_p=0.0, scale=attn.scale
-            )
-        out = out.transpose(1, 2).reshape(bn, t, d)
-        return attn.out_proj(out)
-
-
 class SpaceTimeEncoderLayerWrapper(nn.Module):
-    """Replaces a ``SiglipEncoderLayer`` in-place; adds a temporal sublayer.
+    """Replaces a ``SiglipEncoderLayer`` in-place; adds factorized space-time
+    attention via a single composed attention sublayer (Reading B of MEM
+    Eq. 3).
 
     The wrapper **adopts** the original layer's submodules by reference —
     ``self_attn``, ``layer_norm1``, ``layer_norm2``, ``mlp`` — so its
     ``state_dict`` keys are **identical** to a vanilla ``SiglipEncoderLayer``.
     That means any pi05 / pi05_continuous_state checkpoint can load directly
     into the wrapped layer without any key remapping. The only new state is
-    a non-persistent ``_temporal_pe`` buffer (excluded from state_dict) and
-    an internal ``_temporal_attn`` wrapper that holds a by-reference pointer
-    to ``self_attn`` (also excluded because it's kept in a list).
+    a non-persistent ``_temporal_pe`` buffer (excluded from state_dict).
 
-    The forward computes:
+    The forward computes (single QKV projection per block; two SDPAs share
+    those projections; one residual; one out_proj):
 
-        h_pe  = h + e(t)                                   # broadcast over (B, N)
-        h     = h + temporal_attn( LN1(h_pe) )             # new; causal over T
-        # then the standard SigLIP block:
-        h     = h + spatial_attn( LN1(h) )
-        h     = h + MLP( LN2(h) )
+        h_pe  = h + e(t)                              # broadcast over (B, N)
+        z     = LN1(h_pe)                             # ONE LN
+        Q,K,V = W_Q·z, W_K·z, W_V·z                   # ONE projection
+        V'    = SDPA(Q, K, V; causal mask over T)     # temporal pass per patch
+        out   = SDPA(Q, K, V'; no mask, over N)       # spatial pass per timestep
+        h     = h + W_O(out)                          # ONE residual on h (not h_pe)
+        h     = h + MLP( LN2(h) )                     # standard MLP block
 
-    At ``T=1`` the temporal sublayer is skipped entirely so that the block
-    degenerates to the unmodified SigLIP forward, satisfying the MEM paper's
-    single-frame invariance claim. (With ``T=1`` causal attention over a
-    single timestep is not an identity — it returns ``out_proj(v_proj(
-    LN1(x)))`` — so ``e(0)=0`` alone is insufficient; the block itself must
-    also be bypassed.)
+    Q and K are reused across both passes (same tensor, just permuted into
+    each layout); only V is replaced by ``V'`` for the spatial pass. ``W_O``
+    fires once at the end. This matches the paper's "no new learnable
+    parameters" claim at the projection level: ``W_Q``, ``W_K``, ``W_V``,
+    ``W_O`` are each applied exactly once per block, not twice.
 
-    Reusing ``layer_norm1`` for both the temporal and spatial sublayers keeps
-    the paper's "no new learnable parameters" guarantee. It is an intentional
-    design choice: the two attentions operate on different axes and the
-    LayerNorm is applied to different input tensors each time.
+    At ``T=1`` the temporal SDPA collapses to the identity (a single key,
+    so the attention weight is 1 and ``V`` passes through unchanged) and
+    ``e(t=0)=0`` makes ``h_pe = h``. The block is therefore mathematically
+    identical to a vanilla ``SiglipEncoderLayer`` forward at ``T=1`` — no
+    short-circuit is required for correctness. The wrapper still routes
+    ``T=1`` inputs through ``_spatial_block_forward`` for compute savings
+    and bit-exact match in low-precision dtypes (where the no-op temporal
+    SDPA can drift by ~1 ULP).
 
     Variable ``T`` per forward: the cached PE is built once for
     ``max_num_frames`` rows and sliced as ``pe[max_num_frames - num_frames:]``
@@ -239,10 +198,6 @@ class SpaceTimeEncoderLayerWrapper(nn.Module):
 
         self.max_num_frames = max_num_frames
         self.num_tokens_per_frame = num_tokens_per_frame
-        # The temporal attention re-uses self_attn's Q/K/V/O projections; it
-        # holds its reference in a list (see _TemporalSelfAttention) so the
-        # params don't show up twice in state_dict.
-        self._temporal_attn = _TemporalSelfAttention(self.self_attn)
 
         # Caller-driven flag: when False, ``forward`` short-circuits to the
         # vanilla spatial-only block (`_spatial_block_forward`) regardless of
@@ -342,11 +297,11 @@ class SpaceTimeEncoderLayerWrapper(nn.Module):
         if not self._temporal_active:
             return self._spatial_block_forward(hidden_states, attention_mask, output_attentions)
 
-        # Short-circuit at T=1: temporal self-attention over a single timestep
-        # collapses to ``out_proj(v_proj(LN1(x)))``, which is NOT an identity
-        # and would break single-frame invariance (the MEM paper's guarantee
-        # that a T=1 pass matches the unmodified SigLIP ViT). e(t=0)=0 alone
-        # is insufficient; the block must also be skipped.
+        # Short-circuit at T=1. Under Reading B the block IS naturally
+        # identity at T=1 (the temporal SDPA over a single key returns V
+        # unchanged, and ``e(t=0)=0`` makes ``h_pe = h``), so this is purely
+        # an optimization: it avoids the no-op temporal SDPA and guarantees
+        # bit-exact match with vanilla SigLIP in low-precision dtypes.
         if num_frames is None or num_frames == 1:
             return self._spatial_block_forward(hidden_states, attention_mask, output_attentions)
 
@@ -365,31 +320,111 @@ class SpaceTimeEncoderLayerWrapper(nn.Module):
             )
         b = bt // t
 
-        # Temporal sublayer.
-        x = rearrange(hidden_states, "(b t) n d -> b t n d", b=b, t=t)
+        attn = self.self_attn
+        num_heads = attn.num_heads
+        head_dim = attn.head_dim
+
+        # Reshape (B*T, N, D) -> (B, T, N, D) and add temporal PE.
         # Slice the precomputed PE: take the LAST t rows so the current-frame
-        # row remains zero (PE entries depend only on relative offset from the
-        # current frame, so pe[M-t:M] is byte-identical to a fresh PE built
-        # for t frames).
-        # Cast PE to match tensor device/dtype each call. Both are no-ops if
-        # already aligned (the common case — the buffer is constructed on
-        # the base layer's device). The cast only allocates when something
-        # external has moved the inputs onto a different device without
-        # propagating ``.to()`` through to this wrapper.
+        # row (t = T-1) remains exactly zero (PE entries depend only on the
+        # relative offset from the current frame, so ``pe[M-t:M]`` is
+        # byte-identical to a fresh PE built for t frames). Cast PE to match
+        # the tensor's device/dtype each call; no-op if already aligned.
+        x = rearrange(hidden_states, "(b t) n d -> b t n d", b=b, t=t)
         pe_full = self._temporal_pe.to(device=x.device, dtype=x.dtype)
         pe = pe_full[self.max_num_frames - t :].view(1, t, 1, d)
         x_pe = x + pe
 
-        t_in = rearrange(x_pe, "b t n d -> (b n) t d")
-        t_norm = self.layer_norm1(t_in)
-        t_out = self._temporal_attn(t_norm, temporal_attn_mask=temporal_attn_mask)
-        # Residual on the pre-PE hidden (not on x_pe): PE is a transient
-        # positional signal, not a feature perturbation to carry forward.
-        t_res = rearrange(x, "b t n d -> (b n) t d") + t_out
-        h_after_t = rearrange(t_res, "(b n) t d -> (b t) n d", n=n)
+        # ONE LayerNorm. Its output feeds BOTH attention passes.
+        z = self.layer_norm1(x_pe)
 
-        # Spatial + MLP sublayers.
-        return self._spatial_block_forward(h_after_t, attention_mask, output_attentions)
+        # ONE QKV projection. Q/K/V come from a single application of the
+        # layer's W_Q/W_K/W_V to LN1(h_pe). They are reshaped (not
+        # re-projected) into the temporal and spatial layouts below.
+        q = attn.q_proj(z).view(b, t, n, num_heads, head_dim)
+        k = attn.k_proj(z).view(b, t, n, num_heads, head_dim)
+        v = attn.v_proj(z).view(b, t, n, num_heads, head_dim)
+
+        # ===== Temporal SDPA: per-patch causal attention over T =====
+        # Layout (B*N, H, T, Dh): each spatial patch is its own length-T
+        # causal sequence; flatten (B, N) into the SDPA batch axis.
+        q_t = q.permute(0, 2, 3, 1, 4).reshape(b * n, num_heads, t, head_dim)
+        k_t = k.permute(0, 2, 3, 1, 4).reshape(b * n, num_heads, t, head_dim)
+        v_t = v.permute(0, 2, 3, 1, 4).reshape(b * n, num_heads, t, head_dim)
+
+        if temporal_attn_mask is not None:
+            # Caller-supplied mask already encodes both the causal pattern AND
+            # padded-history blocking; do NOT also set is_causal=True (SDPA
+            # disallows combining the two).
+            v_temp = F.scaled_dot_product_attention(
+                q_t,
+                k_t,
+                v_t,
+                attn_mask=temporal_attn_mask,
+                is_causal=False,
+                dropout_p=0.0,
+                scale=attn.scale,
+            )
+        else:
+            # is_causal=True -> lower-triangular mask. Position i attends to
+            # j <= i; since t = T-1 is the current frame, the current frame
+            # attends to all past frames.
+            v_temp = F.scaled_dot_product_attention(
+                q_t,
+                k_t,
+                v_t,
+                attn_mask=None,
+                is_causal=True,
+                dropout_p=0.0,
+                scale=attn.scale,
+            )
+        # v_temp: (B*N, H, T, Dh). Permute back into (B, T, N, H, Dh) layout
+        # so it can feed the spatial pass as the V input. The .reshape at
+        # the end materializes the new strides into a contiguous tensor.
+        v_temp = v_temp.view(b, n, num_heads, t, head_dim).permute(0, 3, 1, 2, 4)
+
+        # ===== Spatial SDPA: per-timestep bidirectional attention over N =====
+        # Q, K REUSE the same projections from z (NOT recomputed from v_temp).
+        # V is v_temp (the temporally-mixed values). Layout (B*T, H, N, Dh).
+        q_s = q.permute(0, 1, 3, 2, 4).reshape(b * t, num_heads, n, head_dim)
+        k_s = k.permute(0, 1, 3, 2, 4).reshape(b * t, num_heads, n, head_dim)
+        v_s = v_temp.permute(0, 1, 3, 2, 4).reshape(b * t, num_heads, n, head_dim)
+
+        out = F.scaled_dot_product_attention(
+            q_s,
+            k_s,
+            v_s,
+            attn_mask=attention_mask,
+            is_causal=False,
+            dropout_p=0.0,
+            scale=attn.scale,
+        )
+        # (B*T, H, N, Dh) -> (B*T, N, D)
+        out = out.transpose(1, 2).reshape(b * t, n, d)
+
+        # ONE output projection.
+        out = attn.out_proj(out)
+
+        # ONE residual on the original hidden_states (NOT on x_pe). PE is a
+        # transient positional signal that informs the attention computation;
+        # it is not a feature perturbation to carry forward in the residual.
+        h_after_attn = hidden_states + out
+
+        # Standard SigLIP MLP block on the post-attention residual.
+        residual = h_after_attn
+        h_norm = self.layer_norm2(h_after_attn)
+        h_mlp = self.mlp(h_norm)
+        h_out = residual + h_mlp
+
+        outputs: tuple[Tensor, ...] = (h_out,)
+        if output_attentions:
+            # SDPA does not return attention weights, and Reading B never
+            # materializes either α_temporal or α_spatial. Return None to
+            # keep the tuple shape; callers requesting weights at T>1 should
+            # switch to an explicit-attention build of SigLIP if they need
+            # per-layer weights.
+            outputs = outputs + (None,)
+        return outputs
 
 
 @contextmanager

--- a/src/opentau/policies/pi07/video_encoder.py
+++ b/src/opentau/policies/pi07/video_encoder.py
@@ -322,7 +322,6 @@ class SpaceTimeEncoderLayerWrapper(nn.Module):
 
         attn = self.self_attn
         num_heads = attn.num_heads
-        head_dim = attn.head_dim
 
         # Reshape (B*T, N, D) -> (B, T, N, D) and add temporal PE.
         # Slice the precomputed PE: take the LAST t rows so the current-frame
@@ -341,16 +340,16 @@ class SpaceTimeEncoderLayerWrapper(nn.Module):
         # ONE QKV projection. Q/K/V come from a single application of the
         # layer's W_Q/W_K/W_V to LN1(h_pe). They are reshaped (not
         # re-projected) into the temporal and spatial layouts below.
-        q = attn.q_proj(z).view(b, t, n, num_heads, head_dim)
-        k = attn.k_proj(z).view(b, t, n, num_heads, head_dim)
-        v = attn.v_proj(z).view(b, t, n, num_heads, head_dim)
+        q = rearrange(attn.q_proj(z), "b t n (h d) -> b t n h d", h=num_heads)
+        k = rearrange(attn.k_proj(z), "b t n (h d) -> b t n h d", h=num_heads)
+        v = rearrange(attn.v_proj(z), "b t n (h d) -> b t n h d", h=num_heads)
 
         # ===== Temporal SDPA: per-patch causal attention over T =====
         # Layout (B*N, H, T, Dh): each spatial patch is its own length-T
         # causal sequence; flatten (B, N) into the SDPA batch axis.
-        q_t = q.permute(0, 2, 3, 1, 4).reshape(b * n, num_heads, t, head_dim)
-        k_t = k.permute(0, 2, 3, 1, 4).reshape(b * n, num_heads, t, head_dim)
-        v_t = v.permute(0, 2, 3, 1, 4).reshape(b * n, num_heads, t, head_dim)
+        q_t = rearrange(q, "b t n h d -> (b n) h t d")
+        k_t = rearrange(k, "b t n h d -> (b n) h t d")
+        v_t = rearrange(v, "b t n h d -> (b n) h t d")
 
         if temporal_attn_mask is not None:
             # Caller-supplied mask already encodes both the causal pattern AND
@@ -378,17 +377,19 @@ class SpaceTimeEncoderLayerWrapper(nn.Module):
                 dropout_p=0.0,
                 scale=attn.scale,
             )
-        # v_temp: (B*N, H, T, Dh). Permute back into (B, T, N, H, Dh) layout
-        # so it can feed the spatial pass as the V input. The .reshape at
-        # the end materializes the new strides into a contiguous tensor.
-        v_temp = v_temp.view(b, n, num_heads, t, head_dim).permute(0, 3, 1, 2, 4)
+        # v_temp: (B*N, H, T, Dh). Rearrange back into (B, T, N, H, Dh) layout
+        # so it can feed the spatial pass as the V input. ``rearrange`` is
+        # defensive against non-contiguous SDPA outputs (some flash-attn
+        # backends return non-standard strides) — it is a no-op when the
+        # tensor is already contiguous and a copy when it is not.
+        v_temp = rearrange(v_temp, "(b n) h t d -> b t n h d", b=b)
 
         # ===== Spatial SDPA: per-timestep bidirectional attention over N =====
         # Q, K REUSE the same projections from z (NOT recomputed from v_temp).
         # V is v_temp (the temporally-mixed values). Layout (B*T, H, N, Dh).
-        q_s = q.permute(0, 1, 3, 2, 4).reshape(b * t, num_heads, n, head_dim)
-        k_s = k.permute(0, 1, 3, 2, 4).reshape(b * t, num_heads, n, head_dim)
-        v_s = v_temp.permute(0, 1, 3, 2, 4).reshape(b * t, num_heads, n, head_dim)
+        q_s = rearrange(q, "b t n h d -> (b t) h n d")
+        k_s = rearrange(k, "b t n h d -> (b t) h n d")
+        v_s = rearrange(v_temp, "b t n h d -> (b t) h n d")
 
         out = F.scaled_dot_product_attention(
             q_s,
@@ -400,7 +401,7 @@ class SpaceTimeEncoderLayerWrapper(nn.Module):
             scale=attn.scale,
         )
         # (B*T, H, N, Dh) -> (B*T, N, D)
-        out = out.transpose(1, 2).reshape(b * t, n, d)
+        out = rearrange(out, "bt h n d -> bt n (h d)")
 
         # ONE output projection.
         out = attn.out_proj(out)

--- a/tests/policies/test_pi07_video_encoder_cpu.py
+++ b/tests/policies/test_pi07_video_encoder_cpu.py
@@ -538,6 +538,53 @@ class TestSingleFrameInvariance:
 
         torch.testing.assert_close(out_st, out_no_st, rtol=1e-5, atol=1e-5)
 
+    def test_t1_matches_vanilla_siglip_vision_model(self, backbone):
+        """At T=1 the SpaceTime SigLIP video encoder must match the output of
+        an unmodified ``SiglipVisionModel`` (the upstream HuggingFace vision
+        encoder, never wrapped) on the same image, modulo the shared
+        ``multi_modal_projector``.
+
+        This is the direct restatement of the wrapper's "no new params, no
+        behavior change at T=1" claim against the upstream SigLIP class —
+        it does NOT rely on ``suppress_spacetime_temporal`` (the bypass flag)
+        or on a sibling encoder built with stride=999. The wrapper's
+        natural T=1 short-circuit (and equivalently, Reading B's natural
+        identity at T=1: e(t=0)=0 and a single-key temporal SDPA) must
+        produce the same hidden states as the un-instrumented SigLIP
+        forward, so a deepcopy of the same vision_tower (built BEFORE
+        wrapping) gives byte-identical output.
+        """
+        torch.manual_seed(0)
+        vision_tower, projector, _ = backbone
+
+        # Snapshot the un-instrumented SigLIP weights BEFORE constructing the
+        # encoder (which mutates ``vision_tower`` in-place by replacing every
+        # stride-th layer with a SpaceTimeEncoderLayerWrapper). The deepcopy
+        # is a true vanilla SiglipVisionModel — no wrapper, no PE buffer.
+        vt_vanilla = copy.deepcopy(vision_tower)
+        proj_vanilla = copy.deepcopy(projector)
+        vt_vanilla.eval()
+        proj_vanilla.eval()
+
+        encoder = SpaceTimeSiglipVideoEncoder(
+            vision_tower=vision_tower,
+            multi_modal_projector=projector,
+            max_num_frames=4,
+            spacetime_layer_stride=4,  # 6 layers wrapped
+        ).eval()
+
+        image_unit = torch.rand(2, 3, 224, 224)
+        # Encoder rescales [0, 1] → [-1, 1] internally; the vanilla SigLIP
+        # forward expects pre-rescaled pixels.
+        image_siglip = image_unit * 2.0 - 1.0
+
+        with torch.no_grad():
+            out_video = encoder(image_unit.unsqueeze(1))  # (B, 1, C, H, W)
+            last_hidden = vt_vanilla(pixel_values=image_siglip).last_hidden_state
+            out_vanilla = proj_vanilla(last_hidden)
+
+        torch.testing.assert_close(out_video, out_vanilla, rtol=1e-5, atol=1e-5)
+
 
 # ---------------------------------------------------------------------------
 # `suppress_spacetime_temporal` context manager

--- a/tests/policies/test_pi07_video_encoder_cpu.py
+++ b/tests/policies/test_pi07_video_encoder_cpu.py
@@ -175,6 +175,31 @@ class TestTemporalSinusoidalPE:
         # collapses to the unmodified SigLIP forward.
         assert torch.all(pe[-1] == 0)
 
+    @pytest.mark.parametrize("num_frames", [1, 2, 3, 4, 8, 16, 32])
+    @pytest.mark.parametrize("embed_dim", [16, 64, 1152])
+    def test_pe_is_zero_at_t_eq_0(self, num_frames: int, embed_dim: int):
+        """MEM Appendix C boundary condition: ``e(t=0) = 0``.
+
+        The codebase convention places the current frame at array index
+        ``T-1`` (so ``time[T-1] = 0``); this test asserts the boundary holds
+        across every ``T`` the wrapper might encounter at runtime and across
+        ``embed_dim`` values spanning small fixtures up to the real SigLIP
+        hidden size (1152). Required for: (a) the K=1 natural identity in
+        Reading B (the temporal SDPA over a single key returns V unchanged
+        only if ``e(t=0)=0`` keeps ``h_pe = h``), and (b) the variable-T
+        slicing trick — ``pe[max_num_frames - T:]`` is byte-identical to a
+        fresh PE only because each PE's last row is zero by construction.
+        """
+        pe = _build_temporal_sinusoidal_pe(num_frames=num_frames, embed_dim=embed_dim)
+        assert pe.shape == (num_frames, embed_dim)
+        # The "t=0" row: array index T-1 (current frame).
+        torch.testing.assert_close(
+            pe[num_frames - 1],
+            torch.zeros(embed_dim, dtype=pe.dtype),
+            rtol=0,
+            atol=0,
+        )
+
     def test_earlier_rows_are_nonzero(self):
         pe = _build_temporal_sinusoidal_pe(num_frames=8, embed_dim=64)
         assert torch.any(pe[0] != 0)
@@ -191,6 +216,38 @@ class TestTemporalSinusoidalPE:
     def test_zero_num_frames_raises(self):
         with pytest.raises(ValueError, match="num_frames"):
             _build_temporal_sinusoidal_pe(num_frames=0, embed_dim=64)
+
+    def test_pe_supports_20_frames_without_aliasing(self):
+        """The default ``max_period`` must comfortably cover ``T = 20``: every
+        pair of distinct timesteps in ``{-19, ..., 0}`` should have visibly
+        different sinusoidal rows. Pre-fix code (``max_period = 4.0``) failed
+        this — the lowest-frequency component completed ~5 full cycles over
+        the time range, so e.g. rows ``t = -16`` and ``t = -12`` collapsed
+        to nearly-identical encodings in the long-period dims.
+        """
+        pe = _build_temporal_sinusoidal_pe(num_frames=20, embed_dim=64)
+        assert pe.shape == (20, 64)
+        # Current frame still zero (boundary preserved across max_period change).
+        torch.testing.assert_close(pe[-1], torch.zeros(64, dtype=pe.dtype), rtol=0, atol=0)
+        # Any two distinct rows must differ by at least a measurable margin.
+        for i in range(20):
+            for j in range(i + 1, 20):
+                gap = (pe[i] - pe[j]).abs().max().item()
+                assert gap > 1e-2, (
+                    f"rows t={i - 19} and t={j - 19} differ by only {gap:.2e}; "
+                    "max_period likely too small for T=20 (temporal aliasing)"
+                )
+
+    def test_max_period_too_small_raises(self):
+        """Asking for more frames than ``max_period`` can encode without
+        aliasing must raise a clear error rather than silently producing a
+        degenerate PE.
+        """
+        with pytest.raises(ValueError, match="aliasing"):
+            _build_temporal_sinusoidal_pe(num_frames=42, embed_dim=64)
+        # Passing a larger max_period explicitly clears the guard.
+        pe = _build_temporal_sinusoidal_pe(num_frames=42, embed_dim=64, max_period=128.0)
+        assert pe.shape == (42, 64)
 
     def test_pe_slice_matches_fresh_build(self):
         """The MEM-paper PE values depend only on the relative offset from the
@@ -749,6 +806,213 @@ class TestTemporalAttentionMaskBlocksPaddedHistory:
         snapshot = all_padded.clone()
         SpaceTimeSiglipVideoEncoder._build_temporal_attn_mask(all_padded, num_patches=1, dtype=torch.float32)
         torch.testing.assert_close(all_padded, snapshot)
+
+    def test_t_above_1_with_full_pad_matches_t1(self):
+        """T>1 with every history frame masked must produce the same encoder
+        output as a T=1 forward on the current frame alone.
+
+        Reading B at the current-frame slot, when the temporal mask blocks
+        every past key, the temporal SDPA reduces to ``V_temp[current] =
+        V[current]`` (only the current key is attendable, attention weight is
+        1.0). The spatial pass then sees the same Q, K, V the T=1 path would,
+        so the current-frame output is mathematically identical to the T=1
+        forward — modulo low-precision accumulation noise from the no-op
+        temporal SDPA. This pins the "fully-masked-history is exactly T=1"
+        identity that downstream callers rely on at inference time when
+        ``_build_history_batch`` zero-pads missing history slots.
+        """
+        torch.manual_seed(7)
+        encoder = _make_gemma3_encoder(max_num_frames=4, spacetime_stride=4).eval()
+
+        current = torch.rand(1, 1, 3, 224, 224)
+        # Arbitrary past frames; their pixels must not influence the output
+        # because every history slot is marked padded.
+        history = torch.rand(1, 3, 3, 224, 224)
+        video_t4 = torch.cat([history, current], dim=1)
+        pad_full = torch.tensor([[True, True, True, False]])
+
+        with torch.no_grad():
+            out_t1 = encoder(current)
+            out_t4 = encoder(video_t4, obs_history_is_pad=pad_full)
+
+        torch.testing.assert_close(out_t1, out_t4, rtol=1e-5, atol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Mask-structure invariants: Reading B's temporal pass uses a causal mask;
+# the spatial pass is bidirectional (no mask). These tests intercept the
+# SDPA calls inside a single wrapper forward and verify the call shape +
+# mask kwargs match the paper's factorization.
+# ---------------------------------------------------------------------------
+
+
+class TestReadingBMaskStructure:
+    """Verify the two SDPAs inside ``SpaceTimeEncoderLayerWrapper.forward``
+    use the right mask types: temporal = causal, spatial = bidirectional.
+    """
+
+    @staticmethod
+    def _grab_wrapper() -> SpaceTimeEncoderLayerWrapper:
+        encoder = _make_gemma3_encoder(max_num_frames=2, spacetime_stride=4)
+        wrappers = [
+            layer
+            for layer in encoder.vision_tower.vision_model.encoder.layers
+            if isinstance(layer, SpaceTimeEncoderLayerWrapper)
+        ]
+        assert wrappers, "expected at least one SpaceTimeEncoderLayerWrapper"
+        return wrappers[0]
+
+    @staticmethod
+    def _record_sdpa_calls():
+        """Returns ``(install, restore, calls)`` — install the recorder around
+        ``torch.nn.functional.scaled_dot_product_attention`` then restore
+        the original. Records ``q_shape``, ``is_causal``, and the attn_mask
+        identity / shape for each call.
+        """
+        import torch.nn.functional as F  # noqa: N812
+
+        original = F.scaled_dot_product_attention
+        calls: list[dict] = []
+
+        def recorder(q, k, v, attn_mask=None, is_causal=False, **kwargs):
+            calls.append(
+                {
+                    "q_shape": tuple(q.shape),
+                    "is_causal": bool(is_causal),
+                    "attn_mask_is_none": attn_mask is None,
+                    "attn_mask_shape": tuple(attn_mask.shape) if attn_mask is not None else None,
+                }
+            )
+            return original(q, k, v, attn_mask=attn_mask, is_causal=is_causal, **kwargs)
+
+        def install():
+            F.scaled_dot_product_attention = recorder
+
+        def restore():
+            F.scaled_dot_product_attention = original
+
+        return install, restore, calls
+
+    def test_temporal_is_causal_spatial_is_bidirectional_no_mask(self):
+        """Without ``temporal_attn_mask``: the temporal SDPA must use
+        ``is_causal=True`` (lower-triangular causal mask) and the spatial
+        SDPA must use ``is_causal=False`` with ``attn_mask=None``
+        (bidirectional, every patch attends to every other patch within
+        the same timestep).
+        """
+        wrapper = self._grab_wrapper()
+        t = 2
+        n = wrapper.num_tokens_per_frame
+        d = wrapper.embed_dim
+        hidden = torch.randn(t, n, d)
+
+        install, restore, calls = self._record_sdpa_calls()
+        install()
+        try:
+            with torch.no_grad():
+                wrapper(hidden, attention_mask=None, output_attentions=False, num_frames=t)
+        finally:
+            restore()
+
+        # Reading B fires exactly two SDPAs per wrapper forward at T>1.
+        assert len(calls) == 2, f"expected 2 SDPA calls (temporal + spatial), got {len(calls)}"
+
+        temporal, spatial = calls
+        # Temporal: layout (B*N, H, T, Dh); seq axis (dim 2) must equal T.
+        assert temporal["q_shape"][2] == t, f"temporal seq axis expected T={t}, got {temporal['q_shape']}"
+        assert temporal["is_causal"] is True, "temporal SDPA must be causal"
+        assert temporal["attn_mask_is_none"], (
+            "with no caller-supplied temporal_attn_mask, the temporal pass must rely on "
+            "is_causal=True (SDPA disallows combining is_causal with attn_mask)"
+        )
+
+        # Spatial: layout (B*T, H, N, Dh); seq axis (dim 2) must equal N.
+        assert spatial["q_shape"][2] == n, f"spatial seq axis expected N={n}, got {spatial['q_shape']}"
+        assert spatial["is_causal"] is False, "spatial SDPA must be bidirectional (not causal)"
+        assert spatial["attn_mask_is_none"], (
+            "with no caller-supplied attention_mask, the spatial pass must use no mask "
+            "(bidirectional attention over patches at the same timestep)"
+        )
+
+    def test_temporal_uses_provided_mask_spatial_still_bidirectional(self):
+        """When ``temporal_attn_mask`` is supplied: the temporal SDPA must
+        receive that mask (and ``is_causal=False`` so SDPA does not reject
+        the combination), while the spatial SDPA must still be bidirectional
+        with no mask.
+        """
+        wrapper = self._grab_wrapper()
+        t = 2
+        n = wrapper.num_tokens_per_frame
+        d = wrapper.embed_dim
+        hidden = torch.randn(t, n, d)
+
+        # Build a real temporal mask via the encoder helper. Shape (B*N, 1, T, T).
+        pad = torch.tensor([[True, False]])
+        temporal_attn_mask = SpaceTimeSiglipVideoEncoder._build_temporal_attn_mask(
+            pad, num_patches=n, dtype=hidden.dtype
+        )
+
+        install, restore, calls = self._record_sdpa_calls()
+        install()
+        try:
+            with torch.no_grad():
+                wrapper(
+                    hidden,
+                    attention_mask=None,
+                    output_attentions=False,
+                    temporal_attn_mask=temporal_attn_mask,
+                    num_frames=t,
+                )
+        finally:
+            restore()
+
+        assert len(calls) == 2
+        temporal, spatial = calls
+
+        # Temporal: receives the explicit mask; is_causal must be False
+        # (SDPA disallows is_causal=True together with attn_mask=...).
+        assert temporal["is_causal"] is False, (
+            "with caller-supplied temporal_attn_mask, the temporal SDPA must NOT also "
+            "set is_causal=True (SDPA rejects the combination)"
+        )
+        assert not temporal["attn_mask_is_none"], "temporal SDPA must receive the supplied mask"
+        assert temporal["attn_mask_shape"] == tuple(temporal_attn_mask.shape)
+
+        # Spatial: still bidirectional, no mask.
+        assert spatial["is_causal"] is False
+        assert spatial["attn_mask_is_none"], "spatial pass remains bidirectional regardless of temporal mask"
+
+    def test_temporal_default_mask_is_lower_triangular(self):
+        """Direct check that the wrapper's no-temporal-mask path is causal:
+        the temporal pass at the past-frame slot (t=0) must NOT depend on
+        the current-frame slot (t=T-1).
+
+        Modify only the current frame's input and verify the wrapper's
+        output at the past-frame slot is unchanged. This pins the causal
+        mask invariant from the outside, without monkey-patching SDPA.
+        """
+        torch.manual_seed(11)
+        wrapper = self._grab_wrapper()
+        t = 2
+        n = wrapper.num_tokens_per_frame
+        d = wrapper.embed_dim
+
+        past = torch.randn(1, n, d)
+        current_a = torch.randn(1, n, d)
+        current_b = torch.randn(1, n, d)
+        hidden_a = torch.cat([past, current_a], dim=0)  # (T=2, N, D)
+        hidden_b = torch.cat([past, current_b], dim=0)
+
+        with torch.no_grad():
+            out_a = wrapper(hidden_a, num_frames=t)[0]
+            out_b = wrapper(hidden_b, num_frames=t)[0]
+
+        # Past frame at index 0: causal mask must prevent it from seeing
+        # the current frame's data, so out_a[0] must equal out_b[0].
+        torch.testing.assert_close(out_a[0], out_b[0], rtol=1e-5, atol=1e-5)
+        # Sanity: the current-frame output WAS allowed to differ between
+        # the two runs (otherwise the test is vacuous).
+        assert not torch.allclose(out_a[1], out_b[1], rtol=1e-5, atol=1e-5)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What this does                                                                                                                                                                         
                
  Fix the SpaceTime SigLIP video encoder's attention factorization to match MEM Eq. 3 (Reading B), and rescale the temporal sinusoidal PE so it cleanly encodes up to 20 frames. (🐛 Bug 
  + ⚡️ Performance)                                                                                                                                                                      
   
  Reading-B factorization in SpaceTimeEncoderLayerWrapper.forward — replaces the previous "two sub-attentions stacked with shared weights" implementation:                               
  - One LayerNorm on h + e(t) instead of two.                                                                                                                                          
  - One Q/K/V projection instead of two; Q and K reused across temporal and spatial passes (just permuted into each SDPA layout); only V is replaced by V_temp for the spatial pass.     
  - Two SDPA calls — temporal (causal over T, per spatial patch) then spatial (bidirectional over N, per timestep).                                                                    
  - One out_proj, one residual on the original hidden_states (not h_pe).                                                                                                                 
  - Removed the _TemporalSelfAttention private helper and the SiglipAttention import.                                                                                                    
  - Under Reading B the T=1 block is naturally identity (single-key temporal SDPA returns V unchanged + e(t=0)=0), so the existing T=1 short-circuit becomes a perf/precision            
  optimization rather than a correctness requirement.                                                                                                                                    
                                                                                                                                                                                         
  Temporal PE supports T up to 20 without aliasing — _build_temporal_sinusoidal_pe:                                                                                                      
  - Bumped max_period default from 4.0 → 40.0. With T=20 the lowest-frequency sinusoid completes ≤ ½ a cycle over the time range, so every timestep gets a unique low-frequency encoding.
  - Added a guard: num_frames - 1 > max_period raises with a clear suggested override. Callers needing T > 20 pass a larger max_period explicitly (rule of thumb: 2 · (T-1)).            
                                                                                                                                                                                         
  Preserved invariants: state_dict keys identical to vanilla SiglipEncoderLayer (no new params); e(t=0) = 0; current frame at index T-1; pe[max_num_frames - T:] slicing equivalence;    
  suppress_spacetime_temporal context manager; padded-history masking.                                                                                                                   
                                                                                                                                                                                         
 ## How it was tested                                                                                                                                                                      
                                                                                                                                                                                       
  Added 23 new CPU tests in tests/policies/test_pi07_video_encoder_cpu.py:                                                                                                               
   
  - test_pe_is_zero_at_t_eq_0 — 21 parametrized cases (T ∈ {1,2,3,4,8,16,32} × embed_dim ∈ {16,64,1152}) pinning the MEM e(t=0)=0 boundary.                                              
  - test_pe_supports_20_frames_without_aliasing — every pair of distinct rows in a T=20 PE differs by > 1e-2 (would have failed pre-fix).                                              
  - test_max_period_too_small_raises — alias guard + clean override path.                                                                                                                
  - test_t_above_1_with_full_pad_matches_t1 — encoder output at T=4 with all-padded history is assert_close to T=1 forward.                                                              
  - TestReadingBMaskStructure (3 tests) — patches F.scaled_dot_product_attention and asserts the wrapper fires exactly two SDPAs per forward at T>1 with the right mask shape: temporal  
  causal, spatial bidirectional. Includes a behavioral causality check: modifying only the current frame's input leaves the past-frame wrapper output unchanged.                         
                                                                                                                                                                                         
  All 65 CPU tests pass:                                                                                                                                                                 
  pytest tests/policies/test_pi07_video_encoder_cpu.py    # 65 passed in 255s  

## Checklist

- [X] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [X] My PR includes policy-related changes.
  - [X] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
