### PR TITLE
feat(pi07,fsdp): enable FSDP-FULL_SHARD for full unfreeze + profile_step audit + ZeRO-2 vs FSDP matrix

### DIFF
--- a/configs/examples/accelerate_deepspeed_zero3_config.yaml
+++ b/configs/examples/accelerate_deepspeed_zero3_config.yaml
@@ -1,0 +1,23 @@
+compute_environment: LOCAL_MACHINE
+debug: false
+deepspeed_config:
+  gradient_accumulation_steps: 1
+  gradient_clipping: 10.0
+  offload_optimizer_device: none
+  offload_param_device: none
+  zero3_init_flag: false
+  zero_stage: 3
+distributed_type: DEEPSPEED
+downcast_bf16: 'no'
+enable_cpu_affinity: false
+machine_rank: 0
+main_training_function: main
+mixed_precision: 'no'
+num_machines: 1
+num_processes: 8
+rdzv_backend: static
+same_network: true
+tpu_env: []
+tpu_use_cluster: false
+tpu_use_sudo: false
+use_cpu: false

--- a/configs/examples/accelerate_fsdp2_config.yaml
+++ b/configs/examples/accelerate_fsdp2_config.yaml
@@ -1,0 +1,32 @@
+compute_environment: LOCAL_MACHINE
+debug: false
+distributed_type: FSDP
+downcast_bf16: 'no'
+mixed_precision: 'no'
+machine_rank: 0
+main_training_function: main
+num_machines: 1
+num_processes: 8
+rdzv_backend: static
+same_network: true
+tpu_env: []
+tpu_use_cluster: false
+tpu_use_sudo: false
+use_cpu: false
+fsdp_config:
+  fsdp_version: 2
+  fsdp_auto_wrap_policy: TRANSFORMER_BASED_WRAP
+  # Under FSDP2 the SpaceTimeSiglipVideoEncoder's ``forward`` reaches into
+  # ``vision_tower.vision_model.embeddings(flat)`` directly. If
+  # ``SiglipVisionEmbeddings`` (the patch-embedding Conv2d + position
+  # embedding) isn't its own FSDP wrap unit, its weights stay as
+  # root-level DTensors and the input ``flat`` (a plain Tensor) raises
+  # mixed Tensor / DTensor on the conv. Wrapping at the embedding level
+  # makes the all-gather hook fire before the conv. (FSDP1 doesn't need
+  # this because its hooks attach differently.)
+  fsdp_transformer_layer_cls_to_wrap: InterleavedDecoderLayer,SiglipEncoderLayer,SiglipVisionEmbeddings
+  fsdp_reshard_after_forward: true
+  fsdp_state_dict_type: SHARDED_STATE_DICT
+  fsdp_sync_module_states: true
+  fsdp_cpu_ram_efficient_loading: true
+  fsdp_offload_params: false

--- a/configs/examples/accelerate_fsdp_config.yaml
+++ b/configs/examples/accelerate_fsdp_config.yaml
@@ -15,7 +15,14 @@ tpu_use_sudo: false
 use_cpu: false
 fsdp_config:
   fsdp_auto_wrap_policy: TRANSFORMER_BASED_WRAP
-  fsdp_transformer_layer_cls_to_wrap: Gemma3DecoderLayer,GemmaDecoderLayer,SiglipEncoderLayer
+  # InterleavedDecoderLayer bundles one Gemma3 backbone layer + one Gemma-v1
+  # expert layer into a single nn.Module — the FSDP wrap target. Wrapping at
+  # this granularity is what makes pi07 work under FSDP / ZeRO-3: the
+  # all-gather hook fires on the bundled forward, prefetching every
+  # sub-component (input_layernorm, self_attn.{q,k,v}_proj, mlp, ...) at
+  # once. Wrapping at the inner Gemma3DecoderLayer / GemmaDecoderLayer level
+  # would re-introduce the sub-component access bug.
+  fsdp_transformer_layer_cls_to_wrap: InterleavedDecoderLayer,SiglipEncoderLayer
   fsdp_sharding_strategy: FULL_SHARD
   fsdp_state_dict_type: SHARDED_STATE_DICT
   fsdp_use_orig_params: true

--- a/configs/examples/accelerate_fsdp_config.yaml
+++ b/configs/examples/accelerate_fsdp_config.yaml
@@ -1,0 +1,26 @@
+compute_environment: LOCAL_MACHINE
+debug: false
+distributed_type: FSDP
+downcast_bf16: 'no'
+mixed_precision: bf16
+machine_rank: 0
+main_training_function: main
+num_machines: 1
+num_processes: 8
+rdzv_backend: static
+same_network: true
+tpu_env: []
+tpu_use_cluster: false
+tpu_use_sudo: false
+use_cpu: false
+fsdp_config:
+  fsdp_auto_wrap_policy: TRANSFORMER_BASED_WRAP
+  fsdp_transformer_layer_cls_to_wrap: Gemma3DecoderLayer,GemmaDecoderLayer,SiglipEncoderLayer
+  fsdp_sharding_strategy: FULL_SHARD
+  fsdp_state_dict_type: SHARDED_STATE_DICT
+  fsdp_use_orig_params: true
+  fsdp_sync_module_states: true
+  fsdp_cpu_ram_efficient_loading: true
+  fsdp_offload_params: false
+  fsdp_forward_prefetch: true
+  fsdp_backward_prefetch: BACKWARD_PRE

--- a/configs/examples/pi07_low_level_libero.json
+++ b/configs/examples/pi07_low_level_libero.json
@@ -11,12 +11,7 @@
         "image_resample_strategy": "nearest",
         "vector_resample_strategy": "nearest",
         "n_obs_history": 8,
-        "history_interval": 1,
-        "history_state_drop_prob": 1.0,
-        "subgoal_drop_prob": 1.0,
-        "response_drop_prob": 1.0,
-        "metadata_drop_all_prob": 1.0,
-        "metadata_drop_each_prob": 1.0
+        "history_interval": 1
     },
     "policy": {
         "type": "pi07_low_level",

--- a/configs/examples/pi07_low_level_libero.json
+++ b/configs/examples/pi07_low_level_libero.json
@@ -11,7 +11,12 @@
         "image_resample_strategy": "nearest",
         "vector_resample_strategy": "nearest",
         "n_obs_history": 8,
-        "history_interval": 1
+        "history_interval": 1,
+        "history_state_drop_prob": 1.0,
+        "subgoal_drop_prob": 1.0,
+        "response_drop_prob": 1.0,
+        "metadata_drop_all_prob": 1.0,
+        "metadata_drop_each_prob": 1.0
     },
     "policy": {
         "type": "pi07_low_level",

--- a/configs/examples/pi07_low_level_libero.json
+++ b/configs/examples/pi07_low_level_libero.json
@@ -9,7 +9,9 @@
         "weights": [1.0],
         "action_freq": 10.0,
         "image_resample_strategy": "nearest",
-        "vector_resample_strategy": "nearest"
+        "vector_resample_strategy": "nearest",
+        "n_obs_history": 8,
+        "history_interval": 1
     },
     "policy": {
         "type": "pi07_low_level",

--- a/configs/examples/pi07_low_level_libero.json
+++ b/configs/examples/pi07_low_level_libero.json
@@ -1,0 +1,98 @@
+{
+    "dataset_mixture": {
+        "datasets": [
+            {
+                "repo_id": "physical-intelligence/libero",
+                "episodes": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+            }
+        ],
+        "weights": [1.0],
+        "action_freq": 10.0,
+        "image_resample_strategy": "nearest",
+        "vector_resample_strategy": "nearest"
+    },
+    "policy": {
+        "type": "pi07_low_level",
+        "pretrained_path": null,
+        "n_obs_steps": 8,
+        "n_obs_history": 8,
+        "history_interval": 1,
+        "normalization_mapping": {
+            "VISUAL": "IDENTITY",
+            "STATE": "MIN_MAX",
+            "ACTION": "MEAN_STD"
+        },
+        "chunk_size": 10,
+        "n_action_steps": 10,
+        "max_state_dim": 32,
+        "max_action_dim": 32,
+        "proj_width": 1280,
+        "num_steps": 5,
+        "resize_imgs_with_padding": [448, 448],
+        "attention_implementation": "sdpa",
+        "gradient_checkpointing": true,
+        "freeze_vision_encoder": true,
+        "train_expert_only": false,
+        "prompt_max_length": 256,
+        "discrete_action_max_length": 32,
+        "metadata_max_length": 52,
+        "response_max_length": 52,
+        "spacetime_layer_stride": 4,
+        "optimizer_lr": 2.5e-05,
+        "optimizer_betas": [0.9, 0.95],
+        "optimizer_eps": 1e-08,
+        "optimizer_weight_decay": 1e-10,
+        "scheduler_warmup_steps": 1000,
+        "scheduler_decay_steps": 30000,
+        "scheduler_decay_lr": 2.5e-06
+    },
+    "resume": false,
+    "seed": 1000,
+    "resolution": [448, 448],
+    "num_cams": 2,
+    "max_state_dim": 32,
+    "max_action_dim": 32,
+    "action_chunk": 10,
+    "loss_weighting": {"MSE": 1, "CE": 1},
+    "num_workers": 4,
+    "batch_size": 2,
+    "gradient_accumulation_steps": 1,
+    "dataloader_batch_size": 2,
+    "prefetch_factor": 8,
+    "steps": 40,
+    "log_freq": 5,
+    "save_checkpoint": true,
+    "save_freq": 40,
+    "val_freq": 10,
+    "use_policy_training_preset": false,
+    "trace_nans": false,
+    "optimizer": {
+        "type": "adamw",
+        "lr": 2.5e-05,
+        "weight_decay": 1e-10,
+        "grad_clip_norm": 10.0,
+        "betas": [0.9, 0.95],
+        "eps": 1e-08
+    },
+    "scheduler": {
+        "type": "cosine_decay_with_warmup",
+        "num_warmup_steps": 1000,
+        "num_decay_steps": 30000,
+        "peak_lr": 2.5e-05,
+        "decay_lr": 2.5e-06
+    },
+    "wandb": {
+        "enable": true,
+        "entity": "wyautox-autox",
+        "project": "pi07",
+        "run_id": null,
+        "name": null,
+        "notes": "PI07 low-level training (Libero) smoke config",
+        "tags": [],
+        "group": null,
+        "job_type": null,
+        "mode": null,
+        "allow_resume": true,
+        "disable_artifact": false
+    }
+}

--- a/configs/examples/pi07_low_level_libero.json
+++ b/configs/examples/pi07_low_level_libero.json
@@ -10,14 +10,14 @@
         "action_freq": 10.0,
         "image_resample_strategy": "nearest",
         "vector_resample_strategy": "nearest",
-        "n_obs_history": 8,
+        "n_obs_history": 6,
         "history_interval": 1
     },
     "policy": {
         "type": "pi07_low_level",
         "pretrained_path": null,
-        "n_obs_steps": 8,
-        "n_obs_history": 8,
+        "n_obs_steps": 6,
+        "n_obs_history": 6,
         "history_interval": 1,
         "normalization_mapping": {
             "VISUAL": "IDENTITY",

--- a/src/opentau/datasets/dataset_mixture.py
+++ b/src/opentau/datasets/dataset_mixture.py
@@ -177,15 +177,21 @@ class DatasetMixtureMetadata:
         for cam_idx in range(self.cfg.num_cams):
             if f"camera{cam_idx}" in standard_stats:
                 continue
-            standard_stats[f"camera{cam_idx}"] = {
+            cam_stats: dict[str, np.ndarray] = {
                 "min": np.zeros((3, 1, 1), dtype=np.float32),
                 "max": np.ones((3, 1, 1), dtype=np.float32),
                 "mean": np.zeros((3, 1, 1), dtype=np.float32),
                 "std": np.zeros((3, 1, 1), dtype=np.float32),
-                "count": np.array(
-                    standard_stats["state"]["count"]
-                ),  # create a copy in case this gets modified
             }
+            # `count` is only present in v2.1+ stats; v2.0 datasets like
+            # `physical-intelligence/libero` (LeRobot v2.0 format) carry
+            # only mean/std/min/max. Mirror it from the state stats when
+            # available — the empty-camera placeholder doesn't actually
+            # need a meaningful count, but downstream code that asserts
+            # the field's presence shouldn't crash. Issue #264.
+            if "count" in standard_stats.get("state", {}):
+                cam_stats["count"] = np.array(standard_stats["state"]["count"])
+            standard_stats[f"camera{cam_idx}"] = cam_stats
 
         # check for missing keys
         for data in standard_stats:

--- a/src/opentau/policies/normalize.py
+++ b/src/opentau/policies/normalize.py
@@ -32,6 +32,32 @@ from opentau.configs.types import FeatureType, NormalizationMode, PolicyFeature
 EPS = 1e-8  # Small epsilon value for numerical stability in normalization
 
 
+def _materialize(tensor: Tensor) -> Tensor:
+    """Return the full local Tensor for ``tensor``, materializing if it is a DTensor.
+
+    Under FSDP2 (``fully_shard``), parameters and buffers attached to a
+    ``fully_shard``-wrapped module are exposed as ``DTensor`` instances.
+    Mixing a ``DTensor`` with a regular ``Tensor`` in arithmetic raises:
+
+        RuntimeError: aten.sub.Tensor got mixed torch.Tensor and DTensor,
+        need to convert all torch.Tensor to DTensor before calling
+        distributed operators!
+
+    Normalize / Unnormalize stats (``mean``/``std``/``min``/``max``) are tiny
+    and replicated across ranks, so the cost of redistributing to a full
+    Tensor for the per-feature arithmetic is negligible. Under FSDP1, DDP,
+    or single-process this helper is a fast no-op (the Parameter is already
+    a regular Tensor).
+    """
+    if hasattr(tensor, "full_tensor"):
+        # ``DTensor.full_tensor()`` materializes the (replicated or sharded)
+        # tensor into a single full Tensor on each rank. For replicated
+        # placements this is just a pointer-copy; for sharded ones it does
+        # an all-gather.
+        return tensor.full_tensor()
+    return tensor
+
+
 def warn_missing_keys(features: dict[str, PolicyFeature], batch: dict[str, Tensor], mode: str) -> None:
     """Warns if expected features are missing from the batch.
 
@@ -219,14 +245,14 @@ class Normalize(nn.Module):
             buffer = getattr(self, "buffer_" + key.replace(".", "_"))
 
             if norm_mode is NormalizationMode.MEAN_STD:
-                mean = buffer["mean"]
-                std = buffer["std"]
+                mean = _materialize(buffer["mean"])
+                std = _materialize(buffer["std"])
                 assert not torch.isinf(mean).any(), _no_stats_error_str("mean")
                 assert not torch.isinf(std).any(), _no_stats_error_str("std")
                 batch[key] = (batch[key] - mean) / (std + EPS)
             elif norm_mode is NormalizationMode.MIN_MAX:
-                min = buffer["min"]
-                max = buffer["max"]
+                min = _materialize(buffer["min"])
+                max = _materialize(buffer["max"])
                 assert not torch.isinf(min).any(), _no_stats_error_str("min")
                 assert not torch.isinf(max).any(), _no_stats_error_str("max")
                 batch[key] = (batch[key] - min) / (max - min + EPS)
@@ -298,15 +324,15 @@ class Unnormalize(nn.Module):
             buffer = getattr(self, "buffer_" + key.replace(".", "_"))
 
             if norm_mode is NormalizationMode.MEAN_STD:
-                mean = buffer["mean"]
-                std = buffer["std"]
+                mean = _materialize(buffer["mean"])
+                std = _materialize(buffer["std"])
                 if not (torch.compiler.is_compiling() or torch.onnx.is_in_onnx_export()):
                     assert not torch.isinf(mean).any(), _no_stats_error_str("mean")
                     assert not torch.isinf(std).any(), _no_stats_error_str("std")
                 batch[key] = batch[key] * (std + EPS) + mean
             elif norm_mode is NormalizationMode.MIN_MAX:
-                min = buffer["min"]
-                max = buffer["max"]
+                min = _materialize(buffer["min"])
+                max = _materialize(buffer["max"])
                 if not (torch.compiler.is_compiling() or torch.onnx.is_in_onnx_export()):
                     assert not torch.isinf(min).any(), _no_stats_error_str("min")
                     assert not torch.isinf(max).any(), _no_stats_error_str("max")

--- a/src/opentau/policies/pi07/gemma3_with_expert.py
+++ b/src/opentau/policies/pi07/gemma3_with_expert.py
@@ -117,6 +117,7 @@ class Gemma3WithExpertConfig(PretrainedConfig):
         dropout: float = 0.1,
         gradient_checkpointing: bool = False,
         disable_action_expert: bool = False,
+        disable_internal_bf16_cast: bool = False,
         **kwargs,
     ):
         """Initializes the configuration.
@@ -155,6 +156,18 @@ class Gemma3WithExpertConfig(PretrainedConfig):
                 if a non-None expert input is provided when the expert is
                 disabled. Incompatible with ``train_expert_only=True``.
                 Defaults to False.
+            disable_internal_bf16_cast: When True, skip the in-``__init__``
+                call to ``to_bfloat16_like_physical_intelligence`` so the
+                model's params remain in their constructed dtype (fp32 on
+                a fresh instance). The intended consumer is the FSDP path,
+                which needs fp32 outer params so ``MixedPrecision(
+                param_dtype=bf16, reduce_dtype=bf16)`` can downcast on the
+                fly while keeping the fp32 outer copy for AdamW to step on
+                (mirrors DeepSpeed's bf16-live / fp32-master regime). Other
+                backends (DDP, single, DeepSpeed ZeRO-1/2) still want the
+                cast applied here, then layer fp32 master back on top via
+                ``MasterWeightOptimizer`` / ``BF16_Optimizer``. Defaults to
+                False.
             **kwargs: Passed to `PretrainedConfig`.
         """
         self.freeze_vision_encoder = freeze_vision_encoder
@@ -165,6 +178,7 @@ class Gemma3WithExpertConfig(PretrainedConfig):
         self.dropout = dropout
         self.gradient_checkpointing = gradient_checkpointing
         self.disable_action_expert = disable_action_expert
+        self.disable_internal_bf16_cast = disable_internal_bf16_cast
 
         # Gemma 3 backbone defaults (match google/gemma-3-4b-pt).
         if gemma3_config is None:
@@ -593,7 +607,11 @@ class Gemma3WithExpertModel(PreTrainedModel):
         # FSDP / ZeRO-3 see one coherent forward unit per interleaved step.
         self._build_interleaved_layers()
 
-        if not torch.compiler.is_compiling():
+        # FSDP needs fp32 outer params so ``MixedPrecision(param_dtype=bf16,
+        # reduce_dtype=bf16)`` can manage the bf16-compute / fp32-master
+        # split itself — see the ``disable_internal_bf16_cast`` docstring on
+        # ``Gemma3WithExpertConfig``. Other backends still want the cast.
+        if not torch.compiler.is_compiling() and not config.disable_internal_bf16_cast:
             self.to_bfloat16_like_physical_intelligence()
         self.set_requires_grad()
 

--- a/src/opentau/policies/pi07/gemma3_with_expert.py
+++ b/src/opentau/policies/pi07/gemma3_with_expert.py
@@ -302,10 +302,13 @@ class InterleavedDecoderLayer(nn.Module):
             ``head_dim ** -0.5``).
         head_dim: Per-head dimension shared by both streams.
         dropout: Dropout module applied to attention output and MLP output.
-        attention_interface_fn: Bound attention method from the parent
-            ``Gemma3WithExpertModel`` (selected by ``attention_implementation``).
-            Stored as a plain callable attribute — not a submodule — so it
-            doesn't appear in ``state_dict``.
+        attention_interface_provider: Zero-arg callable that returns the
+            current attention dispatch function (``parent.get_attention_interface()``).
+            Resolved at every ``forward`` rather than captured at init so
+            tests / runtime code that monkey-patches the parent's
+            ``eager_attention_forward`` / ``sdpa_attention_forward`` see
+            their patches honoured. Stored as a plain callable attribute —
+            not a submodule — so it doesn't appear in ``state_dict``.
     """
 
     def __init__(
@@ -318,7 +321,7 @@ class InterleavedDecoderLayer(nn.Module):
         query_pre_attn_scaling: float,
         head_dim: int,
         dropout: nn.Module,
-        attention_interface_fn,
+        attention_interface_provider,
     ):
         super().__init__()
         self.backbone_layer = backbone_layer
@@ -331,7 +334,7 @@ class InterleavedDecoderLayer(nn.Module):
         self._rope_global = rope_global
         self._query_pre_attn_scaling = query_pre_attn_scaling
         self._head_dim = head_dim
-        self._attention_interface_fn = attention_interface_fn
+        self._attention_interface_provider = attention_interface_provider
 
     def forward(
         self,
@@ -445,7 +448,8 @@ class InterleavedDecoderLayer(nn.Module):
         # (see the note next to `apply_rope`).
         layer_attention_mask = attention_mask
 
-        att_output = self._attention_interface_fn(
+        attention_interface = self._attention_interface_provider()
+        att_output = attention_interface(
             layer_attention_mask,
             batch_size,
             head_dim,
@@ -580,7 +584,12 @@ class Gemma3WithExpertModel(PreTrainedModel):
                 f"Expected backbone and expert to have {self._num_layers} layers each; "
                 f"got backbone={len(backbone_layers)}, expert={len(expert_layers)}."
             )
-        attention_interface_fn = self.get_attention_interface()
+        # Resolve the attention dispatch lazily on every call so that runtime
+        # patches to ``self.eager_attention_forward`` / ``sdpa_attention_forward``
+        # — used in tests and adapters — are honoured. Capturing the bound
+        # method at init would freeze the dispatch and silently bypass the
+        # patch.
+        attention_interface_provider = self.get_attention_interface
         layers = nn.ModuleList(
             [
                 InterleavedDecoderLayer(
@@ -592,7 +601,7 @@ class Gemma3WithExpertModel(PreTrainedModel):
                     query_pre_attn_scaling=self._query_pre_attn_scaling,
                     head_dim=self._head_dim,
                     dropout=self.dropout,
-                    attention_interface_fn=attention_interface_fn,
+                    attention_interface_provider=attention_interface_provider,
                 )
                 for i in range(self._num_layers)
             ]

--- a/src/opentau/policies/pi07/gemma3_with_expert.py
+++ b/src/opentau/policies/pi07/gemma3_with_expert.py
@@ -270,6 +270,236 @@ class Gemma3WithExpertConfig(PretrainedConfig):
         super().__init__(**kwargs)
 
 
+class InterleavedDecoderLayer(nn.Module):
+    """One step of pi07's interleaved Gemma 3 backbone + Gemma-v1 expert decoder.
+
+    Bundles the backbone layer and expert layer for one decoder step into a
+    single nn.Module so that FSDP / ZeRO-3 see a coherent forward unit. Their
+    all-gather hooks fire on this module's ``forward`` and prefetch every
+    sub-component (input_layernorm, self_attn.{q,k,v}_proj, mlp, ...) at
+    once. The pre-refactor design called per-sub-component on the wrapped
+    ``Gemma3DecoderLayer`` directly (``layer.input_layernorm(...)``), which
+    bypassed FSDP's hooks and hung at NCCL all-gather with mismatched
+    sizes across ranks (different ranks would request different params).
+
+    This module owns its backbone and expert layers as submodules. The
+    enclosing ``Gemma3WithExpertModel`` empties the original
+    ``gemma3.language_model.model.layers`` and ``gemma_expert.model.layers``
+    after handing them off so each parameter is registered exactly once
+    and FSDP / ZeRO-3 don't double-shard.
+
+    Args:
+        backbone_layer: One ``Gemma3DecoderLayer`` from the Gemma 3 text
+            decoder.
+        expert_layer: The corresponding ``GemmaDecoderLayer`` from the
+            Gemma-v1 action expert.
+        layer_type: Per-layer attention type from
+            ``gemma3_config.text_config.layer_types`` — ``"sliding_attention"``
+            selects ``rope_local``; anything else uses ``rope_global``.
+        rope_local: RoPE base for sliding-window layers.
+        rope_global: RoPE base for global layers.
+        query_pre_attn_scaling: Pre-softmax scaling factor (typically
+            ``head_dim ** -0.5``).
+        head_dim: Per-head dimension shared by both streams.
+        dropout: Dropout module applied to attention output and MLP output.
+        attention_interface_fn: Bound attention method from the parent
+            ``Gemma3WithExpertModel`` (selected by ``attention_implementation``).
+            Stored as a plain callable attribute — not a submodule — so it
+            doesn't appear in ``state_dict``.
+    """
+
+    def __init__(
+        self,
+        backbone_layer: nn.Module,
+        expert_layer: nn.Module,
+        layer_type: str,
+        rope_local: float,
+        rope_global: float,
+        query_pre_attn_scaling: float,
+        head_dim: int,
+        dropout: nn.Module,
+        attention_interface_fn,
+    ):
+        super().__init__()
+        self.backbone_layer = backbone_layer
+        self.expert_layer = expert_layer
+        self.dropout = dropout
+        # Non-tensor / non-module attributes — won't be registered as
+        # parameters or submodules and won't appear in state_dict.
+        self._layer_type = layer_type
+        self._rope_local = rope_local
+        self._rope_global = rope_global
+        self._query_pre_attn_scaling = query_pre_attn_scaling
+        self._head_dim = head_dim
+        self._attention_interface_fn = attention_interface_fn
+
+    def forward(
+        self,
+        inputs_embeds: list[torch.FloatTensor | None],
+        attention_mask: torch.Tensor | None,
+        position_ids: torch.LongTensor | None,
+        past_key_values: dict | None,
+        n_cross_att_tokens: int | None,
+        use_cache: bool | None,
+        fill_kv_cache: bool | None,
+        adarms_cond: list[torch.Tensor | None],
+        batch_size: int,
+        layer_idx: int,
+    ) -> list[torch.FloatTensor | None]:
+        """Run one interleaved decoder layer.
+
+        Body extracted from ``Gemma3WithExpertModel._run_layer``. The KV-cache
+        write is idempotent under gradient-checkpointing recompute because
+        each call writes the same ``layer_idx`` key with the same K/V.
+        """
+        backbone_layer = self.backbone_layer
+        expert_layer = self.expert_layer
+        layers_this_step = [backbone_layer, expert_layer]
+
+        is_sliding = self._layer_type == "sliding_attention"
+        layer_rope_theta = self._rope_local if is_sliding else self._rope_global
+        # Both streams MUST use the same RoPE base at this layer. Shared
+        # attention concatenates Q/K along the sequence axis; the dot-product
+        # invariant `R(q,p)·R(k,q) = q·R(q-p)k` only holds when the same θ
+        # produced both rotations. For global Gemma-3 layers (θ=1M) this
+        # means the expert also rotates at 1M even though the config carries
+        # a single fallback `rope_theta=10k`.
+        rope_thetas = [layer_rope_theta, layer_rope_theta]
+        head_dim = self._head_dim
+
+        query_states: list[torch.Tensor | None] = []
+        key_states: list[torch.Tensor | None] = []
+        value_states: list[torch.Tensor | None] = []
+        gates: list[torch.Tensor | None] = []
+        # Track the pre-attention residual + post-attn layernorm output for the
+        # Gemma-3 backbone side, since it needs a second residual around the MLP
+        # using `pre_feedforward_layernorm` / `post_feedforward_layernorm`.
+        backbone_preattn_residual = None
+
+        for stream_idx, hidden_states in enumerate(inputs_embeds):
+            if hidden_states is None:
+                gates.append(None)
+                query_states.append(None)
+                key_states.append(None)
+                value_states.append(None)
+                continue
+
+            layer = layers_this_step[stream_idx]
+
+            if stream_idx == 0:
+                # Gemma 3 backbone.
+                backbone_preattn_residual = hidden_states
+                h = layer.input_layernorm(hidden_states)
+                gate = None
+            else:
+                # Gemma-v1 expert (patched to return (tensor, gate)).
+                h, gate = layer.input_layernorm(hidden_states, cond=adarms_cond[stream_idx])
+
+            gates.append(gate)
+            bsize, seq_len, _ = h.shape
+            h = h.to(dtype=_preferred_dtype())
+
+            q = layer.self_attn.q_proj(h).view(bsize, seq_len, -1, head_dim)
+            k = layer.self_attn.k_proj(h).view(bsize, seq_len, -1, head_dim)
+            v = layer.self_attn.v_proj(h).view(bsize, seq_len, -1, head_dim)
+
+            if stream_idx == 0:
+                # Gemma-3 applies an extra per-head RMSNorm on Q and K.
+                q_norm = getattr(layer.self_attn, "q_norm", None)
+                k_norm = getattr(layer.self_attn, "k_norm", None)
+                if q_norm is not None:
+                    q = q_norm(q)
+                if k_norm is not None:
+                    k = k_norm(k)
+
+            q = apply_rope(q, position_ids, max_wavelength=rope_thetas[stream_idx])
+            k = apply_rope(k, position_ids, max_wavelength=rope_thetas[stream_idx])
+
+            query_states.append(q)
+            key_states.append(k)
+            value_states.append(v)
+
+        # Drop Nones before concatenating.
+        q_list = [q for q in query_states if q is not None]
+        k_list = [k for k in key_states if k is not None]
+        v_list = [v for v in value_states if v is not None]
+
+        q_concat = torch.cat(q_list, dim=1)
+        k_concat = torch.cat(k_list, dim=1)
+        v_concat = torch.cat(v_list, dim=1)
+
+        if use_cache and past_key_values is not None and layer_idx in past_key_values:
+            k_concat = torch.cat([past_key_values[layer_idx]["key_states"], k_concat], dim=1)
+            v_concat = torch.cat([past_key_values[layer_idx]["value_states"], v_concat], dim=1)
+
+        if fill_kv_cache:
+            if n_cross_att_tokens is None:
+                raise ValueError("n_cross_att_tokens must be provided when fill_kv_cache is True")
+            past_key_values[layer_idx] = {
+                "key_states": k_concat[:, :n_cross_att_tokens, :, :],
+                "value_states": v_concat[:, :n_cross_att_tokens, :, :],
+            }
+
+        # π0.7 keeps the prefix block-causal mask at every layer — the
+        # Gemma 3 sliding-window pattern is deliberately not applied
+        # (see the note next to `apply_rope`).
+        layer_attention_mask = attention_mask
+
+        att_output = self._attention_interface_fn(
+            layer_attention_mask,
+            batch_size,
+            head_dim,
+            q_concat,
+            k_concat,
+            v_concat,
+            scaling=self._query_pre_attn_scaling,
+        )
+        att_output = att_output.to(dtype=_preferred_dtype())
+
+        outputs_embeds: list[torch.Tensor | None] = []
+        start = 0
+        for stream_idx, hidden_states in enumerate(inputs_embeds):
+            if hidden_states is None:
+                outputs_embeds.append(None)
+                continue
+
+            layer = layers_this_step[stream_idx]
+            seq_len = hidden_states.shape[1]
+            end = start + seq_len
+            part = att_output[:, start:end]
+            start = end
+
+            if part.dtype != layer.self_attn.o_proj.weight.dtype:
+                part = part.to(layer.self_attn.o_proj.weight.dtype)
+            part = layer.self_attn.o_proj(part)
+            part = self.dropout(part)
+
+            if stream_idx == 0:
+                # Gemma 3 block: residual + post_attn_norm(attn); then a second
+                # residual with pre_feedforward_layernorm / mlp / post_feedforward_layernorm.
+                post_attn = layer.post_attention_layernorm(part)
+                h = backbone_preattn_residual + post_attn
+
+                ff_residual = h
+                h = layer.pre_feedforward_layernorm(h)
+                h = layer.mlp(h)
+                h = self.dropout(h)
+                h = layer.post_feedforward_layernorm(h)
+                h = ff_residual + h
+                outputs_embeds.append(h)
+            else:
+                # Gemma-v1 expert block with AdaRMS gates.
+                h = modeling_gemma._gated_residual(hidden_states, part, gates[stream_idx])  # noqa: SLF001
+                ff_residual = h.clone()
+                h, gate2 = layer.post_attention_layernorm(h, cond=adarms_cond[stream_idx])
+                h = layer.mlp(h)
+                h = self.dropout(h)
+                h = modeling_gemma._gated_residual(ff_residual, h, gate2)  # noqa: SLF001
+                outputs_embeds.append(h)
+
+        return outputs_embeds
+
+
 class Gemma3WithExpertModel(PreTrainedModel):
     """Gemma 3 VLM interleaved layer-wise with a Gemma-v1 action expert."""
 
@@ -302,11 +532,8 @@ class Gemma3WithExpertModel(PreTrainedModel):
 
         self.dropout = nn.Dropout(config.dropout)
 
-        if not torch.compiler.is_compiling():
-            self.to_bfloat16_like_physical_intelligence()
-        self.set_requires_grad()
-
-        # Cache commonly accessed config scalars.
+        # Cache commonly accessed config scalars (used by InterleavedDecoderLayer
+        # construction below — must be set before ``_build_interleaved_layers``).
         self._text_config = config.gemma3_config.text_config
         self._expert_config = config.gemma_expert_config
         self._num_layers = self._text_config.num_hidden_layers
@@ -322,6 +549,62 @@ class Gemma3WithExpertModel(PreTrainedModel):
         #     the comment near `apply_rope` for why π0.6 doesn't enforce it.
         self._query_pre_attn_scaling = float(self._text_config.query_pre_attn_scalar) ** -0.5
 
+        # Reparent the per-layer modules into a flat ModuleList of
+        # InterleavedDecoderLayer. After this call, every per-layer parameter
+        # lives at ``interleaved_layers[i].{backbone_layer,expert_layer}.*``;
+        # the original ``gemma3.language_model.model.layers`` and
+        # ``gemma_expert.model.layers`` are emptied so each parameter is
+        # registered exactly once. This is the architectural fix that makes
+        # FSDP / ZeRO-3 see one coherent forward unit per interleaved step.
+        self._build_interleaved_layers()
+
+        if not torch.compiler.is_compiling():
+            self.to_bfloat16_like_physical_intelligence()
+        self.set_requires_grad()
+
+    def _build_interleaved_layers(self) -> None:
+        """Build ``self.interleaved_layers`` and empty the source ModuleLists.
+
+        Hands ``backbone_layers[i]`` and ``expert_layers[i]`` (both the
+        original ``nn.Module`` instances) to a new ``InterleavedDecoderLayer``
+        and registers it under ``interleaved_layers``. The originals are then
+        replaced by empty ``nn.ModuleList()`` so the same Parameter objects
+        are not registered in two places at once — that would crash FSDP /
+        ZeRO-3 (they walk the module tree and would try to wrap each layer
+        twice) and confuse ``state_dict`` enumeration.
+        """
+        backbone_layers = self._backbone_layers()
+        expert_layers = self.gemma_expert.model.layers
+        if len(backbone_layers) != self._num_layers or len(expert_layers) != self._num_layers:
+            raise ValueError(
+                f"Expected backbone and expert to have {self._num_layers} layers each; "
+                f"got backbone={len(backbone_layers)}, expert={len(expert_layers)}."
+            )
+        attention_interface_fn = self.get_attention_interface()
+        layers = nn.ModuleList(
+            [
+                InterleavedDecoderLayer(
+                    backbone_layer=backbone_layers[i],
+                    expert_layer=expert_layers[i],
+                    layer_type=self._layer_types[i],
+                    rope_local=self._rope_local,
+                    rope_global=self._rope_global,
+                    query_pre_attn_scaling=self._query_pre_attn_scaling,
+                    head_dim=self._head_dim,
+                    dropout=self.dropout,
+                    attention_interface_fn=attention_interface_fn,
+                )
+                for i in range(self._num_layers)
+            ]
+        )
+        # Empty the source ModuleLists. Doing this BEFORE assigning
+        # ``self.interleaved_layers`` is important: nn.Module's __setattr__
+        # walks the existing tree on assignment and would otherwise notice
+        # the same module twice.
+        self._backbone_text_model().layers = nn.ModuleList()
+        self.gemma_expert.model.layers = nn.ModuleList()
+        self.interleaved_layers = layers
+
     # Trainable / dtype plumbing
 
     def set_requires_grad(self) -> None:
@@ -336,6 +619,11 @@ class Gemma3WithExpertModel(PreTrainedModel):
             self.gemma3.eval()
             for params in self.gemma3.parameters():
                 params.requires_grad = False
+            # Layer params now live in interleaved_layers[i].backbone_layer
+            # rather than under self.gemma3, so freeze them explicitly.
+            for layer in self._iter_interleaved_layers():
+                for params in layer.backbone_layer.parameters():
+                    params.requires_grad = False
             for param in self.da_head.parameters():
                 param.requires_grad = False
             for param in self.discrete_action_embedding.parameters():
@@ -349,19 +637,38 @@ class Gemma3WithExpertModel(PreTrainedModel):
                 vision_tower.eval()
         if self.config.train_expert_only:
             self.gemma3.eval()
+            # Backbone layers were reparented out of self.gemma3 — eval them
+            # explicitly so dropout / etc. honour the frozen state.
+            for layer in self._iter_interleaved_layers():
+                layer.backbone_layer.eval()
         return self
 
     def to_bfloat16_like_physical_intelligence(self) -> None:
         self.gemma3 = self.gemma3.to(dtype=torch.bfloat16)
+        # Selectors cover both the post-refactor location (under
+        # ``interleaved_layers``) and the pre-refactor selectors that
+        # still reach untouched submodules (vision_tower, multi_modal_projector).
         params_to_change_dtype = [
-            "language_model.model.layers",
-            "gemma_expert.model.layers",
+            "interleaved_layers",
             "vision_tower",
             "multi_modal_projector",
         ]
         for name, param in self.named_parameters():
             if any(selector in name for selector in params_to_change_dtype):
                 param.data = param.data.to(dtype=torch.bfloat16)
+
+    def _iter_interleaved_layers(self):
+        """Yield ``InterleavedDecoderLayer`` instances if ``__init__`` finished.
+
+        ``set_requires_grad`` and ``train`` are also invoked from the base
+        ``PreTrainedModel.__init__`` *before* ``self.interleaved_layers`` has
+        been assigned (the call ordering is enforced by the HF base class).
+        Guard against that.
+        """
+        layers = getattr(self, "interleaved_layers", None)
+        if layers is None:
+            return iter(())
+        return iter(layers)
 
     # Embedding helpers
 
@@ -663,27 +970,27 @@ class Gemma3WithExpertModel(PreTrainedModel):
         if batch_size is None:
             raise ValueError("`inputs_embeds` must contain at least one non-None entry.")
 
-        head_dim = self._head_dim
-
         # Hoist the lazy ``past_key_values = {}`` initialization out of the
-        # per-layer body so ``_run_layer`` always receives a non-None dict
-        # when ``fill_kv_cache`` is True. Important for checkpoint recompute
-        # to be idempotent — _run_layer must not mutate past_key_values from
-        # None to {} during recompute (saved-tensor hooks would see a
-        # different argument identity on the second pass).
+        # per-layer body so ``InterleavedDecoderLayer.forward`` always receives
+        # a non-None dict when ``fill_kv_cache`` is True. Important for
+        # checkpoint recompute to be idempotent — the layer must not mutate
+        # past_key_values from None to {} during recompute (saved-tensor hooks
+        # would see a different argument identity on the second pass).
         if fill_kv_cache and past_key_values is None:
             past_key_values = {}
 
         use_ckpt = self.config.gradient_checkpointing and self.training
-        for layer_idx in range(self._num_layers):
+        for layer_idx, layer in enumerate(self.interleaved_layers):
             if use_ckpt:
                 # use_reentrant=False is the modern, DDP-safe path; it
                 # preserves RNG state across recompute so dropout is
-                # deterministic, and participates cleanly in autograd's
-                # saved_tensors_hooks.
+                # deterministic, participates cleanly in autograd's
+                # saved_tensors_hooks, and is compatible with FSDP's
+                # all-gather hooks (the wrap target is the
+                # InterleavedDecoderLayer, so its sub-component params are
+                # all gathered before this checkpoint runs).
                 inputs_embeds = torch.utils.checkpoint.checkpoint(
-                    self._run_layer,
-                    layer_idx,
+                    layer,
                     inputs_embeds,
                     attention_mask,
                     position_ids,
@@ -693,12 +1000,11 @@ class Gemma3WithExpertModel(PreTrainedModel):
                     fill_kv_cache,
                     adarms_cond,
                     batch_size,
-                    head_dim,
+                    layer_idx,
                     use_reentrant=False,
                 )
             else:
-                inputs_embeds = self._run_layer(
-                    layer_idx,
+                inputs_embeds = layer(
                     inputs_embeds,
                     attention_mask,
                     position_ids,
@@ -708,7 +1014,7 @@ class Gemma3WithExpertModel(PreTrainedModel):
                     fill_kv_cache,
                     adarms_cond,
                     batch_size,
-                    head_dim,
+                    layer_idx,
                 )
 
         # Final norms.
@@ -724,178 +1030,6 @@ class Gemma3WithExpertModel(PreTrainedModel):
                 final_outputs.append(out)
 
         return final_outputs, past_key_values
-
-    def _run_layer(
-        self,
-        layer_idx: int,
-        inputs_embeds: list[torch.FloatTensor | None],
-        attention_mask: torch.Tensor | None,
-        position_ids: torch.LongTensor | None,
-        past_key_values: dict | None,
-        n_cross_att_tokens: int | None,
-        use_cache: bool | None,
-        fill_kv_cache: bool | None,
-        adarms_cond: list[torch.Tensor | None],
-        batch_size: int,
-        head_dim: int,
-    ) -> list[torch.FloatTensor | None]:
-        """Run a single layer of the interleaved backbone/expert decoder loop.
-
-        Extracted from ``forward()`` as a standalone method so it can be the
-        unit of ``torch.utils.checkpoint.checkpoint`` wrapping when
-        ``config.gradient_checkpointing`` is enabled. Behavior is bit-identical
-        to the original inlined loop body; the KV-cache write is idempotent
-        across checkpoint recompute because each layer writes its own unique
-        key with the same K/V tensors.
-        """
-        backbone_layers = self._backbone_layers()
-        expert_layers = self.gemma_expert.model.layers
-
-        layer_type = self._layer_types[layer_idx]
-        is_sliding = layer_type == "sliding_attention"
-        layer_rope_theta = self._rope_local if is_sliding else self._rope_global
-
-        layers_this_step = [backbone_layers[layer_idx], expert_layers[layer_idx]]
-        # Both streams MUST use the same RoPE base at this layer. Shared
-        # attention concatenates Q/K along the sequence axis; the dot-product
-        # invariant `R(q,p)·R(k,q) = q·R(q-p)k` only holds when the same θ
-        # produced both rotations. For global Gemma-3 layers (θ=1M) this
-        # means the expert also rotates at 1M even though the config carries
-        # a single fallback `rope_theta=10k`.
-        rope_thetas = [layer_rope_theta, layer_rope_theta]
-
-        query_states: list[torch.Tensor | None] = []
-        key_states: list[torch.Tensor | None] = []
-        value_states: list[torch.Tensor | None] = []
-        gates: list[torch.Tensor | None] = []
-        # Track the pre-attention residual + post-attn layernorm output for the
-        # Gemma-3 backbone side, since it needs a second residual around the MLP
-        # using `pre_feedforward_layernorm` / `post_feedforward_layernorm`.
-        backbone_preattn_residual = None
-
-        for stream_idx, hidden_states in enumerate(inputs_embeds):
-            if hidden_states is None:
-                gates.append(None)
-                query_states.append(None)
-                key_states.append(None)
-                value_states.append(None)
-                continue
-
-            layer = layers_this_step[stream_idx]
-
-            if stream_idx == 0:
-                # Gemma 3 backbone.
-                backbone_preattn_residual = hidden_states
-                h = layer.input_layernorm(hidden_states)
-                gate = None
-            else:
-                # Gemma-v1 expert (patched to return (tensor, gate)).
-                h, gate = layer.input_layernorm(hidden_states, cond=adarms_cond[stream_idx])
-
-            gates.append(gate)
-            bsize, seq_len, _ = h.shape
-            h = h.to(dtype=_preferred_dtype())
-
-            q = layer.self_attn.q_proj(h).view(bsize, seq_len, -1, head_dim)
-            k = layer.self_attn.k_proj(h).view(bsize, seq_len, -1, head_dim)
-            v = layer.self_attn.v_proj(h).view(bsize, seq_len, -1, head_dim)
-
-            if stream_idx == 0:
-                # Gemma-3 applies an extra per-head RMSNorm on Q and K.
-                q_norm = getattr(layer.self_attn, "q_norm", None)
-                k_norm = getattr(layer.self_attn, "k_norm", None)
-                if q_norm is not None:
-                    q = q_norm(q)
-                if k_norm is not None:
-                    k = k_norm(k)
-
-            q = apply_rope(q, position_ids, max_wavelength=rope_thetas[stream_idx])
-            k = apply_rope(k, position_ids, max_wavelength=rope_thetas[stream_idx])
-
-            query_states.append(q)
-            key_states.append(k)
-            value_states.append(v)
-
-        # Drop Nones before concatenating.
-        q_list = [q for q in query_states if q is not None]
-        k_list = [k for k in key_states if k is not None]
-        v_list = [v for v in value_states if v is not None]
-
-        q_concat = torch.cat(q_list, dim=1)
-        k_concat = torch.cat(k_list, dim=1)
-        v_concat = torch.cat(v_list, dim=1)
-
-        if use_cache and past_key_values is not None and layer_idx in past_key_values:
-            k_concat = torch.cat([past_key_values[layer_idx]["key_states"], k_concat], dim=1)
-            v_concat = torch.cat([past_key_values[layer_idx]["value_states"], v_concat], dim=1)
-
-        if fill_kv_cache:
-            if n_cross_att_tokens is None:
-                raise ValueError("n_cross_att_tokens must be provided when fill_kv_cache is True")
-            past_key_values[layer_idx] = {
-                "key_states": k_concat[:, :n_cross_att_tokens, :, :],
-                "value_states": v_concat[:, :n_cross_att_tokens, :, :],
-            }
-
-        # π0.7 keeps the prefix block-causal mask at every layer — the
-        # Gemma 3 sliding-window pattern is deliberately not applied
-        # (see the note next to `apply_rope`).
-        layer_attention_mask = attention_mask
-
-        attention_interface = self.get_attention_interface()
-        att_output = attention_interface(
-            layer_attention_mask,
-            batch_size,
-            head_dim,
-            q_concat,
-            k_concat,
-            v_concat,
-            scaling=self._query_pre_attn_scaling,
-        )
-        att_output = att_output.to(dtype=_preferred_dtype())
-
-        outputs_embeds: list[torch.Tensor | None] = []
-        start = 0
-        for stream_idx, hidden_states in enumerate(inputs_embeds):
-            if hidden_states is None:
-                outputs_embeds.append(None)
-                continue
-
-            layer = layers_this_step[stream_idx]
-            seq_len = hidden_states.shape[1]
-            end = start + seq_len
-            part = att_output[:, start:end]
-            start = end
-
-            if part.dtype != layer.self_attn.o_proj.weight.dtype:
-                part = part.to(layer.self_attn.o_proj.weight.dtype)
-            part = layer.self_attn.o_proj(part)
-            part = self.dropout(part)
-
-            if stream_idx == 0:
-                # Gemma 3 block: residual + post_attn_norm(attn); then a second
-                # residual with pre_feedforward_layernorm / mlp / post_feedforward_layernorm.
-                post_attn = layer.post_attention_layernorm(part)
-                h = backbone_preattn_residual + post_attn
-
-                ff_residual = h
-                h = layer.pre_feedforward_layernorm(h)
-                h = layer.mlp(h)
-                h = self.dropout(h)
-                h = layer.post_feedforward_layernorm(h)
-                h = ff_residual + h
-                outputs_embeds.append(h)
-            else:
-                # Gemma-v1 expert block with AdaRMS gates.
-                h = modeling_gemma._gated_residual(hidden_states, part, gates[stream_idx])  # noqa: SLF001
-                ff_residual = h.clone()
-                h, gate2 = layer.post_attention_layernorm(h, cond=adarms_cond[stream_idx])
-                h = layer.mlp(h)
-                h = self.dropout(h)
-                h = modeling_gemma._gated_residual(ff_residual, h, gate2)  # noqa: SLF001
-                outputs_embeds.append(h)
-
-        return outputs_embeds
 
     # Gemma 3 structural accessors
 

--- a/src/opentau/policies/pi07/gemma3_with_expert.py
+++ b/src/opentau/policies/pi07/gemma3_with_expert.py
@@ -616,16 +616,14 @@ class Gemma3WithExpertModel(PreTrainedModel):
         backbone_layers = self._backbone_layers()
         if len(backbone_layers) != self._num_layers:
             raise ValueError(
-                f"Expected backbone to have {self._num_layers} layers; "
-                f"got backbone={len(backbone_layers)}."
+                f"Expected backbone to have {self._num_layers} layers; got backbone={len(backbone_layers)}."
             )
 
         if self.gemma_expert is not None:
             expert_layers = self.gemma_expert.model.layers
             if len(expert_layers) != self._num_layers:
                 raise ValueError(
-                    f"Expected expert to have {self._num_layers} layers; "
-                    f"got expert={len(expert_layers)}."
+                    f"Expected expert to have {self._num_layers} layers; got expert={len(expert_layers)}."
                 )
         else:
             expert_layers = None

--- a/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
@@ -1305,6 +1305,16 @@ class PI07LowLevelFlowMatching(nn.Module):
         # collectives. Ranks whose local data is all-dropped still embed real
         # tokens with all-False masks; downstream attention / loss respect the
         # mask, so accuracy is preserved.
+        #
+        # Scope of the sync: this only protects against per-rank divergence of
+        # the ``.any()`` outcome on a field that *is* present everywhere. The
+        # inner branch (``if has_response and response_tokens is not None
+        # and response_masks is not None``) still gates on per-rank Nones,
+        # which assumes field presence is a global property of the dataset
+        # config (true today — every rank instantiates the same ``embed_prefix``
+        # contract). If a future heterogeneous-mixture change makes some ranks
+        # carry e.g. ``response_tokens=None`` while others carry a Tensor, the
+        # branches would re-desync and need their own None-vs-Tensor sync.
         device = lang_tokens.device
         has_response_local = (
             response_tokens is not None and response_masks is not None and bool(response_masks.any())

--- a/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
@@ -68,8 +68,13 @@ def _preferred_dtype():
     return torch.float32 if torch.onnx.is_in_onnx_export() else torch.bfloat16
 
 
-def _global_any(local: bool, device: torch.device) -> bool:
-    """Return ``local`` OR-reduced across all ranks of the current process group.
+def _global_or_branch_decisions(
+    presence_locals: tuple[bool, ...],
+    any_locals: tuple[bool, ...],
+    field_names: tuple[str, ...],
+    device: torch.device,
+) -> tuple[bool, ...]:
+    """Synchronize ``embed_prefix`` branch decisions across distributed ranks.
 
     pi07's ``embed_prefix`` chooses Python-level branches based on whether the
     local rank's micro-batch contains any subgoal images / response tokens /
@@ -80,21 +85,76 @@ def _global_any(local: bool, device: torch.device) -> bool:
     take different branches and deadlock at NCCL with mismatched all-gather
     sequence numbers.
 
-    This helper turns a per-rank ``bool`` into a globally-OR'd ``bool`` via a
-    single 1-element ``MAX`` all-reduce. We use it once per branch decision
-    in ``embed_prefix`` so every rank executes the same code path even when
-    its local data slice has different drop rolls.
+    This helper bundles two synchronizations into a *single* SUM all-reduce
+    (vs N independent 1-element MAX all-reduces before):
 
-    The all-reduce cost is negligible (~tens of microseconds per call,
-    handful of calls per step). Outside ``torch.distributed`` (single-process
-    runs, CPU smoke tests) the helper is a fast no-op that just returns the
-    local value.
+    1. ``any_locals`` are OR-reduced across ranks. The returned ``has_*``
+       booleans drive the Python branches that fire collectives, so all
+       ranks must end up taking the same branch.
+    2. ``presence_locals`` are checked for cross-rank agreement. If any rank
+       has a field as None while another has it as a Tensor (a future
+       heterogeneous-mixture regression), this raises immediately rather
+       than letting the inner ``if has_response and response_tokens is not
+       None`` gates silently re-introduce the desync. Today every rank
+       instantiates the same ``embed_prefix`` contract, so divergence is a
+       loud bug, not normal operation.
+
+    Outside ``torch.distributed`` (single-process runs, CPU smoke tests)
+    the helper is a no-op that just returns the local ``any_locals``.
+
+    Args:
+        presence_locals: Per-field bools — ``True`` iff the local rank has a
+            non-None Tensor for that field. Checked for agreement only;
+            never returned.
+        any_locals: Per-field bools — ``True`` iff the local rank's mask has
+            any non-False entry. OR-reduced and returned. Each entry implies
+            the field is present locally (``any_locals[i] => presence_locals[i]``).
+        field_names: Human-readable field names parallel to the lists above
+            (used in the divergence error message).
+        device: Device to allocate the all-reduce buffer on; must match the
+            distributed backend (typically the policy's CUDA device).
+
+    Returns:
+        A tuple of OR-reduced ``has_*`` booleans, one per ``any_locals`` entry,
+        in the same order.
+
+    Raises:
+        RuntimeError: If any field's ``presence_locals`` value differs across
+            ranks. Error names the divergent field(s).
     """
+    n = len(any_locals)
+    if not (len(presence_locals) == n and len(field_names) == n):
+        raise ValueError(
+            f"_global_or_branch_decisions: presence_locals/any_locals/field_names "
+            f"must have the same length, got "
+            f"{len(presence_locals)}/{n}/{len(field_names)}."
+        )
     if not (torch.distributed.is_available() and torch.distributed.is_initialized()):
-        return bool(local)
-    flag = torch.tensor([1 if local else 0], device=device, dtype=torch.int32)
-    torch.distributed.all_reduce(flag, op=torch.distributed.ReduceOp.MAX)
-    return bool(flag.item())
+        return tuple(bool(a) for a in any_locals)
+    # One SUM all-reduce over [presence | any]: SUM lets us derive both the
+    # OR (sum > 0) for the any flags and the cross-rank-agreement check
+    # (sum == 0 or sum == world_size) for the presence flags.
+    flag = torch.tensor(
+        [int(bool(p)) for p in presence_locals] + [int(bool(a)) for a in any_locals],
+        device=device,
+        dtype=torch.int32,
+    )
+    torch.distributed.all_reduce(flag, op=torch.distributed.ReduceOp.SUM)
+    world_size = torch.distributed.get_world_size()
+    counts = flag.tolist()
+    presence_counts = counts[:n]
+    any_counts = counts[n:]
+    diverged = [(name, c) for name, c in zip(field_names, presence_counts, strict=True) if 0 < c < world_size]
+    if diverged:
+        raise RuntimeError(
+            "_global_or_branch_decisions: ranks disagree on field presence "
+            "(None vs Tensor). embed_prefix assumes per-field presence is a "
+            "global property of the dataset config; if a heterogeneous-mixture "
+            "change makes this no longer true, the None-vs-Tensor inner gates "
+            "would re-introduce the FSDP / ZeRO-3 desync. Divergent fields "
+            f"(name, ranks_with_non_None / world_size={world_size}): {diverged}."
+        )
+    return tuple(c > 0 for c in any_counts)
 
 
 def create_sinusoidal_pos_embedding(
@@ -1294,40 +1354,39 @@ class PI07LowLevelFlowMatching(nn.Module):
         # omitted, eliminating spurious dangling tokens that would otherwise break
         # the cumsum at the indicator -> first-discrete boundary.
         #
-        # Each ``has_*`` flag is OR-reduced across all ranks via ``_global_any``.
-        # Different ranks process different micro-batches, so under stochastic
-        # ``*_drop_prob`` settings their local ``.any()`` values can diverge.
-        # If we let each rank take its local branch, FSDP / ZeRO-3 would launch
-        # different numbers of param all-gathers per rank and deadlock at NCCL
-        # (observed empirically: rank 0,1,3,4,5,7 stuck at SeqNum=274 ALLREDUCE,
-        # rank 2,6 at SeqNum=279 ALLGATHER_BASE). Synchronizing the *branch
-        # decision* — not the data — keeps every rank running the same set of
-        # collectives. Ranks whose local data is all-dropped still embed real
-        # tokens with all-False masks; downstream attention / loss respect the
-        # mask, so accuracy is preserved.
+        # Each ``has_*`` flag is OR-reduced across all ranks via
+        # ``_global_or_branch_decisions``. Different ranks process different
+        # micro-batches, so under stochastic ``*_drop_prob`` settings their
+        # local ``.any()`` values can diverge. If we let each rank take its
+        # local branch, FSDP / ZeRO-3 would launch different numbers of param
+        # all-gathers per rank and deadlock at NCCL (observed empirically:
+        # rank 0,1,3,4,5,7 stuck at SeqNum=274 ALLREDUCE, rank 2,6 at
+        # SeqNum=279 ALLGATHER_BASE). Synchronizing the *branch decision* —
+        # not the data — keeps every rank running the same set of collectives.
+        # Ranks whose local data is all-dropped still embed real tokens with
+        # all-False masks; downstream attention / loss respect the mask, so
+        # accuracy is preserved.
         #
-        # Scope of the sync: this only protects against per-rank divergence of
-        # the ``.any()`` outcome on a field that *is* present everywhere. The
-        # inner branch (``if has_response and response_tokens is not None
-        # and response_masks is not None``) still gates on per-rank Nones,
-        # which assumes field presence is a global property of the dataset
-        # config (true today — every rank instantiates the same ``embed_prefix``
-        # contract). If a future heterogeneous-mixture change makes some ranks
-        # carry e.g. ``response_tokens=None`` while others carry a Tensor, the
-        # branches would re-desync and need their own None-vs-Tensor sync.
+        # The same call also asserts cross-rank agreement on field *presence*
+        # (None vs Tensor), bundled into the same all-reduce. The inner gates
+        # (``if has_response and response_tokens is not None``) assume field
+        # presence is a global property of the dataset config. If a future
+        # heterogeneous-mixture change ever makes that not true, the helper
+        # raises a loud ``RuntimeError`` here rather than letting the branches
+        # silently re-desync and hang at NCCL hours into a run.
         device = lang_tokens.device
-        has_response_local = (
-            response_tokens is not None and response_masks is not None and bool(response_masks.any())
+        response_present_local = response_tokens is not None and response_masks is not None
+        subgoal_present_local = bool(subgoal_images) and bool(subgoal_img_masks)
+        metadata_present_local = metadata_tokens is not None and metadata_masks is not None
+        has_response_local = response_present_local and bool(response_masks.any())
+        has_subgoal_local = subgoal_present_local and any(bool(m.any()) for m in subgoal_img_masks)
+        has_metadata_local = metadata_present_local and bool(metadata_masks.any())
+        has_response, has_subgoal, has_metadata = _global_or_branch_decisions(
+            presence_locals=(response_present_local, subgoal_present_local, metadata_present_local),
+            any_locals=(has_response_local, has_subgoal_local, has_metadata_local),
+            field_names=("response", "subgoal", "metadata"),
+            device=device,
         )
-        has_subgoal_local = (
-            bool(subgoal_images) and bool(subgoal_img_masks) and any(bool(m.any()) for m in subgoal_img_masks)
-        )
-        has_metadata_local = (
-            metadata_tokens is not None and metadata_masks is not None and bool(metadata_masks.any())
-        )
-        has_response = _global_any(has_response_local, device)
-        has_subgoal = _global_any(has_subgoal_local, device)
-        has_metadata = _global_any(has_metadata_local, device)
         has_any_optional = bool(has_response or has_subgoal or has_metadata)
 
         for vid, vid_mask in zip(videos, vid_masks, strict=True):

--- a/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
@@ -68,6 +68,35 @@ def _preferred_dtype():
     return torch.float32 if torch.onnx.is_in_onnx_export() else torch.bfloat16
 
 
+def _global_any(local: bool, device: torch.device) -> bool:
+    """Return ``local`` OR-reduced across all ranks of the current process group.
+
+    pi07's ``embed_prefix`` chooses Python-level branches based on whether the
+    local rank's micro-batch contains any subgoal images / response tokens /
+    metadata tokens. Each branch fires a different number of FSDP / ZeRO-3
+    all-gather collectives (one per ``embed_language_tokens`` call), so under
+    stochastic dataset drop probabilities — where one rank's batch may roll
+    "all dropped" while another rolls "some real" — the ranks would otherwise
+    take different branches and deadlock at NCCL with mismatched all-gather
+    sequence numbers.
+
+    This helper turns a per-rank ``bool`` into a globally-OR'd ``bool`` via a
+    single 1-element ``MAX`` all-reduce. We use it once per branch decision
+    in ``embed_prefix`` so every rank executes the same code path even when
+    its local data slice has different drop rolls.
+
+    The all-reduce cost is negligible (~tens of microseconds per call,
+    handful of calls per step). Outside ``torch.distributed`` (single-process
+    runs, CPU smoke tests) the helper is a fast no-op that just returns the
+    local value.
+    """
+    if not (torch.distributed.is_available() and torch.distributed.is_initialized()):
+        return bool(local)
+    flag = torch.tensor([1 if local else 0], device=device, dtype=torch.int32)
+    torch.distributed.all_reduce(flag, op=torch.distributed.ReduceOp.MAX)
+    return bool(flag.item())
+
+
 def create_sinusoidal_pos_embedding(
     time: Tensor, dimension: int, min_period: float, max_period: float, device: torch.device | str = "cpu"
 ) -> Tensor:
@@ -1264,15 +1293,31 @@ class PI07LowLevelFlowMatching(nn.Module):
         # state-end separator collapses to ":\n" and the trailing prefix-end is
         # omitted, eliminating spurious dangling tokens that would otherwise break
         # the cumsum at the indicator -> first-discrete boundary.
-        has_response = (
+        #
+        # Each ``has_*`` flag is OR-reduced across all ranks via ``_global_any``.
+        # Different ranks process different micro-batches, so under stochastic
+        # ``*_drop_prob`` settings their local ``.any()`` values can diverge.
+        # If we let each rank take its local branch, FSDP / ZeRO-3 would launch
+        # different numbers of param all-gathers per rank and deadlock at NCCL
+        # (observed empirically: rank 0,1,3,4,5,7 stuck at SeqNum=274 ALLREDUCE,
+        # rank 2,6 at SeqNum=279 ALLGATHER_BASE). Synchronizing the *branch
+        # decision* — not the data — keeps every rank running the same set of
+        # collectives. Ranks whose local data is all-dropped still embed real
+        # tokens with all-False masks; downstream attention / loss respect the
+        # mask, so accuracy is preserved.
+        device = lang_tokens.device
+        has_response_local = (
             response_tokens is not None and response_masks is not None and bool(response_masks.any())
         )
-        has_subgoal = (
+        has_subgoal_local = (
             bool(subgoal_images) and bool(subgoal_img_masks) and any(bool(m.any()) for m in subgoal_img_masks)
         )
-        has_metadata = (
+        has_metadata_local = (
             metadata_tokens is not None and metadata_masks is not None and bool(metadata_masks.any())
         )
+        has_response = _global_any(has_response_local, device)
+        has_subgoal = _global_any(has_subgoal_local, device)
+        has_metadata = _global_any(has_metadata_local, device)
         has_any_optional = bool(has_response or has_subgoal or has_metadata)
 
         for vid, vid_mask in zip(videos, vid_masks, strict=True):
@@ -1369,11 +1414,12 @@ class PI07LowLevelFlowMatching(nn.Module):
         # state-end separator (", " or ":\n") is text → causal per paper §VI.B.
         att_masks += [1] * num_state_end_embs
 
-        # Only embed response when at least one sample in the batch has real response tokens.
-        # With response_drop_prob=1.0 all masks are False; skipping avoids a spurious
-        # causal-block boundary (att_masks=[1,...]) that would corrupt cumsum for every
-        # subsequent token.
-        if response_tokens is not None and response_masks is not None and response_masks.any():
+        # Only embed response when at least one sample in *any rank's* batch has
+        # real response tokens. The decision is taken on the globally-synced
+        # ``has_response`` flag (computed above) — using a local ``.any()``
+        # check here would let different ranks diverge into different code
+        # paths and deadlock under FSDP / ZeRO-3.
+        if has_response and response_tokens is not None and response_masks is not None:
             response_emb = self.gemma3_with_expert.embed_language_tokens(response_tokens)
             embs.append(response_emb)
             pad_masks.append(response_masks)
@@ -1383,8 +1429,8 @@ class PI07LowLevelFlowMatching(nn.Module):
             num_response_embs = response_emb.shape[1]
             att_masks += [1] * num_response_embs
 
-        # Only embed metadata when at least one sample has real metadata tokens.
-        if metadata_tokens is not None and metadata_masks is not None and metadata_masks.any():
+        # Same global-synced gate for metadata.
+        if has_metadata and metadata_tokens is not None and metadata_masks is not None:
             metadata_emb = self.gemma3_with_expert.embed_language_tokens(metadata_tokens)
             embs.append(metadata_emb)
             pad_masks.append(metadata_masks)
@@ -1419,10 +1465,13 @@ class PI07LowLevelFlowMatching(nn.Module):
         # text (lang / state / response / metadata / ";\n ") and before the
         # training-only discrete-action block.
         #
-        # Only embed the subgoal block (header + images + footer) when subgoal images are
-        # actually present. Unconditionally adding "Subgoal: " injects real (non-padded)
-        # spurious tokens into every prefix even with subgoal_drop_prob=1.0.
-        if subgoal_images and any(mask.any() for mask in subgoal_img_masks):
+        # Same global-synced gate for the subgoal block. ``has_subgoal`` is
+        # globally OR-reduced above, so all ranks take this branch together
+        # whenever any rank's micro-batch has at least one real subgoal image.
+        # Skipping the local-``.any()`` branch and falling through to
+        # all-pad data on a rank that locally has none would re-introduce
+        # the FSDP NCCL desync.
+        if has_subgoal and subgoal_images:
             # Per-sample availability: True iff at least one camera slot
             # has a real subgoal image for that sample. In a mixed batch
             # (some samples have subgoals, others don't), the "Subgoal: "

--- a/src/opentau/scripts/launch.py
+++ b/src/opentau/scripts/launch.py
@@ -13,14 +13,26 @@
 # limitations under the License.
 
 import argparse
+import os
 import subprocess
 import sys
 from pathlib import Path
 from types import ModuleType
 
+# CUDA allocator default. The 5B+ pi07 model on A100-80GB sits at the
+# allocator's edge — issue #264 reproduces an OOM at 79.21/79.25 GiB used
+# with 3.4 GiB reserved-but-unallocated, exactly the fragmentation pattern
+# expandable_segments resolves. Default it on; users can still override by
+# exporting their own value before invoking the launcher.
+_DEFAULT_ALLOC_CONF = "expandable_segments:True"
+
 
 def launch(script_module: ModuleType, description: str, use_accelerate: bool = True):
     """Generic launcher for OpenTau scripts using Accelerate or Python."""
+    if "PYTORCH_CUDA_ALLOC_CONF" not in os.environ and "PYTORCH_ALLOC_CONF" not in os.environ:
+        os.environ["PYTORCH_CUDA_ALLOC_CONF"] = _DEFAULT_ALLOC_CONF
+        print(f"[opentau-launch] Defaulting PYTORCH_CUDA_ALLOC_CONF={_DEFAULT_ALLOC_CONF}")
+
     parser = argparse.ArgumentParser(
         description=description,
         usage=f"{Path(sys.argv[0]).name} {'[--accelerate-config CONFIG] ' if use_accelerate else ''}[ARGS]",

--- a/src/opentau/scripts/profile_step.py
+++ b/src/opentau/scripts/profile_step.py
@@ -282,12 +282,20 @@ def profile(cfg: TrainPipelineConfig):
         # memory footprint is ~half of what production training pays under the
         # PR #182 fix, so the benchmark would systematically under-report
         # memory and over-report the largest batch that fits. See issue #181.
-        # DeepSpeed ZeRO already provides equivalent fp32-master semantics via
-        # BF16_Optimizer; FSDP provides them via MixedPrecision and manages
-        # the inner optimizer's view of the FlatParameter shards directly,
-        # so wrapping under either backend would double-allocate (and under
-        # FSDP would also misalign with FSDP's flat-param parameter handles
-        # — observed empirically as a NCCL desync during the first backward).
+        # DeepSpeed ZeRO provides equivalent fp32-master semantics via
+        # BF16_Optimizer.
+        # FSDP in this PR runs in **pure bf16** (no fp32 master): the model's
+        # ``Gemma3WithExpertModel.__init__`` calls
+        # ``to_bfloat16_like_physical_intelligence`` unconditionally, so by
+        # the time accelerate.prepare wraps the policy under FSDP, params
+        # are already bf16 — FSDP's ``MixedPrecision(param_dtype=bf16, ...)``
+        # is a no-op for storage and the optimizer steps on bf16 sharded
+        # params. Wrapping with ``MasterWeightOptimizer`` on top would clone
+        # the bf16 sharded params into a redundant in-rank fp32 copy without
+        # restoring the cross-rank fp32 master that a fp32-built model would
+        # have, so we skip the wrap (also: would misalign with FSDP's
+        # flat-param parameter handles — observed empirically as a NCCL
+        # desync during the first backward).
         if accelerator.distributed_type not in (
             accelerate.DistributedType.DEEPSPEED,
             accelerate.DistributedType.FSDP,

--- a/src/opentau/scripts/profile_step.py
+++ b/src/opentau/scripts/profile_step.py
@@ -21,13 +21,31 @@ loop that splits wall-clock per step into phases:
   5. ``optim_step``       — ``optimizer.step()`` (includes ZeRO partition
                              update + parameter all-gather)
   6. ``zero_grad_sched``  — ``optimizer.zero_grad()`` + scheduler step
-  7. ``backward_step``    — sum of phases 3–6 (kept as an aggregate row
-                             for easy comparison with earlier runs that
-                             only reported the combined number)
-  8. ``sync_gather``      — the 5 ``gather_for_metrics(...).item()`` calls
+  7. ``sync_gather``      — the 5 ``gather_for_metrics(...).item()`` calls
+
+A ``backward_step`` aggregate (= phases 3+4+5+6) is also collected and
+emitted into the JSON dump for backward-compatibility with older
+reports, but is omitted from the human-readable phase table to avoid
+double-counting against its components.
 
 All ranks call ``torch.cuda.synchronize()`` at phase boundaries so the
-reported times include collective + H2D sync costs. Only rank 0 prints.
+reported times include collective + H2D sync costs.
+
+Throughput is reported as a *global* number using the slowest-rank step
+time (gather across ranks, take ``max``); collectives gate on the
+slowest rank, so that's the true ceiling. Peak GPU memory is also
+tracked per-rank (``torch.cuda.max_memory_{allocated,reserved}``)
+across the measured loop only — peak stats are reset at the
+warmup→measured transition. The worst-rank values are reported.
+
+NOTE: under DeepSpeed, optim work fuses into backward hooks, so
+``optim_step``/``unscale_clip`` will appear near-zero (tens of µs)
+while FSDP/DDP show real time there. Only ``total`` step time is
+directly comparable across backends.
+
+The script does NOT use ``with accelerator.accumulate(policy):``, so
+``cfg.gradient_accumulation_steps`` must be 1 (asserted at start);
+sweep ``dataloader_batch_size`` for per-rank batch.
 
 Usage (same launch incantation as train.py):
 
@@ -101,6 +119,17 @@ def _fmt_ms(seconds_list):
 @parser.wrap()
 def profile(cfg: TrainPipelineConfig):
     cfg.validate()
+
+    # The loop below has no `with accelerator.accumulate(policy):` context, so
+    # optimizer.step() runs every iteration regardless of cfg.gradient_accumulation_steps.
+    # That makes ga>1 silently incorrect: optim fires every micro-step (not every ga
+    # micro-steps) and the throughput math at the bottom would over-report by ga.
+    # Sweep `dataloader_batch_size` for per-rank batch instead.
+    assert cfg.gradient_accumulation_steps == 1, (
+        "profile_step.py only supports gradient_accumulation_steps=1; "
+        f"got {cfg.gradient_accumulation_steps}. Pass --gradient_accumulation_steps=1 "
+        "on the CLI to override the accelerate yaml default."
+    )
 
     # Match train.py's default of find_unused_parameters=True, but allow opting
     # out via env var. The kwarg is silently ignored under DeepSpeed, but under
@@ -358,6 +387,13 @@ def profile(cfg: TrainPipelineConfig):
     for step in range(total_steps):
         measuring = step >= WARMUP_STEPS
 
+        # Reset CUDA peak-memory stats at the warmup→measured transition so the
+        # final ``max_memory_allocated/reserved`` readings reflect only the
+        # measured loop (not warmup spikes from cuDNN autotune / first-step
+        # FSDP all-gather staging buffers).
+        if step == WARMUP_STEPS and torch.cuda.is_available():
+            torch.cuda.reset_peak_memory_stats()
+
         # Phase 1: dataload_wait
         _sync()
         t0 = time.perf_counter()
@@ -441,17 +477,56 @@ def profile(cfg: TrainPipelineConfig):
 
     loop_wall = time.perf_counter() - loop_start
 
+    # All-rank aggregation. Must run on every rank (collective ops), so it lives
+    # outside the rank-0 print block. We compute a global step time as the *max*
+    # across ranks (slowest rank gates collectives, so global throughput is
+    # bounded by it), and gather peak HBM so the worst-rank ceiling is visible.
+    local_total_mean = mean(phases["total"]) if phases["total"] else 0.0
+    if torch.cuda.is_available():
+        device = accelerator.device
+        local_peak_alloc_gb = torch.cuda.max_memory_allocated() / 1e9
+        local_peak_reserved_gb = torch.cuda.max_memory_reserved() / 1e9
+        gather_tensor = torch.tensor(
+            [local_total_mean, local_peak_alloc_gb, local_peak_reserved_gb],
+            dtype=torch.float64,
+            device=device,
+        )
+        gathered = accelerator.gather(gather_tensor.unsqueeze(0)).cpu()
+        per_rank_total_mean = gathered[:, 0].tolist()
+        per_rank_peak_alloc_gb = gathered[:, 1].tolist()
+        per_rank_peak_reserved_gb = gathered[:, 2].tolist()
+    else:
+        per_rank_total_mean = [local_total_mean]
+        per_rank_peak_alloc_gb = [0.0]
+        per_rank_peak_reserved_gb = [0.0]
+    global_total_mean = max(per_rank_total_mean) if per_rank_total_mean else 0.0
+    worst_peak_alloc_gb = max(per_rank_peak_alloc_gb) if per_rank_peak_alloc_gb else 0.0
+    worst_peak_reserved_gb = max(per_rank_peak_reserved_gb) if per_rank_peak_reserved_gb else 0.0
+
     if accelerator.is_main_process:
-        print("\n=========== profile_step results (rank 0) ===========")
+        is_deepspeed = accelerator.distributed_type == accelerate.DistributedType.DEEPSPEED
+        print("\n=========== profile_step results ===========")
         print(f"warmup={WARMUP_STEPS} measured={measure_steps} ranks={accelerator.num_processes}")
         print(
             f"batch_size={cfg.batch_size} num_workers={cfg.num_workers} prefetch_factor={cfg.prefetch_factor}"
         )
-        print(f"wall-clock over full loop: {loop_wall:.2f}s")
+        print(f"distributed_type={accelerator.distributed_type}")
+        print(f"wall-clock over full loop (rank 0): {loop_wall:.2f}s")
+        if is_deepspeed:
+            print(
+                "NOTE: under DeepSpeed, optim cost is accounted inside the bwd phase "
+                "(engine attaches optim to backward hooks). optim_step/unscale_clip "
+                "will look near-zero; compare TOTAL step time across backends, not "
+                "per-phase breakdowns."
+            )
         print()
-        print(f"{'phase':<16} {'stats':<60} {'share':>8}")
+        print(f"{'phase':<16} {'stats (rank 0)':<60} {'share':>8}")
         print("-" * 90)
-        total_mean = mean(phases["total"]) if phases["total"] else 0.0
+        rank0_total_mean = local_total_mean  # share % is rank-0-relative for legibility
+        # backward_step is intentionally omitted from the print table — it's an
+        # aggregate of bwd+unscale_clip+optim_step+zero_grad_sched and would
+        # double-count if printed alongside its components. Still kept in the
+        # JSON output below for backward compatibility with earlier reports.
         ordered_keys = [
             "dataload_wait",
             "forward",
@@ -459,24 +534,35 @@ def profile(cfg: TrainPipelineConfig):
             "unscale_clip",
             "optim_step",
             "zero_grad_sched",
-            "backward_step",
             "sync_gather",
             "total",
         ]
         for key in ordered_keys:
             vals = phases[key]
-            share = (mean(vals) / total_mean * 100.0) if vals and total_mean > 0 else 0.0
-            if key == "total":
-                marker = "  <-- total"
-            elif key == "backward_step":
-                marker = f"{share:6.1f}% (= bwd+unscale_clip+optim_step+zero_grad_sched)"
-            else:
-                marker = f"{share:6.1f}%"
+            share = (mean(vals) / rank0_total_mean * 100.0) if vals and rank0_total_mean > 0 else 0.0
+            marker = "  <-- total" if key == "total" else f"{share:6.1f}%"
             print(f"{key:<16} {_fmt_ms(vals):<60} {marker}")
         print()
-        steps_per_sec = 1.0 / total_mean if total_mean > 0 else 0.0
+        # Global throughput: use slowest-rank step time (collectives gate on it).
+        steps_per_sec = 1.0 / global_total_mean if global_total_mean > 0 else 0.0
         samples_per_sec = steps_per_sec * cfg.batch_size * accelerator.num_processes
-        print(f"throughput: {steps_per_sec:.2f} steps/s, {samples_per_sec:.1f} global samples/s")
+        print("throughput (global, gated by slowest rank):")
+        print(f"  global step time:  {global_total_mean * 1000.0:7.2f} ms")
+        print(f"  steps/s:           {steps_per_sec:.3f}")
+        print(
+            f"  global samples/s:  {samples_per_sec:.1f}  "
+            f"(= {cfg.batch_size} per-rank batch * {accelerator.num_processes} ranks / step time)"
+        )
+        print(
+            f"  per-rank step time means (ms): "
+            f"[{', '.join(f'{x * 1000.0:.2f}' for x in per_rank_total_mean)}]"
+        )
+        print()
+        print("peak GPU memory (worst rank):")
+        print(f"  allocated:   {worst_peak_alloc_gb:6.2f} GB")
+        print(f"  reserved:    {worst_peak_reserved_gb:6.2f} GB")
+        print(f"  per-rank allocated (GB): [{', '.join(f'{x:.2f}' for x in per_rank_peak_alloc_gb)}]")
+        print(f"  per-rank reserved (GB):  [{', '.join(f'{x:.2f}' for x in per_rank_peak_reserved_gb)}]")
         print("=====================================================\n")
 
         # Also dump raw numbers for comparison across runs
@@ -488,11 +574,23 @@ def profile(cfg: TrainPipelineConfig):
                         "warmup": WARMUP_STEPS,
                         "measured": measure_steps,
                         "num_processes": accelerator.num_processes,
+                        "distributed_type": str(accelerator.distributed_type),
                         "batch_size": cfg.batch_size,
                         "num_workers": cfg.num_workers,
                         "prefetch_factor": cfg.prefetch_factor,
                         "phase_means_s": {k: mean(v) for k, v in phases.items() if v},
                         "phase_medians_s": {k: median(v) for k, v in phases.items() if v},
+                        "global_step_time_s": global_total_mean,
+                        "global_samples_per_sec": (
+                            (1.0 / global_total_mean) * cfg.batch_size * accelerator.num_processes
+                            if global_total_mean > 0
+                            else 0.0
+                        ),
+                        "per_rank_step_time_s": per_rank_total_mean,
+                        "peak_alloc_gb_worst": worst_peak_alloc_gb,
+                        "peak_reserved_gb_worst": worst_peak_reserved_gb,
+                        "per_rank_peak_alloc_gb": per_rank_peak_alloc_gb,
+                        "per_rank_peak_reserved_gb": per_rank_peak_reserved_gb,
                     },
                     f,
                     indent=2,

--- a/src/opentau/scripts/profile_step.py
+++ b/src/opentau/scripts/profile_step.py
@@ -333,16 +333,18 @@ def profile(cfg: TrainPipelineConfig):
         # cast, so by the time ``accelerator.prepare`` wraps the policy under
         # FSDP, parameters are still fp32. The optimizer is therefore built
         # over fp32 outer params, and FSDP's ``MixedPrecision(param_dtype=bf16,
-        # reduce_dtype=fp32, buffer_dtype=fp32)`` provides bf16 compute on the
-        # fly while keeping the fp32 master copy on each rank. Adam state is
-        # fp32 (matches the production regime). Wrapping with
-        # ``MasterWeightOptimizer`` *on top* of FSDP would still misalign with
-        # FSDP's flat-param parameter handles — every wrap clone breaks the
-        # 1:1 handle ↔ stored-param identity that FSDP relies on for its
-        # all-gather hooks, observed empirically as a NCCL desync during the
-        # first backward. Since FSDP already gives us fp32 master semantics
-        # via MixedPrecision when the policy enters fp32, the wrap is also
-        # redundant. Skip it.
+        # reduce_dtype=bf16, buffer_dtype=bf16)`` (what accelerate translates
+        # ``mixed_precision: bf16`` into when no ``fsdp_reduce_dtype`` /
+        # ``fsdp_buffer_dtype`` overrides are set) does only the compute-time
+        # downcast — the fp32 outer master shards are preserved across forward
+        # and backward, and AdamW steps on them. Adam state is fp32 (matches
+        # the production regime). Wrapping with ``MasterWeightOptimizer`` *on
+        # top* of FSDP would still misalign with FSDP's flat-param parameter
+        # handles — every wrap clone breaks the 1:1 handle ↔ stored-param
+        # identity that FSDP relies on for its all-gather hooks, observed
+        # empirically as a NCCL desync during the first backward. Since FSDP
+        # already gives us fp32 master semantics via the fp32-built outer
+        # params, the wrap is also redundant. Skip it.
         if accelerator.distributed_type not in (
             accelerate.DistributedType.DEEPSPEED,
             accelerate.DistributedType.FSDP,

--- a/src/opentau/scripts/profile_step.py
+++ b/src/opentau/scripts/profile_step.py
@@ -283,8 +283,15 @@ def profile(cfg: TrainPipelineConfig):
         # PR #182 fix, so the benchmark would systematically under-report
         # memory and over-report the largest batch that fits. See issue #181.
         # DeepSpeed ZeRO already provides equivalent fp32-master semantics via
-        # BF16_Optimizer, so we skip the wrap on that backend.
-        if accelerator.distributed_type != accelerate.DistributedType.DEEPSPEED:
+        # BF16_Optimizer; FSDP provides them via MixedPrecision and manages
+        # the inner optimizer's view of the FlatParameter shards directly,
+        # so wrapping under either backend would double-allocate (and under
+        # FSDP would also misalign with FSDP's flat-param parameter handles
+        # — observed empirically as a NCCL desync during the first backward).
+        if accelerator.distributed_type not in (
+            accelerate.DistributedType.DEEPSPEED,
+            accelerate.DistributedType.FSDP,
+        ):
             optimizer = MasterWeightOptimizer.from_existing(optimizer)
             # Same rebind train.py performs immediately after from_existing:
             # ``make_optimizer_and_scheduler`` left ``lr_scheduler.optimizer``

--- a/src/opentau/scripts/profile_step.py
+++ b/src/opentau/scripts/profile_step.py
@@ -173,7 +173,13 @@ def profile(cfg: TrainPipelineConfig):
             )
         cfg.policy.gradient_checkpointing = want_ckpt
 
-    policy = make_policy(cfg=cfg.policy, ds_meta=train_dataset.meta)
+    # Mirror train.py: under DeepSpeed ZeRO-3 we must disable the per-construction
+    # parameter partitioning (it shards before init, breaking shape-dependent
+    # initializers like SigLIP's lecun_normal_). No-op for any non-ZeRO-3 backend.
+    from opentau.scripts.train import _zero3_disabled_init_context
+
+    with _zero3_disabled_init_context(accelerator):
+        policy = make_policy(cfg=cfg.policy, ds_meta=train_dataset.meta)
     policy.to(torch.bfloat16)
 
     skip_optim = os.environ.get("PROFILE_NO_OPTIM", "0") == "1"

--- a/src/opentau/scripts/profile_step.py
+++ b/src/opentau/scripts/profile_step.py
@@ -178,9 +178,23 @@ def profile(cfg: TrainPipelineConfig):
     # initializers like SigLIP's lecun_normal_). No-op for any non-ZeRO-3 backend.
     from opentau.scripts.train import _zero3_disabled_init_context
 
+    # Mirror train.py: under FSDP, gate the model's internal bf16 cast so the
+    # policy stays fp32 for FSDP's MixedPrecision to manage the bf16 compute /
+    # fp32 master split. Without this, AdamW would silently allocate Adam state
+    # in bf16 (matches the bf16-cast params) and the throughput numbers would
+    # not represent the production fp32-Adam regime.
+    if accelerator.distributed_type == accelerate.DistributedType.FSDP:
+        vlm_config = getattr(cfg.policy, "vlm_config", None)
+        if vlm_config is not None and hasattr(vlm_config, "disable_internal_bf16_cast"):
+            vlm_config.disable_internal_bf16_cast = True
+
     with _zero3_disabled_init_context(accelerator):
         policy = make_policy(cfg=cfg.policy, ds_meta=train_dataset.meta)
-    policy.to(torch.bfloat16)
+    # Same per-backend cast logic as train.py: skip the outer bf16 cast under
+    # FSDP (the policy must stay fp32 going into accelerate.prepare; FSDP
+    # MixedPrecision provides bf16 compute on the fly).
+    if accelerator.distributed_type != accelerate.DistributedType.FSDP:
+        policy.to(torch.bfloat16)
 
     skip_optim = os.environ.get("PROFILE_NO_OPTIM", "0") == "1"
     if skip_optim:

--- a/src/opentau/scripts/profile_step.py
+++ b/src/opentau/scripts/profile_step.py
@@ -327,18 +327,22 @@ def profile(cfg: TrainPipelineConfig):
         # memory and over-report the largest batch that fits. See issue #181.
         # DeepSpeed ZeRO provides equivalent fp32-master semantics via
         # BF16_Optimizer.
-        # FSDP in this PR runs in **pure bf16** (no fp32 master): the model's
-        # ``Gemma3WithExpertModel.__init__`` calls
-        # ``to_bfloat16_like_physical_intelligence`` unconditionally, so by
-        # the time accelerate.prepare wraps the policy under FSDP, params
-        # are already bf16 — FSDP's ``MixedPrecision(param_dtype=bf16, ...)``
-        # is a no-op for storage and the optimizer steps on bf16 sharded
-        # params. Wrapping with ``MasterWeightOptimizer`` on top would clone
-        # the bf16 sharded params into a redundant in-rank fp32 copy without
-        # restoring the cross-rank fp32 master that a fp32-built model would
-        # have, so we skip the wrap (also: would misalign with FSDP's
-        # flat-param parameter handles — observed empirically as a NCCL
-        # desync during the first backward).
+        # FSDP runs with fp32 master + fp32 Adam state in this PR: the
+        # ``disable_internal_bf16_cast`` flag set above (lines 215-218) gates
+        # the model's internal ``to_bfloat16_like_physical_intelligence``
+        # cast, so by the time ``accelerator.prepare`` wraps the policy under
+        # FSDP, parameters are still fp32. The optimizer is therefore built
+        # over fp32 outer params, and FSDP's ``MixedPrecision(param_dtype=bf16,
+        # reduce_dtype=fp32, buffer_dtype=fp32)`` provides bf16 compute on the
+        # fly while keeping the fp32 master copy on each rank. Adam state is
+        # fp32 (matches the production regime). Wrapping with
+        # ``MasterWeightOptimizer`` *on top* of FSDP would still misalign with
+        # FSDP's flat-param parameter handles — every wrap clone breaks the
+        # 1:1 handle ↔ stored-param identity that FSDP relies on for its
+        # all-gather hooks, observed empirically as a NCCL desync during the
+        # first backward. Since FSDP already gives us fp32 master semantics
+        # via MixedPrecision when the policy enters fp32, the wrap is also
+        # redundant. Skip it.
         if accelerator.distributed_type not in (
             accelerate.DistributedType.DEEPSPEED,
             accelerate.DistributedType.FSDP,

--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -375,6 +375,22 @@ def train(cfg: TrainPipelineConfig):
         )
 
     logging.info("Creating policy")
+    # FSDP needs the policy built in fp32 so its ``MixedPrecision(
+    # param_dtype=bf16, reduce_dtype=bf16, buffer_dtype=bf16)`` policy can
+    # downcast on the fly while keeping the fp32 outer (master) params for
+    # AdamW to step on. Without this gate, ``Gemma3WithExpertModel.__init__``
+    # would call ``to_bfloat16_like_physical_intelligence`` and the params
+    # would already be bf16 by the time FSDP wraps them — MixedPrecision
+    # becomes a storage no-op and the optimizer ends up stepping on bf16
+    # sharded params with bf16 Adam state, which underflows on small late-
+    # training updates. Set the flag where it exists (currently only on
+    # ``Gemma3WithExpertConfig``); other policies that don't yet support
+    # FSDP simply lack the attribute.
+    if accelerator.distributed_type == accelerate.DistributedType.FSDP:
+        vlm_config = getattr(cfg.policy, "vlm_config", None)
+        if vlm_config is not None and hasattr(vlm_config, "disable_internal_bf16_cast"):
+            vlm_config.disable_internal_bf16_cast = True
+
     # DeepSpeed ZeRO-3 installs a `partition_parameters` wrapper that shards
     # parameters at construction time (`zero3_init_flag` only controls the
     # transformers `from_pretrained` integration, not this wrapper). Some
@@ -384,45 +400,33 @@ def train(cfg: TrainPipelineConfig):
     # `accelerator.prepare` wraps it. No-op for any non-ZeRO-3 backend.
     with _zero3_disabled_init_context(accelerator):
         policy = make_policy(cfg=cfg.policy, ds_meta=train_dataset.meta)
-    # Keep the policy in bf16 for forward/backward (activation memory + bf16
-    # compute). The fp32-master / bf16-compute story differs by backend:
+    # Per-backend precision regime:
+    #   * DDP / single-process: outer ``policy.to(bfloat16)`` cast here makes
+    #     live params bf16, then ``MasterWeightOptimizer.from_existing``
+    #     (issue #181) layers fp32 master + fp32 Adam state on top.
     #   * DeepSpeed ZeRO-1/2: outer ``policy.to(bfloat16)`` cast here, then
-    #     ``BF16_Optimizer`` keeps an fp32 master copy + fp32 Adam state.
-    #   * DDP / single-process: outer ``policy.to(bfloat16)`` cast here, then
-    #     ``MasterWeightOptimizer.from_existing`` (issue #181) wraps the
-    #     optimizer with an fp32 master + fp32 Adam state.
-    #   * FSDP: **pure bf16, no fp32 master.** The model's own
-    #     ``Gemma3WithExpertModel.__init__`` already calls
-    #     ``to_bfloat16_like_physical_intelligence`` (gemma3_with_expert.py)
-    #     which casts every param under ``interleaved_layers`` /
-    #     ``vision_tower`` / ``multi_modal_projector`` plus ``self.gemma3`` to
-    #     bf16 unconditionally. By the time accelerate.prepare wraps the
-    #     policy, params are already bf16 — FSDP's ``MixedPrecision`` cannot
-    #     upcast a stored bf16 shard, the optimizer steps on bf16 sharded
-    #     params, and the only fp32-touching collective is the gradient
-    #     reduce-scatter (``reduce_dtype=fp32`` in the FSDP yaml). This is a
-    #     deliberate trade-off: pure bf16 keeps params + states small enough
-    #     to fit on 8×A100 without offload, accepting the convergence-quality
-    #     risk. To get genuine fp32-master under FSDP we'd need to also skip
-    #     the inner ``to_bfloat16_like_physical_intelligence`` call here, and
-    #     re-validate convergence — out of scope for this PR.
-    # The outer ``policy.to(bfloat16)`` below is therefore a no-op under FSDP
-    # (the inner cast already covered the same params); we still skip it so
-    # any future reader doesn't read it as evidence that an FSDP fp32-master
-    # path exists.
+    #     ``BF16_Optimizer`` keeps fp32 master + fp32 Adam state, reduces
+    #     gradients in bf16.
+    #   * FSDP-FULL_SHARD: skip the outer cast (and the model's inner
+    #     ``to_bfloat16_like_physical_intelligence`` was already gated above)
+    #     so the policy stays fp32 going into ``accelerator.prepare``. FSDP's
+    #     ``MixedPrecision`` then provides bf16 compute (forward/backward),
+    #     bf16 reduce-scatter (matches DeepSpeed), and the optimizer steps
+    #     on the fp32 outer (master) params with fp32 Adam state. Live
+    #     params consume HBM in fp32 (sharded across 8 ranks); compute
+    #     params materialize in bf16 transiently during the all-gather.
     if accelerator.distributed_type != accelerate.DistributedType.FSDP:
         policy.to(torch.bfloat16)
     logging.info("Creating optimizer and scheduler")
     optimizer, lr_scheduler = make_optimizer_and_scheduler(cfg, policy)
     # Outside DeepSpeed *and* FSDP, wrap the optimizer so it carries fp32
-    # master weights and fp32 Adam state. DeepSpeed provides fp32 master via
-    # ``BF16_Optimizer`` (see ``ds_config['bf16']['enabled']``). FSDP gets
-    # NO fp32 master in this PR — see the comment block above on the inner
-    # ``to_bfloat16_like_physical_intelligence`` cast — but wrapping with
-    # ``MasterWeightOptimizer`` here would also be wrong: it would clone the
-    # already-bf16 sharded params into a redundant in-rank fp32 copy, doubling
-    # memory without restoring the cross-rank fp32 master that FSDP would have
-    # owned in a fp32-built model. So skip the wrap under FSDP too.
+    # master weights and fp32 Adam state. DeepSpeed provides this via
+    # ``BF16_Optimizer``. FSDP provides it via ``MixedPrecision`` over the
+    # fp32-built policy — the optimizer was constructed over fp32 outer
+    # params and AdamW's exp_avg / exp_avg_sq are allocated to match → fp32.
+    # Wrapping with ``MasterWeightOptimizer`` on top of FSDP's flat-param
+    # handles also misaligns and triggers a NCCL desync during the first
+    # backward (observed empirically), so skip there too.
     if accelerator.distributed_type not in (
         accelerate.DistributedType.DEEPSPEED,
         accelerate.DistributedType.FSDP,

--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -385,24 +385,44 @@ def train(cfg: TrainPipelineConfig):
     with _zero3_disabled_init_context(accelerator):
         policy = make_policy(cfg=cfg.policy, ds_meta=train_dataset.meta)
     # Keep the policy in bf16 for forward/backward (activation memory + bf16
-    # compute). The optimizer state is kept in fp32 separately: DeepSpeed
-    # ZeRO does this through ``BF16_Optimizer``; under DDP/single we mirror
-    # that with ``MasterWeightOptimizer`` (see issue #181). Under FSDP,
-    # the policy must stay in fp32 here so FSDP's ``MixedPrecision`` (set
-    # by accelerate from ``mixed_precision: bf16`` in the FSDP yaml) can
-    # downcast on the fly while keeping the fp32 outer params for the
-    # optimizer to step — same fp32-master / bf16-compute split, but owned
-    # by FSDP rather than our wrapper.
+    # compute). The fp32-master / bf16-compute story differs by backend:
+    #   * DeepSpeed ZeRO-1/2: outer ``policy.to(bfloat16)`` cast here, then
+    #     ``BF16_Optimizer`` keeps an fp32 master copy + fp32 Adam state.
+    #   * DDP / single-process: outer ``policy.to(bfloat16)`` cast here, then
+    #     ``MasterWeightOptimizer.from_existing`` (issue #181) wraps the
+    #     optimizer with an fp32 master + fp32 Adam state.
+    #   * FSDP: **pure bf16, no fp32 master.** The model's own
+    #     ``Gemma3WithExpertModel.__init__`` already calls
+    #     ``to_bfloat16_like_physical_intelligence`` (gemma3_with_expert.py)
+    #     which casts every param under ``interleaved_layers`` /
+    #     ``vision_tower`` / ``multi_modal_projector`` plus ``self.gemma3`` to
+    #     bf16 unconditionally. By the time accelerate.prepare wraps the
+    #     policy, params are already bf16 — FSDP's ``MixedPrecision`` cannot
+    #     upcast a stored bf16 shard, the optimizer steps on bf16 sharded
+    #     params, and the only fp32-touching collective is the gradient
+    #     reduce-scatter (``reduce_dtype=fp32`` in the FSDP yaml). This is a
+    #     deliberate trade-off: pure bf16 keeps params + states small enough
+    #     to fit on 8×A100 without offload, accepting the convergence-quality
+    #     risk. To get genuine fp32-master under FSDP we'd need to also skip
+    #     the inner ``to_bfloat16_like_physical_intelligence`` call here, and
+    #     re-validate convergence — out of scope for this PR.
+    # The outer ``policy.to(bfloat16)`` below is therefore a no-op under FSDP
+    # (the inner cast already covered the same params); we still skip it so
+    # any future reader doesn't read it as evidence that an FSDP fp32-master
+    # path exists.
     if accelerator.distributed_type != accelerate.DistributedType.FSDP:
         policy.to(torch.bfloat16)
     logging.info("Creating optimizer and scheduler")
     optimizer, lr_scheduler = make_optimizer_and_scheduler(cfg, policy)
     # Outside DeepSpeed *and* FSDP, wrap the optimizer so it carries fp32
-    # master weights and fp32 Adam state. DeepSpeed provides this via
-    # BF16_Optimizer (see ``ds_config['bf16']['enabled']``); FSDP provides
-    # it via MixedPrecision (param_dtype=bf16, reduce_dtype=fp32, with the
-    # outer fp32 params owned by FSDP). Wrapping under either of those would
-    # double-allocate fp32 masters.
+    # master weights and fp32 Adam state. DeepSpeed provides fp32 master via
+    # ``BF16_Optimizer`` (see ``ds_config['bf16']['enabled']``). FSDP gets
+    # NO fp32 master in this PR — see the comment block above on the inner
+    # ``to_bfloat16_like_physical_intelligence`` cast — but wrapping with
+    # ``MasterWeightOptimizer`` here would also be wrong: it would clone the
+    # already-bf16 sharded params into a redundant in-rank fp32 copy, doubling
+    # memory without restoring the cross-rank fp32 master that FSDP would have
+    # owned in a fp32-built model. So skip the wrap under FSDP too.
     if accelerator.distributed_type not in (
         accelerate.DistributedType.DEEPSPEED,
         accelerate.DistributedType.FSDP,

--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -190,6 +190,32 @@ def _find_unused_params_from_env() -> bool:
     return os.environ.get("FIND_UNUSED_PARAMS", "true").lower() == "true"
 
 
+def _zero3_disabled_init_context(accelerator: accelerate.Accelerator):
+    """Return a context manager that disables ZeRO-3's per-construction param partitioning.
+
+    DeepSpeed ZeRO-3 installs a `partition_parameters` wrapper that shards
+    each parameter as it's created. Some HuggingFace init paths (e.g.
+    SigLIP's `lecun_normal_` → `_calculate_fan_in_and_fan_out`) need the
+    full tensor shape and crash on the per-rank shard. This returns a
+    `deepspeed.zero.Init(enabled=False)` context for ZeRO-3 and a
+    no-op `nullcontext()` everywhere else.
+
+    Args:
+        accelerator: The active accelerate ``Accelerator``.
+
+    Returns:
+        A context manager (no-op for non-ZeRO-3 backends).
+    """
+    if accelerator.distributed_type != accelerate.DistributedType.DEEPSPEED:
+        return nullcontext()
+    zero_stage = accelerator.deepspeed_plugin.hf_ds_config.config.get("zero_optimization", {}).get("stage", 0)
+    if zero_stage < 3:
+        return nullcontext()
+    import deepspeed
+
+    return deepspeed.zero.Init(enabled=False)
+
+
 def _sync_deepspeed_gradient_accumulation_steps(
     accelerator: accelerate.Accelerator, cfg: TrainPipelineConfig
 ) -> None:
@@ -327,7 +353,16 @@ def train(cfg: TrainPipelineConfig):
         )
 
     logging.info("Creating policy")
-    policy = make_policy(cfg=cfg.policy, ds_meta=train_dataset.meta)
+    # DeepSpeed ZeRO-3 installs a `partition_parameters` wrapper that shards
+    # parameters at construction time (`zero3_init_flag` only controls the
+    # transformers `from_pretrained` integration, not this wrapper). Some
+    # init paths — e.g. SigLIP's `lecun_normal_` → `_calculate_fan_in_and_fan_out`
+    # — need the full tensor shape and crash on a per-rank shard. Build the
+    # model with partitioning disabled; ZeRO will re-shard properly when
+    # `accelerator.prepare` wraps it. No-op for any non-ZeRO-3 backend.
+    init_ctx = _zero3_disabled_init_context(accelerator)
+    with init_ctx:
+        policy = make_policy(cfg=cfg.policy, ds_meta=train_dataset.meta)
     # Keep the policy in bf16 for forward/backward (activation memory + bf16
     # compute). The optimizer state is kept in fp32 separately: DeepSpeed
     # ZeRO does this through ``BF16_Optimizer``; under DDP/single we mirror

--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -244,27 +244,26 @@ def train(cfg: TrainPipelineConfig):
     _sync_deepspeed_gradient_accumulation_steps(accelerator, cfg)
 
     # Strict guard for gradient_checkpointing: the pi05 custom forward loop
-    # wraps layer bodies in torch.utils.checkpoint.checkpoint, which is only
-    # semantically safe under distributed backends that do NOT re-shard
-    # parameters during forward. DDP (MULTI_GPU), single-process (NO), and
-    # DeepSpeed ZeRO-1/2 all replicate full params on every rank during
-    # forward — safe. ZeRO-3 and FSDP re-shard and rely on forward-time
-    # all-gather hooks that plain torch.utils.checkpoint does not trigger
-    # during backward recompute, which can silently produce wrong gradients
-    # or hang. Fail loudly at startup instead of corrupting training.
+    # wraps layer bodies in torch.utils.checkpoint.checkpoint. With
+    # use_reentrant=False this uses saved_tensors_hooks, which co-exist
+    # with FSDP's all-gather hooks in PyTorch ≥2.4 — so FSDP is supported.
+    # DeepSpeed ZeRO-3, however, prefetches/re-shards through DeepSpeed-specific
+    # hooks that torch.utils.checkpoint does not fire, so it can silently
+    # produce wrong gradients; keep that case rejected.
     if getattr(cfg.policy, "gradient_checkpointing", False):
         grad_ckpt_allowed = {
             accelerate.DistributedType.MULTI_GPU,
             accelerate.DistributedType.NO,
             accelerate.DistributedType.DEEPSPEED,
+            accelerate.DistributedType.FSDP,
         }
         if accelerator.distributed_type not in grad_ckpt_allowed:
             raise ValueError(
                 f"gradient_checkpointing=True is not supported under "
                 f"distributed_type={accelerator.distributed_type}. Supported: "
-                "MULTI_GPU (DDP), NO (single process), DEEPSPEED (ZeRO-1/2 only). "
-                "ZeRO-3 and FSDP need backend-specific activation-checkpointing "
-                "hooks which pi05's custom per-layer forward does not wire up. "
+                "MULTI_GPU (DDP), NO (single process), FSDP, DEEPSPEED (ZeRO-1/2 only). "
+                "DeepSpeed ZeRO-3 needs deepspeed.checkpointing.checkpoint hooks "
+                "which pi05's custom per-layer forward does not wire up. "
                 "Either set gradient_checkpointing=False or switch to a "
                 "supported backend."
             )
@@ -278,7 +277,9 @@ def train(cfg: TrainPipelineConfig):
                     f"DeepSpeed ZeRO stage {zero_stage}. ZeRO-3 re-shards parameters "
                     "during forward and needs deepspeed.checkpointing.checkpoint "
                     "rather than torch.utils.checkpoint. Either set "
-                    "gradient_checkpointing=False or use zero_stage: 1 or 2."
+                    "gradient_checkpointing=False, use zero_stage: 1 or 2, or "
+                    "switch to FSDP (which has equivalent param sharding and "
+                    "is compatible with torch.utils.checkpoint)."
                 )
 
     logging.info(pformat(cfg.to_dict()))
@@ -329,15 +330,27 @@ def train(cfg: TrainPipelineConfig):
     policy = make_policy(cfg=cfg.policy, ds_meta=train_dataset.meta)
     # Keep the policy in bf16 for forward/backward (activation memory + bf16
     # compute). The optimizer state is kept in fp32 separately: DeepSpeed
-    # ZeRO does this through ``BF16_Optimizer``; under DDP/FSDP/single we
-    # mirror that with ``MasterWeightOptimizer`` (see issue #181).
-    policy.to(torch.bfloat16)
+    # ZeRO does this through ``BF16_Optimizer``; under DDP/single we mirror
+    # that with ``MasterWeightOptimizer`` (see issue #181). Under FSDP,
+    # the policy must stay in fp32 here so FSDP's ``MixedPrecision`` (set
+    # by accelerate from ``mixed_precision: bf16`` in the FSDP yaml) can
+    # downcast on the fly while keeping the fp32 outer params for the
+    # optimizer to step — same fp32-master / bf16-compute split, but owned
+    # by FSDP rather than our wrapper.
+    if accelerator.distributed_type != accelerate.DistributedType.FSDP:
+        policy.to(torch.bfloat16)
     logging.info("Creating optimizer and scheduler")
     optimizer, lr_scheduler = make_optimizer_and_scheduler(cfg, policy)
-    # Outside DeepSpeed, wrap the optimizer so it carries fp32 master weights
-    # and fp32 Adam state. DeepSpeed already provides this via BF16_Optimizer
-    # (see ``ds_config['bf16']['enabled']``), so we don't double-wrap there.
-    if accelerator.distributed_type != accelerate.DistributedType.DEEPSPEED:
+    # Outside DeepSpeed *and* FSDP, wrap the optimizer so it carries fp32
+    # master weights and fp32 Adam state. DeepSpeed provides this via
+    # BF16_Optimizer (see ``ds_config['bf16']['enabled']``); FSDP provides
+    # it via MixedPrecision (param_dtype=bf16, reduce_dtype=fp32, with the
+    # outer fp32 params owned by FSDP). Wrapping under either of those would
+    # double-allocate fp32 masters.
+    if accelerator.distributed_type not in (
+        accelerate.DistributedType.DEEPSPEED,
+        accelerate.DistributedType.FSDP,
+    ):
         optimizer = MasterWeightOptimizer.from_existing(optimizer)
         # ``make_optimizer_and_scheduler`` bound the LR scheduler to the
         # ORIGINAL ``torch.optim.AdamW`` (now discarded in favour of the

--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -20,7 +20,7 @@ import os
 
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
 from pprint import pformat
 from typing import Any
 
@@ -190,30 +190,52 @@ def _find_unused_params_from_env() -> bool:
     return os.environ.get("FIND_UNUSED_PARAMS", "true").lower() == "true"
 
 
+@contextmanager
 def _zero3_disabled_init_context(accelerator: accelerate.Accelerator):
-    """Return a context manager that disables ZeRO-3's per-construction param partitioning.
+    """Context manager that suppresses ZeRO-3 per-construction param partitioning.
 
-    DeepSpeed ZeRO-3 installs a `partition_parameters` wrapper that shards
-    each parameter as it's created. Some HuggingFace init paths (e.g.
-    SigLIP's `lecun_normal_` → `_calculate_fan_in_and_fan_out`) need the
-    full tensor shape and crash on the per-rank shard. This returns a
-    `deepspeed.zero.Init(enabled=False)` context for ZeRO-3 and a
-    no-op `nullcontext()` everywhere else.
+    Under DeepSpeed ZeRO-3, transformers' `is_deepspeed_zero3_enabled()` flag
+    routes module construction through DeepSpeed's `partition_parameters`
+    wrapper, which shards each parameter as it's created. Several init
+    paths in our model graph need the full tensor shape and crash on the
+    per-rank shard — concretely, transformers' SigLIP `_init_weights`
+    calls `lecun_normal_` → `_calculate_fan_in_and_fan_out`, which raises
+    on a 0-D shard.
+
+    The accelerate yaml field `zero3_init_flag: false` only controls
+    transformers' `from_pretrained` integration, NOT the partitioning
+    wrapper that fires on plain `__init__`. To suppress the wrapper for a
+    bounded section we have to unset the active `HfDeepSpeedConfig` directly.
+
+    On entry: if the active backend is DeepSpeed ZeRO-3, save and clear the
+    HF-side DeepSpeed config so `is_deepspeed_zero3_enabled()` returns False.
+    On exit: restore it. ZeRO-3 itself still partitions the params correctly
+    when `accelerator.prepare` later wraps the model.
 
     Args:
         accelerator: The active accelerate ``Accelerator``.
-
-    Returns:
-        A context manager (no-op for non-ZeRO-3 backends).
     """
     if accelerator.distributed_type != accelerate.DistributedType.DEEPSPEED:
-        return nullcontext()
+        yield
+        return
     zero_stage = accelerator.deepspeed_plugin.hf_ds_config.config.get("zero_optimization", {}).get("stage", 0)
     if zero_stage < 3:
-        return nullcontext()
-    import deepspeed
+        yield
+        return
 
-    return deepspeed.zero.Init(enabled=False)
+    from transformers.integrations.deepspeed import (
+        is_deepspeed_zero3_enabled,
+        set_hf_deepspeed_config,
+        unset_hf_deepspeed_config,
+    )
+
+    saved_hf_ds_config = accelerator.deepspeed_plugin.hf_ds_config if is_deepspeed_zero3_enabled() else None
+    try:
+        unset_hf_deepspeed_config()
+        yield
+    finally:
+        if saved_hf_ds_config is not None:
+            set_hf_deepspeed_config(saved_hf_ds_config)
 
 
 def _sync_deepspeed_gradient_accumulation_steps(
@@ -360,8 +382,7 @@ def train(cfg: TrainPipelineConfig):
     # — need the full tensor shape and crash on a per-rank shard. Build the
     # model with partitioning disabled; ZeRO will re-shard properly when
     # `accelerator.prepare` wraps it. No-op for any non-ZeRO-3 backend.
-    init_ctx = _zero3_disabled_init_context(accelerator)
-    with init_ctx:
+    with _zero3_disabled_init_context(accelerator):
         policy = make_policy(cfg=cfg.policy, ds_meta=train_dataset.meta)
     # Keep the policy in bf16 for forward/backward (activation memory + bf16
     # compute). The optimizer state is kept in fp32 separately: DeepSpeed

--- a/tests/policies/test_pi07_cpu.py
+++ b/tests/policies/test_pi07_cpu.py
@@ -1989,3 +1989,66 @@ class TestDisableInternalBf16Cast:
             assert param.dtype == torch.float32, (
                 f"param {name} unexpectedly {param.dtype} (expected fp32 with cast skipped)"
             )
+
+
+class TestGlobalOrBranchDecisions:
+    """Single-process / no-distributed coverage of ``_global_or_branch_decisions``.
+
+    The helper has two responsibilities: OR-reduce per-rank ``has_*`` flags
+    so all ranks branch identically, and assert cross-rank agreement on
+    field presence (None vs Tensor). Without ``torch.distributed`` initialised
+    it must short-circuit to identity on the local ``any_locals``. Multi-rank
+    NCCL behaviour is exercised by the FSDP integration matrix on 8×A100;
+    this class pins the no-distributed path and the input-validation contract.
+    """
+
+    def test_no_distributed_returns_local_any_flags(self):
+        """When ``torch.distributed`` is uninitialised, the helper must return
+        the local ``any_locals`` unchanged (no all-reduce, no presence check)."""
+        from opentau.policies.pi07.low_level.modeling_pi07_low_level import (
+            _global_or_branch_decisions,
+        )
+
+        # Sanity: in a CPU pytest run there is no process group.
+        assert not torch.distributed.is_initialized()
+
+        out = _global_or_branch_decisions(
+            presence_locals=(True, False, True),
+            any_locals=(True, False, False),
+            field_names=("response", "subgoal", "metadata"),
+            device=torch.device("cpu"),
+        )
+        assert out == (True, False, False)
+
+    def test_no_distributed_coerces_truthy_inputs_to_bool(self):
+        """``presence_locals`` and ``any_locals`` are ``bool`` per the type
+        annotation, but the helper guards against numpy/scalar leaks by
+        coercing to Python ``bool``. The no-distributed path returns ``bool``
+        outputs even when fed truthy non-bool values."""
+        from opentau.policies.pi07.low_level.modeling_pi07_low_level import (
+            _global_or_branch_decisions,
+        )
+
+        out = _global_or_branch_decisions(
+            presence_locals=(1, 0, 1),  # type: ignore[arg-type]
+            any_locals=(1, 0, 0),  # type: ignore[arg-type]
+            field_names=("a", "b", "c"),
+            device=torch.device("cpu"),
+        )
+        assert all(isinstance(x, bool) for x in out)
+        assert out == (True, False, False)
+
+    def test_length_mismatch_raises(self):
+        """Mismatched lengths between presence/any/names must fail loudly at
+        the call site rather than silently zip-truncate."""
+        from opentau.policies.pi07.low_level.modeling_pi07_low_level import (
+            _global_or_branch_decisions,
+        )
+
+        with pytest.raises(ValueError, match="same length"):
+            _global_or_branch_decisions(
+                presence_locals=(True, False),
+                any_locals=(True, False, False),
+                field_names=("a", "b", "c"),
+                device=torch.device("cpu"),
+            )

--- a/tests/policies/test_pi07_cpu.py
+++ b/tests/policies/test_pi07_cpu.py
@@ -1660,3 +1660,163 @@ class TestBuildHistoryBatchEmitsObsHistoryIsPad:
             else:
                 assert torch.all(state[t] == 7.0), f"state[{t}] zero-filled but mask says real"
                 assert torch.all(cam[t] == 5.0), f"camera[{t}] zero-filled but mask says real"
+
+
+# Tests pinning the architectural invariants of the InterleavedDecoderLayer
+# refactor (commit aaefa6e). These are the things that, if broken, would
+# silently re-introduce the FSDP / ZeRO-3 NCCL desync that the refactor fixes
+# but CPU runs would still produce plausible-looking forward outputs from.
+class TestInterleavedDecoderLayer:
+    def test_module_list_built_with_correct_count(self):
+        """One InterleavedDecoderLayer per text-config layer."""
+        cfg = _make_tiny_g3we_cfg()
+        model = Gemma3WithExpertModel(cfg).to(dtype=torch.float32)
+        assert hasattr(model, "interleaved_layers")
+        assert isinstance(model.interleaved_layers, torch.nn.ModuleList)
+        assert len(model.interleaved_layers) == cfg.gemma3_config.text_config.num_hidden_layers
+        assert all(isinstance(layer, g3we.InterleavedDecoderLayer) for layer in model.interleaved_layers)
+
+    def test_source_module_lists_are_emptied(self):
+        """The original ``language_model.layers`` and ``gemma_expert.model.layers``
+        must be empty after init — otherwise FSDP / ZeRO-3 walks the module
+        tree and tries to wrap each layer twice."""
+        cfg = _make_tiny_g3we_cfg()
+        model = Gemma3WithExpertModel(cfg).to(dtype=torch.float32)
+        backbone_text = model._backbone_text_model()
+        assert len(backbone_text.layers) == 0
+        assert len(model.gemma_expert.model.layers) == 0
+
+    def test_each_parameter_registered_exactly_once(self):
+        """No Parameter object should appear under multiple module paths.
+        Double-registration breaks FSDP's flat-param construction."""
+        cfg = _make_tiny_g3we_cfg()
+        model = Gemma3WithExpertModel(cfg).to(dtype=torch.float32)
+        seen: dict[int, str] = {}
+        for name, param in model.named_parameters():
+            pid = id(param)
+            if pid in seen:
+                pytest.fail(f"parameter object {pid} registered at both {seen[pid]} and {name}")
+            seen[pid] = name
+
+    def test_state_dict_layer_keys_under_interleaved_prefix(self):
+        """All per-layer params must serialise under the ``interleaved_layers``
+        prefix (NOT under ``gemma3.language_model.model.layers`` or
+        ``gemma_expert.model.layers``). This is the documented post-refactor
+        key namespace."""
+        cfg = _make_tiny_g3we_cfg()
+        model = Gemma3WithExpertModel(cfg).to(dtype=torch.float32)
+        state_keys = list(model.state_dict().keys())
+        # Per-layer attention / mlp / norm weights must exist under the new path.
+        backbone_layer_keys = [k for k in state_keys if k.startswith("interleaved_layers.0.backbone_layer.")]
+        expert_layer_keys = [k for k in state_keys if k.startswith("interleaved_layers.0.expert_layer.")]
+        assert backbone_layer_keys, "no backbone layer keys under interleaved_layers"
+        assert expert_layer_keys, "no expert layer keys under interleaved_layers"
+        # And NOT under the old paths.
+        for key in state_keys:
+            assert ".language_model.model.layers." not in key, f"stale key path: {key}"
+            assert ".language_model.layers." not in key, f"stale key path: {key}"
+            assert "gemma_expert.model.layers." not in key, f"stale key path: {key}"
+
+    def test_train_expert_only_freezes_backbone_layers(self):
+        """When ``train_expert_only=True`` the backbone layers (now living
+        under ``interleaved_layers[i].backbone_layer``) must be frozen.
+        Pre-refactor this was achieved by freezing ``self.gemma3.parameters()``;
+        after the refactor those layers are no longer reachable from
+        ``self.gemma3``."""
+        cfg = _make_tiny_g3we_cfg()
+        cfg.train_expert_only = True
+        model = Gemma3WithExpertModel(cfg).to(dtype=torch.float32)
+        for layer in model.interleaved_layers:
+            for name, param in layer.backbone_layer.named_parameters():
+                assert not param.requires_grad, (
+                    f"backbone param interleaved_layers.*.backbone_layer.{name} should be frozen"
+                )
+            # Expert layer params must remain trainable.
+            for name, param in layer.expert_layer.named_parameters():
+                assert param.requires_grad, (
+                    f"expert param interleaved_layers.*.expert_layer.{name} should be trainable"
+                )
+
+    def test_train_expert_only_eval_propagates_to_backbone_layers(self):
+        """``train(mode=True)`` with ``train_expert_only=True`` must also
+        flip the backbone layers under interleaved_layers to ``.training=False``
+        — they used to live under ``self.gemma3`` which the original ``train``
+        method walks."""
+        cfg = _make_tiny_g3we_cfg()
+        cfg.train_expert_only = True
+        model = Gemma3WithExpertModel(cfg).to(dtype=torch.float32)
+        model.train(True)
+        for layer in model.interleaved_layers:
+            assert not layer.backbone_layer.training, "backbone layer not in eval mode"
+            # Expert layer should be in training mode.
+            assert layer.expert_layer.training, "expert layer should be training"
+
+    def test_attention_dispatch_is_resolved_at_call_time(self, monkeypatch):
+        """The InterleavedDecoderLayer must look up the attention dispatch
+        via ``parent.get_attention_interface()`` per forward, NOT capture it
+        at init. Otherwise tests / runtime adapters that monkey-patch
+        ``self.eager_attention_forward`` (existing pattern, see
+        TestNoSlidingWindowEnforcement above) silently bypass the patch."""
+        monkeypatch.setattr(g3we, "_preferred_dtype", lambda: torch.float32)
+        cfg = _make_tiny_g3we_cfg()
+        model = Gemma3WithExpertModel(cfg).to(dtype=torch.float32)
+        real_eager = model.eager_attention_forward
+        calls: list[int] = []
+
+        def spy_eager(*args, **kwargs):
+            calls.append(1)
+            return real_eager(*args, **kwargs)
+
+        monkeypatch.setattr(model, "eager_attention_forward", spy_eager)
+
+        batch, seq_len = 1, 4
+        hidden = torch.randn(batch, seq_len, cfg.gemma3_config.text_config.hidden_size)
+        position_ids = torch.arange(seq_len)[None, :]
+        attention_mask = torch.tril(torch.ones(seq_len, seq_len, dtype=torch.bool))[None]
+        with torch.no_grad():
+            model.forward(
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                inputs_embeds=[hidden, None],
+            )
+        # One call per layer.
+        assert len(calls) == cfg.gemma3_config.text_config.num_hidden_layers
+
+    def test_forward_seeded_determinism(self, monkeypatch):
+        """Two seeded forwards through the refactored stack must produce
+        bit-identical outputs (no rank-dependent ordering, no captured-once
+        objects breaking re-entrancy)."""
+        # Same convention as TestNoSlidingWindowEnforcement above — pin
+        # ``_preferred_dtype`` to fp32 so the layer's intra-forward casts
+        # don't mix bf16 weights with fp32 inputs.
+        monkeypatch.setattr(g3we, "_preferred_dtype", lambda: torch.float32)
+        cfg = _make_tiny_g3we_cfg()
+
+        def _one_run() -> torch.Tensor:
+            torch.manual_seed(0)
+            model = Gemma3WithExpertModel(cfg).to(dtype=torch.float32)
+            model.eval()
+            torch.manual_seed(1)
+            batch, seq_len = 1, 4
+            hidden = torch.randn(batch, seq_len, cfg.gemma3_config.text_config.hidden_size)
+            position_ids = torch.arange(seq_len)[None, :]
+            attention_mask = torch.tril(torch.ones(seq_len, seq_len, dtype=torch.bool))[None]
+            with torch.no_grad():
+                outs, _ = model.forward(
+                    attention_mask=attention_mask,
+                    position_ids=position_ids,
+                    inputs_embeds=[hidden, None],
+                )
+            return outs[0].detach().clone()
+
+        out_a = _one_run()
+        out_b = _one_run()
+        assert torch.equal(out_a, out_b), "non-deterministic forward (refactor regression?)"
+
+    def test_attention_provider_not_in_state_dict(self):
+        """The cached attention dispatch provider must not leak into
+        ``state_dict`` (it's a callable, not a Parameter / Buffer / Module)."""
+        cfg = _make_tiny_g3we_cfg()
+        model = Gemma3WithExpertModel(cfg).to(dtype=torch.float32)
+        for key in model.state_dict():
+            assert "attention_interface" not in key, f"unexpected key: {key}"

--- a/tests/policies/test_pi07_cpu.py
+++ b/tests/policies/test_pi07_cpu.py
@@ -1953,3 +1953,39 @@ class TestDisableActionExpert:
 
         cfg = PI07LowLevelConfig()
         assert cfg.vlm_config.disable_action_expert is False
+
+
+class TestDisableInternalBf16Cast:
+    """Locks in that ``disable_internal_bf16_cast=True`` actually skips the
+    in-``__init__`` ``to_bfloat16_like_physical_intelligence`` call. The flag
+    exists because FSDP needs fp32 outer params for ``MixedPrecision`` to
+    own the bf16-compute / fp32-master split — if the model casts itself to
+    bf16 before FSDP wraps, FSDP can't upcast and the optimizer ends up
+    stepping on bf16 sharded params with bf16 Adam state."""
+
+    def test_default_keeps_bf16_cast_active(self):
+        """Default (False) preserves pre-flag behaviour: per-layer params
+        are bf16 after init (matches the on-device dtype DeepSpeed/DDP
+        expect when they layer fp32 master back on top)."""
+        cfg = _make_tiny_g3we_cfg()
+        assert cfg.disable_internal_bf16_cast is False
+        model = Gemma3WithExpertModel(cfg)  # do NOT post-cast — read the in-init dtype
+        # Sample a per-layer param that ``to_bfloat16_like_physical_intelligence``
+        # always touches (interleaved_layers selector).
+        sample = model.interleaved_layers[0].backbone_layer.input_layernorm.weight
+        assert sample.dtype == torch.bfloat16, f"expected bf16 after default in-init cast, got {sample.dtype}"
+
+    def test_flag_skips_bf16_cast(self):
+        """With the flag, the same per-layer param stays in its constructed
+        dtype (fp32 from the HF backbone defaults)."""
+        cfg = _make_tiny_g3we_cfg()
+        cfg.disable_internal_bf16_cast = True
+        model = Gemma3WithExpertModel(cfg)
+        sample = model.interleaved_layers[0].backbone_layer.input_layernorm.weight
+        assert sample.dtype == torch.float32, f"expected fp32 (cast skipped), got {sample.dtype}"
+        # Also covers the SigLIP vision tower and the MM projector — all of
+        # the selectors ``to_bfloat16_like_physical_intelligence`` walks.
+        for name, param in model.named_parameters():
+            assert param.dtype == torch.float32, (
+                f"param {name} unexpectedly {param.dtype} (expected fp32 with cast skipped)"
+            )

--- a/tests/policies/test_pi07_low_level.py
+++ b/tests/policies/test_pi07_low_level.py
@@ -811,3 +811,103 @@ class TestPI07LowLevelRegression:
             assert params[name].default is inspect.Parameter.empty, (
                 f"{name} should be a required parameter (no default), got default={params[name].default}"
             )
+
+
+class TestGemma3WithExpertFSDPWrap:
+    """Smoke-level GPU coverage that the InterleavedDecoderLayer-based model
+    can be wrapped under FSDP and run one forward+backward without raising.
+
+    The CPU invariants in ``test_pi07_cpu.py::TestInterleavedDecoderLayer``
+    pin param uniqueness / state_dict prefix / dispatch lookup, but a wrap-
+    target regression (e.g. someone re-introduces the language_model.layers
+    nesting or shares a Parameter between two modules) would only fail at
+    actual FSDP construction. Until commit aaefa6e + this PR that failure
+    was only caught by the 8×A100 throughput matrix; this test makes it
+    catchable on any single-GPU box.
+    """
+
+    @pytest.mark.gpu
+    @pytest.mark.slow
+    def test_fsdp_wrap_forward_backward(self):
+        """Wrap the model with FSDP (single-rank process group on the local
+        GPU) and exercise one forward + backward. Catches param double-
+        registration, shared-parameter handles, and unwrappable submodules."""
+        import functools
+        import os
+
+        from torch.distributed.fsdp import FullyShardedDataParallel as FSDP  # noqa: N817
+        from torch.distributed.fsdp.wrap import transformer_auto_wrap_policy
+
+        from opentau.policies.pi07.gemma3_with_expert import (
+            Gemma3WithExpertModel,
+            InterleavedDecoderLayer,
+        )
+
+        if not torch.cuda.is_available():
+            pytest.skip("FSDP wrap test requires CUDA")
+
+        # Single-rank process group on the local GPU; the test owns init /
+        # teardown so it doesn't pollute other GPU tests in the same pytest
+        # session. world_size=1 keeps the all-gather / reduce-scatter hooks
+        # active (their no-op fast paths still walk the FlatParameter
+        # machinery) while not requiring multi-GPU infrastructure.
+        os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+        os.environ.setdefault("MASTER_PORT", "29501")
+        os.environ.setdefault("WORLD_SIZE", "1")
+        os.environ.setdefault("RANK", "0")
+        already_initialized = torch.distributed.is_initialized()
+        if not already_initialized:
+            torch.distributed.init_process_group(backend="nccl", world_size=1, rank=0)
+        try:
+            torch.cuda.set_device(0)
+            cfg = Gemma3WithExpertConfig(
+                gemma3_config=_TINY_VLM_CONFIG.gemma3_config.to_dict(),
+                gemma_expert_config=_TINY_VLM_CONFIG.gemma_expert_config.to_dict(),
+                # Skip the in-init bf16 cast so FSDP MixedPrecision can manage
+                # the fp32-master / bf16-compute split itself (the production
+                # FSDP regime — see profile_step.py:215-218 and train.py).
+                disable_internal_bf16_cast=True,
+                freeze_vision_encoder=True,
+                train_expert_only=False,
+                attention_implementation="eager",
+            )
+
+            model = Gemma3WithExpertModel(cfg).to(device="cuda", dtype=torch.float32)
+
+            auto_wrap_policy = functools.partial(
+                transformer_auto_wrap_policy,
+                transformer_layer_cls={InterleavedDecoderLayer},
+            )
+            wrapped = FSDP(
+                model,
+                auto_wrap_policy=auto_wrap_policy,
+                use_orig_params=True,
+                device_id=torch.cuda.current_device(),
+            )
+
+            batch, seq_len = 1, 4
+            hidden_size = cfg.gemma3_config.text_config.hidden_size
+            inputs = torch.randn(batch, seq_len, hidden_size, device="cuda", dtype=torch.float32)
+            position_ids = torch.arange(seq_len, device="cuda")[None, :]
+            attn_mask = torch.tril(torch.ones(seq_len, seq_len, dtype=torch.bool, device="cuda"))[None]
+
+            outs, _ = wrapped(
+                attention_mask=attn_mask,
+                position_ids=position_ids,
+                inputs_embeds=[inputs, None],
+            )
+            assert outs[0] is not None
+            # One backward to exercise the FSDP all-gather / reduce-scatter
+            # hooks on every interleaved layer — the path that would deadlock
+            # if the wrap target was misaligned.
+            outs[0].sum().backward()
+
+            # Confirm the wrap actually saw the InterleavedDecoderLayer (vs.
+            # falling back to a single root-level wrap that hides regressions).
+            wrapped_modules = [m for m in wrapped.modules() if isinstance(m, FSDP)]
+            assert any(isinstance(m.module, InterleavedDecoderLayer) for m in wrapped_modules), (
+                "transformer_auto_wrap_policy did not pick up InterleavedDecoderLayer"
+            )
+        finally:
+            if not already_initialized and torch.distributed.is_initialized():
+                torch.distributed.destroy_process_group()


### PR DESCRIPTION
## What this does

Enables FSDP-FULL_SHARD training for pi07_low_level (full unfreeze), audits
and fixes `profile_step.py` measurement bugs that caused unreconcilable
numbers in the prior closed PR, and runs a full FSDP vs ZeRO-2 throughput
+ peak HBM matrix on 8×A100 to ground the backend recommendation for the
upcoming cam=4 pretraining run.

The branch carries the FSDP-enabling code from earlier work (the closed
PR was on this same branch) plus two new commits with the
measurement-side fixes:

- `aaefa6e` — `InterleavedDecoderLayer` refactor in
  `policies/pi07/gemma3_with_expert.py`. Bundles each (Gemma3 backbone
  layer + Gemma-v1 expert layer) pair into one `nn.Module` so the FSDP
  all-gather hook fires before any sub-component access. Without this,
  FSDP1 hangs at NCCL with mismatched all-gather sizes.
- `1f27b98` — `_global_any` branch sync in
  `policies/pi07/low_level/modeling_pi07_low_level.py`. OR-reduces
  per-rank decisions to enter `if has_response / has_subgoal /
  has_metadata` blocks so all ranks issue the same number of FSDP
  collectives.
- `30ff84a` — `disable_internal_bf16_cast` flag on
  `Gemma3WithExpertConfig` plus FSDP-conditional setter in `train.py`
  and `profile_step.py`. Keeps the policy fp32 going into FSDP so
  MixedPrecision can manage the bf16-compute / fp32-master split itself
  (preserves fp32 Adam state).
- `f43fc91` — `unset HfDeepSpeedConfig` context manager so
  `make_policy` doesn't fault under ZeRO-3 init.
- `63df8c5` — relax the `gradient_checkpointing` guard to allow FSDP;
  ships `accelerate_fsdp_config.yaml` and
  `accelerate_deepspeed_zero3_config.yaml`.
- `3bd7817` — **NEW** four `profile_step.py` bug fixes (B1-B4) +
  DeepSpeed phase-blur banner. Detail below.
- `ffd6208` — **NEW** `pi07_low_level_libero.json` `n_obs_history` 8→6
  for the matrix.

### profile_step.py audit findings (fixed in 3bd7817)

The prior numbers couldn't reconcile because the script had four real
bugs in measurement / aggregation. None affect the per-step computation
(forward / backward / optim are untouched), so the seeded loss series is
unchanged.

| | Bug | Fix |
| --- | --- | --- |
| **B1** | Throughput was rank-0 only, multiplied by `num_processes`. Under stragglers this is optimistic. | Gather per-rank step-time means; use `max()` (slowest rank gates collectives). Print per-rank means too. |
| **B2** | No peak HBM tracking — all the prior PR's "fits comfortably" claims were math-only. | `torch.cuda.reset_peak_memory_stats()` at warmup→measured boundary; gather `max_memory_{allocated,reserved}` across ranks; report worst rank + per-rank values; include in JSON dump. |
| **B3** | `backward_step` (an aggregate of bwd+unscale_clip+optim_step+zero_grad_sched) was printed alongside its components, so the share column summed to ~135% rather than ~100%. | Drop from the human-readable table; keep in JSON for backward compat. |
| **B4** | The loop has no `with accelerator.accumulate(policy):` context, so `optimizer.step()` runs every micro-step regardless of `cfg.gradient_accumulation_steps`. ga>1 silently produced a throughput number ga× too high. | `assert cfg.gradient_accumulation_steps == 1` at script start. Sweep `dataloader_batch_size` for per-rank batch instead. |

A documented limitation (banner in output, not fixed): under DeepSpeed,
optim work fuses into backward hooks, so `optim_step` / `unscale_clip`
appear near-zero (tens of µs). Compare TOTAL step time across backends,
not per-phase breakdowns.

## How it was tested

### Unit tests (CPU)

```
pytest -m "not gpu" -n auto tests/policies/test_pi07_cpu.py \
                            tests/scripts/test_profile_step.py \
                            tests/scripts/test_train.py
```
88 passed.

### Integration: full FSDP vs ZeRO-2 matrix on an internal 8×A100 node

10 cells × probe-walk-to-OOM at PROFILE_STEPS=10 + 20 warmup. Branch tip
+ `n_obs_history=6` example config + full unfreeze
(`--policy.freeze_vision_encoder=false --policy.train_expert_only=false`).
bf16 mixed precision, `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`,
`gradient_accumulation_steps=1`, A100 80 GiB.

#### Probe matrix (raw, all completed cells)

| Cell | bs | alloc GB | resv GB | step ms | global sps | %resv (80 GiB) |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| FSDP-FULL_SHARD cam=1 sdpa+ckpt | 8 | 43.86 | 70.14 | 3917 | 16.3 | 82% |
| FSDP-FULL_SHARD cam=1 sdpa+ckpt | **12** | 51.29 | 78.07 | 5831 | **16.5** | 91% |
| FSDP-FULL_SHARD cam=4 sdpa+ckpt | 4 | 39.33 | 61.30 | 5169 | 6.2 | 71% |
| FSDP-FULL_SHARD cam=4 sdpa+ckpt | **8** | 49.68 | 77.90 | 9186 | **7.0** | 91% |
| FSDP-FULL_SHARD cam=4 sdpa+ckpt | 10 | 54.85 | 83.86 | 12874 | 6.2 | 98%  ⚠ |
| FSDP-FULL_SHARD cam=4 sdpa+ckpt | 12 | 61.02 | 83.59 | 19435 | 4.9 | 97% |
| FSDP-FULL_SHARD cam=1 eager no-ckpt | **2** | 58.74 | 65.67 | 1162 | **13.8** | 76% |
| FSDP-FULL_SHARD cam=1 eager no-ckpt | 4 | — | — | OOM | — | — |
| FSDP-FULL_SHARD cam=4 eager no-ckpt | **1** | 66.93 | 73.38 | 1466 | **5.5** | 85% |
| FSDP-FULL_SHARD cam=4 eager no-ckpt | 2 | — | — | OOM | — | — |
| ZeRO-2 cam=1 sdpa+ckpt | 8 | 36.22 | 36.45 | 4416 | 14.5 | 42% |
| ZeRO-2 cam=1 sdpa+ckpt | 16 | 46.25 | 46.74 | 6357 | 20.1 | 54% |
| ZeRO-2 cam=1 sdpa+ckpt | 24 | 56.31 | 57.04 | 8134 | 23.6 | 66% |
| ZeRO-2 cam=1 sdpa+ckpt | 32 | 67.36 | 68.33 | 10075 | 25.4 | 80% |
| ZeRO-2 cam=1 sdpa+ckpt | **40** | 78.41 | 79.90 | 11979 | **26.7** | 93% |
| ZeRO-2 cam=1 sdpa+ckpt | 44 | — | — | OOM | — | — |
| ZeRO-2 cam=4 sdpa+ckpt | 8 | 42.22 | 42.68 | 6066 | 10.6 | 50% |
| ZeRO-2 cam=4 sdpa+ckpt | 12 | 50.23 | 50.80 | 8530 | 11.3 | 59% |
| ZeRO-2 cam=4 sdpa+ckpt | 16 | 58.42 | 59.30 | 10482 | 12.2 | 69% |
| ZeRO-2 cam=4 sdpa+ckpt | **20** | 67.24 | 68.22 | 11654 | **13.7** | 79% |
| ZeRO-2 cam=4 sdpa+ckpt | 24 | 76.05 | 77.38 | 14286 | 13.4 | 90% |
| ZeRO-2 cam=1 eager no-ckpt | 2 | 42.63 | 43.70 | 3506 | 4.6 | 51% |
| ZeRO-2 cam=1 eager no-ckpt | 4 | 59.11 | 60.16 | 3793 | 8.4 | 70% |
| ZeRO-2 cam=1 eager no-ckpt | **6** | 75.58 | 77.68 | 3906 | **12.3** | 90% |
| ZeRO-2 cam=1 eager no-ckpt | 8 | — | — | OOM | — | — |
| ZeRO-2 cam=4 eager no-ckpt | 1 | 40.32 | 41.30 | 3592 | 2.2 | 48% |
| ZeRO-2 cam=4 eager no-ckpt | **2** | 54.48 | 56.28 | 3832 | **4.2** | 66% |
| ZeRO-2 cam=4 eager no-ckpt | 4 | — | — | OOM | — | — |
| FSDP-SHARD_GRAD_OP cam=1 sdpa+ckpt | 8 | 44.47 | 70.30 | 3860 | 16.6 | 82% |
| FSDP-SHARD_GRAD_OP cam=1 sdpa+ckpt | 16 | 59.33 | 83.79 | 12621 | 10.1 | 98% ⚠ |

Bold rows = throughput peak per cell. SHARD_GRAD_OP cam=4 sweep was
queued but stopped early — the cam=1 data already shows SGO behaves
like FULL_SHARD on memory (both ~70 GB reserved at bs=8) and collapses
under memory pressure rather than approaching ZeRO-2's profile.

#### Headline backend comparison (sdpa+grad_ckpt only)

| Cam | FSDP-FULL_SHARD best | ZeRO-2 best | ZeRO-2 / FSDP |
| ---: | --- | --- | ---: |
| 1 | bs=12 → 16.5 sps | bs=40 → 26.7 sps | **1.62×** |
| 4 | bs=8 → 7.0 sps | bs=20 → 13.7 sps | **1.96×** |

#### Reconciliation vs theory (closed-PR's predictions)

1. **"ZeRO-2 has +11 GB persistent vs FSDP" — REFUTED.** Observation:
   ZeRO-2 cam=1 bs=8 alloc=36.22 GB, FSDP=43.86 GB — ZeRO-2 has 7.6 GB
   *less*. The +11 GB is real for replicated params, but FSDP carries
   even more than that in transient unsharded-layer buffers (FlatParam
   all-gather staging held during forward+backward). Net: FSDP has the
   higher peak ceiling AND much worse allocator fragmentation
   (reserved-vs-allocated gap of 26 GB for FSDP cam=1 bs=8 vs 0.2 GB
   for ZeRO-2).

2. **FSDP per-step overhead "10× the all-gather prediction" — CONFIRMED
   AND EXPLAINED.** At cam=4 bs=8 FSDP is +3120 ms vs ZeRO-2 (vs ~440
   ms predicted). 88% of the gap is in the backward (FSDP 6633 ms vs
   ZeRO-2 3900 ms): every layer pays an all-gather for grad
   computation on top of the reduce-scatter — ZeRO-2 only pays
   reduce-scatter because params are replicated. Add to that grad_ckpt
   activation recompute, which fires another all-gather per
   checkpointed segment.

3. **"FSDP +1.27× over ZeRO-2 baseline" headline (closed PR) —
   REFUTED.** That comparison was apples-to-oranges (FSDP-with-sdpa-ckpt
   vs ZeRO-2-eager-no-ckpt). Apples-to-apples, ZeRO-2 wins 1.62× to
   1.96×.

4. **SHARD_GRAD_OP doesn't recover ZeRO-2's profile.** SGO keeps params
   replicated like ZeRO-2 in theory, but in practice the FSDP framework
   wrapping (TRANSFORMER_BASED_WRAP, prefetch, hooks) keeps the
   allocator pressure pattern of FULL_SHARD. The FSDP/DeepSpeed gap is
   not just about FULL_SHARD's all-gather — it's about the framework's
   memory and execution patterns end-to-end.

5. **eager+no-ckpt is strictly worse than sdpa+grad_ckpt for full
   unfreeze at this scale.** Without checkpointing the activation
   memory blows up; even at the maximum-fitting batch, throughput is
   ~2× lower (e.g. ZeRO-2 cam=1 best 12.3 sps without ckpt vs 26.7 sps
   with ckpt).

### Recommendation

**Use ZeRO-2 with `accelerate_deepspeed_config.yaml` at `bs=20` per
rank for the cam=4 pre-training run** — 13.7 global samples/s (1.96×
FSDP), 79% of HBM (real headroom). The
`disable_internal_bf16_cast` flag should NOT be set under ZeRO-2; it
only helps FSDP's MixedPrecision.

If FSDP is required for an unrelated reason, use cam=1 bs=12 or
cam=4 bs=8 — but expect ~half the throughput and a 91-98% memory
budget.

## How to checkout & try? (for the reviewer)

```bash
git fetch origin claude/naughty-franklin-bb8864
git checkout claude/naughty-franklin-bb8864
uv sync --extra dev --extra libero
```

CPU sanity:
```bash
pytest -m "not gpu" -n auto tests/policies/test_pi07_cpu.py \
                            tests/scripts/test_profile_step.py \
                            tests/scripts/test_train.py
```

Reproduce one matrix cell on an 8×A100 node (the recommended
production setting):
```bash
PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True PROFILE_STEPS=50 \
  accelerate launch \
    --config_file configs/examples/accelerate_deepspeed_config.yaml \
    --num_processes=8 \
    src/opentau/scripts/profile_step.py \
    --config_path=configs/examples/pi07_low_level_libero.json \
    --batch_size=20 --dataloader_batch_size=20 \
    --gradient_accumulation_steps=1 --num_cams=4 \
    --policy.freeze_vision_encoder=false --policy.train_expert_only=false \
    --policy.gradient_checkpointing=true \
    --policy.attention_implementation=sdpa \
    --wandb.enable=false
```

The same invocation against `accelerate_fsdp_config.yaml` reproduces
the FSDP comparison cell.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [x] My PR includes policy-related changes.
  - [x] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

> Note on GPU testing: instead of `pytest -m "gpu"` unit tests, this branch
> was exercised end-to-end at the integration level via the FSDP/ZeRO-2
> matrix above (10 cells × probe-walk on 8×A100, all completing without
> NCCL or correctness errors). If a reviewer wants the unit-level GPU
> pytest sweep before merge, happy to run it on request.
