### PR TITLE
chore(datasets): collapse skip-timestamp-check warning to once-per-process

### DIFF
--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -1346,12 +1346,20 @@ class LeRobotDataset(BaseDataset):
         # Check timestamps
         # If transform is set, with_transform will decode all columns of a row before returning the desired column(s).
         if self.skip_timestamp_check:
-            logging.warning(
-                "Skipping timestamp sync check for %s (skip_timestamp_check=True). "
-                "Frame-to-frame spacing is NOT verified against 1/fps; downstream "
-                "delta_timestamps lookups may sample unintended frames.",
-                self.repo_id,
-            )
+            # LeRobotDataset is constructed once per rank, so a naive
+            # ``logging.warning`` floods the run log with ``num_processes`` ×
+            # ``num_datasets`` copies of the same message (392 × 8 ≈ 3K lines
+            # for a wide pretraining mixture). Gate to rank 0 — fall through
+            # to logging when no Accelerator is set (single-process dev /
+            # tests).
+            acc = get_proc_accelerator()
+            if acc is None or acc.is_main_process:
+                logging.warning(
+                    "Skipping timestamp sync check for %s (skip_timestamp_check=True). "
+                    "Frame-to-frame spacing is NOT verified against 1/fps; downstream "
+                    "delta_timestamps lookups may sample unintended frames.",
+                    self.repo_id,
+                )
         else:
             no_transform_ds = self.hf_dataset.with_transform(None).with_format("numpy")
             logging.info("Checking timestamps synchronization...")

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -216,6 +216,14 @@ CODEBASE_VERSION = "v2.1"
 # instances within a single process (e.g., train + val constructed for the same repo).
 _CONTROL_MODE_WARNED: set[str] = set()
 
+# ``skip_timestamp_check`` is a mixture-wide decision (with optional per-dataset
+# override) that produces an identical warning for every dataset in the mixture.
+# For a 392-dataset pretraining run on 8 ranks, the naive per-dataset emission
+# floods the run log with ~3K identical lines. This flag makes the warning fire
+# once per process; combined with the rank-0 gate at the call site, that's once
+# per run rather than 8 × num_datasets.
+_SKIP_TIMESTAMP_WARNED: bool = False
+
 
 def suppress_control_mode_warning(repo_id: str) -> None:
     """Mark ``repo_id`` as already-warned so the missing-``control_mode`` warning
@@ -1346,17 +1354,21 @@ class LeRobotDataset(BaseDataset):
         # Check timestamps
         # If transform is set, with_transform will decode all columns of a row before returning the desired column(s).
         if self.skip_timestamp_check:
-            # LeRobotDataset is constructed once per rank, so a naive
-            # ``logging.warning`` floods the run log with ``num_processes`` ×
-            # ``num_datasets`` copies of the same message (392 × 8 ≈ 3K lines
-            # for a wide pretraining mixture). Gate to rank 0 — fall through
-            # to logging when no Accelerator is set (single-process dev /
-            # tests).
+            # ``skip_timestamp_check`` is a mixture-wide decision and the
+            # message is identical for every dataset, so emit it once per
+            # process and only on the main rank. Naive per-dataset / per-rank
+            # logging floods the run log with ``num_processes`` ×
+            # ``num_datasets`` copies of the same line (392 × 8 ≈ 3K for a
+            # wide pretraining mixture). Falls through to logging when no
+            # Accelerator is set (single-process dev / tests).
+            global _SKIP_TIMESTAMP_WARNED
             acc = get_proc_accelerator()
-            if acc is None or acc.is_main_process:
+            if not _SKIP_TIMESTAMP_WARNED and (acc is None or acc.is_main_process):
+                _SKIP_TIMESTAMP_WARNED = True
                 logging.warning(
-                    "Skipping timestamp sync check for %s (skip_timestamp_check=True). "
-                    "Frame-to-frame spacing is NOT verified against 1/fps; downstream "
+                    "skip_timestamp_check=True is in effect for one or more "
+                    "datasets in this mixture (e.g. %s). Frame-to-frame "
+                    "spacing is NOT verified against 1/fps; downstream "
                     "delta_timestamps lookups may sample unintended frames.",
                     self.repo_id,
                 )

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -1033,24 +1033,27 @@ def test_skip_timestamp_warning_emitted_once_per_process(tmp_path, lerobot_datas
     heterogeneous mixture of N datasets emits 1 line, not N."""
     from opentau.datasets import lerobot_dataset as ld_mod
 
+    original = ld_mod._SKIP_TIMESTAMP_WARNED
     ld_mod._SKIP_TIMESTAMP_WARNED = False
+    try:
+        with caplog.at_level(logging.WARNING):
+            ds_a = lerobot_dataset_factory(
+                root=tmp_path / "skip_warn_a",
+                repo_id="warn-once/skip-ts-a",
+                skip_timestamp_check=True,
+            )
+            ds_b = lerobot_dataset_factory(
+                root=tmp_path / "skip_warn_b",
+                repo_id="warn-once/skip-ts-b",
+                skip_timestamp_check=True,
+            )
 
-    with caplog.at_level(logging.WARNING):
-        ds_a = lerobot_dataset_factory(
-            root=tmp_path / "skip_warn_a",
-            repo_id="warn-once/skip-ts-a",
-            skip_timestamp_check=True,
-        )
-        ds_b = lerobot_dataset_factory(
-            root=tmp_path / "skip_warn_b",
-            repo_id="warn-once/skip-ts-b",
-            skip_timestamp_check=True,
-        )
-
-    assert ds_a.skip_timestamp_check is True
-    assert ds_b.skip_timestamp_check is True
-    matching = [r for r in caplog.records if "skip_timestamp_check=True" in r.getMessage()]
-    assert len(matching) == 1
+        assert ds_a.skip_timestamp_check is True
+        assert ds_b.skip_timestamp_check is True
+        matching = [r for r in caplog.records if "skip_timestamp_check=True" in r.getMessage()]
+        assert len(matching) == 1
+    finally:
+        ld_mod._SKIP_TIMESTAMP_WARNED = original
 
 
 def test_robot_type_and_control_mode_in_meta_info(tmp_path, lerobot_dataset_factory, info_factory):

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -1027,6 +1027,32 @@ def test_control_mode_warning_emitted_once_per_repo(tmp_path, lerobot_dataset_fa
     assert len(matching) == 1
 
 
+def test_skip_timestamp_warning_emitted_once_per_process(tmp_path, lerobot_dataset_factory, caplog):
+    """`skip_timestamp_check=True` warns exactly once per process across multiple
+    LeRobotDataset instances — locks in the `_SKIP_TIMESTAMP_WARNED` dedup so a
+    heterogeneous mixture of N datasets emits 1 line, not N."""
+    from opentau.datasets import lerobot_dataset as ld_mod
+
+    ld_mod._SKIP_TIMESTAMP_WARNED = False
+
+    with caplog.at_level(logging.WARNING):
+        ds_a = lerobot_dataset_factory(
+            root=tmp_path / "skip_warn_a",
+            repo_id="warn-once/skip-ts-a",
+            skip_timestamp_check=True,
+        )
+        ds_b = lerobot_dataset_factory(
+            root=tmp_path / "skip_warn_b",
+            repo_id="warn-once/skip-ts-b",
+            skip_timestamp_check=True,
+        )
+
+    assert ds_a.skip_timestamp_check is True
+    assert ds_b.skip_timestamp_check is True
+    matching = [r for r in caplog.records if "skip_timestamp_check=True" in r.getMessage()]
+    assert len(matching) == 1
+
+
 def test_robot_type_and_control_mode_in_meta_info(tmp_path, lerobot_dataset_factory, info_factory):
     """robot_type and control_mode are surfaced as optional fields in the
     standard data format. Verify the underlying meta/info.json values that


### PR DESCRIPTION
## What this does

The ``Skipping timestamp sync check for ...`` warning at
``src/opentau/datasets/lerobot_dataset.py:1348`` previously fired
``num_processes × num_datasets`` times — for a heterogeneous
pretraining mixture (~392 datasets) on 8 GPUs that's ~3,136 identical
lines between accelerate init and the first training step, drowning
the startup log.

``skip_timestamp_check`` is fundamentally a **mixture-wide decision**
(with optional per-dataset override), and the warning text is identical
for every dataset that has it set. So the right collapse is **once per
process** — combined with the rank-0 gate that's *one line per run*,
not per dataset.

Implementation mirrors the existing ``_CONTROL_MODE_WARNED`` dedup
pattern in the same file:

- New module-level ``_SKIP_TIMESTAMP_WARNED: bool`` flag.
- Inside ``LeRobotDataset.__init__``, the warning is gated by both
  rank (``acc.is_main_process``) and the flag — fire once, then flip.
- Falls through to ``logging.warning`` when no Accelerator is set so
  single-process dev / pytest runs are unchanged.
- Message now mentions the first dataset hit as an *example* rather
  than the only one, since the flag is mixture-wide.

## How it was tested

- ``pre-commit run --files src/opentau/datasets/lerobot_dataset.py`` — clean.
- ``pytest -m "not gpu" -n auto tests/datasets/`` — 375 passed, 7
  skipped, no regressions.

Behavior comparison:

| Setup | Lines emitted (before) | Lines emitted (after) |
| --- | ---: | ---: |
| 8 ranks × 392 datasets | ~3,136 | **1** |
| 1 rank (CPU dev) × 5 datasets | 5 | **1** |
| 1 rank × 1 dataset | 1 | 1 |

The opt-in semantic and safety implication of ``skip_timestamp_check``
itself are unchanged — only the per-rank × per-dataset duplication
is suppressed.

## How to checkout & try? (for the reviewer)

```bash
git fetch origin claude/skip-timestamp-warning-rank0
git checkout claude/skip-timestamp-warning-rank0
pytest -m "not gpu" -n auto tests/datasets/
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.