### PR TITLE
test(pi07): set vocab size + FSDP MixedPrecision in FSDP-wrap test (#281)

### DIFF
--- a/tests/policies/test_pi07_low_level.py
+++ b/tests/policies/test_pi07_low_level.py
@@ -839,6 +839,7 @@ class TestGemma3WithExpertFSDPWrap:
         import os
 
         from torch.distributed.fsdp import FullyShardedDataParallel as FSDP  # noqa: N817
+        from torch.distributed.fsdp import MixedPrecision
         from torch.distributed.fsdp.wrap import transformer_auto_wrap_policy
 
         from opentau.policies.pi07.gemma3_with_expert import (
@@ -873,6 +874,10 @@ class TestGemma3WithExpertFSDPWrap:
                 freeze_vision_encoder=True,
                 train_expert_only=False,
                 attention_implementation="eager",
+                # Production wrappers (PI07LowLevelPolicy) inject this from the
+                # FAST tokenizer; here we set it explicitly so the bare
+                # Gemma3WithExpertModel can build its discrete-action head.
+                discrete_action_vocab_size=32,
             )
 
             model = Gemma3WithExpertModel(cfg).to(device="cuda", dtype=torch.float32)
@@ -881,9 +886,19 @@ class TestGemma3WithExpertFSDPWrap:
                 transformer_auto_wrap_policy,
                 transformer_layer_cls={InterleavedDecoderLayer},
             )
+            # Match the production FSDP regime (accelerate's `mixed_precision: bf16`
+            # with no `fsdp_reduce_dtype` override translates to this triple). Without
+            # it, the model's fp32 weights collide with `_preferred_dtype()` casting
+            # activations to bf16 inside `gemma3_with_expert.py:forward`.
+            mixed_precision = MixedPrecision(
+                param_dtype=torch.bfloat16,
+                reduce_dtype=torch.bfloat16,
+                buffer_dtype=torch.bfloat16,
+            )
             wrapped = FSDP(
                 model,
                 auto_wrap_policy=auto_wrap_policy,
+                mixed_precision=mixed_precision,
                 use_orig_params=True,
                 device_id=torch.cuda.current_device(),
             )


### PR DESCRIPTION
## What this does

Fixes #281 (🐛 Bug).

The GPU test `TestGemma3WithExpertFSDPWrap::test_fsdp_wrap_forward_backward`
in `tests/policies/test_pi07_low_level.py` (added in #273) failed in two
distinct ways once it actually ran end-to-end. Issue #281 reports the first;
the second only became visible once the first was unblocked.

1. **`nn.Embedding(num_embeddings=None)`** — the test built
   `Gemma3WithExpertConfig(...)` without `discrete_action_vocab_size`, so the
   default `None` flowed into `Gemma3WithExpertModel.__init__` and
   `nn.Embedding(num_embeddings=None, ...)` raised `TypeError`. Production
   wrappers (`PI07LowLevelPolicy.__init__`) inject the FAST tokenizer's
   vocab size; the bare constructor path doesn't, so the test must pass it
   explicitly. Set to `32`, matching the convention in
   `_make_tiny_g3we_cfg` (`tests/policies/test_pi07_cpu.py:118`).

2. **bf16 / fp32 dtype mismatch** — the test builds the model in fp32 with
   `disable_internal_bf16_cast=True`, expecting (per the inline comment)
   FSDP `MixedPrecision` to handle the fp32-master / bf16-compute split.
   But the `FSDP(...)` call never actually wired up `mixed_precision=...`,
   so the params stayed fp32 while `_preferred_dtype()` in
   `gemma3_with_expert.py` cast activations to bf16 inside `forward` — the
   bf16 input then collided with the fp32 weight in `q_proj`. Wire
   `MixedPrecision(param_dtype=bf16, reduce_dtype=bf16, buffer_dtype=bf16)`
   into the FSDP wrap, mirroring what accelerate's `mixed_precision: bf16`
   config translates to in production (see `scripts/train.py` and
   `scripts/profile_step.py:215-218`).

## How it was tested

Reproduced and verified end-to-end on a single-GPU CUDA box.

Before (origin/main):

```text
FAILED tests/policies/test_pi07_low_level.py::TestGemma3WithExpertFSDPWrap::test_fsdp_wrap_forward_backward
    self.discrete_action_embedding = nn.Embedding(
TypeError: empty() received an invalid combination of arguments - got (tuple, dtype=NoneType, device=NoneType), ...
```

After (this branch):

- `pytest -m gpu -sx tests/policies/test_pi07_low_level.py::TestGemma3WithExpertFSDPWrap::test_fsdp_wrap_forward_backward` → passes.
- `pytest -m gpu -sx tests/policies/test_pi07_low_level.py` → 4 passed, 3 skipped (skips are unrelated, fixture-driven).
- `pytest -m "not gpu" -n auto tests/policies/test_pi07_cpu.py` → 69 passed, no regressions.
- `pre-commit run --files tests/policies/test_pi07_low_level.py` → all hooks pass.

## How to checkout & try? (for the reviewer)

```bash
gh pr checkout <this PR>
pytest -m gpu -sx tests/policies/test_pi07_low_level.py::TestGemma3WithExpertFSDPWrap::test_fsdp_wrap_forward_backward
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [x] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

(Test-only fix to a GPU test; no policy/training-loop changes, so the
policy-changes box is not checked. The targeted GPU test was run on a
single-GPU box per the "How it was tested" section.)