### PR TITLE
ci(gpu) + test(pi07): drop temp push trigger + scope CUDA drain (cleanup of #285)

### DIFF
--- a/.github/workflows/gpu_test.yml
+++ b/.github/workflows/gpu_test.yml
@@ -18,12 +18,6 @@ on:
     # Run at 2:00 AM PST every day (10:00 AM UTC)
     - cron: '0 10 * * *'
   workflow_dispatch:
-  # TEMPORARY: dispatch GPU tests on this branch only to verify the
-  # NCCL 2.27.5 single-rank fix in #285. Reverted before the PR is
-  # marked ready.
-  push:
-    branches:
-      - claude/fix-gpu-tests-TStWF
 
 permissions:
   contents: read  # Required for actions/checkout

--- a/tests/policies/test_pi07_low_level.py
+++ b/tests/policies/test_pi07_low_level.py
@@ -859,15 +859,18 @@ class TestGemma3WithExpertFSDPWrap:
         os.environ.setdefault("MASTER_PORT", "29501")
         os.environ.setdefault("WORLD_SIZE", "1")
         os.environ.setdefault("RANK", "0")
-        # Set the CUDA device and drain stale state from earlier GPU tests
-        # in the same pytest session before init_process_group, since NCCL
-        # binds its communicator to whatever device is current at init time
-        # (issue #283 hint about stale GPU context).
-        torch.cuda.set_device(0)
-        torch.cuda.synchronize()
-        torch.cuda.empty_cache()
         already_initialized = torch.distributed.is_initialized()
         if not already_initialized:
+            # Set the CUDA device and drain stale state from earlier GPU tests
+            # in the same pytest session before init_process_group, since NCCL
+            # binds its communicator to whatever device is current at init time
+            # (issue #283 hint about stale GPU context). When a prior test has
+            # already initialized the PG, NCCL is bound to whichever device that
+            # test picked and re-pinning here can't unbind it — so this drain is
+            # only meaningful on the path where we own the init.
+            torch.cuda.set_device(0)
+            torch.cuda.synchronize()
+            torch.cuda.empty_cache()
             # device_id pins the new PG to the local GPU explicitly, so NCCL
             # forms its communicator eagerly on the correct device instead of
             # the lazy default-device guess (PyTorch ≥ 2.0).


### PR DESCRIPTION
## What this does

Cleanup left by #285's squash-merge.

#285 went through with the temporary `gpu_test.yml` `push` trigger I had added on the fix branch to manually dispatch GPU CI without API auth. The maintainer marked the PR ready and squash-merged it before my follow-up cleanup commit landed, so the trigger leaked into `main`. This PR drops it.

While I'm here, also addressing the `claude[bot]` nit from the original review (PR #285):
**`tests/policies/test_pi07_low_level.py`** — the pre-init CUDA drain (`set_device(0)` / `synchronize()` / `empty_cache()`) was at function scope, so it ran even when an earlier test in the session had already initialized the PG. In that case NCCL is already bound to whichever device that test picked and re-pinning here can't unbind it, so the drain only does useful work on the path where we own the init. Move it inside the `if not already_initialized:` block alongside the actual `init_process_group` call. Comment is updated to spell out the asymmetry.

No functional change to GPU behavior — the GPU CI run on `dd42b69` (`Run Pytest on GPU` job 74911614535, 13min, success) already confirmed the underlying fix works.

## How it was tested

- `pre-commit run --files tests/policies/test_pi07_low_level.py .github/workflows/gpu_test.yml` — all hooks pass.
- `pytest -m "not gpu" -n auto tests/policies/test_pi07_cpu.py tests/policies/test_pi07_low_level.py` — 69 passed, no regressions.
- The `gpu_test.yml` change is trigger-only; the gpu-test job body is unchanged so a re-run on the nightly cron (or manual `workflow_dispatch`) still exercises the same fix that already passed on `dd42b69`.

## How to checkout & try? (for the reviewer)

```bash
git fetch origin claude/fix-gpu-tests-TStWF
git checkout claude/fix-gpu-tests-TStWF
git diff main -- .github/workflows/gpu_test.yml tests/policies/test_pi07_low_level.py
pytest -m "not gpu" -n auto tests/policies/test_pi07_cpu.py tests/policies/test_pi07_low_level.py
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.


---
_Generated by [Claude Code](https://claude.ai/code/session_016gBkgU73SrEbrsoi39PG1v)_