### PR TITLE
fix(datasets): NaN-tolerant aggregate_feature_stats + load-time WARN

### DIFF
--- a/src/opentau/datasets/compute_stats.py
+++ b/src/opentau/datasets/compute_stats.py
@@ -71,6 +71,7 @@ Example:
         >>> aggregated = aggregate_stats(stats_list, weights=weights)
 """
 
+import warnings
 from typing import Optional
 
 import numpy as np
@@ -286,6 +287,12 @@ def aggregate_feature_stats(
     Computes weighted mean and variance using the parallel algorithm for variance
     computation. Min and max are taken as the global min/max across all stats.
 
+    NaN-tolerant per-dim: a contributor whose ``mean``/``std``/``min``/``max`` is
+    NaN at some dim is excluded from the aggregation at that dim only. Clean dims
+    aggregate normally. A dim that is NaN across every contributor stays NaN, so
+    the downstream loader (or ``Normalize`` buffer) can surface it -- but a single
+    bad dataset no longer poisons the global buffer for every other sample.
+
     Args:
         stats_ft_list: List of statistics dictionaries for the same feature.
         weights: Optional weights for each statistics entry. If None, uses
@@ -296,32 +303,44 @@ def aggregate_feature_stats(
     """
     means = np.stack([s["mean"] for s in stats_ft_list])
     variances = np.stack([s["std"] ** 2 for s in stats_ft_list])
+    mins = np.stack([s["min"] for s in stats_ft_list])
+    maxs = np.stack([s["max"] for s in stats_ft_list])
 
-    # if weights are provided, use them to compute the weighted mean and variance
-    # otherwise, use episode counts as weights
-    if weights is not None:
-        counts = np.stack(weights)
-        total_count = counts.sum(axis=0)
-    else:
-        counts = np.stack([s["count"] for s in stats_ft_list])
-        total_count = counts.sum(axis=0)
+    counts = np.stack(weights) if weights is not None else np.stack([s["count"] for s in stats_ft_list])
+    total_count = counts.sum(axis=0)
 
-    # Prepare weighted mean by matching number of dimensions
     while counts.ndim < means.ndim:
         counts = np.expand_dims(counts, axis=-1)
 
-    # Compute the weighted mean
-    weighted_means = means * counts
-    total_mean = weighted_means.sum(axis=0) / total_count
+    mean_weights = np.where(np.isnan(means), 0.0, counts).astype(np.float64)
+    mean_weight_sum = mean_weights.sum(axis=0)
+    safe_means = np.where(np.isnan(means), 0.0, means)
+    total_mean = np.divide(
+        (safe_means * mean_weights).sum(axis=0),
+        mean_weight_sum,
+        out=np.full(mean_weight_sum.shape, np.nan, dtype=np.float64),
+        where=mean_weight_sum > 0,
+    )
 
-    # Compute the variance using the parallel algorithm
-    delta_means = means - total_mean
-    weighted_variances = (variances + delta_means**2) * counts
-    total_variance = weighted_variances.sum(axis=0) / total_count
+    var_weights = np.where(np.isnan(variances) | np.isnan(means), 0.0, counts).astype(np.float64)
+    var_weight_sum = var_weights.sum(axis=0)
+    safe_variances = np.where(np.isnan(variances), 0.0, variances)
+    delta_means = np.where(np.isnan(means), 0.0, means - total_mean)
+    total_variance = np.divide(
+        ((safe_variances + delta_means**2) * var_weights).sum(axis=0),
+        var_weight_sum,
+        out=np.full(var_weight_sum.shape, np.nan, dtype=np.float64),
+        where=var_weight_sum > 0,
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=RuntimeWarning)
+        agg_min = np.nanmin(mins, axis=0)
+        agg_max = np.nanmax(maxs, axis=0)
 
     return {
-        "min": np.min(np.stack([s["min"] for s in stats_ft_list]), axis=0),
-        "max": np.max(np.stack([s["max"] for s in stats_ft_list]), axis=0),
+        "min": agg_min,
+        "max": agg_max,
         "mean": total_mean,
         "std": np.sqrt(total_variance),
         "count": total_count,

--- a/src/opentau/datasets/compute_stats.py
+++ b/src/opentau/datasets/compute_stats.py
@@ -287,11 +287,19 @@ def aggregate_feature_stats(
     Computes weighted mean and variance using the parallel algorithm for variance
     computation. Min and max are taken as the global min/max across all stats.
 
-    NaN-tolerant per-dim: a contributor whose ``mean``/``std``/``min``/``max`` is
-    NaN at some dim is excluded from the aggregation at that dim only. Clean dims
-    aggregate normally. A dim that is NaN across every contributor stays NaN, so
-    the downstream loader (or ``Normalize`` buffer) can surface it -- but a single
-    bad dataset no longer poisons the global buffer for every other sample.
+    Non-finite-tolerant per-dim: a contributor whose ``mean``/``std``/``min``/``max``
+    is non-finite (NaN or +/-Inf) at some dim is excluded from the aggregation at
+    that dim only. Clean dims aggregate normally. A dim that is non-finite across
+    every contributor stays NaN, so the downstream loader (or ``Normalize`` buffer)
+    can surface it -- but a single bad dataset no longer poisons the global buffer
+    for every other sample.
+
+    The mean and variance use *different* per-dim masks: a contributor is dropped
+    from the mean at a dim iff its ``mean`` is non-finite there, but dropped from
+    the variance at a dim iff *either* its ``mean`` or its ``std`` is non-finite
+    there (you can't form a Chan-style variance contribution without a finite
+    ``std``). ``count`` is unconditional: the sum of contributors' counts, not a
+    per-dim effective contributor count.
 
     Args:
         stats_ft_list: List of statistics dictionaries for the same feature.
@@ -312,9 +320,12 @@ def aggregate_feature_stats(
     while counts.ndim < means.ndim:
         counts = np.expand_dims(counts, axis=-1)
 
-    mean_weights = np.where(np.isnan(means), 0.0, counts).astype(np.float64)
+    means_bad = ~np.isfinite(means)
+    variances_bad = ~np.isfinite(variances)
+
+    mean_weights = np.where(means_bad, 0.0, counts).astype(np.float64)
     mean_weight_sum = mean_weights.sum(axis=0)
-    safe_means = np.where(np.isnan(means), 0.0, means)
+    safe_means = np.where(means_bad, 0.0, means)
     total_mean = np.divide(
         (safe_means * mean_weights).sum(axis=0),
         mean_weight_sum,
@@ -322,10 +333,11 @@ def aggregate_feature_stats(
         where=mean_weight_sum > 0,
     )
 
-    var_weights = np.where(np.isnan(variances) | np.isnan(means), 0.0, counts).astype(np.float64)
+    # Chan-style parallel weighted variance, non-finite-masked per dim.
+    var_weights = np.where(variances_bad | means_bad, 0.0, counts).astype(np.float64)
     var_weight_sum = var_weights.sum(axis=0)
-    safe_variances = np.where(np.isnan(variances), 0.0, variances)
-    delta_means = np.where(np.isnan(means), 0.0, means - total_mean)
+    safe_variances = np.where(variances_bad, 0.0, variances)
+    delta_means = np.where(means_bad, 0.0, means - total_mean)
     total_variance = np.divide(
         ((safe_variances + delta_means**2) * var_weights).sum(axis=0),
         var_weight_sum,
@@ -333,10 +345,14 @@ def aggregate_feature_stats(
         where=var_weight_sum > 0,
     )
 
+    # Mask +/-Inf to NaN so nanmin/nanmax exclude them too. (nanmin/nanmax skip NaN
+    # but not Inf: +Inf would still poison max, -Inf would still poison min.)
+    mins_safe = np.where(np.isfinite(mins), mins, np.nan)
+    maxs_safe = np.where(np.isfinite(maxs), maxs, np.nan)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=RuntimeWarning)
-        agg_min = np.nanmin(mins, axis=0)
-        agg_max = np.nanmax(maxs, axis=0)
+        agg_min = np.nanmin(mins_safe, axis=0)
+        agg_max = np.nanmax(maxs_safe, axis=0)
 
     return {
         "min": agg_min,

--- a/src/opentau/datasets/dataset_mixture.py
+++ b/src/opentau/datasets/dataset_mixture.py
@@ -202,9 +202,10 @@ class DatasetMixtureMetadata:
                 )
 
         # Surface non-finite stats with the offending repo + dim, so that the
-        # NaN-tolerant aggregator in `aggregate_feature_stats` doesn't silently
-        # drop a dataset's contribution. Cameras get min=0/max=1/mean=0/std=0
-        # placeholders for missing slots, so we only check non-camera features.
+        # non-finite-tolerant aggregator in `aggregate_feature_stats` doesn't
+        # silently drop a dataset's contribution. Cameras get
+        # min=0/max=1/mean=0/std=0 placeholders for missing slots, so we only
+        # check non-camera features.
         for data in standard_stats:
             if data.startswith("camera"):
                 continue
@@ -214,13 +215,12 @@ class DatasetMixtureMetadata:
                 if bad.size > 0:
                     logging.warning(
                         "Dataset %r: non-finite values in %r.%r at flat indices %s "
-                        "(shape=%s); excluded from aggregated %r stats at those dims.",
+                        "(shape=%s); these dims are excluded from aggregation.",
                         repo_id,
                         data,
                         stat_name,
                         bad.tolist(),
                         tuple(arr.shape),
-                        data,
                     )
 
         return standard_stats

--- a/src/opentau/datasets/dataset_mixture.py
+++ b/src/opentau/datasets/dataset_mixture.py
@@ -201,6 +201,28 @@ class DatasetMixtureMetadata:
                     f"The dataset {repo_id} is missing required statistics: {', '.join(sorted(missing_keys))}"
                 )
 
+        # Surface non-finite stats with the offending repo + dim, so that the
+        # NaN-tolerant aggregator in `aggregate_feature_stats` doesn't silently
+        # drop a dataset's contribution. Cameras get min=0/max=1/mean=0/std=0
+        # placeholders for missing slots, so we only check non-camera features.
+        for data in standard_stats:
+            if data.startswith("camera"):
+                continue
+            for stat_name in ("mean", "std", "min", "max"):
+                arr = np.asarray(standard_stats[data][stat_name])
+                bad = np.flatnonzero(~np.isfinite(arr.ravel()))
+                if bad.size > 0:
+                    logging.warning(
+                        "Dataset %r: non-finite values in %r.%r at flat indices %s "
+                        "(shape=%s); excluded from aggregated %r stats at those dims.",
+                        repo_id,
+                        data,
+                        stat_name,
+                        bad.tolist(),
+                        tuple(arr.shape),
+                        data,
+                    )
+
         return standard_stats
 
     @property

--- a/tests/datasets/test_compute_stats.py
+++ b/tests/datasets/test_compute_stats.py
@@ -260,6 +260,49 @@ def test_aggregate_feature_stats_nan_tolerant_per_dim():
     np.testing.assert_allclose(result["count"], np.array([20]))
 
 
+def test_aggregate_feature_stats_inf_masked_per_dim():
+    """+/-Inf in a contributor's stats must be masked per-dim the same way NaN is.
+
+    Naive ``np.nanmin`` / ``np.nanmax`` skip NaN but *not* Inf -- +Inf would still
+    poison the aggregated max, -Inf the aggregated min, and ``np.where(np.isnan(...))``
+    would leave them in the weighted-mean numerator. This regression locks in the
+    ``~np.isfinite`` predicate so a contributor with +/-Inf is excluded per dim
+    just like a NaN contributor.
+    """
+    inf = float("inf")
+    stats_ft_list = [
+        {  # contributor A: dim 0 fully Inf-poisoned, dim 1 clean
+            "min": np.array([-inf, 2.0]),
+            "max": np.array([inf, 12.0]),
+            "mean": np.array([inf, 6.0]),
+            "std": np.array([inf, 2.5]),
+            "count": np.array([10]),
+        },
+        {  # contributor B: clean everywhere
+            "min": np.array([1.0, 1.5]),
+            "max": np.array([10.0, 11.0]),
+            "mean": np.array([5.0, 5.5]),
+            "std": np.array([2.0, 2.0]),
+            "count": np.array([10]),
+        },
+    ]
+    result = aggregate_feature_stats(stats_ft_list)
+    # dim 0: only B contributes (A is Inf at every stat); naive nanmin/nanmax
+    # would return -inf / +inf here without the ~np.isfinite mask.
+    np.testing.assert_allclose(result["min"][0], 1.0)
+    np.testing.assert_allclose(result["max"][0], 10.0)
+    np.testing.assert_allclose(result["mean"][0], 5.0)
+    np.testing.assert_allclose(result["std"][0], 2.0)
+    # dim 1: both contribute (A's stats are finite at this dim).
+    np.testing.assert_allclose(result["min"][1], 1.5)
+    np.testing.assert_allclose(result["max"][1], 12.0)
+    np.testing.assert_allclose(result["mean"][1], 5.75)
+    assert np.isfinite(result["min"]).all()
+    assert np.isfinite(result["max"]).all()
+    assert np.isfinite(result["mean"]).all()
+    assert np.isfinite(result["std"]).all()
+
+
 def test_aggregate_feature_stats_all_nan_dim_stays_nan():
     """If every contributor is NaN at a dim, the result is NaN there (not silently clean).
 

--- a/tests/datasets/test_compute_stats.py
+++ b/tests/datasets/test_compute_stats.py
@@ -222,6 +222,75 @@ def test_aggregate_feature_stats():
     np.testing.assert_allclose(result["count"], np.array([2]))
 
 
+def test_aggregate_feature_stats_nan_tolerant_per_dim():
+    """A NaN at one contributor's dim must not poison clean dims for other contributors.
+
+    Regression: a single dataset's NaN min/max would poison every sample's
+    normalize buffer because np.min/np.max propagate NaN. The fix uses
+    np.nanmin/np.nanmax + per-dim NaN-aware weighted mean/variance.
+    """
+    nan = float("nan")
+    stats_ft_list = [
+        {  # contributor A: dim 0 is NaN, dim 1 is clean
+            "min": np.array([nan, 2.0]),
+            "max": np.array([nan, 12.0]),
+            "mean": np.array([nan, 6.0]),
+            "std": np.array([nan, 2.5]),
+            "count": np.array([10]),
+        },
+        {  # contributor B: both dims clean
+            "min": np.array([1.0, 1.5]),
+            "max": np.array([10.0, 11.0]),
+            "mean": np.array([5.0, 5.5]),
+            "std": np.array([2.0, 2.0]),
+            "count": np.array([10]),
+        },
+    ]
+    result = aggregate_feature_stats(stats_ft_list)
+    # dim 0: only B contributes (A is NaN at this dim)
+    np.testing.assert_allclose(result["min"][0], 1.0)
+    np.testing.assert_allclose(result["max"][0], 10.0)
+    np.testing.assert_allclose(result["mean"][0], 5.0)
+    np.testing.assert_allclose(result["std"][0], 2.0)
+    # dim 1: weighted average of A and B (equal counts)
+    np.testing.assert_allclose(result["min"][1], 1.5)
+    np.testing.assert_allclose(result["max"][1], 12.0)
+    np.testing.assert_allclose(result["mean"][1], 5.75)
+    # count is unaffected by per-dim NaN masking
+    np.testing.assert_allclose(result["count"], np.array([20]))
+
+
+def test_aggregate_feature_stats_all_nan_dim_stays_nan():
+    """If every contributor is NaN at a dim, the result is NaN there (not silently clean).
+
+    Lets downstream loaders surface the case rather than masking it.
+    """
+    nan = float("nan")
+    stats_ft_list = [
+        {
+            "min": np.array([nan, 2.0]),
+            "max": np.array([nan, 12.0]),
+            "mean": np.array([nan, 6.0]),
+            "std": np.array([nan, 2.5]),
+            "count": np.array([10]),
+        },
+        {
+            "min": np.array([nan, 1.5]),
+            "max": np.array([nan, 11.0]),
+            "mean": np.array([nan, 5.5]),
+            "std": np.array([nan, 2.0]),
+            "count": np.array([10]),
+        },
+    ]
+    result = aggregate_feature_stats(stats_ft_list)
+    assert np.isnan(result["min"][0])
+    assert np.isnan(result["max"][0])
+    assert np.isnan(result["mean"][0])
+    assert np.isnan(result["std"][0])
+    np.testing.assert_allclose(result["min"][1], 1.5)
+    np.testing.assert_allclose(result["max"][1], 12.0)
+
+
 def test_aggregate_stats():
     all_stats = [
         {


### PR DESCRIPTION
## What this does

Fixes a NaN propagation bug in `aggregate_feature_stats` where a single dataset whose action `min`/`max` stats contained NaN at any dim poisoned the global mixture buffer. `np.min` / `np.max` / weighted-mean all propagate NaN, so the aggregated buffer's NaN dims turned every sample's normalized `discrete_actions` into NaN regardless of source repo, blowing up the FAST tokenizer at the first batch (`OverflowError: Python int too large to convert to C int` from `chr()` on garbage cast from NaN).

- `aggregate_feature_stats` now masks per-dim NaN contributors via `np.nanmin`/`np.nanmax` for min/max, plus a NaN-aware weighted mean/variance that zeroes a contributor's weight where its mean (or variance) is NaN. Clean dims aggregate exactly as before; a dim that is NaN across every contributor stays NaN so the downstream loader (or `Normalize` buffer) can still surface it.
- `DatasetMixtureMetadata._to_standard_data_format` now logs a `WARNING` with the offending `repo_id`, key, stat name, and bad flat-dim indices, so a contaminator can be identified from training logs without a separate diagnostic patch.

Label: bug.

## How it was tested

- Added two regressions in `tests/datasets/test_compute_stats.py`:
  - `test_aggregate_feature_stats_nan_tolerant_per_dim` — a contributor with NaN at one dim must not affect aggregation at clean dims for other contributors.
  - `test_aggregate_feature_stats_all_nan_dim_stays_nan` — if every contributor is NaN at a dim, the aggregated result stays NaN there (downstream is responsible for surfacing it).
- `pytest -m "not gpu" -n auto tests/datasets/test_compute_stats.py` → 17/17 pass.
- `pytest -m "not gpu" -n auto tests/datasets/` → 378 passed, 7 skipped (gpu-only), 0 failures.
- The original `test_aggregate_feature_stats` covers the no-NaN happy path and continues to pass — clean inputs aggregate bit-identically to the prior implementation.
- Root cause was independently reproduced and confirmed via a temporary `[NaN-trace]` diagnostic patch (already reverted) which showed 14 of 32 padded action dims had NaN in `normalize.actions.{min,max}` after `_to_standard_data_format` + `aggregate_stats`, while pre-normalize raw `batch['actions']` was finite — proving the contamination came from the aggregator buffer, not runtime parquet data.

End-to-end verification on real GPU infrastructure is left to a follow-up dispatch by the reviewer; the unit tests cover the aggregator path that was broken.

## How to checkout & try? (for the reviewer)

```bash
git checkout claude/sad-sanderson-957544
pytest -m "not gpu" -n auto tests/datasets/test_compute_stats.py
```

To exercise the load-time WARN, point any pi07/pi05/pi06 training config at a dataset whose action stats contain NaN — the warning lands at `DatasetMixtureMetadata` construction time, naming the offending `repo_id`, key, stat name, and bad flat-dim indices.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).