### PR TITLE
ci: make Claude PR Review non-blocking when API limit hits

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -47,6 +47,7 @@ jobs:
       || github.event.pull_request.user.login == 'claude[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## What this does
Adds `continue-on-error: true` to the `review` job in `.github/workflows/claude-pr-review.yml`. When the Anthropic API rate limit is reached the action errors out and turns the PR check red, which currently makes the per-commit rollup show a ❌ even though every other CI passed. With this flag, GitHub reports the workflow run as success regardless of the job outcome, so the PR shows green; the failure itself is still visible in the Actions tab if you want to debug it, and manual review remains the fallback when the automated review can't run.

## How it was tested
- Inspected the one-line diff against `.github/workflows/claude-pr-review.yml`.
- Ran `pre-commit run --files .github/workflows/claude-pr-review.yml` locally — yaml/zizmor/gitleaks/typos all pass.
- End-to-end behavior is exercised by this PR itself: if the Claude PR Review job fails (e.g. rate-limited), the per-commit checkmark should still report green once other required checks pass.

## How to checkout & try? (for the reviewer)
```bash
git fetch origin claude/ci-pass-with-exceptions-x8qZE
git checkout claude/ci-pass-with-exceptions-x8qZE
git diff main -- .github/workflows/claude-pr-review.yml
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).


---
_Generated by [Claude Code](https://claude.ai/code/session_01WsMv6YJPuRageo2SUj9ERP)_