### PR TITLE
ci: move Claude PR Review continue-on-error to step level

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -47,7 +47,6 @@ jobs:
       || github.event.pull_request.user.login == 'claude[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -55,6 +54,7 @@ jobs:
           persist-credentials: false
 
       - uses: anthropics/claude-code-action@v1
+        continue-on-error: true
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # Match the bot allowlist in the job-level `if:` above. Never `*` on


### PR DESCRIPTION
## What this does
Follow-up to #291. The previous PR put `continue-on-error: true` at the **job** level on the `review` job, but GitHub's job-level flag only changes the workflow run's overall conclusion — the per-job check status still reflects the job's actual outcome, so the `review` check on a PR still showed ❌ when the action rate-limited (e.g. #292 run 25751881797). Moving the flag down onto the `anthropics/claude-code-action@v1` step instead masks the failure before it propagates to the job's conclusion, so the check run reports success and the per-commit ✓/✗ rollup goes green. Drops the now-redundant job-level flag.

## How it was tested
- Single-line move, verified diff is exactly `-continue-on-error: true` at the job and `+continue-on-error: true` on the action step.
- `pre-commit run --files .github/workflows/claude-pr-review.yml` — clean (yaml/zizmor/gitleaks/typos).
- End-to-end behavior will be exercised by this PR itself: after merge, a fresh PR that hits the rate limit should report the `review` check as green.

## How to checkout & try? (for the reviewer)
```bash
git fetch origin claude/ci-pass-step-level-continue-on-error
git checkout claude/ci-pass-step-level-continue-on-error
git diff main -- .github/workflows/claude-pr-review.yml
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).


---
_Generated by [Claude Code](https://claude.ai/code/session_01WsMv6YJPuRageo2SUj9ERP)_