### PR TITLE
feat(train): log per-rank HBM around LIBERO eval boundary

### DIFF
--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -698,6 +698,12 @@ def train(cfg: TrainPipelineConfig):
             accelerator.wait_for_everyone()
 
         if is_eval_step and eval_envs:
+            if torch.cuda.is_available():
+                pre_eval_alloc_gib = torch.cuda.memory_allocated() / 1024**3
+                pre_eval_resv_gib = torch.cuda.memory_reserved() / 1024**3
+                torch.cuda.reset_peak_memory_stats()
+            else:
+                pre_eval_alloc_gib = pre_eval_resv_gib = 0.0
             step_id = get_step_identifier(step, cfg.steps)
             logging.info(f"Eval policy at step {step}")
             with (
@@ -754,6 +760,32 @@ def train(cfg: TrainPipelineConfig):
             # This barrier is to ensure all processes finishes evaluation before the next training step
             # Some processes might be slower than others
             accelerator.wait_for_everyone()
+
+            if torch.cuda.is_available():
+                eval_hbm_probe = {
+                    "rank": accelerator.process_index,
+                    "pre_alloc": pre_eval_alloc_gib,
+                    "pre_resv": pre_eval_resv_gib,
+                    "peak_alloc": torch.cuda.max_memory_allocated() / 1024**3,
+                    "peak_resv": torch.cuda.max_memory_reserved() / 1024**3,
+                    "post_alloc": torch.cuda.memory_allocated() / 1024**3,
+                    "post_resv": torch.cuda.memory_reserved() / 1024**3,
+                }
+                gathered_eval_hbm = gather_object([eval_hbm_probe])
+                if accelerator.is_main_process:
+                    for s in sorted(gathered_eval_hbm, key=lambda x: x["rank"]):
+                        logging.info(
+                            "Eval HBM probe step=%d rank=%d pre=%.2f/%.2f peak=%.2f/%.2f post=%.2f/%.2f retained_alloc=%+.2f GiB",
+                            step,
+                            s["rank"],
+                            s["pre_alloc"],
+                            s["pre_resv"],
+                            s["peak_alloc"],
+                            s["peak_resv"],
+                            s["post_alloc"],
+                            s["post_resv"],
+                            s["post_alloc"] - s["pre_alloc"],
+                        )
 
     if cfg.eval_freq > 0 and eval_envs:
         close_envs(eval_envs)


### PR DESCRIPTION
## What this does

Adds a per-rank HBM probe around the LIBERO eval block in `src/opentau/scripts/train.py`:

- Just before the eval rollouts: snapshot `torch.cuda.memory_allocated()` / `memory_reserved()` and call `reset_peak_memory_stats()` so the peak counters cover only the eval window.
- Just after the post-eval `accelerator.wait_for_everyone()` barrier: gather `{pre, peak, post}` allocated/reserved per rank via `gather_object`, and emit one structured `logging.info` line per rank on rank 0 with the `post − pre` retained delta.

No-op when `eval_envs is None` (the existing eval gate) or when CUDA is unavailable.

## Motivation

We have empirical evidence from an 8-GPU ZeRO-2 training run that crashes correlate with the `eval_freq` step boundary:

- Two `CUDA OOM` failures in `accelerator.backward` ~3 training steps after LIBERO eval finishes (78.8 GiB used / 310 MiB free on rank 0, vs. the steady-state training peak of ~50 GiB for the same cam=4 ZeRO-2 sdpa+ckpt cell in #273's matrix).
- One NCCL `ALLGATHER` timeout where only one rank had enqueued the next collective post-eval — the other 7 were stuck in a non-collective code path. Consistent with asymmetric env teardown.

Both patterns are consistent with LIBERO sim envs / vectorized rollouts retaining CUDA buffers across the eval → training boundary, but we can't confirm without a measurement. This probe makes the retained-vs-peak distinction visible directly in the run log every `eval_freq` steps (~once every 24 min of wall-clock on the current config), so the next failure has actionable data attached.

## How it was tested

- `pre-commit run --files src/opentau/scripts/train.py` — all hooks pass (ruff, ruff-format, pyupgrade, typos, bandit, license-header, secret-scan).
- `pytest -m "not gpu" -n auto tests/scripts/` — 155 passed locally.

End-to-end verification needs a GPU node and is not covered by CI; on the next training launch with `eval_freq > 0` and `eval_envs` configured, the log will get one new line per rank per eval boundary in the form:

```
Eval HBM probe step=13000 rank=0 pre=50.21/50.78 peak=72.40/78.83 post=58.10/60.22 retained_alloc=+7.89 GiB
```

## Overhead

Negligible. `torch.cuda.memory_*` reads poll allocator bookkeeping (no kernel launch, no CUDA sync). `gather_object` of a ~50-byte dict across 8 ranks is sub-ms and is placed immediately after the existing `accelerator.wait_for_everyone()` so it doesn't add a sync point. Fires once per `eval_freq` training steps.

## How to checkout & try? (for the reviewer)

```bash
git fetch origin claude/awesome-booth-b2f762
git checkout claude/awesome-booth-b2f762
uv sync --extra dev --extra libero
```

CPU sanity:

```bash
pytest -m "not gpu" -n auto tests/scripts/
```

Inspect the new lines:

```bash
sed -n '700,795p' src/opentau/scripts/train.py
```

To exercise the probe end-to-end (needs a GPU + LIBERO env):

```bash
opentau-train \
    --accelerate-config configs/examples/accelerate_deepspeed_config.yaml \
    --config_path=configs/examples/pi05_training_config.json \
    --eval_freq=10 --steps=20
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.