### PR TITLE
feat(eval): configurable pi07 metadata on EnvConfig

### DIFF
--- a/src/opentau/envs/configs.py
+++ b/src/opentau/envs/configs.py
@@ -19,12 +19,77 @@ import abc
 import logging
 from copy import copy
 from dataclasses import dataclass, field
+from typing import Literal
 
 import draccus
 
 from opentau.configs.types import FeatureType, PolicyFeature
 from opentau.constants import ACTION, OBS_IMAGES, OBS_STATE
 from opentau.utils.accelerate_utils import get_proc_accelerator
+
+CONTROL_MODE_CHOICES = ("joint", "ee")
+
+
+@dataclass
+class EnvMetadataConfig:
+    """Optional pi07 metadata fields, broadcast across the rollout batch.
+
+    These describe properties of the environment / robot / demonstration
+    style that the pi07 prefix tokenizes as a ``"Metadata: ..."`` segment.
+    They live on the env config (not the eval config) because they're
+    properties of *what is being run*, not *how many episodes to run*.
+
+    Each field defaults to ``None`` — the corresponding batch key is omitted
+    and the policy's ``prepare_metadata`` pad path produces no segment in
+    the prefix. Set a value to inject it for every env in the rollout.
+    Allowed values mirror the training-time distribution emitted by
+    :meth:`BaseDataset._emit_optional_keys`.
+
+    Args:
+        speed: Positive integer multiple of 10 (matches the rounded
+            episode-length bucket used at training time), or ``None``.
+        quality: Integer in ``[1, 5]``, or ``None``.
+        mistake: ``True`` / ``False``, or ``None``.
+        robot_type: Non-empty robot identifier string (e.g. ``"UR5"``), or
+            ``None``.
+        control_mode: ``"joint"`` (joint-position control) or ``"ee"``
+            (end-effector control), or ``None``.
+    """
+
+    speed: int | None = None
+    quality: int | None = None
+    mistake: bool | None = None
+    robot_type: str | None = None
+    control_mode: Literal["joint", "ee"] | None = None
+
+    def __post_init__(self) -> None:
+        # `isinstance(x, bool)` guards exclude Python bools — `bool` is a
+        # subclass of `int`, so without them `speed=True` would silently
+        # pass the type check and fail later with a confusing value error.
+        if self.speed is not None:
+            if not isinstance(self.speed, int) or isinstance(self.speed, bool):
+                raise TypeError(f"env.metadata.speed must be int, got {type(self.speed).__name__}")
+            if self.speed <= 0 or self.speed % 10 != 0:
+                raise ValueError(f"env.metadata.speed must be a positive multiple of 10, got {self.speed}")
+        if self.quality is not None:
+            if not isinstance(self.quality, int) or isinstance(self.quality, bool):
+                raise TypeError(f"env.metadata.quality must be int, got {type(self.quality).__name__}")
+            if not 1 <= self.quality <= 5:
+                raise ValueError(f"env.metadata.quality must be in [1, 5], got {self.quality}")
+        if self.mistake is not None and not isinstance(self.mistake, bool):
+            raise TypeError(f"env.metadata.mistake must be bool, got {type(self.mistake).__name__}")
+        if self.robot_type is not None:
+            if not isinstance(self.robot_type, str):
+                raise TypeError(f"env.metadata.robot_type must be str, got {type(self.robot_type).__name__}")
+            if self.robot_type == "":
+                raise ValueError(
+                    "env.metadata.robot_type must be a non-empty string; use ``None`` to leave it missing."
+                )
+        if self.control_mode is not None and self.control_mode not in CONTROL_MODE_CHOICES:
+            raise ValueError(
+                f"env.metadata.control_mode must be one of {CONTROL_MODE_CHOICES} or None, "
+                f"got {self.control_mode!r}"
+            )
 
 
 @dataclass
@@ -43,6 +108,9 @@ class EnvConfig(draccus.ChoiceRegistry, abc.ABC):
             (e.g., mapping env observations into ``OBS_IMAGES`` / ``OBS_STATE``).
         max_parallel_tasks: Maximum number of tasks to run in parallel within the env.
         disable_env_checker: Whether to disable Gymnasium environment checking.
+        metadata: Optional pi07 metadata fields (speed/quality/mistake/
+            robot_type/control_mode) broadcast across the eval batch.
+            Defaults to all-``None`` (no metadata injected).
 
     """
 
@@ -54,6 +122,7 @@ class EnvConfig(draccus.ChoiceRegistry, abc.ABC):
     features_map: dict[str, str] = field(default_factory=dict)
     max_parallel_tasks: int = 1
     disable_env_checker: bool = True
+    metadata: EnvMetadataConfig = field(default_factory=EnvMetadataConfig)
 
     @property
     def type(self) -> str:

--- a/src/opentau/envs/configs.py
+++ b/src/opentau/envs/configs.py
@@ -19,7 +19,7 @@ import abc
 import logging
 from copy import copy
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Literal, get_args
 
 import draccus
 
@@ -27,7 +27,11 @@ from opentau.configs.types import FeatureType, PolicyFeature
 from opentau.constants import ACTION, OBS_IMAGES, OBS_STATE
 from opentau.utils.accelerate_utils import get_proc_accelerator
 
-CONTROL_MODE_CHOICES = ("joint", "ee")
+# Single source of truth for the ``control_mode`` enum: the type alias is
+# used in the dataclass annotation, the runtime tuple is derived from it
+# via ``get_args`` so the two can't drift if a new mode is ever added.
+ControlMode = Literal["joint", "ee"]
+CONTROL_MODE_CHOICES: tuple[str, ...] = get_args(ControlMode)
 # Training-side bucket size for ``speed_raw`` in seconds. Must stay in
 # lockstep with the divisor used by ``BaseDataset._emit_optional_keys``
 # (currently a literal ``10`` inside the ``round(duration_s / N) * N``
@@ -74,7 +78,7 @@ class EnvMetadataConfig:
     quality: int | None = None
     mistake: bool | None = None
     robot_type: str | None = None
-    control_mode: Literal["joint", "ee"] | None = None
+    control_mode: ControlMode | None = None
 
     def __post_init__(self) -> None:
         # `isinstance(x, bool)` guards exclude Python bools — `bool` is a

--- a/src/opentau/envs/configs.py
+++ b/src/opentau/envs/configs.py
@@ -28,6 +28,12 @@ from opentau.constants import ACTION, OBS_IMAGES, OBS_STATE
 from opentau.utils.accelerate_utils import get_proc_accelerator
 
 CONTROL_MODE_CHOICES = ("joint", "ee")
+# Training-side bucket size for ``speed_raw`` in seconds. Must stay in
+# lockstep with the divisor used by ``BaseDataset._emit_optional_keys``
+# (currently a literal ``10`` inside the ``round(duration_s / N) * N``
+# expression in ``src/opentau/datasets/lerobot_dataset.py``). Update both
+# call sites together if the bucket size ever changes.
+SPEED_BUCKET_SECONDS = 10
 
 
 @dataclass
@@ -45,11 +51,19 @@ class EnvMetadataConfig:
     Allowed values mirror the training-time distribution emitted by
     :meth:`BaseDataset._emit_optional_keys`.
 
+    Only the pi07 family of policies consumes these keys today; setting
+    them when evaluating another policy (e.g. pi0, pi05) will pass
+    validation but the values will be ignored downstream.
+
     Args:
-        speed: Positive integer multiple of 10 (matches the rounded
-            episode-length bucket used at training time), or ``None``.
+        speed: Positive integer multiple of ``SPEED_BUCKET_SECONDS`` (= 10
+            seconds; matches the rounded episode-duration bucket used at
+            training time), or ``None``.
         quality: Integer in ``[1, 5]``, or ``None``.
-        mistake: ``True`` / ``False``, or ``None``.
+        mistake: ``True`` / ``False``, or ``None``. Note that ``False`` is
+            semantically distinct from ``None``: ``False`` emits a
+            ``"Mistake: False"`` segment into the prefix, ``None`` omits
+            the segment entirely.
         robot_type: Non-empty robot identifier string (e.g. ``"UR5"``), or
             ``None``.
         control_mode: ``"joint"`` (joint-position control) or ``"ee"``
@@ -69,8 +83,11 @@ class EnvMetadataConfig:
         if self.speed is not None:
             if not isinstance(self.speed, int) or isinstance(self.speed, bool):
                 raise TypeError(f"env.metadata.speed must be int, got {type(self.speed).__name__}")
-            if self.speed <= 0 or self.speed % 10 != 0:
-                raise ValueError(f"env.metadata.speed must be a positive multiple of 10, got {self.speed}")
+            if self.speed <= 0 or self.speed % SPEED_BUCKET_SECONDS != 0:
+                raise ValueError(
+                    f"env.metadata.speed must be a positive multiple of "
+                    f"{SPEED_BUCKET_SECONDS}, got {self.speed}"
+                )
         if self.quality is not None:
             if not isinstance(self.quality, int) or isinstance(self.quality, bool):
                 raise TypeError(f"env.metadata.quality must be int, got {type(self.quality).__name__}")

--- a/src/opentau/envs/utils.py
+++ b/src/opentau/envs/utils.py
@@ -170,9 +170,10 @@ def add_eval_metadata(observation: dict[str, Any], cfg: TrainPipelineConfig) -> 
     (``torch.long`` for ``speed`` / ``quality``, ``torch.bool`` for
     ``mistake``). String fields (``robot_type`` / ``control_mode``) are
     broadcast as ``list[str]`` of length ``num_envs``. Fields set to
-    ``None`` on the config — or a missing ``cfg.env`` entirely — are
-    skipped, so the corresponding batch key stays absent and the policy's
-    ``prepare_metadata`` pad default kicks in.
+    ``None`` on the config are skipped, so the corresponding batch key
+    stays absent and the policy's ``prepare_metadata`` pad default kicks
+    in. ``cfg.env`` is guaranteed non-``None`` here — ``eval_policy``
+    dereferences ``cfg.env.type`` before the rollout loop starts.
 
     Args:
         observation: Observation dict produced by ``preprocess_observation``
@@ -182,9 +183,6 @@ def add_eval_metadata(observation: dict[str, Any], cfg: TrainPipelineConfig) -> 
     Returns:
         The observation dict, mutated in place.
     """
-    if cfg.env is None:
-        return observation
-
     meta = cfg.env.metadata
     state = observation["state"]
     batch_size = state.shape[0]

--- a/src/opentau/envs/utils.py
+++ b/src/opentau/envs/utils.py
@@ -161,6 +161,53 @@ def add_envs_task(env: gym.vector.VectorEnv, observation: dict[str, Any]) -> dic
     return observation
 
 
+def add_eval_metadata(observation: dict[str, Any], cfg: TrainPipelineConfig) -> dict[str, Any]:
+    r"""Inject pi07 inference-time metadata from ``cfg.env.metadata``.
+
+    Numeric fields (``speed`` / ``quality`` / ``mistake``) are broadcast as
+    ``(num_envs,)`` tensors with a parallel ``{key}_is_pad=False`` flag,
+    using the same dtypes the dataset emits at training time
+    (``torch.long`` for ``speed`` / ``quality``, ``torch.bool`` for
+    ``mistake``). String fields (``robot_type`` / ``control_mode``) are
+    broadcast as ``list[str]`` of length ``num_envs``. Fields set to
+    ``None`` on the config — or a missing ``cfg.env`` entirely — are
+    skipped, so the corresponding batch key stays absent and the policy's
+    ``prepare_metadata`` pad default kicks in.
+
+    Args:
+        observation: Observation dict produced by ``preprocess_observation``
+            (must contain ``state`` to source the batch size and device).
+        cfg: Training/eval pipeline config; reads ``cfg.env.metadata``.
+
+    Returns:
+        The observation dict, mutated in place.
+    """
+    if cfg.env is None:
+        return observation
+
+    meta = cfg.env.metadata
+    state = observation["state"]
+    batch_size = state.shape[0]
+    device = state.device
+
+    for key, dtype in (
+        ("speed", torch.long),
+        ("quality", torch.long),
+        ("mistake", torch.bool),
+    ):
+        val = getattr(meta, key)
+        if val is not None:
+            observation[key] = torch.tensor([val] * batch_size, dtype=dtype, device=device)
+            observation[f"{key}_is_pad"] = torch.zeros(batch_size, dtype=torch.bool, device=device)
+
+    for key in ("robot_type", "control_mode"):
+        val = getattr(meta, key)
+        if val is not None:
+            observation[key] = [val] * batch_size
+
+    return observation
+
+
 def _close_single_env(env: Any) -> None:
     try:
         env.close()

--- a/src/opentau/scripts/eval.py
+++ b/src/opentau/scripts/eval.py
@@ -52,6 +52,7 @@ from opentau.configs.train import TrainPipelineConfig
 from opentau.envs.factory import make_envs
 from opentau.envs.utils import (
     add_envs_task,
+    add_eval_metadata,
     check_env_attributes_and_types,
     close_envs,
     preprocess_observation,
@@ -144,6 +145,7 @@ def rollout(
         # Infer "task" from attributes of environments.
         # TODO: works with SyncVectorEnv but not AsyncVectorEnv
         observation = add_envs_task(env, observation)
+        observation = add_eval_metadata(observation, cfg=cfg)
 
         if return_observations:
             all_observations.append(deepcopy(observation))
@@ -188,6 +190,7 @@ def rollout(
     if return_observations:
         observation = preprocess_observation(observation, cfg=cfg)
         observation = add_envs_task(env, observation)
+        observation = add_eval_metadata(observation, cfg=cfg)
         all_observations.append(deepcopy(observation))
 
     # Stack the sequence along the first dimension so that we have (batch, sequence, *) tensors.

--- a/tests/envs/test_configs.py
+++ b/tests/envs/test_configs.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass
 import pytest
 
 from opentau.configs.types import FeatureType, PolicyFeature
-from opentau.envs.configs import EnvConfig
+from opentau.envs.configs import EnvConfig, EnvMetadataConfig
 
 
 class TestEnvConfig:
@@ -172,3 +172,89 @@ class TestEnvConfigRegistry:
         # Should be able to get all registered choices
         for choice in choices:
             assert choice in EnvConfig._choice_registry
+
+
+class TestEnvMetadataConfig:
+    """Pin the validation contract for the optional pi07 metadata fields
+    attached to ``EnvConfig.metadata``. The defaults (all ``None``) must
+    stay frozen because eval rollouts that don't set them rely on the
+    policy's ``prepare_metadata`` pad path for backwards compatibility.
+    """
+
+    def test_all_none_default_passes(self):
+        cfg = EnvMetadataConfig()
+        assert cfg.speed is None
+        assert cfg.quality is None
+        assert cfg.mistake is None
+        assert cfg.robot_type is None
+        assert cfg.control_mode is None
+
+    @pytest.mark.parametrize("mode", ["joint", "ee"])
+    @pytest.mark.parametrize("speed", [10, 50, 100, 1000])
+    def test_valid_values_pass(self, mode, speed):
+        EnvMetadataConfig(
+            speed=speed,
+            quality=3,
+            mistake=False,
+            robot_type="UR5",
+            control_mode=mode,
+        )
+
+    @pytest.mark.parametrize("bad_speed", [-10, 0, 1, 5, 9, 11, 15, 1001])
+    def test_speed_must_be_positive_multiple_of_10(self, bad_speed):
+        with pytest.raises(ValueError, match=r"speed must be a positive multiple of 10"):
+            EnvMetadataConfig(speed=bad_speed)
+
+    def test_speed_rejects_bool(self):
+        with pytest.raises(TypeError, match=r"speed must be int"):
+            EnvMetadataConfig(speed=True)
+
+    def test_speed_rejects_float(self):
+        with pytest.raises(TypeError, match=r"speed must be int"):
+            EnvMetadataConfig(speed=500.0)
+
+    @pytest.mark.parametrize("bad_quality", [0, 6, -1, 100])
+    def test_quality_out_of_range(self, bad_quality):
+        with pytest.raises(ValueError, match=r"quality must be in \[1, 5\]"):
+            EnvMetadataConfig(quality=bad_quality)
+
+    def test_quality_rejects_bool(self):
+        with pytest.raises(TypeError, match=r"quality must be int"):
+            EnvMetadataConfig(quality=True)
+
+    def test_mistake_rejects_non_bool(self):
+        with pytest.raises(TypeError, match=r"mistake must be bool"):
+            EnvMetadataConfig(mistake=1)
+
+    def test_robot_type_rejects_empty(self):
+        with pytest.raises(ValueError, match=r"robot_type must be a non-empty string"):
+            EnvMetadataConfig(robot_type="")
+
+    def test_robot_type_rejects_non_str(self):
+        with pytest.raises(TypeError, match=r"robot_type must be str"):
+            EnvMetadataConfig(robot_type=42)
+
+    @pytest.mark.parametrize("bad_mode", ["joint_position", "EE", "Joint", "cartesian", ""])
+    def test_control_mode_must_be_joint_or_ee(self, bad_mode):
+        with pytest.raises(ValueError, match=r"control_mode must be one of"):
+            EnvMetadataConfig(control_mode=bad_mode)
+
+
+class TestEnvConfigMetadataField:
+    """Verify the ``metadata`` field is wired onto every concrete
+    ``EnvConfig`` subclass via the abstract base, with the all-``None``
+    default that preserves prior eval behavior.
+    """
+
+    def test_concrete_subclass_has_metadata_default(self):
+        @EnvConfig.register_subclass("test_env_metadata_default")
+        @dataclass
+        class TestEnvConfigWithMetadata(EnvConfig):
+            @property
+            def gym_kwargs(self) -> dict:
+                return {}
+
+        config = TestEnvConfigWithMetadata()
+        assert isinstance(config.metadata, EnvMetadataConfig)
+        assert config.metadata.speed is None
+        assert config.metadata.control_mode is None

--- a/tests/envs/test_utils.py
+++ b/tests/envs/test_utils.py
@@ -15,11 +15,18 @@
 # limitations under the License.
 
 import warnings
+from types import SimpleNamespace
 
 import gymnasium as gym
 import pytest
+import torch
 
-from opentau.envs.utils import are_all_envs_same_type, check_env_attributes_and_types
+from opentau.envs.configs import EnvMetadataConfig
+from opentau.envs.utils import (
+    add_eval_metadata,
+    are_all_envs_same_type,
+    check_env_attributes_and_types,
+)
 
 
 def make_type1_env():
@@ -190,3 +197,119 @@ class TestCheckEnvAttributesAndTypes:
 
             # Should not issue warning about missing attributes
             assert len(w) == 0
+
+
+def _make_obs(batch_size: int = 2, device: str = "cpu") -> dict:
+    """Minimal observation dict mirroring what ``preprocess_observation`` emits.
+
+    ``add_eval_metadata`` only reads ``observation["state"]`` (for batch size
+    and device), so anything richer would be dead weight.
+    """
+    return {"state": torch.zeros(batch_size, 8, device=device, dtype=torch.float32)}
+
+
+def _make_cfg(**metadata_kwargs) -> SimpleNamespace:
+    """Build a duck-typed ``cfg`` exposing only ``cfg.env.metadata``.
+
+    Avoids constructing a full ``TrainPipelineConfig`` (which pulls in
+    optimizer/dataset/policy validation) just to read five attributes.
+    """
+    return SimpleNamespace(env=SimpleNamespace(metadata=EnvMetadataConfig(**metadata_kwargs)))
+
+
+class TestAddEvalMetadata:
+    """Pin the contract between the rollout-time helper and the policy's
+    ``prepare_metadata`` reader. The dtypes, shapes, and missing-key skip
+    behaviour below are what ``prepare_metadata`` relies on — drift here
+    silently changes the prefix the model sees at eval.
+    """
+
+    def test_all_none_default_skips_every_key(self):
+        obs = _make_obs()
+        original_keys = set(obs.keys())
+        out = add_eval_metadata(obs, cfg=_make_cfg())
+        assert out is obs  # mutated-in-place contract
+        assert set(out.keys()) == original_keys, (
+            "no metadata keys should be injected when every field is None"
+        )
+
+    @pytest.mark.parametrize("batch_size", [1, 4])
+    def test_speed_injects_long_tensor_with_pad_flag(self, batch_size):
+        obs = _make_obs(batch_size=batch_size)
+        add_eval_metadata(obs, cfg=_make_cfg(speed=20))
+
+        assert obs["speed"].dtype == torch.long
+        assert obs["speed"].shape == (batch_size,)
+        assert torch.equal(obs["speed"], torch.full((batch_size,), 20, dtype=torch.long))
+
+        assert obs["speed_is_pad"].dtype == torch.bool
+        assert obs["speed_is_pad"].shape == (batch_size,)
+        assert not obs["speed_is_pad"].any()
+
+    def test_quality_injects_long_tensor_with_pad_flag(self):
+        obs = _make_obs(batch_size=3)
+        add_eval_metadata(obs, cfg=_make_cfg(quality=4))
+
+        assert obs["quality"].dtype == torch.long
+        assert torch.equal(obs["quality"], torch.full((3,), 4, dtype=torch.long))
+        assert obs["quality_is_pad"].dtype == torch.bool
+        assert not obs["quality_is_pad"].any()
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test_mistake_injects_bool_tensor_with_pad_flag(self, value):
+        obs = _make_obs(batch_size=2)
+        add_eval_metadata(obs, cfg=_make_cfg(mistake=value))
+
+        assert obs["mistake"].dtype == torch.bool
+        assert obs["mistake"].shape == (2,)
+        assert torch.equal(obs["mistake"], torch.full((2,), value, dtype=torch.bool))
+        assert obs["mistake_is_pad"].dtype == torch.bool
+        assert not obs["mistake_is_pad"].any()
+
+    def test_mistake_false_vs_none_differ(self):
+        """``mistake=False`` injects a key; ``mistake=None`` (default) does not.
+
+        This is the foot-gun called out in code review: ``False`` is *not*
+        "no mistake info available" — that's ``None``.
+        """
+        obs_false = _make_obs()
+        add_eval_metadata(obs_false, cfg=_make_cfg(mistake=False))
+        assert "mistake" in obs_false
+        assert "mistake_is_pad" in obs_false
+
+        obs_none = _make_obs()
+        add_eval_metadata(obs_none, cfg=_make_cfg(mistake=None))
+        assert "mistake" not in obs_none
+        assert "mistake_is_pad" not in obs_none
+
+    @pytest.mark.parametrize("key,value", [("robot_type", "UR5"), ("control_mode", "ee")])
+    def test_string_fields_broadcast_as_list(self, key, value):
+        obs = _make_obs(batch_size=3)
+        add_eval_metadata(obs, cfg=_make_cfg(**{key: value}))
+
+        assert obs[key] == [value, value, value]
+        assert f"{key}_is_pad" not in obs, "string fields use empty-string as pad signal, not a flag"
+
+    def test_partial_fields_only_inject_specified_keys(self):
+        obs = _make_obs()
+        add_eval_metadata(obs, cfg=_make_cfg(speed=30, robot_type="UR5"))
+
+        assert "speed" in obs and "speed_is_pad" in obs
+        assert "robot_type" in obs
+        for absent in ("quality", "quality_is_pad", "mistake", "mistake_is_pad", "control_mode"):
+            assert absent not in obs, f"unset field {absent} should not be injected"
+
+    def test_device_propagation(self):
+        """Newly-injected tensors must live on the same device as ``state``.
+
+        Using "meta" device makes this CPU-host portable (no real CUDA
+        required) while still exercising the device-routing branch in the
+        helper.
+        """
+        obs = _make_obs(batch_size=2, device="meta")
+        add_eval_metadata(obs, cfg=_make_cfg(speed=20, mistake=True))
+
+        assert obs["speed"].device.type == "meta"
+        assert obs["speed_is_pad"].device.type == "meta"
+        assert obs["mistake"].device.type == "meta"
+        assert obs["mistake_is_pad"].device.type == "meta"


### PR DESCRIPTION
## What this does

Adds an `EnvMetadataConfig` dataclass attached to every `EnvConfig` subclass via the abstract base (CLI: `--env.metadata.*`), so the optional pi07 inference-time metadata fields — `speed`, `quality`, `mistake`, `robot_type`, `control_mode` — become configurable per eval run instead of always defaulting to "missing" / pad.

When a field is `None` (the default for every field), the corresponding batch key is omitted and the policy's `prepare_metadata` pad path produces no segment in the prefix → existing eval rollouts are byte-identical. When a field is set, the value is broadcast across the rollout batch with the dataset-matching dtype (`torch.long` for `speed`/`quality`, `torch.bool` for `mistake`, `list[str]` for `robot_type`/`control_mode`) and a parallel `{key}_is_pad=False` flag where applicable.

Note: `mistake=False` is semantically distinct from `mistake=None`. `False` emits a `Mistake: False` segment into the prefix; `None` omits the segment entirely.

Validation pinned in `EnvMetadataConfig.__post_init__`:
- `speed`: positive int, multiple of `SPEED_BUCKET_SECONDS` (= 10 seconds) — matches #295's training-side bucket (duration-seconds rounded to 10 s). Constant exposed so the divisor only lives in one place on the eval side.
- `quality`: int in `[1, 5]`.
- `mistake`: bool.
- `robot_type`: non-empty string.
- `control_mode`: `Literal["joint", "ee"]`.

Only the pi07 family of policies consumes these keys today — setting them against a vanilla pi0 / pi05 eval will pass validation but the values get ignored downstream.

CLI usage:

```bash
opentau-eval --config_path=... \
    --env.metadata.speed=20 \
    --env.metadata.quality=3 \
    --env.metadata.mistake=false \
    --env.metadata.robot_type=UR5 \
    --env.metadata.control_mode=ee
```

`response` and `subgoal*` stay absent for now (the policy's same pad-default mechanism handles them, and there's no eval-time source for them yet). The gRPC inference server is out of scope — wiring these fields to deployment would need new proto fields in `robot_inference.proto` and matching unpacking in `server.py::_prepare_observation`.

The injection point is a new helper `add_eval_metadata(observation, cfg)` in `envs/utils.py`, called in the rollout loop in `scripts/eval.py` right after `add_envs_task`. The helper trusts `cfg.env` non-`None` because `eval_policy` dereferences `cfg.env.type` before the rollout loop ever runs.

Refs #295 — the training-side `speed_raw` is being switched to a 10-second duration bucket; this PR keeps the eval-side validator in lockstep so a sweep like `--env.metadata.speed=20` lines up with values the model actually saw in training.

## How it was tested

- `pre-commit run --files src/opentau/envs/configs.py src/opentau/envs/utils.py src/opentau/scripts/eval.py tests/envs/test_configs.py tests/envs/test_utils.py` — all hooks pass (ruff lint+format, pyupgrade, bandit, typos, gitleaks, etc.).
- `pytest -m "not gpu" -n auto tests/configs tests/envs/test_utils.py tests/envs/test_configs.py tests/scripts` — 315 passed, 0 failed. Coverage spans:
  - **Config validator** (`tests/envs/test_configs.py::TestEnvMetadataConfig` + `::TestEnvConfigMetadataField`, 37 cases) — valid values, invalid `speed` / `quality` / `mistake` / `robot_type` / `control_mode`, the `Literal["joint", "ee"]` constraint, the all-`None` default field on a fresh `EnvConfig` subclass.
  - **Injection helper** (`tests/envs/test_utils.py::TestAddEvalMetadata`, 9 cases parametrised to 14 runs) — dtype/shape per field, mutated-in-place return contract, the `False` vs `None` semantic on `mistake`, partial-fields skip path, list-of-strings broadcast for string fields, device propagation (via `device="meta"` so the CPU suite still exercises the routing branch).
- Pre-existing failures in `tests/envs/test_factory.py` and `tests/utils/test_libero_utils.py` under the full `pytest -m "not gpu"` run are unrelated — they're LIBERO config bootstrap issues (interactive `input()` from `libero.libero.__init__` when `~/.libero/config.yaml` is missing and `LIBERO_CONFIG_PATH` is unset). CI sets `LIBERO_CONFIG_PATH=.github/assets/libero` in `cpu_test.yml`, so they pass there.

## How to checkout & try? (for the reviewer)

```bash
gh pr checkout 296
uv sync --extra dev
pytest -sx tests/envs/test_configs.py::TestEnvMetadataConfig \
           tests/envs/test_configs.py::TestEnvConfigMetadataField \
           tests/envs/test_utils.py::TestAddEvalMetadata
```

End-to-end sanity that the new keys reach the policy at eval time (drop a `print(metadata[0])` inside `prepare_metadata` at the `f"Metadata: {' '.join(segments)}"` line, then run the LIBERO smoke):

```bash
opentau-eval --config_path=configs/dev/dev_config.json \
    --env.metadata.speed=20 \
    --env.metadata.robot_type=UR5 \
    --env.metadata.control_mode=ee
# Expect the prefix to include the substrings "Speed: 20", "Robot: UR5",
# and "Control: ee" (the actual format ends up with doubled spaces between
# segments because prepare_metadata does " ".join() on segments that already
# end with ", " — not relevant to this PR, just don't grep for one literal).
```

Also confirm the no-op default — same command without any `--env.metadata.*` overrides should print an empty metadata string (the policy's pad path).

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).