### PR TITLE
fix(metrics): only report L1/Accuracy when policy returns them

### DIFF
--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -108,14 +108,23 @@ def update_policy(
     # This calls `torch.distributed.all_gather_into_tensor` under the hood, which is not so efficient.
     # We don't actually want to broadcast the gathered tensors to all processes, but only to the main process.
     # Nonetheless, we still do this for correctness, safety, and simplicity.
-    _first_loss_tensor = next(lt for lt in losses.values() if isinstance(lt, torch.Tensor))
-    zero = torch.tensor(0.0, device=_first_loss_tensor.device, dtype=_first_loss_tensor.dtype)
+    # ``L1`` and ``Accuracy`` are optional — only the value head currently returns
+    # them; the VLA policies (pi0/pi05/pi06/pi07) return only ``MSE`` and ``CE``.
+    # Gating the gather on ``key in losses`` keeps the collective count aligned
+    # across ranks because the keys returned by ``forward`` are determined by
+    # the policy class, which is identical on every rank.
     loss = accelerator.gather_for_metrics(loss).mean().item()
     mse_loss = accelerator.gather_for_metrics(losses["MSE"]).to(dtype=torch.float32).mean().item()
     ce_loss = accelerator.gather_for_metrics(losses["CE"]).to(dtype=torch.float32).mean().item()
-    l1_loss = accelerator.gather_for_metrics(losses.get("L1", zero)).to(dtype=torch.float32).mean().item()
+    l1_loss = (
+        accelerator.gather_for_metrics(losses["L1"]).to(dtype=torch.float32).mean().item()
+        if "L1" in losses
+        else None
+    )
     accuracy = (
-        accelerator.gather_for_metrics(losses.get("Accuracy", zero)).to(dtype=torch.float32).mean().item()
+        accelerator.gather_for_metrics(losses["Accuracy"]).to(dtype=torch.float32).mean().item()
+        if "Accuracy" in losses
+        else None
     )
     # This actually calls `.update` method of the `AverageMeter` class. This operation is not idempotent.
     # See MetricsTracker.__setattr__ for more details.
@@ -125,20 +134,22 @@ def update_policy(
         train_metrics.loss = loss
         train_metrics.mse_loss = mse_loss
         train_metrics.ce_loss = ce_loss
-        train_metrics.l1_loss = l1_loss
-        train_metrics.accuracy = accuracy
+        if l1_loss is not None:
+            if "l1_loss" not in train_metrics.metrics:
+                train_metrics.metrics["l1_loss"] = AverageMeter("l1_loss", ":.6f")
+            train_metrics.l1_loss = l1_loss
+        if accuracy is not None:
+            if "accuracy" not in train_metrics.metrics:
+                train_metrics.metrics["accuracy"] = AverageMeter("accuracy", ":.3f")
+            train_metrics.accuracy = accuracy
         train_metrics.lr = optimizer.param_groups[0]["lr"]
 
     return train_metrics
 
 
-_VAL_METRIC_KEYS: tuple[str, ...] = ("loss", "mse_loss", "ce_loss", "l1_loss", "accuracy")
-
-
 def _mixture_weighted_aggregate(
     per_dataset_trackers: dict[str, MetricsTracker],
     name_to_weight: dict[str, float],
-    metric_keys: tuple[str, ...] = _VAL_METRIC_KEYS,
 ) -> dict[str, float]:
     """Mixture-weighted average of per-dataset validation metrics.
 
@@ -149,17 +160,27 @@ def _mixture_weighted_aggregate(
     -- empty trackers, or all selected datasets have weight 0 -- every metric
     is returned as ``0.0``.
 
+    The aggregated metric keys are derived from the first tracker's meters.
+    All per-dataset trackers share the same meter set because they're all
+    populated by the same policy's ``forward`` (which deterministically
+    returns the same loss keys for every batch and every rank), so any
+    tracker's keys are representative.
+
     Args:
         per_dataset_trackers: One ``MetricsTracker`` per non-empty validation
             dataset, keyed by dataset name.
         name_to_weight: Mapping from dataset name to its mixture weight (need
             not be normalized; need not be a strict subset/superset of the
             tracker keys, but must contain every tracker key).
-        metric_keys: The metric attribute names to aggregate.
 
     Returns:
-        Dict mapping each ``metric_keys`` entry to its weighted average.
+        Dict mapping each metric name found on the trackers to its weighted
+        average. Empty when ``per_dataset_trackers`` is empty.
     """
+    if not per_dataset_trackers:
+        return {}
+    metric_keys = tuple(next(iter(per_dataset_trackers.values())).metrics.keys())
+
     weights = {name: name_to_weight[name] for name in per_dataset_trackers}
     total = sum(weights.values())
     if total <= 0:
@@ -520,13 +541,15 @@ def train(cfg: TrainPipelineConfig):
 
     policy.train()
 
-    # setup metrics tracker to average metrics over the logging interval
+    # setup metrics tracker to average metrics over the logging interval.
+    # ``l1_loss`` and ``accuracy`` are populated lazily in ``update_policy``
+    # iff the policy's ``forward`` returns ``"L1"`` / ``"Accuracy"`` (only the
+    # value head currently does); omitting them here keeps logs clean for VLA
+    # policies that don't emit those losses.
     train_metrics = {
         "loss": AverageMeter("total_loss", ":.6f"),
         "mse_loss": AverageMeter("mse_loss", ":.6f"),
         "ce_loss": AverageMeter("ce_loss", ":.6f"),
-        "l1_loss": AverageMeter("l1_loss", ":.6f"),
-        "accuracy": AverageMeter("accuracy", ":.3f"),
         "lr": AverageMeter("lr", ":0.1e"),
         "grad_norm": AverageMeter("grad_norm", ":.3f"),
     }
@@ -573,8 +596,10 @@ def train(cfg: TrainPipelineConfig):
             accelerator.log({"Training/Loss": log_dict["loss"]}, step=step)
             accelerator.log({"Training/MSE Loss": log_dict["mse_loss"]}, step=step)
             accelerator.log({"Training/CE Loss": log_dict["ce_loss"]}, step=step)
-            accelerator.log({"Training/L1 Loss": log_dict["l1_loss"]}, step=step)
-            accelerator.log({"Training/Accuracy": log_dict["accuracy"]}, step=step)
+            if "l1_loss" in train_tracker.metrics:
+                accelerator.log({"Training/L1 Loss": log_dict["l1_loss"]}, step=step)
+            if "accuracy" in train_tracker.metrics:
+                accelerator.log({"Training/Accuracy": log_dict["accuracy"]}, step=step)
             accelerator.log({"Training/Learning Rate": log_dict["lr"]}, step=step)
             accelerator.log({"Training/Grad Norm": log_dict["grad_norm"]}, step=step)
             accelerator.log({"Training/Num Samples": log_dict["samples"]}, step=step)
@@ -603,14 +628,15 @@ def train(cfg: TrainPipelineConfig):
             policy.eval()
 
             def _make_val_tracker(current_step: int = step) -> MetricsTracker:
+                # ``l1_loss`` and ``accuracy`` are populated lazily below iff the
+                # policy's ``forward`` returns ``"L1"`` / ``"Accuracy"``. See
+                # ``update_policy`` for the symmetric training-side pattern.
                 return MetricsTracker(
                     cfg.batch_size * accelerator.num_processes,
                     {
                         "loss": AverageMeter("val_total_loss", ":.6f"),
                         "mse_loss": AverageMeter("val_mse_loss", ":.6f"),
                         "ce_loss": AverageMeter("val_ce_loss", ":.6f"),
-                        "l1_loss": AverageMeter("val_l1_loss", ":.6f"),
-                        "accuracy": AverageMeter("val_accuracy", ":.3f"),
                     },
                     initial_step=current_step,
                 )
@@ -631,14 +657,9 @@ def train(cfg: TrainPipelineConfig):
                             + cfg.loss_weighting["CE"] * losses["CE"]
                         )
 
-                        # Gather and average metrics across processes
-                        _first_loss_tensor = next(
-                            lt for lt in losses.values() if isinstance(lt, torch.Tensor)
-                        )
-                        zero = torch.tensor(
-                            0.0, device=_first_loss_tensor.device, dtype=_first_loss_tensor.dtype
-                        )
-
+                        # Gather and average metrics across processes. ``L1`` /
+                        # ``Accuracy`` are optional — see ``update_policy`` for
+                        # the symmetric training-side gating rationale.
                         loss = accelerator.gather_for_metrics(loss).mean().item()
                         mse_loss = (
                             accelerator.gather_for_metrics(losses["MSE"])
@@ -650,24 +671,31 @@ def train(cfg: TrainPipelineConfig):
                             accelerator.gather_for_metrics(losses["CE"]).to(dtype=torch.float32).mean().item()
                         )
                         l1_loss = (
-                            accelerator.gather_for_metrics(losses.get("L1", zero))
-                            .to(dtype=torch.float32)
-                            .mean()
-                            .item()
+                            accelerator.gather_for_metrics(losses["L1"]).to(dtype=torch.float32).mean().item()
+                            if "L1" in losses
+                            else None
                         )
                         accuracy = (
-                            accelerator.gather_for_metrics(losses.get("Accuracy", zero))
+                            accelerator.gather_for_metrics(losses["Accuracy"])
                             .to(dtype=torch.float32)
                             .mean()
                             .item()
+                            if "Accuracy" in losses
+                            else None
                         )
 
                         if accelerator.is_main_process:
                             ds_tracker.loss = loss
                             ds_tracker.mse_loss = mse_loss
                             ds_tracker.ce_loss = ce_loss
-                            ds_tracker.l1_loss = l1_loss
-                            ds_tracker.accuracy = accuracy
+                            if l1_loss is not None:
+                                if "l1_loss" not in ds_tracker.metrics:
+                                    ds_tracker.metrics["l1_loss"] = AverageMeter("val_l1_loss", ":.6f")
+                                ds_tracker.l1_loss = l1_loss
+                            if accuracy is not None:
+                                if "accuracy" not in ds_tracker.metrics:
+                                    ds_tracker.metrics["accuracy"] = AverageMeter("val_accuracy", ":.3f")
+                                ds_tracker.accuracy = accuracy
 
             if accelerator.is_main_process:
                 for ds_name, ds_tracker in per_dataset_trackers.items():
@@ -676,8 +704,10 @@ def train(cfg: TrainPipelineConfig):
                     accelerator.log({f"Validation/{ds_name}/Loss": ds_dict["loss"]}, step=step)
                     accelerator.log({f"Validation/{ds_name}/MSE Loss": ds_dict["mse_loss"]}, step=step)
                     accelerator.log({f"Validation/{ds_name}/CE Loss": ds_dict["ce_loss"]}, step=step)
-                    accelerator.log({f"Validation/{ds_name}/L1 Loss": ds_dict["l1_loss"]}, step=step)
-                    accelerator.log({f"Validation/{ds_name}/Accuracy": ds_dict["accuracy"]}, step=step)
+                    if "l1_loss" in ds_tracker.metrics:
+                        accelerator.log({f"Validation/{ds_name}/L1 Loss": ds_dict["l1_loss"]}, step=step)
+                    if "accuracy" in ds_tracker.metrics:
+                        accelerator.log({f"Validation/{ds_name}/Accuracy": ds_dict["accuracy"]}, step=step)
 
                 # Mixture-weighted aggregate across the per-dataset trackers, so the
                 # overall scalar reflects the training mixture rather than being
@@ -690,8 +720,10 @@ def train(cfg: TrainPipelineConfig):
                 accelerator.log({"Validation/Loss": agg["loss"]}, step=step)
                 accelerator.log({"Validation/MSE Loss": agg["mse_loss"]}, step=step)
                 accelerator.log({"Validation/CE Loss": agg["ce_loss"]}, step=step)
-                accelerator.log({"Validation/L1 Loss": agg["l1_loss"]}, step=step)
-                accelerator.log({"Validation/Accuracy": agg["accuracy"]}, step=step)
+                if "l1_loss" in agg:
+                    accelerator.log({"Validation/L1 Loss": agg["l1_loss"]}, step=step)
+                if "accuracy" in agg:
+                    accelerator.log({"Validation/Accuracy": agg["accuracy"]}, step=step)
 
             # This barrier is probably necessary to ensure
             # other processes wait for the main process to finish saving

--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -134,17 +134,49 @@ def update_policy(
         train_metrics.loss = loss
         train_metrics.mse_loss = mse_loss
         train_metrics.ce_loss = ce_loss
-        if l1_loss is not None:
-            if "l1_loss" not in train_metrics.metrics:
-                train_metrics.metrics["l1_loss"] = AverageMeter("l1_loss", ":.6f")
-            train_metrics.l1_loss = l1_loss
-        if accuracy is not None:
-            if "accuracy" not in train_metrics.metrics:
-                train_metrics.metrics["accuracy"] = AverageMeter("accuracy", ":.3f")
-            train_metrics.accuracy = accuracy
+        _observe_optional(train_metrics, "l1_loss", "l1_loss", ":.6f", l1_loss)
+        _observe_optional(train_metrics, "accuracy", "accuracy", ":.3f", accuracy)
         train_metrics.lr = optimizer.param_groups[0]["lr"]
 
     return train_metrics
+
+
+def _observe_optional(
+    tracker: MetricsTracker,
+    key: str,
+    display_name: str,
+    fmt: str,
+    value: float | None,
+) -> None:
+    """Lazily allocate-and-update an optional ``AverageMeter`` on ``tracker``.
+
+    Centralizes the lazy-allocation pattern used for optional loss metrics
+    (currently ``l1_loss`` and ``accuracy``) that only some policies — e.g.
+    the value head — emit. Allocating the meter on first observation rather
+    than at tracker construction keeps the Python log line and the wandb
+    dashboard clean for policies that never produce the metric.
+
+    Callers must already be on the main process: this function mutates
+    ``tracker.metrics`` and that mutation should not be performed on
+    non-main ranks (mirroring the surrounding ``if accelerator.is_main_process:``
+    guards on regular metric assignments).
+
+    Args:
+        tracker: The ``MetricsTracker`` to update.
+        key: The metric attribute name (used both as the ``metrics`` dict key
+            and as the attribute on ``tracker``).
+        display_name: Display name passed to the ``AverageMeter`` constructor
+            when first allocating it (e.g. ``"l1_loss"`` for train,
+            ``"val_l1_loss"`` for validation).
+        fmt: Format string passed to the ``AverageMeter`` constructor.
+        value: Value to record; if ``None`` (the metric was absent from this
+            batch's ``losses``) the function is a no-op.
+    """
+    if value is None:
+        return
+    if key not in tracker.metrics:
+        tracker.metrics[key] = AverageMeter(display_name, fmt)
+    setattr(tracker, key, value)
 
 
 def _mixture_weighted_aggregate(
@@ -688,14 +720,8 @@ def train(cfg: TrainPipelineConfig):
                             ds_tracker.loss = loss
                             ds_tracker.mse_loss = mse_loss
                             ds_tracker.ce_loss = ce_loss
-                            if l1_loss is not None:
-                                if "l1_loss" not in ds_tracker.metrics:
-                                    ds_tracker.metrics["l1_loss"] = AverageMeter("val_l1_loss", ":.6f")
-                                ds_tracker.l1_loss = l1_loss
-                            if accuracy is not None:
-                                if "accuracy" not in ds_tracker.metrics:
-                                    ds_tracker.metrics["accuracy"] = AverageMeter("val_accuracy", ":.3f")
-                                ds_tracker.accuracy = accuracy
+                            _observe_optional(ds_tracker, "l1_loss", "val_l1_loss", ":.6f", l1_loss)
+                            _observe_optional(ds_tracker, "accuracy", "val_accuracy", ":.3f", accuracy)
 
             if accelerator.is_main_process:
                 for ds_name, ds_tracker in per_dataset_trackers.items():

--- a/tests/scripts/test_train.py
+++ b/tests/scripts/test_train.py
@@ -214,9 +214,13 @@ class TestMixtureWeightedAggregate:
         assert agg["l1_loss"] == pytest.approx(0.25 * 4.0 + 0.75 * 8.0)
         assert agg["accuracy"] == pytest.approx(0.25 * 0.1 + 0.75 * 0.5)
 
-    def test_empty_trackers_returns_zeros(self):
-        agg = _mixture_weighted_aggregate({}, {})
-        assert agg == {"loss": 0.0, "mse_loss": 0.0, "ce_loss": 0.0, "l1_loss": 0.0, "accuracy": 0.0}
+    def test_empty_trackers_returns_empty_dict(self):
+        # Without any trackers the function has no way to know which metric
+        # keys the policy emits, so it returns an empty dict rather than a
+        # zeroed-out hardcoded key set. Caller (``train.py``) never invokes
+        # this with empty trackers in practice; the empty-input path is here
+        # only as a documented degenerate case.
+        assert _mixture_weighted_aggregate({}, {}) == {}
 
     def test_all_zero_weights_returns_zeros(self):
         trackers = {"a": _make_tracker(loss=1.0), "b": _make_tracker(loss=2.0)}
@@ -224,6 +228,36 @@ class TestMixtureWeightedAggregate:
         agg = _mixture_weighted_aggregate(trackers, weights)
         # Avoids div-by-zero; behaviour matches "no signal to average".
         assert agg["loss"] == 0.0
+
+    def test_aggregates_only_keys_present_on_trackers(self):
+        # Mirrors the production case where the policy returns only MSE+CE
+        # (every VLA policy except the value head). ``l1_loss``/``accuracy``
+        # meters are absent from the tracker, so the aggregate must not
+        # invent them.
+        def _make_partial_tracker(loss: float, mse: float, ce: float) -> MetricsTracker:
+            tracker = MetricsTracker(
+                batch_size=8,
+                metrics={
+                    "loss": AverageMeter("val_total_loss", ":.3f"),
+                    "mse_loss": AverageMeter("val_mse_loss", ":.3f"),
+                    "ce_loss": AverageMeter("val_ce_loss", ":.3f"),
+                },
+            )
+            tracker.loss = loss
+            tracker.mse_loss = mse
+            tracker.ce_loss = ce
+            return tracker
+
+        trackers = {
+            "a": _make_partial_tracker(loss=1.0, mse=2.0, ce=3.0),
+            "b": _make_partial_tracker(loss=5.0, mse=6.0, ce=7.0),
+        }
+        weights = {"a": 1.0, "b": 3.0}
+        agg = _mixture_weighted_aggregate(trackers, weights)
+        assert set(agg.keys()) == {"loss", "mse_loss", "ce_loss"}
+        assert agg["loss"] == pytest.approx(0.25 * 1.0 + 0.75 * 5.0)
+        assert agg["mse_loss"] == pytest.approx(0.25 * 2.0 + 0.75 * 6.0)
+        assert agg["ce_loss"] == pytest.approx(0.25 * 3.0 + 0.75 * 7.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What this does

Stops reporting `l1_loss` and `accuracy` in the training and validation paths when the active policy doesn't emit them. Today every step calls `accelerator.gather_for_metrics(losses.get("L1", zero))` / `.get("Accuracy", zero)` and feeds those into the tracker + wandb, even though only `ValueFunction` populates those keys — every VLA policy (`pi0`, `pi05`, `pi05_mem`, `pi06`, `pi07/*`, `pi07_paligemma/*`) returns just `MSE` + `CE`. The result is two extra all-gathers per step and constant-zero `Training/L1 Loss` / `Training/Accuracy` / `Validation/*/L1 Loss` / `Validation/*/Accuracy` series cluttering wandb.

Changes in `src/opentau/scripts/train.py`:
- `update_policy`: gather L1/Accuracy only when the key is in `losses`; lazy-allocate the meter on first observation. Drop the `_first_loss_tensor` / `zero` plumbing — no longer needed once the `.get(..., zero)` fallback is gone.
- Validation loop: same pattern (gather, lazy meter, conditional logging) for the per-dataset trackers.
- Train + per-dataset + aggregate log blocks: gate the `accelerator.log` calls for L1/Accuracy on meter / key presence.
- `_make_val_tracker` and the training tracker construction: drop the always-on `l1_loss` / `accuracy` meters so the Python log line is clean for VLA policies.
- `_mixture_weighted_aggregate`: derive the metric key set from the trackers themselves instead of the hardcoded `_VAL_METRIC_KEYS` tuple (constant removed).

Rank-safety: the gating decision is determined by the policy class (identical on every rank and deterministic over batches), so the `gather_for_metrics` collective count stays aligned across ranks — matches the invariant in `CLAUDE.md` rule 5.

Label: 🐛 Bug

## How it was tested

- `pre-commit run --files src/opentau/scripts/train.py tests/scripts/test_train.py` — all hooks pass (ruff reformatted once, then clean).
- `pytest tests/scripts/test_train.py` — 17/17 pass, including:
  - `test_aggregates_only_keys_present_on_trackers` (new) — confirms the aggregate handles partial-meter trackers (the production VLA case).
  - `test_empty_trackers_returns_empty_dict` (updated) — empty input now returns `{}` since we can't derive metric keys without a tracker.
- Confirmed the unrelated CPU-suite failures (HF Hub network timeouts, missing `LIBERO_CONFIG_PATH`, weights downloads) reproduce on the base branch — they're sandbox/network issues, not caused by this PR.

## How to checkout & try? (for the reviewer)

```bash
git fetch origin claude/fix-metric-reporting-QkoKJ
git checkout claude/fix-metric-reporting-QkoKJ
pytest -sx tests/scripts/test_train.py
```

After running a smoke training with a VLA policy (e.g. `configs/examples/pi05_training_config.json`), the wandb dashboard should no longer show `Training/L1 Loss`, `Training/Accuracy`, or the corresponding validation series.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).

---
_Generated by [Claude Code](https://claude.ai/code/session_01TWGQmJHHYm7qaBBY5Pjkw9)_