### PR TITLE
fix(configs): remove invalid fields from pi07 libero smoke config

### DIFF
--- a/configs/examples/pi07_low_level_libero.json
+++ b/configs/examples/pi07_low_level_libero.json
@@ -10,14 +10,12 @@
         "action_freq": 10.0,
         "image_resample_strategy": "nearest",
         "vector_resample_strategy": "nearest",
-        "n_obs_history": 6,
-        "history_interval": 1
+        "n_obs_history": 6
     },
     "policy": {
         "type": "pi07_low_level",
         "pretrained_path": null,
         "n_obs_steps": 6,
-        "n_obs_history": 6,
         "history_interval": 1,
         "normalization_mapping": {
             "VISUAL": "IDENTITY",


### PR DESCRIPTION
## What this does

The pi07 low-level LIBERO smoke config — added in [#273](https://github.com/TensorAuto/OpenTau/pull/273) and referenced in that PR's repro recipe — declares two fields that the dataclasses don't accept, so `draccus.parse` rejects the file before any `train.py` / `profile_step.py` invocation can start:

1. `dataset_mixture.history_interval: 1` — not a field on `DatasetMixtureConfig` (see `src/opentau/configs/default.py:164`). The temporal-stride knob lives on the policy (`PI07LowLevelConfig.history_interval`, defaults to `1`), and the dataset reads it from the policy config — see the `DatasetMixtureConfig.n_obs_history` docstring at `src/opentau/configs/default.py:183`.
2. `policy.n_obs_history: 6` — not a field on `PI07LowLevelConfig` (see `src/opentau/policies/pi07/low_level/configuration_pi07_low_level.py:40`). The policy-side temporal count is `n_obs_steps` (also already set to `6` in the same JSON), and per the field's docstring it must equal `dataset_mixture.n_obs_history`.

Reproduction before this PR:

```
$ accelerate launch --config_file configs/examples/accelerate_deepspeed_config.yaml \
    src/opentau/scripts/profile_step.py \
    --config_path=configs/examples/pi07_low_level_libero.json \
    --batch_size=2 --dataloader_batch_size=2 --gradient_accumulation_steps=1 --num_cams=1
draccus.utils.DecodingError: `dataset_mixture`: The fields `history_interval` are not valid for DatasetMixtureConfig
```

Fix: drop both stray keys. The remaining `policy.history_interval: 1` and `policy.n_obs_steps: 6` already cover the intended behaviour. No other config in `configs/` has the same field skew — I grepped every `*.json` under `configs/` for `history_interval` / `n_obs_history` / `n_obs_steps` and only this one file is broken; `configs/examples/pi05_mem_training_config.json` shows the correct pattern (`dataset_mixture.n_obs_history`, `policy.n_obs_steps`).

## How it was tested

1. Loaded the fixed config via `draccus.parse(TrainPipelineConfig, config_path='configs/examples/pi07_low_level_libero.json', args=[])`; verified parsed values: `dataset_mixture.n_obs_history == 6`, `policy.n_obs_steps == 6`, `policy.history_interval == 1`, `policy.obs_buffer_size == 6`.
2. Re-ran the [#273](https://github.com/TensorAuto/OpenTau/pull/273) repro recipe on CPU — the original `DecodingError` is gone and the script proceeds past config decode into dataset loading.
3. `pre-commit run --files configs/examples/pi07_low_level_libero.json` — all hooks pass.
4. `pytest tests/policies/test_pi07_cpu.py tests/policies/test_pi07_video_encoder_cpu.py tests/policies/test_pi07_attention_layout.py -m "not gpu" -n auto` — 147 / 147 passed.

## How to checkout & try? (for the reviewer)

```bash
gh pr checkout <this-pr>

python -c "
import draccus
from opentau.configs.train import TrainPipelineConfig
cfg = draccus.parse(TrainPipelineConfig, config_path='configs/examples/pi07_low_level_libero.json', args=[])
assert cfg.dataset_mixture.n_obs_history == 6
assert cfg.policy.n_obs_steps == 6
assert cfg.policy.history_interval == 1
print('OK')
"
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.