### PR TITLE
fix(datasets): memory-map parquet instead of rewriting to Arrow

### DIFF
--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -97,10 +97,11 @@ import datasets
 import numpy as np
 import packaging.version
 import PIL.Image
+import pyarrow.dataset as pa_ds
 import torch
 import torch.nn.functional as F  # noqa: N812
 import torch.utils
-from datasets import concatenate_datasets, load_dataset
+from datasets import Dataset, concatenate_datasets
 from einops import rearrange
 from huggingface_hub import HfApi, hf_hub_download, snapshot_download
 from huggingface_hub.constants import REPOCARD_NAME
@@ -1551,14 +1552,13 @@ class LeRobotDataset(BaseDataset):
 
     def load_hf_dataset(self) -> datasets.Dataset:
         """hf_dataset contains all the observations, states, actions, rewards, etc."""
-        if self.episodes is None:
-            path = str(self.root / "data")
-            hf_dataset = load_dataset("parquet", data_dir=path, split="train")
-        else:
-            files = [str(self.root / self.meta.get_data_file_path(ep_idx)) for ep_idx in self.episodes]
-            hf_dataset = load_dataset("parquet", data_files=files, split="train")
-
-        # TODO(aliberts): hf_dataset.set_format("torch")
+        data_dir = self.root / "data"
+        paths = sorted(data_dir.glob("*/*.parquet"))
+        if not paths:
+            raise FileNotFoundError(f"No parquet files under {data_dir}")
+        features = get_hf_features_from_features(self.meta.features)
+        filters = pa_ds.field("episode_index").isin(self.episodes) if self.episodes is not None else None
+        hf_dataset = Dataset.from_parquet([str(p) for p in paths], filters=filters, features=features)
         hf_dataset.set_transform(hf_transform_to_torch)
         return hf_dataset
 

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -1562,7 +1562,9 @@ class LeRobotDataset(BaseDataset):
         # datasets with a non-default `info["data_path"]` (deeper nesting,
         # flat layout, etc.) keep working. Default template is
         # "data/chunk-{episode_chunk:03d}/episode_{episode_index:06d}.parquet"
-        # which yields the glob "data/chunk-*/episode_*.parquet".
+        # which yields the glob "data/chunk-*/episode_*.parquet". Assumes the
+        # template uses simple `{name}` / `{name:fmt}` placeholders and no
+        # literal `{{`/`}}` escapes — true for every in-repo writer.
         glob_pattern = re.sub(r"\{[^}]+\}", "*", self.meta.data_path)
         paths = sorted(self.root.glob(glob_pattern))
         if not paths:
@@ -1575,9 +1577,20 @@ class LeRobotDataset(BaseDataset):
         # $HF_HOME/datasets/parquet/ — 1-5x the source size (compression-dependent)
         # and one cache entry per distinct (paths, filter) combo. Issue #277 has
         # the empirical numbers; verified on physical-intelligence/libero.
+        #
         # Trade-off: `to_table(filter=...)` materializes the filtered rows into
-        # RAM. Typical training subsets are fine; full-corpus loads on multi-GB
-        # repos will be RAM-bound (vs. mmapped Arrow cache before).
+        # RAM rather than mmapping a disk-backed Arrow cache. RAM cost scales
+        # with `len(filtered rows) × avg-row-size`; concretely:
+        # ~350 MB for physical-intelligence/libero with episodes=[0..9],
+        # ~46 GB for humanoid-everyday-A-overlay with episodes=None (full corpus).
+        # Narrow `episodes=` picks are fine; an episodes=None load on a multi-GB
+        # image-heavy repo will OOM on a small dev box — pass a manageable
+        # subset, or restore a mmap'd Arrow cache via tmp pa.ipc files if RAM
+        # ever becomes the binding constraint.
+        #
+        # The `Dataset(table, info=DatasetInfo(features=features))` constructor
+        # signature has been stable since datasets 2.x; the project pin is
+        # `datasets>=2.19.0`, so we're well inside the supported window.
         pa_dataset = pa_ds.dataset(list(map(str, paths)), format="parquet")
         filter_expr = pa_ds.field("episode_index").isin(self.episodes) if self.episodes is not None else None
         table = pa_dataset.to_table(filter=filter_expr)

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -102,7 +102,7 @@ import pyarrow.dataset as pa_ds
 import torch
 import torch.nn.functional as F  # noqa: N812
 import torch.utils
-from datasets import Dataset, concatenate_datasets
+from datasets import Dataset, DatasetInfo, concatenate_datasets
 from einops import rearrange
 from huggingface_hub import HfApi, hf_hub_download, snapshot_download
 from huggingface_hub.constants import REPOCARD_NAME
@@ -1568,8 +1568,20 @@ class LeRobotDataset(BaseDataset):
         if not paths:
             raise FileNotFoundError(f"No parquet files matching {glob_pattern!r} under {self.root}")
         features = get_hf_features_from_features(self.meta.features)
-        filters = pa_ds.field("episode_index").isin(self.episodes) if self.episodes is not None else None
-        hf_dataset = Dataset.from_parquet(list(map(str, paths)), filters=filters, features=features)
+        # Read parquet directly via pyarrow.dataset and wrap the resulting
+        # pa.Table in a HF Dataset. Going through `load_dataset("parquet", ...)`
+        # or `Dataset.from_parquet(...)` both route through ParquetDatasetBuilder,
+        # which rewrites the parquet bytes into an uncompressed Arrow cache at
+        # $HF_HOME/datasets/parquet/ — 1-5x the source size (compression-dependent)
+        # and one cache entry per distinct (paths, filter) combo. Issue #277 has
+        # the empirical numbers; verified on physical-intelligence/libero.
+        # Trade-off: `to_table(filter=...)` materializes the filtered rows into
+        # RAM. Typical training subsets are fine; full-corpus loads on multi-GB
+        # repos will be RAM-bound (vs. mmapped Arrow cache before).
+        pa_dataset = pa_ds.dataset(list(map(str, paths)), format="parquet")
+        filter_expr = pa_ds.field("episode_index").isin(self.episodes) if self.episodes is not None else None
+        table = pa_dataset.to_table(filter=filter_expr)
+        hf_dataset = Dataset(table, info=DatasetInfo(features=features))
         hf_dataset.set_transform(hf_transform_to_torch)
         return hf_dataset
 

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -87,6 +87,7 @@ import functools
 import json
 import logging
 import math
+import re
 import shutil
 import traceback
 from abc import abstractmethod
@@ -1261,7 +1262,12 @@ class LeRobotDataset(BaseDataset):
             delta_timestamps_lower,
             delta_timestamps_upper,
         )
-        self.episodes = episodes
+        # Sort episodes here so that hf_dataset row layout (sorted by
+        # episode_index after the glob in load_hf_dataset) stays aligned with
+        # episode_data_index["from"/"to"] (built in self.episodes order in
+        # get_episode_data_index). Mismatched order would silently return
+        # rows from the wrong episode for callers that pass an unsorted list.
+        self.episodes = sorted(episodes) if episodes is not None else None
         self.tolerance_s = tolerance_s
         self.skip_timestamp_check = skip_timestamp_check
         self.revision = revision if revision else CODEBASE_VERSION
@@ -1552,13 +1558,18 @@ class LeRobotDataset(BaseDataset):
 
     def load_hf_dataset(self) -> datasets.Dataset:
         """hf_dataset contains all the observations, states, actions, rewards, etc."""
-        data_dir = self.root / "data"
-        paths = sorted(data_dir.glob("*/*.parquet"))
+        # Derive the parquet glob from the meta data_path template so that
+        # datasets with a non-default `info["data_path"]` (deeper nesting,
+        # flat layout, etc.) keep working. Default template is
+        # "data/chunk-{episode_chunk:03d}/episode_{episode_index:06d}.parquet"
+        # which yields the glob "data/chunk-*/episode_*.parquet".
+        glob_pattern = re.sub(r"\{[^}]+\}", "*", self.meta.data_path)
+        paths = sorted(self.root.glob(glob_pattern))
         if not paths:
-            raise FileNotFoundError(f"No parquet files under {data_dir}")
+            raise FileNotFoundError(f"No parquet files matching {glob_pattern!r} under {self.root}")
         features = get_hf_features_from_features(self.meta.features)
         filters = pa_ds.field("episode_index").isin(self.episodes) if self.episodes is not None else None
-        hf_dataset = Dataset.from_parquet([str(p) for p in paths], filters=filters, features=features)
+        hf_dataset = Dataset.from_parquet(list(map(str, paths)), filters=filters, features=features)
         hf_dataset.set_transform(hf_transform_to_torch)
         return hf_dataset
 

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -79,6 +79,10 @@ def _assert_episode_row_alignment(dataset) -> None:
     used to build episode_data_index/epi2idx (e.g. unsorted self.episodes vs.
     sorted-by-filename row layout from Dataset.from_parquet).
     """
+    # Reach into the underlying pa.Table to bypass the set_transform=hf_transform_to_torch
+    # set in load_hf_dataset — calling `hf_dataset["episode_index"]` here would
+    # route the column through the torch transform, which is wrong for a raw
+    # episode_index check. Don't "simplify" this without removing the transform.
     ep_idx_col = dataset.hf_dataset.data.table.column("episode_index").to_pylist()
     for ep in dataset.episodes:
         pos = dataset.epi2idx[ep]

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -72,6 +72,74 @@ def test_dataset_initialization(tmp_path, lerobot_dataset_factory):
     assert dataset.num_frames == len(dataset)
 
 
+def _assert_episode_row_alignment(dataset) -> None:
+    """For each episode, verify hf_dataset rows in [from:to] all carry that episode_index.
+
+    This catches the case where hf_dataset row order disagrees with the order
+    used to build episode_data_index/epi2idx (e.g. unsorted self.episodes vs.
+    sorted-by-filename row layout from Dataset.from_parquet).
+    """
+    ep_idx_col = dataset.hf_dataset.data.table.column("episode_index").to_pylist()
+    for ep in dataset.episodes:
+        pos = dataset.epi2idx[ep]
+        start = int(dataset.episode_data_index["from"][pos])
+        end = int(dataset.episode_data_index["to"][pos])
+        assert end > start, f"Episode {ep} has empty row span [{start}:{end}]"
+        rows = ep_idx_col[start:end]
+        assert all(e == ep for e in rows), (
+            f"Episode {ep} at hf_dataset[{start}:{end}] has mismatched episode_index values "
+            f"(saw {sorted(set(rows))})"
+        )
+
+
+def test_dataset_unsorted_episodes_row_alignment(tmp_path, lerobot_dataset_factory):
+    """Regression: passing an unsorted episodes list must still yield correct row indexing.
+
+    Before the parquet-loader switch to Dataset.from_parquet, `data_files=[...]` produced
+    rows in self.episodes order, so unsorted picks happened to work. With the
+    glob-based loader, rows come back sorted by filename — so __init__ must sort
+    self.episodes for episode_data_index/epi2idx to line up.
+    """
+    dataset = lerobot_dataset_factory(
+        root=tmp_path / "test",
+        repo_id=DUMMY_REPO_ID,
+        total_episodes=10,
+        total_frames=400,
+        episodes=[6, 2, 5],
+    )
+    assert dataset.episodes == [2, 5, 6], "self.episodes should be sorted at the boundary"
+    _assert_episode_row_alignment(dataset)
+
+
+def test_dataset_sparse_episodes_row_alignment(tmp_path, lerobot_dataset_factory):
+    """Sparse non-contiguous episodes filtered out of a larger corpus stay aligned."""
+    dataset = lerobot_dataset_factory(
+        root=tmp_path / "test",
+        repo_id=DUMMY_REPO_ID,
+        total_episodes=10,
+        total_frames=400,
+        episodes=[3, 7],
+    )
+    assert dataset.episodes == [3, 7]
+    _assert_episode_row_alignment(dataset)
+    # Confirm the filter actually dropped the unselected episodes.
+    ep_idx_col = dataset.hf_dataset.data.table.column("episode_index").to_pylist()
+    assert set(ep_idx_col) == {3, 7}
+
+
+def test_dataset_no_episodes_loads_all(tmp_path, lerobot_dataset_factory):
+    """episodes=None loads every episode and stays aligned with episode_data_index."""
+    dataset = lerobot_dataset_factory(
+        root=tmp_path / "test",
+        repo_id=DUMMY_REPO_ID,
+        total_episodes=4,
+        total_frames=200,
+        episodes=None,
+    )
+    assert dataset.episodes == [0, 1, 2, 3]
+    _assert_episode_row_alignment(dataset)
+
+
 def test_add_frame_missing_task(tmp_path, empty_lerobot_dataset_factory):
     features = {"state": {"dtype": "float32", "shape": (1,), "names": None}}
     dataset = empty_lerobot_dataset_factory(root=tmp_path / "test", features=features)


### PR DESCRIPTION
## What this does

Fixes #277.

`LeRobotDataset.load_hf_dataset()` previously called `datasets.load_dataset("parquet", ...)`, which routes through `ParquetDatasetBuilder` and materializes the source parquet into an uncompressed Arrow cache under `$HF_HOME/datasets/parquet/default-<hash>/...`. The Arrow rewrite is 1–5× the source parquet size (compression-dependent: ~1× for vector-only data, ~4–5× for image-heavy parquets per #277), and because the cache key includes `data_files`, every distinct `episodes=` pick produces a new cache entry. On a populated `$HF_HOME` this can roughly double on-disk corpus size.

**Empirical investigation on a real OpenTau-compatible dataset (`physical-intelligence/libero`, 10 episodes, 347 MB source parquet) — see follow-up comments for the scripts and numbers:**

| Approach | $HF_HOME/datasets/parquet/ after 3 calls | Cache entries |
|---|---|---|
| Old: `load_dataset("parquet", data_files=picked)` | 347 MB | 2 |
| `Dataset.from_parquet([all_paths], filters=...)` (HF LeRobot's pattern) | **347 MB** | **2** |
| `pa_ds.dataset(paths).to_table(filter=...)` + `Dataset(table)` (this PR) | **0 MB** | **0** |

The upstream LeRobot fix ([huggingface/lerobot#2982](https://github.com/huggingface/lerobot/pull/2982)) advertises `Dataset.from_parquet` as memory-mapped, but in `datasets==4.5.0` it still routes through `ParquetDatasetReader` → `ParquetDatasetBuilder` and writes the same Arrow cache. The only working fix is to bypass HF Datasets' parquet builder entirely and read via `pyarrow.dataset` directly.

### Implementation

[src/opentau/datasets/lerobot_dataset.py](src/opentau/datasets/lerobot_dataset.py):

1. **Imports**: drop `load_dataset`, add `Dataset`, `DatasetInfo` from `datasets`, `pyarrow.dataset as pa_ds`, and `import re`.

2. **`load_hf_dataset()` rewritten**: derive the parquet glob from `self.meta.data_path` (so non-default `info["data_path"]` layouts keep working), build a `pa_ds.dataset(paths)` lazy view, apply `pa_ds.field("episode_index").isin(self.episodes)` via `to_table(filter=...)`, and wrap the resulting `pa.Table` in `Dataset(table, info=DatasetInfo(features=features))`.

3. **Sort `self.episodes` at the `__init__` boundary** ([line 1264](src/opentau/datasets/lerobot_dataset.py:1264)). The new loader returns rows in sorted (chunk, episode_index) order regardless of the caller's `episodes=` order; `get_episode_data_index` builds `episode_data_index["from"/"to"]` in `self.episodes`-list order. Without the sort, an unsorted user list (e.g. `episodes=[5, 2, 8]`) would silently mis-align rows — `episode_data_index["from"][epi2idx[5]] = 0` but row 0 would be episode 2. Sorting makes the assumption explicit and matches what every other in-repo caller already does.

### Trade-off: RAM cost scales with filtered rows

`pa_ds.to_table(filter=...)` materializes the filtered rows into RAM rather than mmapping a disk-backed Arrow cache. The old `load_dataset("parquet", ...)` wrote an uncompressed Arrow cache to disk and mmap'd it — the kernel paged in only what `__getitem__` touched, so resident memory stayed near the working set even on multi-GB corpora. With this PR, the entire filtered `pa.Table` is in process memory at the end of `load_hf_dataset`.

**Measured on physical-intelligence/libero, episodes=[0..9]:**

| Phase | Peak RSS | pa.Table nbytes |
|---|---|---|
| Before `LeRobotDataset(...)` | 799 MB | — |
| After `LeRobotDataset(...)` | **3503 MB** | **347 MB** |

The persistent data cost is bounded by the `pa.Table` (347 MB = source parquet size). The extra ~2.7 GB peak RSS is import / pyarrow scratch / dataset-stats transients and decays after construction. The principled scaling rule: **`pa.Table.nbytes ≈ filtered_rows × avg_row_size`** — so an `episodes=None` load on `humanoid-everyday-A-overlay` (46 GB parquet, image-heavy) would need ~46 GB resident before training starts.

**Practical implication:** narrow `episodes=` picks are fine; a default `episodes=None` load on a multi-GB image-heavy repo can OOM. `factory.make_dataset(...)`, `scripts/visualize_dataset.py`, `scripts/fit_fast_tokenizer.py`, and `v21/convert_stats.py` all use `episodes=None` and may need an explicit subset on big repos. Given #277 is specifically about disk-doubling on shared `$HF_HOME`, this is the trade-off worth making; if a real OOM shows up, the escape hatch is to write the filtered table to a tmp `pa.ipc` file and mmap it back.

The trade-off is also called out inline at the `load_hf_dataset` definition so a future reader hitting OOM on a small dev box can see why.

## How it was tested

- `pre-commit run --files src/opentau/datasets/lerobot_dataset.py tests/datasets/test_datasets.py` — clean.
- `pytest -m "not gpu" -n auto tests/datasets/` — **392 passed, 7 skipped**. Includes 3 new regression tests in `tests/datasets/test_datasets.py`:
  - `test_dataset_unsorted_episodes_row_alignment` — `episodes=[6, 2, 5]`, asserts `dataset.episodes` is sorted and every row in `hf_dataset[from[idx]:to[idx]]` carries the expected `episode_index`. Fails without the sort.
  - `test_dataset_sparse_episodes_row_alignment` — sparse `episodes=[3, 7]` out of 10.
  - `test_dataset_no_episodes_loads_all` — `episodes=None` default path.
- `pytest -m "not gpu" -n auto` (full CPU suite) — 1153 passed. 3 pre-existing failures unrelated to this change (HF Hub 429, missing libero assets, xdist flake).
- **Disk-cost verification on an internal GPU dev box** with real `physical-intelligence/libero` (10 episodes) via the full `LeRobotDataset(cfg, ...)` constructor: zero growth in `$HF_HOME/datasets/parquet/` across two distinct `episodes=` picks. Numbers in follow-up comments.
- **RAM measurement** on the same dev box: peak RSS 799 MB → 3503 MB; pa.Table nbytes 347 MB (matches source parquet, confirming the linear scaling).
- **Loader-determinism check**: hashed rows at idx 0, 1, len/4, len/2, 3·len/4, len-1 across two `LeRobotDataset(...)` constructions with the same seed — all 6 hashes bit-identical. The change is loader-only and doesn't touch the training-loop primitives listed in CLAUDE.md rule #3, so a loader-determinism check is the right scope. Full smoke-config seeded determinism can be added before un-drafting if you want belt-and-suspenders.

## How to checkout & try? (for the reviewer)

```bash
git checkout claude/bold-antonelli-665e34
uv sync --extra dev --extra libero
pytest -m "not gpu" -n auto tests/datasets/
```

Disk-cost win on a host with a real dataset cached:

```bash
du -sh "$HF_HOME/datasets/parquet/" 2>/dev/null || echo "empty"
# (then run any LeRobotDataset load)
du -sh "$HF_HOME/datasets/parquet/"
```

The second `du` should match the first (zero growth).

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.