### PR TITLE
feat(pi07): ring attention with blockwise remat + ZeRO-2 2D parallelism

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,6 +183,9 @@ select = ["E4", "E7", "E9", "F", "I", "N", "B", "C4", "SIM"]
 "src/opentau/scripts/grpc/server.py" = ["N802"]
 # Uppercase names for rotation matrices follow standard math convention
 "src/opentau/scripts/recordhuman_to_lerobot.py" = ["N803", "N806"]
+# Attention math uses uppercase identifiers per the FlashAttention paper:
+# S=scores, P=softmax probs, O=output, LSE=log-sum-exp, D=row grad correction.
+"src/opentau/policies/pi07/ring_attention.py" = ["N803", "N806", "E741"]
 
 [tool.bandit]
 exclude_dirs = [

--- a/src/opentau/configs/train.py
+++ b/src/opentau/configs/train.py
@@ -177,6 +177,18 @@ class TrainPipelineConfig(HubMixin):
     # gRPC inference server configuration
     server: ServerConfig = field(default_factory=ServerConfig)
 
+    # Ring attention (sequence parallelism) group size.
+    #
+    # When set together with a ring-aware policy (pi07 with
+    # ``policy.attention_implementation="ring"``), splits the WORLD process
+    # group into ``world_size / ring_group_size`` ring sub-groups of this
+    # size. Sequence parallelism happens within each ring; DP replication
+    # is implicit via ZeRO over WORLD with a ``loss *= ring_group_size``
+    # pre-backward correction (see ``scripts/train.py``). Must divide
+    # world size. ``None`` (default) keeps single-device / pure-DP
+    # behaviour.
+    ring_group_size: int | None = None
+
     def __post_init__(self):
         """Initialize post-creation attributes and validate batch size configuration."""
         self.checkpoint_path = None

--- a/src/opentau/policies/pi07/gemma3_with_expert.py
+++ b/src/opentau/policies/pi07/gemma3_with_expert.py
@@ -284,10 +284,10 @@ class Gemma3WithExpertConfig(PretrainedConfig):
                 "`train_expert_only=False` (the high-level-planner default) when "
                 "`disable_action_expert=True`."
             )
-        if self.attention_implementation not in ["eager", "sdpa", "fa2"]:
+        if self.attention_implementation not in ["eager", "sdpa", "fa2", "ring"]:
             raise ValueError(
                 f"Wrong value provided for `attention_implementation` ({self.attention_implementation}). "
-                "Expected 'eager', 'sdpa', or 'fa2'."
+                "Expected 'eager', 'sdpa', 'fa2', or 'ring'."
             )
         if self.attention_implementation == "fa2":
             # fa2 has been considered but never implemented for pi07 because of
@@ -849,9 +849,41 @@ class Gemma3WithExpertModel(PreTrainedModel):
         impl = self.config.attention_implementation
         if impl == "sdpa":
             return self.sdpa_attention_forward
+        if impl == "ring":
+            return self.ring_attention_forward
         # "eager" and legacy "fa2" both land here; "fa2" already warned during
         # config construction.
         return self.eager_attention_forward
+
+    def ring_attention_forward(
+        self,
+        attention_mask: torch.Tensor,
+        batch_size: int,
+        head_dim: int,
+        query_states: torch.Tensor,
+        key_states: torch.Tensor,
+        value_states: torch.Tensor,
+        scaling: float | None = None,
+    ) -> torch.Tensor:
+        """Ring attention dispatch matching the eager/sdpa signature.
+
+        When no ring group is active (single device / world_size 1) the
+        underlying call collapses to SDPA so single-GPU tests don't depend on
+        torch.distributed init.
+        """
+        from opentau.policies.pi07.ring_attention import ring_attention_forward as _ring_fwd
+
+        return _ring_fwd(
+            attention_mask,
+            batch_size,
+            head_dim,
+            query_states,
+            key_states,
+            value_states,
+            num_query_heads=self._text_config.num_attention_heads,
+            num_kv_heads=self._text_config.num_key_value_heads,
+            scaling=scaling,
+        )
 
     def eager_attention_forward(
         self,
@@ -1060,43 +1092,113 @@ class Gemma3WithExpertModel(PreTrainedModel):
         if fill_kv_cache and past_key_values is None:
             past_key_values = {}
 
-        use_ckpt = self.config.gradient_checkpointing and self.training
+        # Ring attention sharding: under attention_implementation="ring"
+        # and a no-cache forward, split inputs_embeds + position_ids along
+        # the sequence axis so every decoder layer sees only this rank's
+        # contiguous slice. The replicated attention_mask is sliced inside
+        # the ring kernel using rank offsets. After the decoder stack we
+        # all-gather along the seq axis before the final norms, so the
+        # rest of the policy sees the full sequence as usual. Padding to a
+        # multiple of ring world size is done here too; the mask masks the
+        # pad inert. ZeRO-2 grad checkpointing is intentionally replaced by
+        # the blockwise rematerialization performed inside _RingAttention.
+        from opentau.policies.pi07.ring_attention import (
+            gather_seq,
+            get_ring_group,
+            ring_world_size,
+            split_seq,
+        )
+
+        ring_active = (
+            self.config.attention_implementation == "ring"
+            and not use_cache
+            and not fill_kv_cache
+            and get_ring_group() is not None
+            and ring_world_size() > 1
+        )
+        ring_pad_amount = 0
+        original_seq_lens: list[int] = []
+        if ring_active:
+            ring_ws = ring_world_size()
+            for hs in inputs_embeds:
+                original_seq_lens.append(0 if hs is None else hs.shape[1])
+            # Pi07 training calls forward one stream at a time; pick the
+            # active stream and pad / slice it. Multi-stream + ring is not
+            # supported and would have a non-contiguous global-seq layout.
+            active_streams = [i for i, hs in enumerate(inputs_embeds) if hs is not None]
+            if len(active_streams) != 1:
+                raise ValueError(
+                    "attention_implementation='ring' currently supports single-stream "
+                    f"forwards only; got {len(active_streams)} active stream(s). "
+                    "Pi07 training already issues single-stream forwards for VLM and "
+                    "action-expert separately — check the caller."
+                )
+            active = active_streams[0]
+            hs = inputs_embeds[active]
+            assert hs is not None
+            bsz, seq, hid = hs.shape
+            rem = seq % ring_ws
+            if rem != 0:
+                ring_pad_amount = ring_ws - rem
+                pad_embed = torch.zeros((bsz, ring_pad_amount, hid), dtype=hs.dtype, device=hs.device)
+                hs = torch.cat([hs, pad_embed], dim=1)
+                if position_ids is not None:
+                    pad_pos = torch.zeros(
+                        (bsz, ring_pad_amount), dtype=position_ids.dtype, device=position_ids.device
+                    )
+                    position_ids = torch.cat([position_ids, pad_pos], dim=1)
+                # Pad mask: add ring_pad_amount along both Q and K axes
+                # with False so padded queries attend to nothing and
+                # padded keys are not attended to by anything.
+                if attention_mask is not None:
+                    am = attention_mask
+                    pad_q = torch.zeros(
+                        (am.shape[0], ring_pad_amount, am.shape[2]),
+                        dtype=am.dtype,
+                        device=am.device,
+                    )
+                    am = torch.cat([am, pad_q], dim=1)
+                    pad_k = torch.zeros(
+                        (am.shape[0], am.shape[1], ring_pad_amount),
+                        dtype=am.dtype,
+                        device=am.device,
+                    )
+                    am = torch.cat([am, pad_k], dim=2)
+                    attention_mask = am
+            # Shard along seq dim.
+            new_embeds = list(inputs_embeds)
+            new_embeds[active] = split_seq(hs, seq_dim=1)
+            inputs_embeds = new_embeds
+            if position_ids is not None:
+                position_ids = split_seq(position_ids, seq_dim=1)
+
         for layer_idx, layer in enumerate(self.interleaved_layers):
-            if use_ckpt:
-                # use_reentrant=False is the modern, DDP-safe path; it
-                # preserves RNG state across recompute so dropout is
-                # deterministic, participates cleanly in autograd's
-                # saved_tensors_hooks, and is compatible with FSDP's
-                # all-gather hooks (the wrap target is the
-                # InterleavedDecoderLayer, so its sub-component params are
-                # all gathered before this checkpoint runs).
-                inputs_embeds = torch.utils.checkpoint.checkpoint(
-                    layer,
-                    inputs_embeds,
-                    attention_mask,
-                    position_ids,
-                    past_key_values,
-                    n_cross_att_tokens,
-                    use_cache,
-                    fill_kv_cache,
-                    adarms_cond,
-                    batch_size,
-                    layer_idx,
-                    use_reentrant=False,
-                )
-            else:
-                inputs_embeds = layer(
-                    inputs_embeds,
-                    attention_mask,
-                    position_ids,
-                    past_key_values,
-                    n_cross_att_tokens,
-                    use_cache,
-                    fill_kv_cache,
-                    adarms_cond,
-                    batch_size,
-                    layer_idx,
-                )
+            inputs_embeds = layer(
+                inputs_embeds,
+                attention_mask,
+                position_ids,
+                past_key_values,
+                n_cross_att_tokens,
+                use_cache,
+                fill_kv_cache,
+                adarms_cond,
+                batch_size,
+                layer_idx,
+            )
+
+        if ring_active:
+            # Gather along seq dim before the final norms so downstream
+            # heads / loss see the full sequence layout they expect.
+            gathered: list[torch.FloatTensor | None] = []
+            for stream_idx, hs in enumerate(inputs_embeds):
+                if hs is None:
+                    gathered.append(None)
+                    continue
+                full = gather_seq(hs, seq_dim=1)
+                if ring_pad_amount > 0:
+                    full = full[:, : original_seq_lens[stream_idx]]
+                gathered.append(full)
+            inputs_embeds = gathered
 
         # Final norms.
         final_outputs: list[torch.Tensor | None] = []

--- a/src/opentau/policies/pi07/ring_attention.py
+++ b/src/opentau/policies/pi07/ring_attention.py
@@ -1,0 +1,592 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Ring attention for pi07.
+
+Implements Liu, Zaharia & Abbeel, "Ring Attention with Blockwise
+Transformers for Near-Infinite Context" (arXiv:2310.01889) directly on
+torch.distributed P2P primitives. Per-block compute uses online softmax
+so the (Q_total, K_total) score matrix never materialises on any rank;
+the backward recomputes per-block S from saved (q,k,v,LSE) — the
+blockwise rematerialization in §3.2.2 of the paper, which replaces the
+per-layer torch.utils.checkpoint pi07 used before.
+
+Process group layout for 2-D parallelism with DeepSpeed ZeRO-2:
+ring_size * dp_size == world_size. Ring sub-groups are contiguous
+([0, R), [R, 2R), ...). The DP axis is implicit: ZeRO runs over WORLD
+with the loss pre-scaled by ring_size so that the MEAN reduction over
+WORLD collapses to a SUM over ring members and a MEAN over DP — this
+avoids issuing collectives on a second NCCL communicator that competes
+with ZeRO's on the same CUDA streams.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import torch
+import torch.distributed as dist
+from einops import rearrange, repeat
+
+# Finite stand-in for -inf for masked attention scores. Picked well below
+# log(fp32_eps) so exp(masked - unmasked_max) underflows cleanly to 0,
+# but far enough from fp32's representable limit that compositions with
+# (S - LSE) etc. don't cancel into NaN under bf16 mixed-precision.
+_NEG_INF = -1.0e9
+
+
+# --- Process group state ---------------------------------------------------
+
+_RING_GROUP: dist.ProcessGroup | None = None
+
+
+def set_ring_group(group: dist.ProcessGroup | None) -> None:
+    """Pin the ring process group used by ring_attention_forward."""
+    global _RING_GROUP
+    _RING_GROUP = group
+
+
+def get_ring_group() -> dist.ProcessGroup | None:
+    """Return the active ring group, or None when ring is inactive.
+
+    Inactive cases collapse to a single-device SDPA fallback:
+    distributed not available, not initialised, or world size 1.
+    """
+    if _RING_GROUP is not None:
+        return _RING_GROUP
+    if not dist.is_available() or not dist.is_initialized():
+        return None
+    if dist.get_world_size() <= 1:
+        return None
+    return dist.group.WORLD
+
+
+def ring_world_size(group: dist.ProcessGroup | None = None) -> int:
+    g = group if group is not None else get_ring_group()
+    return 1 if g is None else dist.get_world_size(g)
+
+
+def ring_rank(group: dist.ProcessGroup | None = None) -> int:
+    g = group if group is not None else get_ring_group()
+    return 0 if g is None else dist.get_rank(g)
+
+
+def build_ring_groups(ring_size: int) -> dist.ProcessGroup:
+    """Build contiguous ring sub-groups of size ``ring_size`` and pin ours.
+
+    With world=8 and ring_size=4 we get rings {0,1,2,3} and {4,5,6,7}.
+    DP is handled implicitly by ZeRO over WORLD (see module docstring), so
+    we do not create a DP sub-group communicator. When ring_size equals
+    world size we reuse the WORLD group rather than duplicating it.
+
+    All ranks must call this in the same order — ``dist.new_group``
+    requires every rank participate even in sub-groups they don't join.
+    """
+    if not dist.is_available() or not dist.is_initialized():
+        raise RuntimeError("build_ring_groups requires torch.distributed initialised.")
+    world = dist.get_world_size()
+    rank = dist.get_rank()
+    if ring_size < 1 or world % ring_size != 0:
+        raise ValueError(f"world_size {world} must be divisible by ring_size {ring_size}.")
+
+    num_rings = world // ring_size
+    if num_rings == 1:
+        my_group: dist.ProcessGroup = dist.group.WORLD  # type: ignore[assignment]
+    else:
+        my_group = None  # type: ignore[assignment]
+        for rid in range(num_rings):
+            ranks = list(range(rid * ring_size, (rid + 1) * ring_size))
+            g = dist.new_group(ranks=ranks)
+            if rank in ranks:
+                my_group = g
+        assert my_group is not None
+    set_ring_group(my_group)
+    return my_group
+
+
+def dp_rank(ring_size: int | None = None) -> int:
+    """This rank's DP index = world_rank // ring_size."""
+    if not dist.is_available() or not dist.is_initialized():
+        return 0
+    R = ring_size if ring_size is not None else ring_world_size()
+    return 0 if R <= 0 else dist.get_rank() // R
+
+
+def dp_world_size(ring_size: int | None = None) -> int:
+    if not dist.is_available() or not dist.is_initialized():
+        return 1
+    R = ring_size if ring_size is not None else ring_world_size()
+    return 1 if R <= 0 else dist.get_world_size() // R
+
+
+# --- Differentiable shard / gather along a seq dim -------------------------
+
+
+class _AllGatherSeq(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x: torch.Tensor, seq_dim: int, group: dist.ProcessGroup):
+        ctx.seq_dim = seq_dim
+        ctx.group = group
+        ctx.rank = dist.get_rank(group)
+        ctx.world_size = dist.get_world_size(group)
+        x_c = x.contiguous()
+        moved = x_c.transpose(0, seq_dim).contiguous()
+        out = torch.empty(
+            (moved.shape[0] * ctx.world_size, *moved.shape[1:]),
+            dtype=moved.dtype,
+            device=moved.device,
+        )
+        dist.all_gather_into_tensor(out, moved, group=group)
+        return out.transpose(0, seq_dim).contiguous()
+
+    @staticmethod
+    def backward(ctx, grad_out: torch.Tensor):
+        chunks = torch.chunk(grad_out, ctx.world_size, dim=ctx.seq_dim)
+        return chunks[ctx.rank].contiguous(), None, None
+
+
+def split_seq(x: torch.Tensor, seq_dim: int, group: dist.ProcessGroup | None = None) -> torch.Tensor:
+    """Return this rank's contiguous slice along ``seq_dim``.
+
+    Length along ``seq_dim`` must be divisible by ring world size; the
+    caller pads upstream and arranges for the corresponding mask /
+    position_ids slices to mask the pad inert.
+    """
+    g = group if group is not None else get_ring_group()
+    ws = 1 if g is None else dist.get_world_size(g)
+    if ws == 1:
+        return x
+    L = x.shape[seq_dim]
+    if L % ws != 0:
+        raise ValueError(f"seq length {L} along dim {seq_dim} not divisible by ring ws {ws}.")
+    return torch.chunk(x, ws, dim=seq_dim)[dist.get_rank(g)].contiguous()
+
+
+def gather_seq(x: torch.Tensor, seq_dim: int, group: dist.ProcessGroup | None = None) -> torch.Tensor:
+    """Differentiable all-gather along ``seq_dim``. Backward = take-this-rank's-slice."""
+    g = group if group is not None else get_ring_group()
+    ws = 1 if g is None else dist.get_world_size(g)
+    if ws == 1:
+        return x
+    return _AllGatherSeq.apply(x, seq_dim, g)
+
+
+def broadcast_batch_within_ring(batch) -> None:
+    """In-place broadcast every CUDA tensor in ``batch`` from each ring's
+    lowest-ranked member to its followers.
+
+    Belt-and-braces guarantee that all ranks within a ring see identical
+    sample data — they must, because ring attention computes a single
+    logical forward pass distributed across the ring. Seeding by DP
+    index narrows the gap but doesn't cover worker-side stochasticity
+    (random augmentation, dataloader pickling order) reliably.
+
+    No-op when ring is inactive.
+    """
+    g = get_ring_group()
+    if g is None or dist.get_world_size(g) <= 1:
+        return
+    my_local = dist.get_rank(g)
+    my_global = dist.get_rank()
+    src_global = my_global - my_local  # local rank 0 within the ring
+
+    def _walk(obj):
+        if isinstance(obj, torch.Tensor):
+            if obj.is_cuda:
+                dist.broadcast(obj, src=src_global, group=g)
+            return
+        if isinstance(obj, dict):
+            for v in obj.values():
+                _walk(v)
+        elif isinstance(obj, (list, tuple)):
+            for v in obj:
+                _walk(v)
+
+    _walk(batch)
+
+
+# --- Ring rotation (P2P with global rank translation) ----------------------
+
+
+def _ring_rotate(
+    *tensors: torch.Tensor,
+    group: dist.ProcessGroup,
+    forward_dir: bool = True,
+) -> tuple[torch.Tensor, ...]:
+    """Rotate ``tensors`` one step around the ring.
+
+    forward_dir=True sends to rank+1, receives from rank-1 (used in fwd).
+    forward_dir=False sends to rank-1, receives from rank+1 (used in bwd
+    to walk dK/dV opposite the K/V they belong to).
+
+    ``P2POp`` requires the peer argument to be a GLOBAL rank even when
+    ``group`` is a sub-group; we translate through ``get_global_rank``.
+    """
+    ws = dist.get_world_size(group)
+    if ws == 1:
+        return tuple(tensors)
+    local = dist.get_rank(group)
+    if forward_dir:
+        send_to_local = (local + 1) % ws
+        recv_from_local = (local - 1) % ws
+    else:
+        send_to_local = (local - 1) % ws
+        recv_from_local = (local + 1) % ws
+    send_to_global = dist.get_global_rank(group, send_to_local)
+    recv_from_global = dist.get_global_rank(group, recv_from_local)
+
+    ops: list[dist.P2POp] = []
+    recv_buffers: list[torch.Tensor] = []
+    for t in tensors:
+        tc = t.contiguous()
+        rb = torch.empty_like(tc)
+        ops.append(dist.P2POp(dist.isend, tc, send_to_global, group=group))
+        ops.append(dist.P2POp(dist.irecv, rb, recv_from_global, group=group))
+        recv_buffers.append(rb)
+    reqs = dist.batch_isend_irecv(ops)
+    for r in reqs:
+        r.wait()
+    return tuple(recv_buffers)
+
+
+# --- GQA expand / reduce ---------------------------------------------------
+
+
+def _expand_kv(t: torch.Tensor, num_kv: int, num_q: int) -> torch.Tensor:
+    """(B, S, Hkv, D) -> (B, S, Hq, D) by repeating each KV head."""
+    if num_kv == num_q:
+        return t
+    g = num_q // num_kv
+    return repeat(t, "b s h d -> b s (h g) d", g=g)
+
+
+def _reduce_kv_grad(g: torch.Tensor, num_kv: int, num_q: int) -> torch.Tensor:
+    """Inverse of :func:`_expand_kv` for grads — sum-reduce groups back."""
+    if num_kv == num_q:
+        return g
+    groups = num_q // num_kv
+    return rearrange(g, "b s (h gr) d -> b s h gr d", gr=groups).sum(dim=3)
+
+
+# --- Core ring autograd Function ------------------------------------------
+
+_RING_Q_TILE = 256
+
+
+def set_ring_q_tile(tile: int) -> None:
+    global _RING_Q_TILE
+    _RING_Q_TILE = int(tile)
+
+
+def _compute_block(
+    q: torch.Tensor,
+    k_block: torch.Tensor,
+    v_block: torch.Tensor,
+    mask_block: torch.Tensor,
+    scaling: float,
+    num_q: int,
+    num_kv: int,
+):
+    """Return (S [B,Hq,Sq,Sk], v32, k32) for one (Q-tile, K-block).
+
+    fp32 score + softmax accumulator matches eager_attention_forward to
+    within bf16 reassociation noise. Per-tile, not global — peak score
+    memory is O(B*Hq*q_tile*Sk_block), not O(B*Hq*Sq*Sk_total).
+    """
+    k_e = _expand_kv(k_block, num_kv, num_q)
+    v_e = _expand_kv(v_block, num_kv, num_q)
+    q32 = q.to(torch.float32)
+    k32 = k_e.to(torch.float32)
+    v32 = v_e.to(torch.float32)
+    S = torch.einsum("bqhd,bkhd->bhqk", q32, k32) * scaling
+    S = torch.where(mask_block.unsqueeze(1), S, torch.full_like(S, _NEG_INF))
+    return S, v32, k32
+
+
+class _RingAttention(torch.autograd.Function):
+    """Ring attention with online softmax (fwd) and blockwise remat (bwd).
+
+    Saved tensors are per-rank shards plus the final output and LSE; full
+    score matrices and per-block softmax outputs are recomputed in
+    backward from saved (q,k,v,LSE) — the blockwise rematerialization in
+    Liu et al. §3.2.2.
+    """
+
+    @staticmethod
+    def forward(
+        ctx,
+        q_local: torch.Tensor,  # (B, Sq_local, Hq, D)
+        k_local: torch.Tensor,  # (B, Sk_local, Hkv, D)
+        v_local: torch.Tensor,  # (B, Sk_local, Hkv, D)
+        attn_mask: torch.Tensor,  # (B, Sq_total, Sk_total) bool, replicated
+        scaling: float,
+        num_q: int,
+        num_kv: int,
+        group: dist.ProcessGroup,
+        q_lens: tuple[int, ...],
+        k_lens: tuple[int, ...],
+    ) -> torch.Tensor:
+        ws = dist.get_world_size(group)
+        rank = dist.get_rank(group)
+
+        B, Sq, Hq, D = q_local.shape
+        device = q_local.device
+        out_dtype = q_local.dtype
+
+        # Per-rank Q and K offsets into the replicated mask.
+        q_off = [0]
+        for L in q_lens:
+            q_off.append(q_off[-1] + L)
+        k_off = [0]
+        for L in k_lens:
+            k_off.append(k_off[-1] + L)
+        my_q_lo = q_off[rank]
+
+        m = torch.full((B, Hq, Sq), _NEG_INF, device=device, dtype=torch.float32)
+        l = torch.zeros((B, Hq, Sq), device=device, dtype=torch.float32)
+        O = torch.zeros((B, Sq, Hq, D), device=device, dtype=torch.float32)
+
+        k_cur = k_local.contiguous()
+        v_cur = v_local.contiguous()
+        owner = rank
+        q_tile = min(_RING_Q_TILE, Sq)
+
+        for step in range(ws):
+            k_lo, k_hi = k_off[owner], k_off[owner + 1]
+
+            for qs in range(0, Sq, q_tile):
+                qe = min(qs + q_tile, Sq)
+                q_tile_local = q_local[:, qs:qe].contiguous()
+                mt = attn_mask[:, my_q_lo + qs : my_q_lo + qe, k_lo:k_hi]
+
+                S, v32, _ = _compute_block(q_tile_local, k_cur, v_cur, mt, scaling, num_q, num_kv)
+                m_s = m[:, :, qs:qe]
+                l_s = l[:, :, qs:qe]
+                O_s = O[:, qs:qe]
+
+                block_max = S.max(dim=-1).values  # (B, Hq, q_tile)
+                m_new = torch.maximum(m_s, block_max)
+                # Fully-masked-row safety: when block_max == _NEG_INF and m_s
+                # == _NEG_INF, m_new == _NEG_INF; alpha = exp(0) = 1 and
+                # P = exp(0) = 1 so l accumulates Sk_block. l > 0 holds for
+                # every row by the time forward returns, so O/l is finite.
+                alpha = torch.exp(m_s - m_new)
+                P = torch.exp(S - m_new.unsqueeze(-1))
+                l_new = alpha * l_s + P.sum(dim=-1)
+                O_new = alpha.permute(0, 2, 1).unsqueeze(-1) * O_s + torch.einsum("bhqk,bkhd->bqhd", P, v32)
+                m[:, :, qs:qe] = m_new
+                l[:, :, qs:qe] = l_new
+                O[:, qs:qe] = O_new
+
+            if step < ws - 1:
+                k_cur, v_cur = _ring_rotate(k_cur, v_cur, group=group, forward_dir=True)
+                owner = (owner - 1) % ws
+
+        O = O / l.permute(0, 2, 1).unsqueeze(-1)
+        LSE = m + torch.log(l)
+
+        # Mask any row that *never* saw an unmasked key. l == Sk_total
+        # exactly for those (P=1 everywhere). Test on m instead: m stays
+        # _NEG_INF iff no real score was ever observed. Zero out so they
+        # contribute nothing to downstream loss / gradients.
+        no_real_score = m <= _NEG_INF / 2  # (B, Hq, Sq)
+        if no_real_score.any():
+            O = torch.where(no_real_score.permute(0, 2, 1).unsqueeze(-1), torch.zeros_like(O), O)
+            LSE = torch.where(no_real_score, torch.zeros_like(LSE), LSE)
+
+        ctx.save_for_backward(q_local, k_local, v_local, O, LSE, attn_mask, no_real_score)
+        ctx.scaling = scaling
+        ctx.num_q = num_q
+        ctx.num_kv = num_kv
+        ctx.group = group
+        ctx.q_off = tuple(q_off)
+        ctx.k_off = tuple(k_off)
+        return O.to(out_dtype)
+
+    @staticmethod
+    def backward(ctx, grad_O: torch.Tensor):
+        q_local, k_local, v_local, O, LSE, attn_mask, no_real_score = ctx.saved_tensors
+        scaling = ctx.scaling
+        num_q = ctx.num_q
+        num_kv = ctx.num_kv
+        group = ctx.group
+        q_off = ctx.q_off
+        k_off = ctx.k_off
+
+        ws = dist.get_world_size(group)
+        rank = dist.get_rank(group)
+        my_q_lo = q_off[rank]
+
+        # Zero grad on no-real-score rows so they don't propagate junk back.
+        grad_O32 = grad_O.to(torch.float32)
+        if no_real_score.any():
+            grad_O32 = torch.where(
+                no_real_score.permute(0, 2, 1).unsqueeze(-1),
+                torch.zeros_like(grad_O32),
+                grad_O32,
+            )
+
+        O32 = O.to(torch.float32)
+        D = (O32 * grad_O32).sum(dim=-1)  # (B, Sq, Hq)
+        D_bhq = D.permute(0, 2, 1)  # (B, Hq, Sq)
+
+        dq_local = torch.zeros_like(q_local, dtype=torch.float32)
+        dk_cur = torch.zeros_like(k_local, dtype=torch.float32)
+        dv_cur = torch.zeros_like(v_local, dtype=torch.float32)
+
+        k_cur = k_local.contiguous()
+        v_cur = v_local.contiguous()
+        owner = rank
+        Sq = q_local.shape[1]
+        q_tile = min(_RING_Q_TILE, Sq)
+
+        for step in range(ws):
+            k_lo, k_hi = k_off[owner], k_off[owner + 1]
+
+            for qs in range(0, Sq, q_tile):
+                qe = min(qs + q_tile, Sq)
+                q_tile_local = q_local[:, qs:qe].contiguous()
+                mt = attn_mask[:, my_q_lo + qs : my_q_lo + qe, k_lo:k_hi]
+
+                S, v32, k32 = _compute_block(q_tile_local, k_cur, v_cur, mt, scaling, num_q, num_kv)
+                LSE_tile = LSE[:, :, qs:qe]
+                # For no_real_score rows LSE is 0; S is _NEG_INF; P =
+                # exp(_NEG_INF) ≈ 0, so dV/dK/dQ contributions for those
+                # rows underflow to 0 — exactly what we want.
+                P = torch.exp(S - LSE_tile.unsqueeze(-1))
+
+                grad_O_tile = grad_O32[:, qs:qe]
+                D_tile = D_bhq[:, :, qs:qe]
+
+                dv_tile_e = torch.einsum("bhqk,bqhd->bkhd", P, grad_O_tile)
+                dv_tile = _reduce_kv_grad(dv_tile_e, num_kv, num_q)
+
+                dP = torch.einsum("bqhd,bkhd->bhqk", grad_O_tile, v32)
+                dS = P * (dP - D_tile.unsqueeze(-1))
+
+                dq_local[:, qs:qe] = dq_local[:, qs:qe] + torch.einsum("bhqk,bkhd->bqhd", dS, k32) * scaling
+                dk_tile_e = torch.einsum("bhqk,bqhd->bkhd", dS, q_tile_local.to(torch.float32)) * scaling
+                dk_tile = _reduce_kv_grad(dk_tile_e, num_kv, num_q)
+
+                dk_cur = dk_cur + dk_tile
+                dv_cur = dv_cur + dv_tile
+
+            if step < ws - 1:
+                k_cur, v_cur, dk_cur, dv_cur = _ring_rotate(
+                    k_cur, v_cur, dk_cur, dv_cur, group=group, forward_dir=True
+                )
+                owner = (owner - 1) % ws
+
+        # One more rotation in fwd direction brings dk/dv back to their owner.
+        if ws > 1:
+            dk_cur, dv_cur = _ring_rotate(dk_cur, dv_cur, group=group, forward_dir=True)
+
+        return (
+            dq_local.to(q_local.dtype),
+            dk_cur.to(k_local.dtype),
+            dv_cur.to(v_local.dtype),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+
+
+# --- Public entry point ----------------------------------------------------
+
+
+def _sdpa_fallback(
+    attention_mask: torch.Tensor,
+    batch_size: int,
+    head_dim: int,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    num_q: int,
+    num_kv: int,
+    scaling: float,
+) -> torch.Tensor:
+    """Numerically-equivalent SDPA path for ws==1 / no distributed."""
+    k_e = _expand_kv(k, num_kv, num_q)
+    v_e = _expand_kv(v, num_kv, num_q)
+    q_t = q.transpose(1, 2)
+    k_t = k_e.transpose(1, 2)
+    v_t = v_e.transpose(1, 2)
+    attn = attention_mask[:, None, :, :]
+    out = torch.nn.functional.scaled_dot_product_attention(
+        q_t,
+        k_t,
+        v_t,
+        attn_mask=attn,
+        dropout_p=0.0,
+        is_causal=False,
+        scale=scaling,
+    )
+    return out.permute(0, 2, 1, 3).reshape(batch_size, -1, num_q * head_dim)
+
+
+def ring_attention_forward(
+    attention_mask: torch.Tensor,
+    batch_size: int,
+    head_dim: int,
+    query_states: torch.Tensor,
+    key_states: torch.Tensor,
+    value_states: torch.Tensor,
+    *,
+    num_query_heads: int,
+    num_kv_heads: int,
+    scaling: float | None = None,
+    q_lengths_per_rank: Sequence[int] | None = None,
+    k_lengths_per_rank: Sequence[int] | None = None,
+    group: dist.ProcessGroup | None = None,
+) -> torch.Tensor:
+    """Drop-in replacement for eager_/sdpa_attention_forward.
+
+    Inputs are the local per-rank shards of Q/K/V; ``attention_mask`` is the
+    *replicated* (B, Q_total, K_total) bool mask. Returns the local slice of
+    attention output as (B, Sq_local, num_query_heads * head_dim).
+    """
+    g = group if group is not None else get_ring_group()
+    ws = ring_world_size(g)
+    if scaling is None:
+        scaling = head_dim**-0.5
+
+    if ws == 1 or g is None:
+        return _sdpa_fallback(
+            attention_mask,
+            batch_size,
+            head_dim,
+            query_states,
+            key_states,
+            value_states,
+            num_query_heads,
+            num_kv_heads,
+            scaling,
+        )
+
+    if q_lengths_per_rank is None:
+        q_lengths_per_rank = (query_states.shape[1],) * ws
+    if k_lengths_per_rank is None:
+        k_lengths_per_rank = (key_states.shape[1],) * ws
+
+    out_local = _RingAttention.apply(
+        query_states,
+        key_states,
+        value_states,
+        attention_mask,
+        scaling,
+        num_query_heads,
+        num_kv_heads,
+        g,
+        tuple(q_lengths_per_rank),
+        tuple(k_lengths_per_rank),
+    )
+    return out_local.reshape(batch_size, -1, num_query_heads * head_dim)

--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -73,10 +73,23 @@ def update_policy(
     lr_scheduler: AcceleratedScheduler | None = None,
 ) -> tuple[MetricsTracker, dict]:
     policy.train()
+    if train_config.ring_group_size is not None and train_config.ring_group_size > 1:
+        from opentau.policies.pi07.ring_attention import broadcast_batch_within_ring
+
+        broadcast_batch_within_ring(batch)
     losses = policy.forward(batch)
     loss = (
         train_config.loss_weighting["MSE"] * losses["MSE"] + train_config.loss_weighting["CE"] * losses["CE"]
     )
+
+    # 2D parallelism correction: ZeRO runs MEAN-over-WORLD on the gradient,
+    # but ring members share a single logical sample (each rank computes a
+    # partial gradient on its sequence slice; the sum across the ring is
+    # the true sample gradient). Pre-multiplying the loss by ring_group_size
+    # turns MEAN-over-WORLD into SUM-over-ring × MEAN-over-DP, which is
+    # what we want. No-op when ring is inactive.
+    if train_config.ring_group_size is not None and train_config.ring_group_size > 1:
+        loss = loss * train_config.ring_group_size
 
     accelerator.backward(loss)
     accelerator.unscale_gradients(optimizer=optimizer)
@@ -340,6 +353,30 @@ def train(cfg: TrainPipelineConfig):
     # Register accelerator globally for use in other modules, (e.g., detect current rank, etc.)
     set_proc_accelerator(accelerator)
 
+    # Build ring-attention sub-groups if requested. Sequence parallelism
+    # happens within each ring; DP-replication is implicit via ZeRO over
+    # WORLD with a loss-scale correction (see `train_step` below). Must
+    # come BEFORE `accelerator.prepare`: that call wraps the optimizer
+    # under DeepSpeed and reads the WORLD process group; we keep WORLD as
+    # ZeRO's group and only carve out a sub-group for the ring kernel.
+    if cfg.ring_group_size is not None and cfg.ring_group_size > 1:
+        import torch.distributed as _dist
+
+        from opentau.policies.pi07.ring_attention import build_ring_groups
+
+        if not _dist.is_available() or not _dist.is_initialized():
+            raise RuntimeError(
+                "ring_group_size requires torch.distributed to be initialised "
+                "before training starts. Launch via `accelerate launch` (or "
+                "torchrun) so the world is set up by the time `train()` is called."
+            )
+        ws = _dist.get_world_size()
+        if ws % cfg.ring_group_size != 0:
+            raise ValueError(
+                f"world_size ({ws}) must be divisible by ring_group_size ({cfg.ring_group_size})."
+            )
+        build_ring_groups(cfg.ring_group_size)
+
     # Must run before `encode_accelerator_state_dict` + `init_trackers` below so the
     # wandb-logged accelerator config and the value DeepSpeed consumes at prepare()
     # time both reflect TrainPipelineConfig.
@@ -403,7 +440,31 @@ def train(cfg: TrainPipelineConfig):
             logging.info(f"tracker initialized with wandb job id: {tracker.id}")
 
     if cfg.seed is not None:
-        set_seed(cfg.seed, accelerator=accelerator)
+        if cfg.ring_group_size is not None and cfg.ring_group_size > 1:
+            # Under ring attention, every rank in the same ring sub-group
+            # must see the same sample stream — they jointly attend over
+            # one logical sequence per step. Seeding by DP index instead
+            # of global process index achieves that without needing a
+            # per-step broadcast: ranks 0..R-1 share dp_rank=0, ranks
+            # R..2R-1 share dp_rank=1, etc.
+            from opentau.policies.pi07.ring_attention import dp_rank
+
+            magic_number = 12345
+            effective_seed = cfg.seed + dp_rank(cfg.ring_group_size) * magic_number
+            import random as _random
+
+            import numpy as _np
+
+            _random.seed(effective_seed)
+            _np.random.seed(effective_seed)
+            torch.manual_seed(effective_seed)
+            if torch.cuda.is_available():
+                torch.cuda.manual_seed_all(effective_seed)
+            from accelerate.utils import set_seed as _accel_set_seed
+
+            _accel_set_seed(effective_seed)
+        else:
+            set_seed(cfg.seed, accelerator=accelerator)
 
     # Enable anomaly detection for debugging NaN/Inf values
     # (warning: large computational overhead)


### PR DESCRIPTION
## What this does

Adds ring attention (Liu, Zaharia & Abbeel 2023, arXiv:2310.01889) as a new ``attention_implementation`` on pi07, with ZeRO-2 2D parallelism:

- **Sequence parallelism**: ``ring_group_size`` carves the world into contiguous ring sub-groups of size R. Within each ring, attention K/V rotate around the ranks via ``dist.batch_isend_irecv``; the (Q_total, K_total) score matrix is never materialised on any rank — online softmax accumulates ``O``, ``m``, ``l`` per Q-tile.
- **Blockwise rematerialization (replaces the existing grad checkpointing)**: the backward recomputes per-block ``S``, ``P`` from saved ``(q, k, v, LSE)`` rather than saving them. This is Liu et al. §3.2.2. The old per-layer ``torch.utils.checkpoint`` wrapper in ``Gemma3WithExpertModel.forward`` is removed.
- **2D parallelism with DeepSpeed ZeRO-2**: ``ring_size × dp_size == world_size``. The DP axis is **implicit** — ZeRO runs over WORLD with a ``loss *= ring_group_size`` correction so the MEAN-over-WORLD reduction collapses to SUM-over-ring × MEAN-over-DP. No second NCCL communicator competes with ZeRO's on shared CUDA streams (one of the failure modes from earlier ring + ZeRO experiments).
- **Fully-masked-row safety**: rows where every K position is masked out (PAD-only rows) would otherwise drive the online softmax through ``exp(-inf - -inf)``. The forward detects them via ``m == _NEG_INF`` after all ring steps and zeros their ``O`` and ``LSE``; the backward propagates zero through them.
- **Mask is replicated, position_ids and inputs_embeds are sharded**: the ring kernel slices the global (B, Q_total, K_total) bool mask using rank offsets, so the InterleavedDecoderLayer interface is unchanged. ``Gemma3WithExpertModel.forward`` shards ``inputs_embeds`` and ``position_ids`` along the seq axis before the decoder stack and all-gathers after the last layer, so heads and loss see the full sequence layout.
- **Same-batch-within-ring**: seeds the dataloader by DP index (so ranks in the same ring draw the same sample stream) and broadcasts the batch in-place once per step as a belt-and-braces guard against worker-side stochasticity.

New config knobs:
- ``TrainPipelineConfig.ring_group_size`` (top-level): must divide world size. ``None`` keeps the legacy single-ring / pure-DP behaviour.
- ``Gemma3WithExpertConfig.attention_implementation = \"ring\"``: opts into ring; falls back to SDPA when world size is 1 or distributed is not initialised, so single-GPU tests and the eager dispatch keep working.

## How it was tested

- ``pre-commit run --all-files``: ruff, ruff-format, pyupgrade, gitleaks, bandit, zizmor — all pass.
- Smoke run on gpu-387 (bot_387 reservation, 8x A100 80GB) via ``/fss/bot/slurm/init_training.sh`` with ``configs/pi07_ring_zero2_smoke.json`` (ring_group_size=4, ZeRO-2, 20 steps, bs=4): currently blocked at the train.sh guard requiring ``WANDB_TOKEN`` / ``HUGGINGFACE_TOKEN`` in the sbatch env (non-interactive ssh doesn't see them). Re-run from an interactive cluster shell to validate end-to-end before merging.

## How to checkout & try? (for the reviewer)

\`\`\`bash
git fetch origin && git checkout feat/pi07-ring-attn

# Smoke test on a 8x A100 node (bot_387 reservation on a100-training):
/fss/bot/slurm/init_training.sh \\
  --accelerate-config /fss/bot/configs/accelerate/zero2-8a100-bf16.yaml \\
  --train-config /home/williamyue/configs/pi07_ring_zero2_smoke.json \\
  --reservation bot_387 --no-resume --extra-env libero \\
  --opentau-dir /fss/bot/OpenTau-ringattn \\
  --wandb-job-name pi07-ring-zero2-smoke
\`\`\`

To exercise the single-GPU SDPA fallback path:

\`\`\`bash
opentau-train --config_path=configs/examples/pi07_low_level_libero.json --policy.attention_implementation=ring
\`\`\`

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [x] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m \"gpu\") and regression tests.