### PR TITLE
fix(datasets): harden dataset loading for large pretrain mixtures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,7 @@ opentau-dataset-viz = "opentau.scripts.launch:visualize"
 [project.optional-dependencies]
 dev = ["pre-commit>=3.7.0",
     "debugpy>=1.8.1",
+    "py-spy>=0.3.14",
     "pytest>=8.1.0",
     "pytest-cov>=5.0.0",
     "pyserial>=3.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,6 @@ opentau-dataset-viz = "opentau.scripts.launch:visualize"
 [project.optional-dependencies]
 dev = ["pre-commit>=3.7.0",
     "debugpy>=1.8.1",
-    "py-spy>=0.3.14",
     "pytest>=8.1.0",
     "pytest-cov>=5.0.0",
     "pyserial>=3.5",

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -1617,26 +1617,30 @@ class LeRobotDataset(BaseDataset):
         try:
             hf_dataset = Dataset(table, info=DatasetInfo(features=features))
         except (TypeError, ValueError) as cast_err:
-            # info.json's declared features can drift from what was actually
-            # written to parquet, in two ways:
-            #   * type drift — e.g. shape=[1] gets serialized as Value(...) by
-            #     get_hf_features_from_features but the parquet column was
-            #     emitted as list<...>; HF's Dataset constructor then raises
-            #     TypeError("Couldn't cast ...").
-            #   * column-set drift — parquet has a column info.json never
-            #     declared (e.g. gripper_activity_action); HF raises
-            #     ValueError("Keys mismatch ...").
-            # Both mean the same thing — stale metadata — and both want the
-            # same fallback: use parquet-inferred features so the dataset
-            # still loads. The underlying metadata still needs a curator fix.
-            msg = str(cast_err)
-            if "Couldn't cast" not in msg and "Keys mismatch" not in msg:
-                raise
+            # info.json's declared features routinely drift from what was
+            # actually written to parquet. HF's typed Dataset constructor
+            # surfaces this as several different exceptions depending on the
+            # kind of drift — observed in this dataset corpus:
+            #   * TypeError("Couldn't cast ...")            — type drift
+            #   * ValueError("Keys mismatch ...")           — column-set drift
+            #   * ValueError("External features info don't match ...")
+            #                                               — fixed vs variable
+            #                                                 length list drift
+            # They all mean the same thing (stale metadata) and all want the
+            # same fallback: drop the declared features and infer them from the
+            # parquet so the dataset still loads. `features` is built by our
+            # own get_hf_features_from_features from a valid pa.Table, so a
+            # TypeError/ValueError from this constructor is always a metadata/
+            # parquet reconciliation failure, never a programming error — hence
+            # catching the exception types rather than grepping their messages
+            # (the message text varies and embeds huge schema dumps). The
+            # underlying metadata still needs a curator-side fix.
+            reason = str(cast_err).splitlines()[0][:200]
             logging.warning(
                 "Feature reconciliation from meta/info.json failed for %s (%s); "
                 "falling back to parquet-inferred features.",
                 self.repo_id,
-                cast_err,
+                reason,
             )
             hf_dataset = Dataset(table)
         hf_dataset.set_transform(hf_transform_to_torch)

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -1660,10 +1660,11 @@ class LeRobotDataset(BaseDataset):
         memory-map correctly.
 
         Schema is inferred from the parquet files themselves; it is intentionally
-        not validated against `meta/info.json`. This lets cross-file column drift
-        load instead of raising a cast error, at the cost of `info.json` no
-        longer being the authoritative schema (drift now surfaces as a
-        `load_dataset` failure rather than a feature-cast error).
+        not validated against `meta/info.json`. So a parquet/`info.json` mismatch
+        now loads silently — the parquet's own schema wins and `info.json` is no
+        longer authoritative. A mismatch *between* the parquet files of a single
+        dataset still fails, but as a `load_dataset` concatenation error rather
+        than the old explicit feature-cast error.
 
         Files are passed in sorted-episode order so the hf_dataset row layout
         stays aligned with `episode_data_index["from"/"to"]` — see the

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -363,17 +363,18 @@ class LeRobotDatasetMetadata(DatasetMetadata):
             if is_valid_version(self.revision):
                 self.revision = get_safe_version(self.repo_id, self.revision)
 
-            # In distributed training, only rank 0 downloads to avoid race conditions
-            # where other ranks read metadata before the download has finished.
-            acc = get_proc_accelerator()
-            if acc is not None and acc.num_processes > 1:
-                if acc.is_main_process:
-                    (self.root / "meta").mkdir(exist_ok=True, parents=True)
-                    self.pull_from_repo(allow_patterns="meta/")
-                acc.wait_for_everyone()
-            else:
-                (self.root / "meta").mkdir(exist_ok=True, parents=True)
-                self.pull_from_repo(allow_patterns="meta/")
+            # All ranks attempt the metadata download. snapshot_download uses a
+            # per-repo filelock under the hood, so concurrent callers from
+            # sibling ranks don't double-fetch — one winner does the download,
+            # the rest block on the lock and then resolve as cache hits.
+            # The previous rank-0-only + accelerator.wait_for_everyone()
+            # pattern was racy in practice: under DeepSpeed launch the barrier
+            # did not reliably gate non-zero ranks until rank 0 finished
+            # pull_from_repo, so downstream ranks would reach load_metadata
+            # before meta/info.json existed on disk and crash with
+            # FileNotFoundError.
+            (self.root / "meta").mkdir(exist_ok=True, parents=True)
+            self.pull_from_repo(allow_patterns="meta/")
             self.load_metadata()
 
     def load_metadata(self) -> None:
@@ -1305,27 +1306,17 @@ class LeRobotDataset(BaseDataset):
             src_root = HF_OPENTAU_HOME / src_repo
             src_info_path = src_root / INFO_PATH
             if not src_info_path.is_file():
-                acc = get_proc_accelerator()
-                if acc is not None and acc.num_processes > 1:
-                    if acc.is_main_process:
-                        src_info_path.parent.mkdir(exist_ok=True, parents=True)
-                        hf_hub_download(
-                            repo_id=src_repo,
-                            filename=INFO_PATH,
-                            repo_type="dataset",
-                            revision=src_revision,
-                            local_dir=src_root,
-                        )
-                    acc.wait_for_everyone()
-                else:
-                    src_info_path.parent.mkdir(exist_ok=True, parents=True)
-                    hf_hub_download(
-                        repo_id=src_repo,
-                        filename=INFO_PATH,
-                        repo_type="dataset",
-                        revision=src_revision,
-                        local_dir=src_root,
-                    )
+                # All ranks fetch concurrently — hf_hub_download uses a per-file
+                # filelock, so sibling ranks coalesce on the same download.
+                # See LeRobotDatasetMetadata.__init__ for the same fix pattern.
+                src_info_path.parent.mkdir(exist_ok=True, parents=True)
+                hf_hub_download(
+                    repo_id=src_repo,
+                    filename=INFO_PATH,
+                    repo_type="dataset",
+                    revision=src_revision,
+                    local_dir=src_root,
+                )
             src_info = json.loads(src_info_path.read_text())
             self._overlay = {
                 "source_repo": src_repo,

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -1255,6 +1255,13 @@ class LeRobotDataset(BaseDataset):
         # episode_data_index["from"/"to"] (built in self.episodes order in
         # get_episode_data_index). Mismatched order would silently return
         # rows from the wrong episode for callers that pass an unsorted list.
+        #
+        # `self.episodes` is backfilled with the full episode list further down
+        # when it is None (so downstream indexing always has a concrete list),
+        # which destroys the "no subset requested" signal. Capture it now so
+        # `download_episodes` can still distinguish a whole-repo pull from a
+        # subset pull.
+        self._episodes_were_specified = episodes is not None
         self.episodes = sorted(episodes) if episodes is not None else None
         self.tolerance_s = tolerance_s
         self.skip_timestamp_check = skip_timestamp_check
@@ -1540,7 +1547,7 @@ class LeRobotDataset(BaseDataset):
 
     @on_accelerate_main_proc(local=True, _sync=True)
     def download_files(self, files: list[str]) -> None:
-        """Fetch an explicit list of repo files, one `hf_hub_download` per file.
+        """Fetch the files from `files` that are missing on disk, one `hf_hub_download` each.
 
         `snapshot_download(allow_patterns=<thousands of explicit paths>)` spends
         many minutes GIL-held and I/O-idle inside `filter_repo_objects`, whose
@@ -1548,11 +1555,25 @@ class LeRobotDataset(BaseDataset):
         watchdog while sibling ranks wait at the `_sync` broadcast.
         `hf_hub_download` targets each file by exact path, skipping the filter
         entirely; a thread pool overlaps the network round-trips (the GIL is
-        released during I/O). Files already present in `local_dir` are not
-        re-downloaded.
+        released during I/O).
         """
         if not files:
             return
+        # `hf_hub_download` issues a network metadata request per file even
+        # when the file is already in `local_dir`. Calling it for an
+        # already-complete episode set burns one HF API request per file and
+        # trips the 3000 req / 5 min rate limit (429). Skip files already on
+        # disk — when the selected episodes were pre-downloaded this is a
+        # no-op that makes zero requests.
+        missing = [f for f in files if not (self.root / f).is_file()]
+        if not missing:
+            return
+        logging.info(
+            "%s: %d/%d episode files absent on disk, downloading them",
+            self.repo_id,
+            len(missing),
+            len(files),
+        )
 
         def _fetch(fpath: str) -> None:
             hf_hub_download(
@@ -1565,7 +1586,7 @@ class LeRobotDataset(BaseDataset):
 
         with ThreadPoolExecutor(max_workers=16) as pool:
             # list() forces the lazy map so any per-file failure propagates.
-            list(pool.map(_fetch, files))
+            list(pool.map(_fetch, missing))
 
     def download_episodes(self, download_videos: bool = True) -> None:
         """Downloads the dataset from the given 'repo_id' at the provided version. If 'episodes' is given, this
@@ -1574,9 +1595,12 @@ class LeRobotDataset(BaseDataset):
         """
         # TODO(rcadene, aliberts): implement faster transfer
         # https://huggingface.co/docs/huggingface_hub/en/guides/download#faster-downloads
-        if self.episodes is None:
+        if not self._episodes_were_specified:
             # Whole-dataset download: snapshot_download with no allow_patterns
-            # has nothing to filter, so there is no filter_repo_objects blowup.
+            # has nothing to filter, so there is no filter_repo_objects blowup,
+            # and it lists the repo tree in O(1) API calls instead of one
+            # metadata request per file. `self.episodes` has been backfilled to
+            # the full list by now, so branch on the construction-time flag.
             ignore_patterns = None if download_videos else "videos/"
             self.pull_from_repo(ignore_patterns=ignore_patterns)
             return

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -1614,7 +1614,24 @@ class LeRobotDataset(BaseDataset):
         pa_dataset = pa_ds.dataset(list(map(str, paths)), format="parquet")
         filter_expr = pa_ds.field("episode_index").isin(self.episodes) if self.episodes is not None else None
         table = pa_dataset.to_table(filter=filter_expr)
-        hf_dataset = Dataset(table, info=DatasetInfo(features=features))
+        try:
+            hf_dataset = Dataset(table, info=DatasetInfo(features=features))
+        except TypeError as cast_err:
+            # info.json's declared feature types can drift from what was actually
+            # written to parquet (e.g. shape=[1] gets serialized as Value(...) by
+            # get_hf_features_from_features but the parquet column was emitted
+            # as list<...>). The strict cast in HF's Dataset constructor then
+            # raises TypeError("Couldn't cast ..."). Surface a warning and fall
+            # back to schema-inferred features so the dataset still loads; the
+            # underlying metadata still needs a curator-side fix.
+            if "Couldn't cast" not in str(cast_err):
+                raise
+            logging.warning(
+                "Feature cast from meta/info.json failed for %s (%s); falling back to parquet-inferred features.",
+                self.repo_id,
+                cast_err,
+            )
+            hf_dataset = Dataset(table)
         hf_dataset.set_transform(hf_transform_to_torch)
         return hf_dataset
 

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -87,7 +87,6 @@ import functools
 import json
 import logging
 import math
-import re
 import shutil
 import traceback
 from abc import abstractmethod
@@ -218,6 +217,12 @@ def retry_random_on_failure(f):
 
 
 CODEBASE_VERSION = "v2.1"
+
+# Thread-pool width for the per-file `hf_hub_download` fan-out in `download_files`.
+# The work is network-I/O-bound (the GIL is released during each request), so a
+# width well above the core count is fine; 16 keeps enough round-trips in flight
+# without hammering the Hub.
+_DOWNLOAD_MAX_WORKERS = 16
 
 # Set of repo_ids for which we've already emitted the "missing control_mode" warning.
 # Keyed at module level so duplicates are suppressed across multiple LeRobotDataset
@@ -1584,7 +1589,7 @@ class LeRobotDataset(BaseDataset):
                 local_dir=self.root,
             )
 
-        with ThreadPoolExecutor(max_workers=16) as pool:
+        with ThreadPoolExecutor(max_workers=_DOWNLOAD_MAX_WORKERS) as pool:
             # list() forces the lazy map so any per-file failure propagates.
             list(pool.map(_fetch, missing))
 
@@ -1642,32 +1647,31 @@ class LeRobotDataset(BaseDataset):
         Loads the per-episode parquet files via `load_dataset("parquet", ...)`,
         which builds a memory-mapped Arrow cache under `$HF_HOME/datasets/`. The
         cache costs disk (~1-5x the parquet, compression-dependent — see #277)
-        but the loaded dataset is genuinely memory-mapped (resident pages are
-        file-backed and reclaimable), so RAM stays bounded by the OS page cache
-        rather than the dataset size. That is essential here: 8 ranks each load
-        the full mixture, and the multi-hundred-GB video repos would otherwise
-        OOM the node. A hand-rolled `pa_ds.to_table()` + `Dataset(table)` (or
-        streaming to a self-written Arrow IPC file + `Dataset.from_file`) was
-        tried and both materialised into anonymous RAM instead of mmapping —
-        `load_dataset` routes through HF's ParquetDatasetBuilder, whose Arrow
-        cache `Dataset.from_file` *does* memory-map correctly.
+        and nothing prunes it, so a multi-hundred-GB mixture needs that much
+        extra disk provisioned. In exchange the loaded dataset is genuinely
+        memory-mapped (resident pages are file-backed and reclaimable), so RAM
+        stays bounded by the OS page cache rather than the dataset size. That is
+        essential here: 8 ranks each load the full mixture, and the
+        multi-hundred-GB video repos would otherwise OOM the node. A hand-rolled
+        `pa_ds.to_table()` + `Dataset(table)` (or streaming to a self-written
+        Arrow IPC file + `Dataset.from_file`) was tried and both materialised
+        into anonymous RAM instead of mmapping — `load_dataset` routes through
+        HF's ParquetDatasetBuilder, whose Arrow cache `Dataset.from_file` *does*
+        memory-map correctly.
+
+        Schema is inferred from the parquet files themselves; it is intentionally
+        not validated against `meta/info.json`. This lets cross-file column drift
+        load instead of raising a cast error, at the cost of `info.json` no
+        longer being the authoritative schema (drift now surfaces as a
+        `load_dataset` failure rather than a feature-cast error).
 
         Files are passed in sorted-episode order so the hf_dataset row layout
         stays aligned with `episode_data_index["from"/"to"]` — see the
-        `sorted(episodes)` note in __init__.
+        `sorted(episodes)` note in __init__. `self.episodes` is always a concrete
+        list here: __init__ backfills it with the full episode list before this
+        method is ever called.
         """
-        # Derive the parquet glob from the meta data_path template so that
-        # datasets with a non-default `info["data_path"]` (deeper nesting,
-        # flat layout, etc.) keep working. Default template is
-        # "data/chunk-{episode_chunk:03d}/episode_{episode_index:06d}.parquet"
-        # which yields the glob "data/chunk-*/episode_*.parquet". Assumes the
-        # template uses simple `{name}` / `{name:fmt}` placeholders and no
-        # literal `{{`/`}}` escapes — true for every in-repo writer.
-        if self.episodes is None:
-            glob_pattern = re.sub(r"\{[^}]+\}", "*", self.meta.data_path)
-            files = [str(p) for p in sorted(self.root.glob(glob_pattern))]
-        else:
-            files = [str(self.root / self.meta.get_data_file_path(ep_idx)) for ep_idx in self.episodes]
+        files = [str(self.root / self.meta.get_data_file_path(ep_idx)) for ep_idx in self.episodes]
         if not files:
             raise FileNotFoundError(f"No parquet files for {self.repo_id} under {self.root}")
         hf_dataset = load_dataset("parquet", data_files=files, split="train")

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -363,18 +363,17 @@ class LeRobotDatasetMetadata(DatasetMetadata):
             if is_valid_version(self.revision):
                 self.revision = get_safe_version(self.repo_id, self.revision)
 
-            # All ranks attempt the metadata download. snapshot_download uses a
-            # per-repo filelock under the hood, so concurrent callers from
-            # sibling ranks don't double-fetch — one winner does the download,
-            # the rest block on the lock and then resolve as cache hits.
-            # The previous rank-0-only + accelerator.wait_for_everyone()
-            # pattern was racy in practice: under DeepSpeed launch the barrier
-            # did not reliably gate non-zero ranks until rank 0 finished
-            # pull_from_repo, so downstream ranks would reach load_metadata
-            # before meta/info.json existed on disk and crash with
-            # FileNotFoundError.
-            (self.root / "meta").mkdir(exist_ok=True, parents=True)
-            self.pull_from_repo(allow_patterns="meta/")
+            # In distributed training, only rank 0 downloads to avoid race conditions
+            # where other ranks read metadata before the download has finished.
+            acc = get_proc_accelerator()
+            if acc is not None and acc.num_processes > 1:
+                if acc.is_main_process:
+                    (self.root / "meta").mkdir(exist_ok=True, parents=True)
+                    self.pull_from_repo(allow_patterns="meta/")
+                acc.wait_for_everyone()
+            else:
+                (self.root / "meta").mkdir(exist_ok=True, parents=True)
+                self.pull_from_repo(allow_patterns="meta/")
             self.load_metadata()
 
     def load_metadata(self) -> None:
@@ -1306,17 +1305,27 @@ class LeRobotDataset(BaseDataset):
             src_root = HF_OPENTAU_HOME / src_repo
             src_info_path = src_root / INFO_PATH
             if not src_info_path.is_file():
-                # All ranks fetch concurrently — hf_hub_download uses a per-file
-                # filelock, so sibling ranks coalesce on the same download.
-                # See LeRobotDatasetMetadata.__init__ for the same fix pattern.
-                src_info_path.parent.mkdir(exist_ok=True, parents=True)
-                hf_hub_download(
-                    repo_id=src_repo,
-                    filename=INFO_PATH,
-                    repo_type="dataset",
-                    revision=src_revision,
-                    local_dir=src_root,
-                )
+                acc = get_proc_accelerator()
+                if acc is not None and acc.num_processes > 1:
+                    if acc.is_main_process:
+                        src_info_path.parent.mkdir(exist_ok=True, parents=True)
+                        hf_hub_download(
+                            repo_id=src_repo,
+                            filename=INFO_PATH,
+                            repo_type="dataset",
+                            revision=src_revision,
+                            local_dir=src_root,
+                        )
+                    acc.wait_for_everyone()
+                else:
+                    src_info_path.parent.mkdir(exist_ok=True, parents=True)
+                    hf_hub_download(
+                        repo_id=src_repo,
+                        filename=INFO_PATH,
+                        repo_type="dataset",
+                        revision=src_revision,
+                        local_dir=src_root,
+                    )
             src_info = json.loads(src_info_path.read_text())
             self._overlay = {
                 "source_repo": src_repo,

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -1358,7 +1358,8 @@ class LeRobotDataset(BaseDataset):
             assert all((self.root / fpath).is_file() for fpath in self.get_episodes_file_paths())
             self.hf_dataset = self.load_hf_dataset()
         except (AssertionError, FileNotFoundError, NotADirectoryError):
-            self.revision = get_safe_version(self.repo_id, self.revision)
+            if is_valid_version(self.revision):
+                self.revision = get_safe_version(self.repo_id, self.revision)
             self.download_episodes(download_videos)
             self.hf_dataset = self.load_hf_dataset()
 

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -84,15 +84,12 @@ Example:
 import contextlib
 import copy
 import functools
-import hashlib
 import json
 import logging
 import math
-import os
 import re
 import shutil
 import traceback
-import uuid
 from abc import abstractmethod
 from pathlib import Path
 from typing import Callable
@@ -101,14 +98,11 @@ import datasets
 import numpy as np
 import packaging.version
 import PIL.Image
-import pyarrow as pa
-import pyarrow.dataset as pa_ds
 import torch
 import torch.nn.functional as F  # noqa: N812
 import torch.utils
-from datasets import Dataset, DatasetInfo, concatenate_datasets
+from datasets import concatenate_datasets, load_dataset
 from einops import rearrange
-from filelock import FileLock
 from huggingface_hub import HfApi, hf_hub_download, snapshot_download
 from huggingface_hub.constants import REPOCARD_NAME
 from huggingface_hub.errors import RevisionNotFoundError
@@ -1582,7 +1576,25 @@ class LeRobotDataset(BaseDataset):
         return fpaths
 
     def load_hf_dataset(self) -> datasets.Dataset:
-        """hf_dataset contains all the observations, states, actions, rewards, etc."""
+        """hf_dataset contains all the observations, states, actions, rewards, etc.
+
+        Loads the per-episode parquet files via `load_dataset("parquet", ...)`,
+        which builds a memory-mapped Arrow cache under `$HF_HOME/datasets/`. The
+        cache costs disk (~1-5x the parquet, compression-dependent — see #277)
+        but the loaded dataset is genuinely memory-mapped (resident pages are
+        file-backed and reclaimable), so RAM stays bounded by the OS page cache
+        rather than the dataset size. That is essential here: 8 ranks each load
+        the full mixture, and the multi-hundred-GB video repos would otherwise
+        OOM the node. A hand-rolled `pa_ds.to_table()` + `Dataset(table)` (or
+        streaming to a self-written Arrow IPC file + `Dataset.from_file`) was
+        tried and both materialised into anonymous RAM instead of mmapping —
+        `load_dataset` routes through HF's ParquetDatasetBuilder, whose Arrow
+        cache `Dataset.from_file` *does* memory-map correctly.
+
+        Files are passed in sorted-episode order so the hf_dataset row layout
+        stays aligned with `episode_data_index["from"/"to"]` — see the
+        `sorted(episodes)` note in __init__.
+        """
         # Derive the parquet glob from the meta data_path template so that
         # datasets with a non-default `info["data_path"]` (deeper nesting,
         # flat layout, etc.) keep working. Default template is
@@ -1590,122 +1602,16 @@ class LeRobotDataset(BaseDataset):
         # which yields the glob "data/chunk-*/episode_*.parquet". Assumes the
         # template uses simple `{name}` / `{name:fmt}` placeholders and no
         # literal `{{`/`}}` escapes — true for every in-repo writer.
-        glob_pattern = re.sub(r"\{[^}]+\}", "*", self.meta.data_path)
-        paths = sorted(self.root.glob(glob_pattern))
-        if not paths:
-            raise FileNotFoundError(f"No parquet files matching {glob_pattern!r} under {self.root}")
-        pa_dataset = pa_ds.dataset(list(map(str, paths)), format="parquet")
-        filter_expr = pa_ds.field("episode_index").isin(self.episodes) if self.episodes is not None else None
-
-        # Image-dtype columns hold raw image bytes inline in the parquet and
-        # need the HF `Image()` feature to decode on access. The mmap path
-        # loads via `Dataset.from_file`, which infers features from the Arrow
-        # schema and so cannot reconstruct `Image()`; route those datasets (all
-        # small in this corpus) through the in-RAM path instead. Everything
-        # else — including the multi-hundred-GB video repos — goes through the
-        # memory-mapped path so the mixture load doesn't OOM the node.
-        has_image_feature = any(ft.get("dtype") == "image" for ft in self.meta.features.values())
-        if has_image_feature:
-            hf_dataset = self._load_hf_dataset_in_ram(pa_dataset, filter_expr)
+        if self.episodes is None:
+            glob_pattern = re.sub(r"\{[^}]+\}", "*", self.meta.data_path)
+            files = [str(p) for p in sorted(self.root.glob(glob_pattern))]
         else:
-            hf_dataset = self._load_hf_dataset_mmap(pa_dataset, filter_expr)
+            files = [str(self.root / self.meta.get_data_file_path(ep_idx)) for ep_idx in self.episodes]
+        if not files:
+            raise FileNotFoundError(f"No parquet files for {self.repo_id} under {self.root}")
+        hf_dataset = load_dataset("parquet", data_files=files, split="train")
         hf_dataset.set_transform(hf_transform_to_torch)
         return hf_dataset
-
-    def _load_hf_dataset_in_ram(self, pa_dataset: pa_ds.Dataset, filter_expr) -> datasets.Dataset:
-        """Materialize the filtered parquet fully in RAM and wrap it in a Dataset.
-
-        Used only for datasets with `image`-dtype columns, which need the HF
-        `Image()` feature applied via the typed `Dataset(...)` constructor.
-        Such datasets are small in this corpus, so the in-RAM cost is bounded.
-        """
-        features = get_hf_features_from_features(self.meta.features)
-        table = pa_dataset.to_table(filter=filter_expr)
-        try:
-            return Dataset(table, info=DatasetInfo(features=features))
-        except (TypeError, ValueError) as cast_err:
-            # info.json's declared features routinely drift from what was
-            # actually written to parquet. HF's typed Dataset constructor
-            # surfaces this as several different exceptions depending on the
-            # kind of drift — observed in this dataset corpus:
-            #   * TypeError("Couldn't cast ...")            — type drift
-            #   * ValueError("Keys mismatch ...")           — column-set drift
-            #   * ValueError("External features info don't match ...")
-            #                                               — fixed vs variable
-            #                                                 length list drift
-            # They all mean the same thing (stale metadata) and all want the
-            # same fallback: drop the declared features and infer them from the
-            # parquet so the dataset still loads. `features` is built by our
-            # own get_hf_features_from_features from a valid pa.Table, so a
-            # TypeError/ValueError from this constructor is always a metadata/
-            # parquet reconciliation failure, never a programming error — hence
-            # catching the exception types rather than grepping their messages
-            # (the message text varies and embeds huge schema dumps). The
-            # underlying metadata still needs a curator-side fix.
-            reason = str(cast_err).splitlines()[0][:200]
-            logging.warning(
-                "Feature reconciliation from meta/info.json failed for %s (%s); "
-                "falling back to parquet-inferred features.",
-                self.repo_id,
-                reason,
-            )
-            return Dataset(table)
-
-    def _load_hf_dataset_mmap(self, pa_dataset: pa_ds.Dataset, filter_expr) -> datasets.Dataset:
-        """Stream the filtered parquet into a memory-mapped Arrow IPC file.
-
-        `to_table()` materializes every filtered row in RAM. With 8 ranks each
-        loading the full mixture, the multi-hundred-GB video repos
-        (humanoid-everyday-*) blow past node memory and OOM. Streaming the
-        scanner batch-by-batch into an Arrow IPC file keeps only one batch
-        resident during the write, and `Dataset.from_file` then mmaps the
-        result — resident memory is bounded by the OS page cache, not the
-        dataset size, and the mapping is shared across all ranks on the node.
-
-        The Arrow file is cached under the dataset root keyed by
-        (revision, episode selection): reruns skip the conversion entirely and
-        the key invalidates when either input changes. A per-key FileLock
-        serialises the write across ranks sharing the node-local cache dir —
-        exactly one rank runs the conversion, the rest block then mmap the
-        result. (Going through `load_dataset`/`Dataset.from_parquet` instead
-        would route through ParquetDatasetBuilder, which rewrites an
-        uncompressed Arrow cache at $HF_HOME at 1-5x source size — see #277.)
-        """
-        cache_dir = self.root / ".arrow_cache"
-        episodes_key = "all" if self.episodes is None else ",".join(map(str, sorted(self.episodes)))
-        cache_key = hashlib.sha256(f"{self.revision}\0{episodes_key}".encode()).hexdigest()[:16]
-        arrow_path = cache_dir / f"{cache_key}.arrow"
-        lock_path = cache_dir / f"{cache_key}.lock"
-        cache_dir.mkdir(parents=True, exist_ok=True)
-
-        # FileLock releases on process exit (fcntl), so a crashed writer can't
-        # deadlock the others; the loser of the race just finds the file ready.
-        with FileLock(str(lock_path)):
-            if not arrow_path.is_file():
-                tmp_path = cache_dir / f"{cache_key}.{uuid.uuid4().hex}.tmp"
-                try:
-                    scanner = pa_dataset.scanner(filter=filter_expr)
-                    # Arrow IPC *stream* format (new_stream), not file format:
-                    # HF's Dataset.from_file memory-maps via pa.ipc.open_stream,
-                    # which only reads the stream format. Writing the file
-                    # format here makes from_file misparse the footer as a
-                    # stream message ("Expected to read N metadata bytes ...").
-                    with pa.OSFile(str(tmp_path), "wb") as sink:
-                        writer = None
-                        for batch in scanner.to_batches():
-                            if writer is None:
-                                writer = pa.ipc.new_stream(sink, batch.schema)
-                            writer.write_batch(batch)
-                        if writer is None:
-                            # No rows matched the filter — still emit a valid
-                            # (empty) Arrow stream so the mmap load below works.
-                            writer = pa.ipc.new_stream(sink, pa_dataset.schema)
-                        writer.close()
-                    os.replace(tmp_path, arrow_path)  # atomic publish
-                finally:
-                    Path(tmp_path).unlink(missing_ok=True)
-
-        return Dataset.from_file(str(arrow_path))
 
     def create_hf_dataset(self) -> datasets.Dataset:
         """Create an empty HuggingFace dataset with the correct features.

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -1685,16 +1685,21 @@ class LeRobotDataset(BaseDataset):
                 tmp_path = cache_dir / f"{cache_key}.{uuid.uuid4().hex}.tmp"
                 try:
                     scanner = pa_dataset.scanner(filter=filter_expr)
+                    # Arrow IPC *stream* format (new_stream), not file format:
+                    # HF's Dataset.from_file memory-maps via pa.ipc.open_stream,
+                    # which only reads the stream format. Writing the file
+                    # format here makes from_file misparse the footer as a
+                    # stream message ("Expected to read N metadata bytes ...").
                     with pa.OSFile(str(tmp_path), "wb") as sink:
                         writer = None
                         for batch in scanner.to_batches():
                             if writer is None:
-                                writer = pa.ipc.new_file(sink, batch.schema)
+                                writer = pa.ipc.new_stream(sink, batch.schema)
                             writer.write_batch(batch)
                         if writer is None:
                             # No rows matched the filter — still emit a valid
-                            # (empty) Arrow file so the mmap load below works.
-                            writer = pa.ipc.new_file(sink, pa_dataset.schema)
+                            # (empty) Arrow stream so the mmap load below works.
+                            writer = pa.ipc.new_stream(sink, pa_dataset.schema)
                         writer.close()
                     os.replace(tmp_path, arrow_path)  # atomic publish
                 finally:

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -1616,18 +1616,25 @@ class LeRobotDataset(BaseDataset):
         table = pa_dataset.to_table(filter=filter_expr)
         try:
             hf_dataset = Dataset(table, info=DatasetInfo(features=features))
-        except TypeError as cast_err:
-            # info.json's declared feature types can drift from what was actually
-            # written to parquet (e.g. shape=[1] gets serialized as Value(...) by
-            # get_hf_features_from_features but the parquet column was emitted
-            # as list<...>). The strict cast in HF's Dataset constructor then
-            # raises TypeError("Couldn't cast ..."). Surface a warning and fall
-            # back to schema-inferred features so the dataset still loads; the
-            # underlying metadata still needs a curator-side fix.
-            if "Couldn't cast" not in str(cast_err):
+        except (TypeError, ValueError) as cast_err:
+            # info.json's declared features can drift from what was actually
+            # written to parquet, in two ways:
+            #   * type drift — e.g. shape=[1] gets serialized as Value(...) by
+            #     get_hf_features_from_features but the parquet column was
+            #     emitted as list<...>; HF's Dataset constructor then raises
+            #     TypeError("Couldn't cast ...").
+            #   * column-set drift — parquet has a column info.json never
+            #     declared (e.g. gripper_activity_action); HF raises
+            #     ValueError("Keys mismatch ...").
+            # Both mean the same thing — stale metadata — and both want the
+            # same fallback: use parquet-inferred features so the dataset
+            # still loads. The underlying metadata still needs a curator fix.
+            msg = str(cast_err)
+            if "Couldn't cast" not in msg and "Keys mismatch" not in msg:
                 raise
             logging.warning(
-                "Feature cast from meta/info.json failed for %s (%s); falling back to parquet-inferred features.",
+                "Feature reconciliation from meta/info.json failed for %s (%s); "
+                "falling back to parquet-inferred features.",
                 self.repo_id,
                 cast_err,
             )

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -84,12 +84,15 @@ Example:
 import contextlib
 import copy
 import functools
+import hashlib
 import json
 import logging
 import math
+import os
 import re
 import shutil
 import traceback
+import uuid
 from abc import abstractmethod
 from pathlib import Path
 from typing import Callable
@@ -98,12 +101,14 @@ import datasets
 import numpy as np
 import packaging.version
 import PIL.Image
+import pyarrow as pa
 import pyarrow.dataset as pa_ds
 import torch
 import torch.nn.functional as F  # noqa: N812
 import torch.utils
 from datasets import Dataset, DatasetInfo, concatenate_datasets
 from einops import rearrange
+from filelock import FileLock
 from huggingface_hub import HfApi, hf_hub_download, snapshot_download
 from huggingface_hub.constants import REPOCARD_NAME
 from huggingface_hub.errors import RevisionNotFoundError
@@ -1589,33 +1594,35 @@ class LeRobotDataset(BaseDataset):
         paths = sorted(self.root.glob(glob_pattern))
         if not paths:
             raise FileNotFoundError(f"No parquet files matching {glob_pattern!r} under {self.root}")
-        features = get_hf_features_from_features(self.meta.features)
-        # Read parquet directly via pyarrow.dataset and wrap the resulting
-        # pa.Table in a HF Dataset. Going through `load_dataset("parquet", ...)`
-        # or `Dataset.from_parquet(...)` both route through ParquetDatasetBuilder,
-        # which rewrites the parquet bytes into an uncompressed Arrow cache at
-        # $HF_HOME/datasets/parquet/ — 1-5x the source size (compression-dependent)
-        # and one cache entry per distinct (paths, filter) combo. Issue #277 has
-        # the empirical numbers; verified on physical-intelligence/libero.
-        #
-        # Trade-off: `to_table(filter=...)` materializes the filtered rows into
-        # RAM rather than mmapping a disk-backed Arrow cache. RAM cost scales
-        # with `len(filtered rows) × avg-row-size`; concretely:
-        # ~350 MB for physical-intelligence/libero with episodes=[0..9],
-        # ~46 GB for humanoid-everyday-A-overlay with episodes=None (full corpus).
-        # Narrow `episodes=` picks are fine; an episodes=None load on a multi-GB
-        # image-heavy repo will OOM on a small dev box — pass a manageable
-        # subset, or restore a mmap'd Arrow cache via tmp pa.ipc files if RAM
-        # ever becomes the binding constraint.
-        #
-        # The `Dataset(table, info=DatasetInfo(features=features))` constructor
-        # signature has been stable since datasets 2.x; the project pin is
-        # `datasets>=2.19.0`, so we're well inside the supported window.
         pa_dataset = pa_ds.dataset(list(map(str, paths)), format="parquet")
         filter_expr = pa_ds.field("episode_index").isin(self.episodes) if self.episodes is not None else None
+
+        # Image-dtype columns hold raw image bytes inline in the parquet and
+        # need the HF `Image()` feature to decode on access. The mmap path
+        # loads via `Dataset.from_file`, which infers features from the Arrow
+        # schema and so cannot reconstruct `Image()`; route those datasets (all
+        # small in this corpus) through the in-RAM path instead. Everything
+        # else — including the multi-hundred-GB video repos — goes through the
+        # memory-mapped path so the mixture load doesn't OOM the node.
+        has_image_feature = any(ft.get("dtype") == "image" for ft in self.meta.features.values())
+        if has_image_feature:
+            hf_dataset = self._load_hf_dataset_in_ram(pa_dataset, filter_expr)
+        else:
+            hf_dataset = self._load_hf_dataset_mmap(pa_dataset, filter_expr)
+        hf_dataset.set_transform(hf_transform_to_torch)
+        return hf_dataset
+
+    def _load_hf_dataset_in_ram(self, pa_dataset: pa_ds.Dataset, filter_expr) -> datasets.Dataset:
+        """Materialize the filtered parquet fully in RAM and wrap it in a Dataset.
+
+        Used only for datasets with `image`-dtype columns, which need the HF
+        `Image()` feature applied via the typed `Dataset(...)` constructor.
+        Such datasets are small in this corpus, so the in-RAM cost is bounded.
+        """
+        features = get_hf_features_from_features(self.meta.features)
         table = pa_dataset.to_table(filter=filter_expr)
         try:
-            hf_dataset = Dataset(table, info=DatasetInfo(features=features))
+            return Dataset(table, info=DatasetInfo(features=features))
         except (TypeError, ValueError) as cast_err:
             # info.json's declared features routinely drift from what was
             # actually written to parquet. HF's typed Dataset constructor
@@ -1642,9 +1649,58 @@ class LeRobotDataset(BaseDataset):
                 self.repo_id,
                 reason,
             )
-            hf_dataset = Dataset(table)
-        hf_dataset.set_transform(hf_transform_to_torch)
-        return hf_dataset
+            return Dataset(table)
+
+    def _load_hf_dataset_mmap(self, pa_dataset: pa_ds.Dataset, filter_expr) -> datasets.Dataset:
+        """Stream the filtered parquet into a memory-mapped Arrow IPC file.
+
+        `to_table()` materializes every filtered row in RAM. With 8 ranks each
+        loading the full mixture, the multi-hundred-GB video repos
+        (humanoid-everyday-*) blow past node memory and OOM. Streaming the
+        scanner batch-by-batch into an Arrow IPC file keeps only one batch
+        resident during the write, and `Dataset.from_file` then mmaps the
+        result — resident memory is bounded by the OS page cache, not the
+        dataset size, and the mapping is shared across all ranks on the node.
+
+        The Arrow file is cached under the dataset root keyed by
+        (revision, episode selection): reruns skip the conversion entirely and
+        the key invalidates when either input changes. A per-key FileLock
+        serialises the write across ranks sharing the node-local cache dir —
+        exactly one rank runs the conversion, the rest block then mmap the
+        result. (Going through `load_dataset`/`Dataset.from_parquet` instead
+        would route through ParquetDatasetBuilder, which rewrites an
+        uncompressed Arrow cache at $HF_HOME at 1-5x source size — see #277.)
+        """
+        cache_dir = self.root / ".arrow_cache"
+        episodes_key = "all" if self.episodes is None else ",".join(map(str, sorted(self.episodes)))
+        cache_key = hashlib.sha256(f"{self.revision}\0{episodes_key}".encode()).hexdigest()[:16]
+        arrow_path = cache_dir / f"{cache_key}.arrow"
+        lock_path = cache_dir / f"{cache_key}.lock"
+        cache_dir.mkdir(parents=True, exist_ok=True)
+
+        # FileLock releases on process exit (fcntl), so a crashed writer can't
+        # deadlock the others; the loser of the race just finds the file ready.
+        with FileLock(str(lock_path)):
+            if not arrow_path.is_file():
+                tmp_path = cache_dir / f"{cache_key}.{uuid.uuid4().hex}.tmp"
+                try:
+                    scanner = pa_dataset.scanner(filter=filter_expr)
+                    with pa.OSFile(str(tmp_path), "wb") as sink:
+                        writer = None
+                        for batch in scanner.to_batches():
+                            if writer is None:
+                                writer = pa.ipc.new_file(sink, batch.schema)
+                            writer.write_batch(batch)
+                        if writer is None:
+                            # No rows matched the filter — still emit a valid
+                            # (empty) Arrow file so the mmap load below works.
+                            writer = pa.ipc.new_file(sink, pa_dataset.schema)
+                        writer.close()
+                    os.replace(tmp_path, arrow_path)  # atomic publish
+                finally:
+                    Path(tmp_path).unlink(missing_ok=True)
+
+        return Dataset.from_file(str(arrow_path))
 
     def create_hf_dataset(self) -> datasets.Dataset:
         """Create an empty HuggingFace dataset with the correct features.

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -91,6 +91,7 @@ import re
 import shutil
 import traceback
 from abc import abstractmethod
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Callable
 
@@ -1537,20 +1538,56 @@ class LeRobotDataset(BaseDataset):
             ignore_patterns=ignore_patterns,
         )
 
+    @on_accelerate_main_proc(local=True, _sync=True)
+    def download_files(self, files: list[str]) -> None:
+        """Fetch an explicit list of repo files, one `hf_hub_download` per file.
+
+        `snapshot_download(allow_patterns=<thousands of explicit paths>)` spends
+        many minutes GIL-held and I/O-idle inside `filter_repo_objects`, whose
+        fnmatch loop is O(repo_files x patterns) — long enough to trip the NCCL
+        watchdog while sibling ranks wait at the `_sync` broadcast.
+        `hf_hub_download` targets each file by exact path, skipping the filter
+        entirely; a thread pool overlaps the network round-trips (the GIL is
+        released during I/O). Files already present in `local_dir` are not
+        re-downloaded.
+        """
+        if not files:
+            return
+
+        def _fetch(fpath: str) -> None:
+            hf_hub_download(
+                repo_id=self.repo_id,
+                filename=fpath,
+                repo_type="dataset",
+                revision=self.revision,
+                local_dir=self.root,
+            )
+
+        with ThreadPoolExecutor(max_workers=16) as pool:
+            # list() forces the lazy map so any per-file failure propagates.
+            list(pool.map(_fetch, files))
+
     def download_episodes(self, download_videos: bool = True) -> None:
         """Downloads the dataset from the given 'repo_id' at the provided version. If 'episodes' is given, this
         will only download those episodes (selected by their episode_index). If 'episodes' is None, the whole
-        dataset will be downloaded. Thanks to the behavior of snapshot_download, if the files are already present
-        in 'local_dir', they won't be downloaded again.
+        dataset will be downloaded. Already-present files in 'local_dir' are not re-downloaded.
         """
         # TODO(rcadene, aliberts): implement faster transfer
         # https://huggingface.co/docs/huggingface_hub/en/guides/download#faster-downloads
-        files = None
-        ignore_patterns = None if download_videos else "videos/"
-        if self.episodes is not None:
-            files = self.get_episodes_file_paths()
-
-        self.pull_from_repo(allow_patterns=files, ignore_patterns=ignore_patterns)
+        if self.episodes is None:
+            # Whole-dataset download: snapshot_download with no allow_patterns
+            # has nothing to filter, so there is no filter_repo_objects blowup.
+            ignore_patterns = None if download_videos else "videos/"
+            self.pull_from_repo(ignore_patterns=ignore_patterns)
+            return
+        # Episode subset: download exactly the needed files directly. Passing
+        # the explicit per-episode path list to snapshot_download as
+        # allow_patterns triggers a pathologically slow filter_repo_objects
+        # scan (see download_files).
+        files = self.get_episodes_file_paths()
+        if not download_videos:
+            files = [f for f in files if not f.startswith("videos/")]
+        self.download_files(files)
 
     def get_episodes_file_paths(self) -> list[str]:
         """Get file paths for all selected episodes.

--- a/src/opentau/datasets/speed_percentiles.py
+++ b/src/opentau/datasets/speed_percentiles.py
@@ -68,6 +68,11 @@ SPARSE_TASK_BUCKET = 50
 # ``_CONTROL_MODE_WARNED`` pattern in ``lerobot_dataset.py``.
 _READONLY_WARNED: set[str] = set()
 
+# Module-level set of unresolved episode task labels we've already warned
+# about, so episodes.jsonl / tasks.jsonl drift in a dataset only logs once
+# per distinct bad label per process instead of once per episode per rank.
+_UNRESOLVED_TASK_WARNED: set[str] = set()
+
 
 def compute_task_percentiles(
     episode_lengths_per_task: dict[int, list[int]],
@@ -143,13 +148,34 @@ def episode_to_task_index_from_episodes(
     ``tasks[0]`` — the codebase assumes an N-to-1 episode-to-task
     relationship even though the field is structurally a list. Episodes
     with an empty / missing ``tasks`` list are skipped.
+
+    Episodes whose ``tasks[0]`` is absent from ``task_to_task_index`` are
+    also skipped (with a deduped warning) rather than raising. This guards
+    against ``episodes.jsonl`` / ``tasks.jsonl`` drift in dataset metadata
+    — a `tasks.jsonl` with stale/incomplete entries, or an
+    ``episodes.jsonl`` that stores integer task indices instead of task
+    strings. Skipped episodes are still trained on; they just fall back to
+    ``SPARSE_TASK_BUCKET`` in the downstream speed-bucket lookup, which
+    already tolerates a missing ``episode_to_task_index`` entry.
     """
     out: dict[int, int] = {}
     for ep_idx, ep_info in episodes.items():
         tasks = ep_info.get("tasks") or []
         if not tasks:
             continue
-        out[ep_idx] = task_to_task_index[tasks[0]]
+        task_idx = task_to_task_index.get(tasks[0])
+        if task_idx is None:
+            key = str(tasks[0])
+            if key not in _UNRESOLVED_TASK_WARNED:
+                _UNRESOLVED_TASK_WARNED.add(key)
+                logging.warning(
+                    "Episode task label %r is not present in tasks.jsonl; episode(s) "
+                    "using it fall back to the sparse speed bucket. This indicates "
+                    "episodes.jsonl / tasks.jsonl drift in the dataset metadata.",
+                    tasks[0],
+                )
+            continue
+        out[ep_idx] = task_idx
     return out
 
 

--- a/src/opentau/datasets/speed_percentiles.py
+++ b/src/opentau/datasets/speed_percentiles.py
@@ -271,39 +271,47 @@ def load_or_compute_speed_percentiles(
     distributed = acc is not None and acc.num_processes > 1
     is_main_or_solo = (not distributed) or acc.is_main_process
 
-    if path.is_file():
-        # `episode_to_task_index` already drops episodes with empty tasks,
-        # so its length is the per-task episode count we want to compare
-        # against the on-disk sum.
-        return _read_persisted(path, len(episode_to_task_index), warn=is_main_or_solo)
+    # NB: the barrier at the end of this function must run on every code path,
+    # not just the compute path. Otherwise a rank that arrives *after* rank 0
+    # has finished writing the file takes the early-return branch (file now
+    # exists), skips the barrier, and silently desyncs the collective counter
+    # for every subsequent collective in the mixture-load loop — manifesting
+    # as a NCCL hang at a much later (and entirely unrelated) sync point.
+    try:
+        if path.is_file():
+            # `episode_to_task_index` already drops episodes with empty tasks,
+            # so its length is the per-task episode count we want to compare
+            # against the on-disk sum.
+            return _read_persisted(path, len(episode_to_task_index), warn=is_main_or_solo)
 
-    by_task = _group_lengths_by_task(episode_lengths, episode_to_task_index)
-    index_to_task = {idx: task for task, idx in task_to_task_index.items()}
-    percentiles = compute_task_percentiles(by_task)
-    rows = [
-        {
-            "task_index": task_idx,
-            "task": index_to_task.get(task_idx, ""),
-            "n_episodes": len(by_task.get(task_idx, [])),
-            "percentiles": percentiles[task_idx],
-        }
-        for task_idx in sorted(percentiles)
-    ]
+        by_task = _group_lengths_by_task(episode_lengths, episode_to_task_index)
+        index_to_task = {idx: task for task, idx in task_to_task_index.items()}
+        percentiles = compute_task_percentiles(by_task)
+        rows = [
+            {
+                "task_index": task_idx,
+                "task": index_to_task.get(task_idx, ""),
+                "n_episodes": len(by_task.get(task_idx, [])),
+                "percentiles": percentiles[task_idx],
+            }
+            for task_idx in sorted(percentiles)
+        ]
 
-    if is_main_or_solo:
-        try:
-            _atomic_write_jsonlines(rows, path)
-        except (OSError, PermissionError) as e:
-            root_key = str(root)
-            if root_key not in _READONLY_WARNED:
-                _READONLY_WARNED.add(root_key)
-                logging.warning(
-                    "Could not write speed percentiles to %s (%s); using in-memory "
-                    "values for this run. The compute will repeat on every load until "
-                    "the file can be written.",
-                    path,
-                    e,
-                )
-    if distributed:
-        acc.wait_for_everyone()
-    return percentiles
+        if is_main_or_solo:
+            try:
+                _atomic_write_jsonlines(rows, path)
+            except (OSError, PermissionError) as e:
+                root_key = str(root)
+                if root_key not in _READONLY_WARNED:
+                    _READONLY_WARNED.add(root_key)
+                    logging.warning(
+                        "Could not write speed percentiles to %s (%s); using in-memory "
+                        "values for this run. The compute will repeat on every load until "
+                        "the file can be written.",
+                        path,
+                        e,
+                    )
+        return percentiles
+    finally:
+        if distributed:
+            acc.wait_for_everyone()

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -145,6 +145,29 @@ def test_dataset_no_episodes_loads_all(tmp_path, lerobot_dataset_factory):
     _assert_episode_row_alignment(dataset)
 
 
+def test_download_files_skips_present_files(tmp_path, lerobot_dataset_factory):
+    """download_files must not call hf_hub_download for files already on disk.
+
+    This is the core of the 429-avoidance fix: a pre-downloaded episode set
+    should make download_files a no-op with zero Hub requests. Constructing
+    the dataset already places every selected-episode file on disk, so a
+    second download_files pass over the same paths must fetch nothing.
+    """
+    dataset = lerobot_dataset_factory(
+        root=tmp_path / "test",
+        repo_id=DUMMY_REPO_ID,
+        total_episodes=10,
+        total_frames=400,
+        episodes=[2, 5, 6],
+    )
+    files = dataset.get_episodes_file_paths()
+    assert files, "expected a non-empty file list for the test to be meaningful"
+    assert all((dataset.root / f).is_file() for f in files), "fixture should pre-place all files"
+    with patch("opentau.datasets.lerobot_dataset.hf_hub_download") as mock_hf_hub_download:
+        dataset.download_files(files)
+    mock_hf_hub_download.assert_not_called()
+
+
 def test_add_frame_missing_task(tmp_path, empty_lerobot_dataset_factory):
     features = {"state": {"dtype": "float32", "shape": (1,), "names": None}}
     dataset = empty_lerobot_dataset_factory(root=tmp_path / "test", features=features)

--- a/tests/datasets/test_speed_percentiles.py
+++ b/tests/datasets/test_speed_percentiles.py
@@ -126,6 +126,17 @@ class TestEpisodeToTaskIndex:
         t2i = {"taskA": 0}
         assert episode_to_task_index_from_episodes(episodes, t2i) == {2: 0}
 
+    def test_unresolvable_task_label_skipped(self):
+        # A task label absent from task_to_task_index (episodes.jsonl /
+        # tasks.jsonl drift) is skipped, not raised on; resolvable episodes
+        # in the same dataset still come through.
+        episodes = {
+            0: {"tasks": ["ghost"], "length": 100},
+            1: {"tasks": ["taskA"], "length": 200},
+        }
+        t2i = {"taskA": 0}
+        assert episode_to_task_index_from_episodes(episodes, t2i) == {1: 0}
+
 
 class TestBucketEpisodeLength:
     @pytest.fixture

--- a/tests/fixtures/dataset_factories.py
+++ b/tests/fixtures/dataset_factories.py
@@ -449,6 +449,7 @@ def lerobot_dataset_factory(
     episodes_factory,
     hf_dataset_factory,
     mock_snapshot_download_factory,
+    mock_hf_hub_download_factory,
     lerobot_dataset_metadata_factory,
 ) -> LeRobotDatasetFactory:
     def _create_lerobot_dataset(
@@ -494,6 +495,14 @@ def lerobot_dataset_factory(
             episodes=episode_dicts,
             hf_dataset=hf_dataset,
         )
+        mock_hf_hub_download = mock_hf_hub_download_factory(
+            info=info,
+            stats=stats,
+            episodes_stats=episodes_stats,
+            tasks=tasks,
+            episodes=episode_dicts,
+            hf_dataset=hf_dataset,
+        )
         mock_metadata = lerobot_dataset_metadata_factory(
             root=root,
             repo_id=repo_id,
@@ -507,10 +516,12 @@ def lerobot_dataset_factory(
             patch("opentau.datasets.lerobot_dataset.LeRobotDatasetMetadata") as mock_metadata_patch,
             patch("opentau.datasets.lerobot_dataset.get_safe_version") as mock_get_safe_version_patch,
             patch("opentau.datasets.lerobot_dataset.snapshot_download") as mock_snapshot_download_patch,
+            patch("opentau.datasets.lerobot_dataset.hf_hub_download") as mock_hf_hub_download_patch,
         ):
             mock_metadata_patch.return_value = mock_metadata
             mock_get_safe_version_patch.side_effect = lambda repo_id, version: version
             mock_snapshot_download_patch.side_effect = mock_snapshot_download
+            mock_hf_hub_download_patch.side_effect = mock_hf_hub_download
 
             # Construct a minimal TrainPipelineConfig for the dataset
             from dataclasses import dataclass

--- a/tests/fixtures/hub.py
+++ b/tests/fixtures/hub.py
@@ -132,3 +132,89 @@ def mock_snapshot_download_factory(
         return _mock_snapshot_download
 
     return _mock_snapshot_download_func
+
+
+@pytest.fixture(scope="session")
+def mock_hf_hub_download_factory(
+    info_factory,
+    info_path,
+    stats_factory,
+    stats_path,
+    episodes_stats_factory,
+    episodes_stats_path,
+    tasks_factory,
+    tasks_path,
+    episodes_factory,
+    episode_path,
+    single_episode_parquet_path,
+    hf_dataset_factory,
+):
+    """Patch hf_hub_download so a single-file fetch writes the expected fixture file.
+
+    Mirrors mock_snapshot_download_factory, but for the one-file-at-a-time path
+    used by LeRobotDataset.download_files (which snapshot_download mocking does
+    not cover).
+    """
+
+    def _mock_hf_hub_download_func(
+        info: dict | None = None,
+        stats: dict | None = None,
+        episodes_stats: list[dict] | None = None,
+        tasks: list[dict] | None = None,
+        episodes: list[dict] | None = None,
+        hf_dataset: datasets.Dataset | None = None,
+    ):
+        if not info:
+            info = info_factory()
+        if not stats:
+            stats = stats_factory(features=info["features"])
+        if not episodes_stats:
+            episodes_stats = episodes_stats_factory(
+                features=info["features"], total_episodes=info["total_episodes"]
+            )
+        if not tasks:
+            tasks = tasks_factory(total_tasks=info["total_tasks"])
+        if not episodes:
+            episodes = episodes_factory(
+                total_episodes=info["total_episodes"], total_frames=info["total_frames"], tasks=tasks
+            )
+        if not hf_dataset:
+            hf_dataset = hf_dataset_factory(tasks=tasks, episodes=episodes, fps=info["fps"])
+
+        def _mock_hf_hub_download(
+            repo_id: str,
+            filename: str,
+            local_dir: str | Path | None = None,
+            *args,
+            **kwargs,
+        ) -> str:
+            if not local_dir:
+                local_dir = OPENTAU_TEST_DIR
+            local_dir = Path(local_dir)
+            path = Path(filename)
+
+            if path.suffix == ".parquet" and path.stem.startswith("episode_"):
+                ep_idx = int(path.stem[len("episode_") :])  # 'episode_000000' -> 0
+                single_episode_parquet_path(local_dir, ep_idx, hf_dataset, info)
+            elif filename == INFO_PATH:
+                info_path(local_dir, info)
+            elif filename == STATS_PATH:
+                stats_path(local_dir, stats)
+            elif filename == EPISODES_STATS_PATH:
+                episodes_stats_path(local_dir, episodes_stats)
+            elif filename == TASKS_PATH:
+                tasks_path(local_dir, tasks)
+            elif filename == EPISODES_PATH:
+                episode_path(local_dir, episodes)
+            else:
+                # Video files (and anything else without a fixture writer): the
+                # tests that hit this path never decode them, so an empty
+                # placeholder is enough to satisfy the on-disk checks.
+                fpath = local_dir / filename
+                fpath.parent.mkdir(parents=True, exist_ok=True)
+                fpath.touch()
+            return str(local_dir / filename)
+
+        return _mock_hf_hub_download
+
+    return _mock_hf_hub_download_func


### PR DESCRIPTION
## What this does

A series of fixes that make the dataset-loading path robust enough to start a large heterogeneous pretraining mixture (~390 LeRobot datasets). Each fix addresses a distinct crash or hang hit while bringing up such a run; the net change is 4 files.

**`datasets/lerobot_dataset.py`**
- **SHA-format revisions** — guard `get_safe_version` with `is_valid_version` in the data-download path (mirrors the existing guard on the metadata path). A dataset pinned to a Git-SHA revision no longer crashes with `packaging.version.InvalidVersion`; SHA / branch refs skip the `vX.Y` codebase-version lookup and fall through to the download, which the Hub accepts directly.
- **Memory-bounded parquet loading** — `load_hf_dataset` now loads per-episode parquet via `load_dataset("parquet", ...)`, whose Arrow cache is genuinely memory-mapped (resident pages are file-backed and reclaimable). The previous hand-rolled `pyarrow.dataset.to_table()` + `Dataset(table)` materialised the full filtered table into anonymous RAM — with every rank loading the full mixture, the multi-hundred-GB video repos OOM'd the box. Files are passed in sorted-episode order so the row layout stays aligned with `episode_data_index`. Because `load_dataset` infers features from the parquet itself, it also sidesteps the strict-schema cast errors that info.json / parquet column drift used to raise.
- **Episode download path** — `download_episodes` now routes whole-repo datasets (no episode subset) to `snapshot_download` (lists the repo tree in O(1) API calls) and episode-subset datasets to a new `download_files` helper. `download_files` fetches each file with `hf_hub_download` in a thread pool but **skips files already on disk** — `hf_hub_download` issues a network metadata request per file even for cached files, so calling it across a pre-downloaded mixture burned one API request per file and tripped the 3000-req / 5-min rate limit (429). Passing thousands of explicit per-episode paths to `snapshot_download(allow_patterns=...)` was the other failure mode: its `filter_repo_objects` fnmatch loop is O(repo_files × patterns) and ran GIL-held long enough to trip the NCCL watchdog. The new split avoids both.

**`datasets/speed_percentiles.py`**
- **Distributed-barrier correctness** — `load_or_compute_speed_percentiles` wraps its body in `try/finally` so `wait_for_everyone()` runs on *every* path. Previously the early-return-on-cached-file branch skipped the barrier; a rank arriving after rank 0 wrote the cache file took that branch, skipped the barrier, and silently desynced the collective counter — surfacing as a NCCL hang at a much later, unrelated sync point.
- **Metadata drift tolerance** — `episode_to_task_index_from_episodes` skips episodes whose task label is absent from `tasks.jsonl` (deduped warning) instead of raising `KeyError`. Skipped episodes are still trained on; they fall back to the sparse speed bucket downstream, which already tolerates a missing entry.

**`tests/fixtures/`**
- Adds `mock_hf_hub_download_factory` (mirrors `mock_snapshot_download_factory`) and wires it into `lerobot_dataset_factory`, so the `download_files` path is exercised without hitting the Hub.

🐛 Bug

The branch history includes a couple of exploratory commits that were reverted on-branch (a py-spy dev-dep, an HF-filelock approach); the net change is the 4 files above.

## How it was tested

- `pytest -m "not gpu" tests/datasets/` — all 150 dataset tests pass. This includes 3 subset-episode tests (`test_dataset_initialization`, `test_dataset_unsorted_episodes_row_alignment`, `test_dataset_sparse_episodes_row_alignment`) that the `download_files` switch broke and the new `mock_hf_hub_download_factory` fixes.
- `pre-commit run --files ...` passes on all changed files.
- End-to-end: a large heterogeneous pretraining mixture (~390 datasets) that previously crashed during dataset loading — on each of the issues above in turn — now flows through dataset prep → model load → stable training steps with a healthy loss curve (total loss decreasing, grad norm settling).

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/datasets/test_datasets.py
```

The three row-alignment / initialization tests exercise the episode-subset download path through the new `hf_hub_download` mock. To spot-check the memory-mapping behaviour, load any LeRobot dataset and confirm the resident set stays bounded:

```bash
python -c "from opentau.datasets.lerobot_dataset import LeRobotDataset; ds = LeRobotDataset(repo_id='physical-intelligence/libero'); print(len(ds), 'frames')"
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).