### PR TITLE
feat(dev): add py-spy to dev extra for debugging hung runs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,8 @@ Three drop-in profiling scripts read the same `TrainPipelineConfig`:
 
 `FIND_UNUSED_PARAMS=false` (env var, read in `train.py`) reclaims ~10-15% of step time once a config has been audited.
 
+For *hung* runs (NCCL collective stuck, dataloader worker wedged in a C extension, anything `debugpy` can't reach), `py-spy` is in the `dev` extra. `py-spy dump --pid <pid>` attaches non-cooperatively and prints the Python stack of every thread — pair with `pgrep -f 'opentau/scripts/train.py'` to find ranks. Run as the same user as the target on Linux (no `sudo` typically needed); on macOS, prefix with `sudo` (Apple ptrace restriction).
+
 ## Architecture
 
 ### Configuration system (draccus)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,7 @@ opentau-dataset-viz = "opentau.scripts.launch:visualize"
 [project.optional-dependencies]
 dev = ["pre-commit>=3.7.0",
     "debugpy>=1.8.1",
+    "py-spy>=0.4.0",
     "pytest>=8.1.0",
     "pytest-cov>=5.0.0",
     "pyserial>=3.5",

--- a/uv.lock
+++ b/uv.lock
@@ -2460,6 +2460,7 @@ dev = [
     { name = "debugpy" },
     { name = "myst-parser" },
     { name = "pre-commit" },
+    { name = "py-spy" },
     { name = "pyserial" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -2543,6 +2544,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.2.2" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.7.0" },
     { name = "protobuf", specifier = ">=4.25.0" },
+    { name = "py-spy", marker = "extra == 'dev'", specifier = ">=0.4.0" },
     { name = "pymunk", specifier = ">=6.6.0" },
     { name = "pynput", specifier = ">=1.7.7" },
     { name = "pyopengl", marker = "sys_platform == 'linux' and extra == 'libero'", specifier = "==3.1.7" },
@@ -2777,6 +2779,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/37/a8/d832f7293ebb21690860d2e01d8115e5ff6f2ae8bbdc953f0eb0fa4bd2c7/py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690", size = 104716, upload-time = "2022-10-25T20:38:06.303Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/a9/023730ba63db1e494a271cb018dcd361bd2c917ba7004c3e49d5daf795a2/py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5", size = 22335, upload-time = "2022-10-25T20:38:27.636Z" },
+]
+
+[[package]]
+name = "py-spy"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/d8/5b71371f50cf153b1307e5a11ac8a4ce4d85651dae946bd7e9a064146545/py_spy-0.4.2.tar.gz", hash = "sha256:90e600b27bb6bb40479637baca5a5b4bc2ba3395c93d889e672315d93042c4ae", size = 286374, upload-time = "2026-04-24T22:08:54.906Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/21/ec030145a0c7992bd4b9eafb2f06f56358b3a5339eab4a16534baf3c69aa/py_spy-0.4.2-py2.py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:1ccf688393105111684435f035bc14ec3f22117dd2b85b2414612cf27a22755a", size = 3743992, upload-time = "2026-04-24T22:08:45.438Z" },
+    { url = "https://files.pythonhosted.org/packages/50/80/de5fd27243c2be03692ecd317bf0dbe24b4c6f78f689ce111e7277a7cb09/py_spy-0.4.2-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:a0e6f6810ccf0fc5e64e85e0182a5b626c4496eec01b14fb8755154b363a4831", size = 1859057, upload-time = "2026-04-24T22:08:46.946Z" },
+    { url = "https://files.pythonhosted.org/packages/89/23/3eb4c23c684ebd667674ce1d076ae855e0621d1d9bd5e052aa3f7982f757/py_spy-0.4.2-py2.py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:142887e984a4e541071c99a4401ff8c3770f255d329dbd0f64e8c1dd51882cce", size = 2828136, upload-time = "2026-04-24T22:08:48.519Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/01/6314152cf9ad3310ebacbf2c47b5ed858086530f8e12b1a665725ca5e0f4/py_spy-0.4.2-py2.py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7f1c6d9b0e2379ead5bf792df43f4cf36153aa79e6dda4fb8ac7740cf8017110", size = 2857707, upload-time = "2026-04-24T22:08:49.677Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/1f/0960a129d504728d28a51dbd5a04ce94031eb75bac676341da7aefdd8232/py_spy-0.4.2-py2.py3-none-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:24720573f95230653b457671a1dcc3c5a381fcf4e92677761e328a430ad251b2", size = 2301852, upload-time = "2026-04-24T22:08:51.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/34/dd7d3c763a00b7b965e25a5eab0acd1a345dbaf0f45fffe595278873a1c0/py_spy-0.4.2-py2.py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:aeb0323409199c785f730645e9f4bb7a7b9ca2c481f2c331a55642b5d13fa52f", size = 2936518, upload-time = "2026-04-24T22:08:52.264Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ed/1409cdb557e558a6c98003ab12fdd4284699e158c167c187cb0f124eea4c/py_spy-0.4.2-py2.py3-none-win_amd64.whl", hash = "sha256:8b06a353c177677e4e1701b288d8c58e2f8d4208ee81a8048d9f72ba800918f8", size = 1894002, upload-time = "2026-04-24T22:08:53.811Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What this does

Adds `py-spy>=0.4.0` to the `dev` optional-dependencies group in `pyproject.toml` so it is installed as part of the standard `uv sync --extra dev --extra libero` setup.

`py-spy` is a sampling profiler that attaches to a *running* Python process and dumps per-thread Python stacks (`py-spy dump --pid <PID>`). Unlike `debugpy` (already in `dev`), it does not require the target process to cooperate, so it is the right tool when a worker is stuck in a C extension, inside a NCCL `wait`, or in a dataloader fork — the failure modes called out in the distributed-collective guidance in `CLAUDE.md`. Closes #305.

The `uv.lock` update pulls in `py-spy 0.4.2` with wheels for linux x86_64 / aarch64 / armv7l / i686, macOS (intel + Apple silicon, universal2), and win_amd64 — every platform the rest of the project targets.

Label: `dev-tooling`, `enhancement` (no runtime / policy / training-loop code touched).

## How it was tested

- Resolved on Linux x86_64 (Python 3.10.20, uv 0.11.6) — `uv lock` reports `Added py-spy v0.4.2`, no other version changes.
- `uv sync --extra dev` in a fresh venv on Linux installs `py-spy 0.4.2` as `.venv/bin/py-spy`; `--version` / `--help` work.
- End-to-end `py-spy dump --pid <PID>` on Linux against a Python process sleeping inside `shallow() -> mid() -> deep()` correctly returns the Python stack frames.
- `uv sync --extra dev` on macOS arm64 (uv 0.11.8) installs the universal2 wheel; binary runs and `dump` correctly reports the macOS root-privileges requirement (`This program requires root on OSX. Try running again with elevated permissions by going 'sudo !!'`) — the documented expectation under Apple's ptrace restrictions.
- No source code changed, so no unit tests added; existing `cpu_test.yml` continues to exercise the lock via the standard `uv sync --extra dev --extra libero` step.

## How to checkout & try? (for the reviewer)

```bash
git fetch origin feat/add-py-spy-dev-dep && git checkout feat/add-py-spy-dev-dep
uv sync --extra dev --extra libero
.venv/bin/py-spy --version    # py-spy 0.4.2
```

Then, against any running OpenTau training process:

```bash
py-spy dump --pid $(pgrep -f 'opentau/scripts/train.py' | head -1)
```

(On macOS prefix with `sudo`; on Linux dev/cluster boxes it can usually attach to your own processes without elevation.)

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.