### PR TITLE
chore: bump version to v0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ huggingface = "https://huggingface.co/TensorAuto"
 
 [project]
 name = "opentau"
-version = "0.4.0"
+version = "0.5.0"
 description = "OpenTau: Tensor's VLA Training Infrastructure for Real-World Robotics in Pytorch"
 authors = [
     { name = "Shuheng Liu", email = "wish1104@icloud.com" },


### PR DESCRIPTION
## What this does
Bumps the package version from `0.4.0` to `0.5.0` in `pyproject.toml`.

## How it was tested
Version-only bump — no behavior changes. Pre-commit hooks pass.

## How to checkout & try? (for the reviewer)
```bash
grep '^version' pyproject.toml
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).