### PR TITLE
feat(envs): make LIBERO sim control frequency configurable

### DIFF
--- a/configs/examples/advantage_config.json
+++ b/configs/examples/advantage_config.json
@@ -1,12 +1,12 @@
 {
     "datasets": [
         {
-            "repo_id": "physical-intelligence/libero",
+            "repo_id": "TensorAuto/libero",
             "root": "/akshay/libero",
             "episodes": [0,1,2,3,4,5,6,7,8,9]
         },
         {
-            "repo_id": "physical-intelligence/libero",
+            "repo_id": "TensorAuto/libero",
             "root": "/akshay/libero1",
             "episodes": [10,11,12,13,14,15,16,17,18,19]
         }
@@ -15,7 +15,7 @@
         1.0,
         1.0
     ],
-    "action_freq": 30.0,
+    "action_freq": 20.0,
     "image_resample_strategy": "nearest",
     "vector_resample_strategy": "nearest"
 }

--- a/configs/examples/pi05_continuous_state_training_config.json
+++ b/configs/examples/pi05_continuous_state_training_config.json
@@ -2,7 +2,7 @@
     "dataset_mixture": {
         "datasets": [
             {
-                "repo_id": "physical-intelligence/libero",
+                "repo_id": "TensorAuto/libero",
                 "episodes": [
                     0,1,2,3,4,5,6,7,8,9
                 ]
@@ -12,7 +12,7 @@
         "weights": [
             1.0
         ],
-        "action_freq": 10.0,
+        "action_freq": 20.0,
         "image_resample_strategy": "nearest",
         "vector_resample_strategy": "nearest"
     },

--- a/configs/examples/pi05_libero_eval_config.json
+++ b/configs/examples/pi05_libero_eval_config.json
@@ -115,7 +115,7 @@
     "env": {
         "type": "libero",
         "task": "libero_10",
-        "fps": 30,
+        "fps": 20,
         "max_parallel_tasks": 1,
         "task_ids": [
             8

--- a/configs/examples/pi05_mem_training_config.json
+++ b/configs/examples/pi05_mem_training_config.json
@@ -105,7 +105,7 @@
     "env": {
         "type": "libero",
         "task": "libero_10",
-        "fps": 10,
+        "fps": 20,
         "max_parallel_tasks": 1,
         "task_ids": [0],
         "episode_length": 100,

--- a/configs/examples/pi05_mem_training_config.json
+++ b/configs/examples/pi05_mem_training_config.json
@@ -2,7 +2,7 @@
     "dataset_mixture": {
         "datasets": [
             {
-                "repo_id": "physical-intelligence/libero",
+                "repo_id": "TensorAuto/libero",
                 "episodes": [
                     0,1,2,3,4,5,6,7,8,9
                 ]
@@ -12,7 +12,7 @@
         "weights": [
             1.0
         ],
-        "action_freq": 10.0,
+        "action_freq": 20.0,
         "n_obs_history": 8,
         "image_resample_strategy": "nearest",
         "vector_resample_strategy": "nearest"

--- a/configs/examples/pi05_training_config.json
+++ b/configs/examples/pi05_training_config.json
@@ -2,7 +2,7 @@
     "dataset_mixture": {
         "datasets": [
             {
-                "repo_id": "physical-intelligence/libero",
+                "repo_id": "TensorAuto/libero",
                 "episodes": [
                     0,1,2,3,4,5,6,7,8,9
                 ]
@@ -12,7 +12,7 @@
         "weights": [
             1.0
         ],
-        "action_freq": 10.0,
+        "action_freq": 20.0,
         "image_resample_strategy": "nearest",
         "vector_resample_strategy": "nearest"
     },

--- a/configs/examples/pi06_training_config.json
+++ b/configs/examples/pi06_training_config.json
@@ -2,7 +2,7 @@
     "dataset_mixture": {
         "datasets": [
             {
-                "repo_id": "physical-intelligence/libero",
+                "repo_id": "TensorAuto/libero",
                 "episodes": [
                     0,1,2,3,4,5,6,7,8,9
                 ]
@@ -12,7 +12,7 @@
         "weights": [
             1.0
         ],
-        "action_freq": 10.0,
+        "action_freq": 20.0,
         "image_resample_strategy": "nearest",
         "vector_resample_strategy": "nearest"
     },

--- a/configs/examples/pi07_libero.json
+++ b/configs/examples/pi07_libero.json
@@ -2,11 +2,11 @@
     "dataset_mixture": {
         "datasets": [
             {
-                "repo_id": "physical-intelligence/libero"
+                "repo_id": "TensorAuto/libero"
             }
         ],
         "weights": [1.0],
-        "action_freq": 10.0,
+        "action_freq": 20.0,
         "image_resample_strategy": "nearest",
         "vector_resample_strategy": "nearest",
         "val_split_ratio": 0.05,

--- a/configs/examples/pi07_libero.json
+++ b/configs/examples/pi07_libero.json
@@ -104,7 +104,7 @@
     "env": {
         "type": "libero",
         "task": "libero_10",
-        "fps": 10,
+        "fps": 20,
         "max_parallel_tasks": 1,
         "task_ids": [0, 1, 2, 3, 4, 5, 6, 8],
         "episode_length": 700,

--- a/configs/examples/pi07_low_level_libero.json
+++ b/configs/examples/pi07_low_level_libero.json
@@ -2,12 +2,12 @@
     "dataset_mixture": {
         "datasets": [
             {
-                "repo_id": "physical-intelligence/libero",
+                "repo_id": "TensorAuto/libero",
                 "episodes": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
             }
         ],
         "weights": [1.0],
-        "action_freq": 10.0,
+        "action_freq": 20.0,
         "image_resample_strategy": "nearest",
         "vector_resample_strategy": "nearest",
         "n_obs_history": 6

--- a/configs/examples/pi_config.json
+++ b/configs/examples/pi_config.json
@@ -2,7 +2,7 @@
     "dataset_mixture": {
         "datasets": [
             {
-                "repo_id": "physical-intelligence/libero",
+                "repo_id": "TensorAuto/libero",
                 "episodes": [
                     0,1,2,3,4,5,6,7,8,9
                 ]
@@ -11,7 +11,7 @@
         "weights": [
             1.0
         ],
-        "action_freq": 10.0,
+        "action_freq": 20.0,
         "image_resample_strategy": "nearest",
         "vector_resample_strategy": "nearest"
     },

--- a/configs/examples/pi_config.json
+++ b/configs/examples/pi_config.json
@@ -109,7 +109,7 @@
     "env": {
         "type": "libero",
         "task": "libero_10",
-        "fps": 10,
+        "fps": 20,
         "max_parallel_tasks": 1,
         "task_ids": [
             8

--- a/configs/examples/pi_config.json
+++ b/configs/examples/pi_config.json
@@ -11,7 +11,7 @@
         "weights": [
             1.0
         ],
-        "action_freq": 30.0,
+        "action_freq": 10.0,
         "image_resample_strategy": "nearest",
         "vector_resample_strategy": "nearest"
     },

--- a/configs/examples/value_config.json
+++ b/configs/examples/value_config.json
@@ -12,7 +12,7 @@
             1.0,
             1.0
         ],
-        "action_freq": 30.0,
+        "action_freq": 10.0,
         "image_resample_strategy": "nearest",
         "vector_resample_strategy": "nearest"
     },

--- a/configs/examples/value_config.json
+++ b/configs/examples/value_config.json
@@ -2,7 +2,7 @@
     "dataset_mixture": {
         "datasets": [
             {
-                "repo_id": "physical-intelligence/libero"
+                "repo_id": "TensorAuto/libero"
             },
             {
                 "vqa": "clevr"
@@ -12,7 +12,7 @@
             1.0,
             1.0
         ],
-        "action_freq": 10.0,
+        "action_freq": 20.0,
         "image_resample_strategy": "nearest",
         "vector_resample_strategy": "nearest"
     },

--- a/configs/libero/reproduce_pi05_libero.json
+++ b/configs/libero/reproduce_pi05_libero.json
@@ -2,14 +2,14 @@
     "dataset_mixture": {
         "datasets": [
             {
-                "repo_id": "physical-intelligence/libero"
+                "repo_id": "TensorAuto/libero"
             }
 
         ],
         "weights": [
             1.0
         ],
-        "action_freq": 10.0,
+        "action_freq": 20.0,
         "image_resample_strategy": "nearest",
         "vector_resample_strategy": "nearest"
     },

--- a/configs/libero/reproduce_pi05_libero.json
+++ b/configs/libero/reproduce_pi05_libero.json
@@ -101,7 +101,7 @@
     "env": {
         "type": "libero",
         "task": "libero_10",
-        "fps": 10,
+        "fps": 20,
         "max_parallel_tasks": 1,
         "task_ids": [0,1,2,3,4,5,6,8],
         "episode_length": 700,

--- a/docs/source/tutorials/RECAP.rst
+++ b/docs/source/tutorials/RECAP.rst
@@ -23,7 +23,7 @@ Stage 1: SFT Training the VLA policy on whole libero dataset till convergence.
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Pi0 pretrained checkpoint is used as starting point for this step.
-Pi0 is trained on whole libero dataset (physical-intelligence/libero) for around 10k steps before it converges to 80% success rate on moka pot libero-10 task.
+Pi0 is trained on whole libero dataset (TensorAuto/libero) for around 10k steps before it converges to 80% success rate on moka pot libero-10 task.
 During the whole training, :math:`I_t` indicator is set to True for all the data points, i.e. assuming that the expert policy is always taking optimal action for a given state.
 Training the policy on whole libero tasks gives a better baseline for the offline RL training compared to just training on a single task.
 
@@ -35,14 +35,14 @@ Example of important config fields for SFT training:
     "dataset_mixture": {
         "datasets": [
             {
-                "repo_id": "physical-intelligence/libero"
+                "repo_id": "TensorAuto/libero"
             }
 
         ],
         "weights": [
             1.0
         ],
-        "action_freq": 10.0,
+        "action_freq": 20.0,
         "image_resample_strategy": "nearest",
         "vector_resample_strategy": "nearest"
     },
@@ -115,13 +115,13 @@ Example of important config fields for value function training:
     "dataset_mixture": {
         "datasets": [
             {
-                "repo_id": "physical-intelligence/libero"
+                "repo_id": "TensorAuto/libero"
             }
         ],
         "weights": [
             1.0
         ],
-        "action_freq": 10.0,
+        "action_freq": 20.0,
         "image_resample_strategy": "nearest",
         "vector_resample_strategy": "nearest"
     },
@@ -177,7 +177,7 @@ Example of important config fields for value function training:
     "dataset_mixture": {
         "datasets": [
             {
-                "repo_id": "physical-intelligence/libero",
+                "repo_id": "TensorAuto/libero",
                 "episodes": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
             },
             {
@@ -189,7 +189,7 @@ Example of important config fields for value function training:
             1.0,
             1.0
         ],
-        "action_freq": 10.0,
+        "action_freq": 20.0,
         "image_resample_strategy": "nearest",
         "vector_resample_strategy": "nearest"
     },
@@ -267,7 +267,7 @@ Example of important config fields for VLA policy fine-tuning:
     "dataset_mixture": {
         "datasets": [
             {
-                "repo_id": "physical-intelligence/libero"
+                "repo_id": "TensorAuto/libero"
             },
             {
                 "repo_id": "OpenTau/libero-rollouts",
@@ -279,7 +279,7 @@ Example of important config fields for VLA policy fine-tuning:
             1.0,
             1.0
         ],
-        "action_freq": 10.0,
+        "action_freq": 20.0,
         "image_resample_strategy": "nearest",
         "vector_resample_strategy": "nearest"
     },
@@ -318,7 +318,7 @@ Example:
    {
     "datasets": [
         {
-            "repo_id": "physical-intelligence/libero",
+            "repo_id": "TensorAuto/libero",
             "root": "/home/autox/akshay/OpenTau/libero_rollout_0_rank0/rank0",
             "episodes": [4]
             }
@@ -326,7 +326,7 @@ Example:
     "weights": [
         1.0
     ],
-    "action_freq": 10.0,
+    "action_freq": 20.0,
     "image_resample_strategy": "nearest",
     "vector_resample_strategy": "nearest",
     "val_split_ratio": 0

--- a/docs/source/tutorials/datasets.rst
+++ b/docs/source/tutorials/datasets.rst
@@ -15,7 +15,7 @@ You can define a dataset mixture in your configuration file using the ``dataset_
         "dataset_mixture": {
             "datasets": [
                 {
-                    "repo_id": "physical-intelligence/libero"
+                    "repo_id": "TensorAuto/libero"
                 },
                 {
                     "repo_id": "lerobot/droid_100"
@@ -25,7 +25,7 @@ You can define a dataset mixture in your configuration file using the ``dataset_
                 0.3,
                 0.7
             ],
-            "action_freq": 30.0,
+            "action_freq": 20.0,
         },
         ...
     }
@@ -44,7 +44,7 @@ For example:
         "dataset_mixture": {
             "datasets": [
                 {
-                    "repo_id": "physical-intelligence/libero",
+                    "repo_id": "TensorAuto/libero",
                     "data_features_name_mapping": {
                         "camera0": "observation.images.exterior_image_1_left",
                         "camera1": "observation.images.exterior_image_2_left"
@@ -59,7 +59,7 @@ For example:
                 0.3,
                 0.7
             ],
-            "action_freq": 30.0,
+            "action_freq": 20.0,
         },
         ...
     }

--- a/src/opentau/datasets/dataset_mixture.py
+++ b/src/opentau/datasets/dataset_mixture.py
@@ -183,9 +183,8 @@ class DatasetMixtureMetadata:
                 "mean": np.zeros((3, 1, 1), dtype=np.float32),
                 "std": np.zeros((3, 1, 1), dtype=np.float32),
             }
-            # `count` is only present in v2.1+ stats; v2.0 datasets like
-            # `physical-intelligence/libero` (LeRobot v2.0 format) carry
-            # only mean/std/min/max. Mirror it from the state stats when
+            # `count` is only present in v2.1+ stats; LeRobot v2.0-format
+            # datasets carry only mean/std/min/max. Mirror it from the state stats when
             # available — the empty-camera placeholder doesn't actually
             # need a meaningful count, but downstream code that asserts
             # the field's presence shouldn't crash. Issue #264.

--- a/src/opentau/datasets/standard_data_format_mapping.py
+++ b/src/opentau/datasets/standard_data_format_mapping.py
@@ -79,6 +79,14 @@ DATA_FEATURES_NAME_MAPPING = {
         "prompt": "task",
         "response": "response",
     },
+    # `TensorAuto/libero` is the corrected re-export of upstream
+    # `physical-intelligence/libero`: identical frames/episodes, but the fps
+    # label is fixed (10 -> 20 Hz) and the format bumped (v2.0 -> v2.1). The
+    # upstream copy carries a *wrong* fps=10 label even though its actions are
+    # authored at the sim's native 20 Hz, which silently breaks training/eval
+    # frequency alignment. We deliberately do NOT keep a
+    # `physical-intelligence/libero` entry here (an unmapped repo_id raises at
+    # dataset build) to discourage its use — point configs at `TensorAuto/libero`.
     "TensorAuto/libero": {
         "camera0": "image",
         "camera1": "wrist_image",

--- a/src/opentau/datasets/standard_data_format_mapping.py
+++ b/src/opentau/datasets/standard_data_format_mapping.py
@@ -79,7 +79,7 @@ DATA_FEATURES_NAME_MAPPING = {
         "prompt": "task",
         "response": "response",
     },
-    "physical-intelligence/libero": {
+    "TensorAuto/libero": {
         "camera0": "image",
         "camera1": "wrist_image",
         "state": "state",

--- a/src/opentau/envs/configs.py
+++ b/src/opentau/envs/configs.py
@@ -125,7 +125,9 @@ class EnvConfig(draccus.ChoiceRegistry, abc.ABC):
         import_name: Name under which the environment should be imported. For LIBERO, this doesn't need to be set.
         make_id: Gymnasium/Gym environment id (e.g., ``"CartPole-v1"``) when using ``gym.make``-style construction.
         task: Optional task or suite identifier understood by the environment.
-        fps: Target frames-per-second used for stepping/rendering.
+        fps: Target stepping frequency in Hz. Exact meaning is env-specific; for
+            LIBERO it is the robosuite control frequency (``LiberoEnv`` overrides
+            the default to 20).
         features: Mapping from logical feature names (e.g., ``"action"``,
             ``"pixels/agentview_image"``) to :class:`~opentau.configs.types.PolicyFeature`
             definitions consumed by policies.
@@ -218,6 +220,10 @@ class LiberoEnv(EnvConfig):
     )
 
     def __post_init__(self):
+        if self.fps <= 0:
+            raise ValueError(
+                f"LIBERO env.fps (robosuite control frequency in Hz) must be positive, got {self.fps}"
+            )
         if self.obs_type == "pixels":
             self.features["pixels/agentview_image"] = PolicyFeature(
                 type=FeatureType.VISUAL, shape=(360, 360, 3)

--- a/src/opentau/envs/configs.py
+++ b/src/opentau/envs/configs.py
@@ -180,7 +180,10 @@ class LiberoEnv(EnvConfig):
     Args:
         task: The LIBERO task or suite to use (e.g., ``"libero_10"``).
         task_ids: Optional list of specific task IDs within the suite to use (if ``None``, all tasks in the suite are used).
-        fps: Target frames-per-second for stepping/rendering.
+        fps: Robosuite control frequency (Hz) for the LIBERO sim — the rate at
+            which each ``env.step`` advances the simulation. Threaded through to
+            ``OffScreenRenderEnv(control_freq=...)``. Defaults to 20, robosuite's
+            native LIBERO rate (the value used before this field was wired up).
         episode_length: Maximum length of each episode in steps.
         obs_type: Type of observations to use (e.g., ``"pixels_agent_pos"``).
         render_mode: Rendering mode for the environment (e.g., ``"rgb_array"``).
@@ -193,7 +196,7 @@ class LiberoEnv(EnvConfig):
 
     task: str = "libero_10"  # can also choose libero_spatial, libero_object, etc.
     task_ids: list[int] | None = None
-    fps: int = 30
+    fps: int = 20  # robosuite control frequency (Hz); see field docstring above
     episode_length: int = 520
     obs_type: str = "pixels_agent_pos"
     render_mode: str = "rgb_array"
@@ -269,4 +272,5 @@ class LiberoEnv(EnvConfig):
             "obs_type": self.obs_type,
             "render_mode": self.render_mode,
             "task_ids": task_ids,
+            "control_freq": self.fps,
         }

--- a/src/opentau/envs/libero.py
+++ b/src/opentau/envs/libero.py
@@ -122,6 +122,7 @@ class LiberoEnv(gym.Env):
         camera_name_mapping: dict[str, list[str]] | None = None,
         num_steps_wait: int = 10,
         render_cam: str | None = None,
+        control_freq: int = 20,
     ):
         r"""Initialize the LiberoEnv.
         Args:
@@ -140,6 +141,8 @@ class LiberoEnv(gym.Env):
             camera_name_mapping: Optional mapping from raw camera names to desired observation keys.
             num_steps_wait: Number of no-op steps to take after reset to stabilize the environment.
             render_cam: The camera name to use for rendering. If None, uses the first camera.
+            control_freq: Robosuite control frequency in Hz — how far each ``step`` advances the
+                sim (one control step = ``1 / control_freq`` seconds). Passed to ``OffScreenRenderEnv``.
         """
         super().__init__()
         self.task_id = task_id
@@ -172,6 +175,7 @@ class LiberoEnv(gym.Env):
                 f"got string {self.camera_name_mapping[cam]} for {cam} instead"
             )
         self.num_steps_wait = num_steps_wait
+        self.control_freq = control_freq
         self.episode_index = episode_index
         # Load once and keep
         self._init_states = _get_task_init_states(task_suite, self.task_id) if self.init_states else None
@@ -239,6 +243,7 @@ class LiberoEnv(gym.Env):
             "bddl_file_name": task_bddl_file,
             "camera_heights": self.observation_height,
             "camera_widths": self.observation_width,
+            "control_freq": self.control_freq,
         }
         env = OffScreenRenderEnv(**env_args)
         env.reset()

--- a/src/opentau/scripts/value_visualizer_app.py
+++ b/src/opentau/scripts/value_visualizer_app.py
@@ -56,7 +56,7 @@ def load_dataset_config(path: Path) -> tuple[Path, str, list[int]]:
         raise ValueError(f"No 'datasets' in {path}")
     first = datasets[0]
     root = Path(first["root"]).resolve()
-    repo_id = first.get("repo_id", "physical-intelligence/libero")
+    repo_id = first.get("repo_id", "TensorAuto/libero")
     episodes = first.get("episodes", [0])
     episodes = sorted(episodes) if isinstance(episodes, list) else list(range(episodes))
     return root, repo_id, episodes

--- a/tests/datasets/test_speed_percentiles.py
+++ b/tests/datasets/test_speed_percentiles.py
@@ -358,7 +358,7 @@ class TestLoadOrComputeSpeedPercentiles:
 
 
 class TestLiberoSnapshot:
-    """Sanity check against the well-formed `physical-intelligence/libero`
+    """Sanity check against the well-formed `TensorAuto/libero`
     distribution: every task should be well populated (>= 10 distinct
     lengths) and each yields 10 ascending percentiles spanning a sensible
     frame range. Skips when the dataset isn't cached locally.
@@ -366,9 +366,9 @@ class TestLiberoSnapshot:
 
     def test_compute_smoke(self):
         lerobot_root = os.environ.get("LEROBOT_HOME") or os.path.expanduser("~/.cache/huggingface/lerobot")
-        ep_path = os.path.join(lerobot_root, "physical-intelligence/libero/meta/episodes.jsonl")
+        ep_path = os.path.join(lerobot_root, "TensorAuto/libero/meta/episodes.jsonl")
         if not os.path.isfile(ep_path):
-            pytest.skip(f"no local copy of physical-intelligence/libero at {ep_path}")
+            pytest.skip(f"no local copy of TensorAuto/libero at {ep_path}")
         import json
         from collections import defaultdict
 

--- a/tests/envs/test_libero_control_freq.py
+++ b/tests/envs/test_libero_control_freq.py
@@ -55,6 +55,14 @@ def test_libero_gym_kwargs_carries_control_freq():
     assert gym_kwargs["control_freq"] == 10
 
 
+@pytest.mark.parametrize("bad_fps", [0, -5])
+def test_libero_config_rejects_nonpositive_fps(bad_fps):
+    # fps now drives the sim control loop, so a non-positive value must fail loudly
+    # at config time rather than passing through to robosuite.
+    with pytest.raises(ValueError, match="must be positive"):
+        LiberoEnvConfig(fps=bad_fps)
+
+
 @patch("opentau.envs.libero.get_libero_path", return_value="/tmp/libero")
 @patch("opentau.envs.libero.OffScreenRenderEnv")
 def test_control_freq_reaches_robosuite(mock_offscreen, _mock_path):

--- a/tests/envs/test_libero_control_freq.py
+++ b/tests/envs/test_libero_control_freq.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+r"""The LIBERO sim control frequency must be configurable via ``env.fps``.
+
+Before this was wired, ``OffScreenRenderEnv`` was built without ``control_freq``,
+so the sim always ran at robosuite's hardcoded 20 Hz regardless of the config.
+These tests pin the wiring: config ``fps`` -> ``gym_kwargs["control_freq"]`` ->
+``OffScreenRenderEnv(control_freq=...)``.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from opentau.envs.configs import LiberoEnv as LiberoEnvConfig
+from opentau.envs.libero import LiberoEnv as LiberoGymEnv
+
+
+def _make_task_suite() -> Mock:
+    """A task suite whose ``get_task`` returns string-valued fields os.path.join can consume."""
+    task = Mock()
+    task.name = "demo_task"
+    task.language = "do something"
+    task.problem_folder = "problem_folder"
+    task.bddl_file = "task.bddl"
+    suite = Mock()
+    suite.get_task.return_value = task
+    return suite
+
+
+def test_libero_config_fps_defaults_to_20():
+    # 20 Hz is robosuite's native LIBERO rate and the de-facto rate before fps was wired.
+    assert LiberoEnvConfig().fps == 20
+
+
+def test_libero_gym_kwargs_carries_control_freq():
+    cfg = LiberoEnvConfig(fps=10, task_ids=[0])
+    # Force the no-accelerator branch so the property doesn't need the LIBERO benchmark.
+    with patch("opentau.envs.configs.get_proc_accelerator", return_value=None):
+        gym_kwargs = cfg.gym_kwargs
+    assert gym_kwargs["control_freq"] == 10
+
+
+@patch("opentau.envs.libero.get_libero_path", return_value="/tmp/libero")
+@patch("opentau.envs.libero.OffScreenRenderEnv")
+def test_control_freq_reaches_robosuite(mock_offscreen, _mock_path):
+    # A value distinct from both the default (20) and the dataset label (10) proves it threads through.
+    LiberoGymEnv(
+        task_suite=_make_task_suite(),
+        task_id=0,
+        task_suite_name="libero_10",
+        init_states=False,
+        control_freq=13,
+    )
+    assert mock_offscreen.call_args.kwargs["control_freq"] == 13
+
+
+@patch("opentau.envs.libero.get_libero_path", return_value="/tmp/libero")
+@patch("opentau.envs.libero.OffScreenRenderEnv")
+def test_control_freq_defaults_to_20(mock_offscreen, _mock_path):
+    LiberoGymEnv(
+        task_suite=_make_task_suite(),
+        task_id=0,
+        task_suite_name="libero_10",
+        init_states=False,
+    )
+    assert mock_offscreen.call_args.kwargs["control_freq"] == 20
+
+
+@pytest.mark.gpu
+def test_control_freq_reaches_real_robosuite_sim():
+    """On a real LIBERO sim (needs GL + assets), the configured control_freq must reach robosuite.
+
+    The mocked tests above can't catch robosuite silently dropping the kwarg; this one builds the
+    actual ``OffScreenRenderEnv`` and reads back ``control_freq`` from the underlying robosuite env.
+    """
+    import gymnasium as gym
+
+    from opentau.envs.libero import create_libero_envs
+
+    envs = create_libero_envs(
+        task="libero_10",
+        n_envs=1,
+        gym_kwargs={"task_ids": {"libero_10": [0]}, "control_freq": 13},
+        env_cls=gym.vector.SyncVectorEnv,
+    )
+    vec = envs["libero_10"][0]
+    try:
+        assert vec.envs[0]._env.env.control_freq == 13
+    finally:
+        vec.close()


### PR DESCRIPTION
## What this does

🗃️ Feature / 🐛 Bug

The LIBERO eval env built `OffScreenRenderEnv` with only `bddl_file_name` + camera sizes, so the simulation always ran at robosuite's hardcoded `control_freq=20` Hz. The `EnvConfig.fps` field existed but was **dead** — it was never placed in `gym_kwargs`, so it never reached env construction. (Upstream LeRobot's LIBERO env carries the same dead field.)

This wires `env.fps` through to robosuite's `control_freq`:

```
gym_kwargs  ->  LiberoEnv.__init__(control_freq=...)  ->  OffScreenRenderEnv(control_freq=...)
```

The LIBERO default is set to **20** (robosuite's native rate, so the no-arg path is unchanged), with a `fps > 0` guard.

**Why 20 is the right default.** An fps ablation on a `pi05_mem` checkpoint (`libero_10`, 64 episodes per setting, single GPU, identical seed/config — only `env.fps` varied):

| sim `control_freq` | `libero_10` success |
| --- | --- |
| **20 Hz** (default) | **92.19%** |
| 10 Hz | 39.06% |

20 Hz reproduces the training-time eval; 10 Hz collapses it. The data is authored at the sim's native 20 Hz.

## Dataset: `physical-intelligence/libero` → `TensorAuto/libero` (20 fps)

Every reference to `physical-intelligence/libero` is re-pointed to **`TensorAuto/libero`** and `dataset_mixture.action_freq` is set to **20** across the demo configs and docs. `TensorAuto/libero` is **published** — a `v2.1` re-export of the *same* frames/episodes (1693 episodes / 273465 frames, verified equal) with the fps label corrected `10 → 20` Hz (no resampling). Upstream `physical-intelligence/libero` ships a wrong `fps=10` label even though its actions are authored at 20 Hz; the corrected copy makes the dataset rate, `action_freq`, and sim `control_freq` all line up at **20**.

## Compatibility notes

- **`env.fps` is now active.** If your own config explicitly set it to a non-20 value (the old example configs shipped `fps: 10`), that value was previously ignored and will now take effect — set it to 20, or remove it, to keep the prior 20 Hz behavior.
- **`physical-intelligence/libero` is intentionally removed from `standard_data_format_mapping.py`** (not aliased), with an explanatory comment, to discourage the wrongly-labeled dataset. A config still pointing at it (without its own `data_features_name_mapping`) will error at dataset build — switch to `TensorAuto/libero`.

## How it was tested

- Added `tests/envs/test_libero_control_freq.py`: CPU mock tests (`env.fps` → `gym_kwargs["control_freq"]`; `OffScreenRenderEnv` built with the configured `control_freq`; default 20; rejects `fps <= 0`) plus a `@pytest.mark.gpu` real-sim readback.
- `pre-commit run --all-files` and `pytest -m "not gpu" -n auto` pass; the gpu test passes on a CUDA box.
- fps ablation above (20 Hz → 92.19% vs 10 Hz → 39.06% on `libero_10`).
- Verified `TensorAuto/libero` metadata: `fps=20`, `v2.1`, same episode/frame counts as the upstream copy.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/envs/test_libero_control_freq.py -m "not gpu"
```

The sim frequency is now a config field / CLI override on any libero config:

```bash
opentau-eval --accelerate-config configs/examples/accelerate_ddp_config.yaml --config_path=configs/libero/reproduce_pi05_libero.json --env.fps=20
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
