### PR TITLE
fix(datasets): set batch_size in v2.0->v2.1 converter fake config

### DIFF
--- a/src/opentau/datasets/v21/convert_dataset_v20_to_v21.py
+++ b/src/opentau/datasets/v21/convert_dataset_v20_to_v21.py
@@ -95,7 +95,10 @@ def create_fake_train_config() -> TrainPipelineConfig:
     mixture_cfg = DatasetMixtureConfig(datasets=[dataset_cfg], weights=[1.0])
     policy_cfg = DummyPolicyConfig()
 
-    # Create the main config with minimal required parameters
+    # Create the main config with minimal required parameters.
+    # batch_size is required: TrainPipelineConfig.__post_init__ raises when neither
+    # batch_size nor dataloader_batch_size is set. Conversion never trains, so any
+    # valid value works.
     cfg = TrainPipelineConfig(
         dataset_mixture=mixture_cfg,
         policy=policy_cfg,
@@ -104,6 +107,7 @@ def create_fake_train_config() -> TrainPipelineConfig:
         max_state_dim=32,
         max_action_dim=32,
         action_chunk=50,
+        batch_size=1,
     )
 
     return cfg


### PR DESCRIPTION
## What this does

Fixes a startup crash in the LeRobot v2.0→v2.1 dataset converter (🐛 Bug).

`create_fake_train_config()` in `src/opentau/datasets/v21/convert_dataset_v20_to_v21.py` builds a `TrainPipelineConfig` without `batch_size` or `dataloader_batch_size`. `TrainPipelineConfig.__post_init__` now raises when both are unset:

```
ValueError: At least one of `batch_size` and `dataloader_batch_size` should be set.
```

So `convert_dataset(...)` — and the `convert_dataset_v20_to_v21.py` CLI — failed immediately, before loading any data. This sets `batch_size=1`; the conversion only reads data to recompute per-episode stats and never trains, so any valid batch size works.

## How it was tested

- Confirmed `create_fake_train_config()` now constructs successfully and returns a config with `batch_size=1`, `dataloader_batch_size=1`, `gradient_accumulation_steps=1` (the invariant `batch_size == dataloader_batch_size * gradient_accumulation_steps` holds). Before this change it raised `ValueError`.
- `pre-commit run --files src/opentau/datasets/v21/convert_dataset_v20_to_v21.py` passes (ruff, ruff-format, pyupgrade, gitleaks, bandit, etc.).

## How to checkout & try? (for the reviewer)

```bash
python -c "from opentau.datasets.v21.convert_dataset_v20_to_v21 import create_fake_train_config; print(create_fake_train_config().batch_size)"
```

Prints `1` instead of raising `ValueError`.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).