### PR TITLE
feat(train): log LIBERO grid-summary eval videos to wandb

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ dependencies = [
     "torch>=2.7.1",
     "torchcodec>=0.4.0, <0.5.0; sys_platform != 'win32' and (sys_platform != 'linux' or (platform_machine != 'aarch64' and platform_machine != 'arm64' and platform_machine != 'armv7l')) and (sys_platform != 'darwin' or platform_machine != 'x86_64')",
     "torchvision>=0.22.1",
-    "wandb>=0.16.3",
+    "wandb>=0.27.0",
     "zarr>=2.17.0",
     "scikit-learn>=1.7.1",
     "onnx>=1.18.0",

--- a/src/opentau/scripts/eval.py
+++ b/src/opentau/scripts/eval.py
@@ -24,6 +24,7 @@ import concurrent.futures as cf
 import datetime as dt
 import json
 import logging
+import re
 import threading
 import time
 from collections import defaultdict
@@ -887,6 +888,23 @@ def consolidate_eval_info(eval_infos: list[dict]) -> dict:
         "per_group": per_groups,
         "overall": overall,
     }
+
+
+def collect_grid_summary_videos(videos_dir: Path) -> list[tuple[str, str]]:
+    """Find per-task grid_summary.mp4 files under ``videos_dir`` for wandb logging.
+
+    Returns sorted ``(task_name, path)`` pairs, where ``task_name`` is the
+    per-task subdir name with any trailing ``_rank{N}`` stripped (so wandb keys
+    stay stable across GPU-count changes). Individual ``eval_episode_*.mp4``
+    clips are intentionally excluded.
+    """
+    if not videos_dir.exists():
+        return []
+    results = [
+        (re.sub(r"_rank\d+$", "", grid_path.parent.name), str(grid_path))
+        for grid_path in videos_dir.rglob("grid_summary.mp4")
+    ]
+    return sorted(results)
 
 
 def main():

--- a/src/opentau/scripts/eval.py
+++ b/src/opentau/scripts/eval.py
@@ -894,9 +894,16 @@ def collect_grid_summary_videos(videos_dir: Path) -> list[tuple[str, str]]:
     """Find per-task grid_summary.mp4 files under ``videos_dir`` for wandb logging.
 
     Returns sorted ``(task_name, path)`` pairs, where ``task_name`` is the
-    per-task subdir name with any trailing ``_rank{N}`` stripped (so wandb keys
-    stay stable across GPU-count changes). Individual ``eval_episode_*.mp4``
-    clips are intentionally excluded.
+    per-task subdir name (``{task_group}_{task_id}_rank{N}``) with any trailing
+    ``_rank{N}`` stripped, so wandb keys stay stable across GPU-count changes.
+    Individual ``eval_episode_*.mp4`` clips are intentionally excluded.
+
+    Assumes each ``(task_group, task_id)`` is evaluated on exactly one rank, which
+    the disjoint round-robin task sharding guarantees (``idx % num_processes ==
+    process_index`` in ``envs/configs.py``). Under that assumption the stripped
+    key is unique; if the same task were ever evaluated on multiple ranks, the
+    keys would collide and the later video would overwrite the earlier one at the
+    same step.
     """
     if not videos_dir.exists():
         return []

--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -817,12 +817,17 @@ def train(cfg: TrainPipelineConfig):
                     json.dump(eval_info, f, indent=2)
 
                 # Log grid-summary eval videos to wandb (skip individual clips).
+                # Main-process-only, and globs the shared videos_dir, so it
+                # assumes every rank wrote to a filesystem the main process can
+                # read (true for the single-node multi-GPU setup; non-rank-0
+                # videos on a multi-node run without a shared FS won't be seen).
                 if cfg.wandb.enable and cfg.eval.max_episodes_rendered > 0:
-                    for task_name, grid_path in collect_grid_summary_videos(videos_dir):
-                        accelerator.log(
-                            {f"Eval Videos/{task_name}": wandb.Video(grid_path)},
-                            step=step,
-                        )
+                    grid_videos = {
+                        f"Eval Videos/{task_name}": wandb.Video(grid_path)
+                        for task_name, grid_path in collect_grid_summary_videos(videos_dir)
+                    }
+                    if grid_videos:
+                        accelerator.log(grid_videos, step=step)
 
             # This barrier is to ensure all processes finishes evaluation before the next training step
             # Some processes might be slower than others

--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -26,6 +26,7 @@ from typing import Any
 
 import accelerate
 import torch
+import wandb
 from accelerate.optimizer import AcceleratedOptimizer
 from accelerate.scheduler import AcceleratedScheduler
 from accelerate.utils import DistributedDataParallelKwargs, gather_object
@@ -41,7 +42,7 @@ from opentau.optim.factory import make_optimizer_and_scheduler
 from opentau.optim.master_weights import MasterWeightOptimizer
 from opentau.policies.factory import make_policy
 from opentau.policies.pretrained import PreTrainedPolicy
-from opentau.scripts.eval import consolidate_eval_info, eval_policy_all
+from opentau.scripts.eval import collect_grid_summary_videos, consolidate_eval_info, eval_policy_all
 from opentau.utils.accelerate_utils import set_proc_accelerator
 from opentau.utils.logging_utils import AverageMeter, MetricsTracker
 from opentau.utils.random_utils import set_seed
@@ -814,6 +815,14 @@ def train(cfg: TrainPipelineConfig):
                 videos_dir = cfg.output_dir / "eval" / f"videos_step_{step_id}"
                 with open(videos_dir / "eval_info.json", "w") as f:
                     json.dump(eval_info, f, indent=2)
+
+                # Log grid-summary eval videos to wandb (skip individual clips).
+                if cfg.wandb.enable and cfg.eval.max_episodes_rendered > 0:
+                    for task_name, grid_path in collect_grid_summary_videos(videos_dir):
+                        accelerator.log(
+                            {f"Eval Videos/{task_name}": wandb.Video(grid_path)},
+                            step=step,
+                        )
 
             # This barrier is to ensure all processes finishes evaluation before the next training step
             # Some processes might be slower than others

--- a/tests/scripts/test_eval.py
+++ b/tests/scripts/test_eval.py
@@ -1,0 +1,37 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+from opentau.scripts.eval import collect_grid_summary_videos
+
+
+def _touch(p: Path):
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_bytes(b"x")
+
+
+def test_collect_grid_summary_videos_strips_rank_and_excludes_clips(tmp_path):
+    _touch(tmp_path / "libero_10_3_rank0" / "grid_summary.mp4")
+    _touch(tmp_path / "libero_10_3_rank0" / "eval_episode_0.mp4")  # must be excluded
+    _touch(tmp_path / "libero_goal_1_rank2" / "grid_summary.mp4")
+
+    out = collect_grid_summary_videos(tmp_path)
+
+    assert [name for name, _ in out] == ["libero_10_3", "libero_goal_1"]
+    assert all(p.endswith("grid_summary.mp4") for _, p in out)
+
+
+def test_collect_grid_summary_videos_missing_dir(tmp_path):
+    assert collect_grid_summary_videos(tmp_path / "does_not_exist") == []

--- a/uv.lock
+++ b/uv.lock
@@ -2394,7 +2394,7 @@ wheels = [
 
 [[package]]
 name = "opentau"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },
@@ -2579,7 +2579,7 @@ requires-dist = [
     { name = "torchcodec", marker = "(platform_machine != 'aarch64' and platform_machine != 'arm64' and platform_machine != 'armv7l' and sys_platform == 'linux') or (platform_machine != 'x86_64' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')", specifier = ">=0.4.0,<0.5.0" },
     { name = "torchvision", specifier = ">=0.22.1" },
     { name = "transformers", specifier = "==4.53.3" },
-    { name = "wandb", specifier = ">=0.16.3" },
+    { name = "wandb", specifier = ">=0.27.0" },
     { name = "zarr", specifier = ">=2.17.0" },
 ]
 provides-extras = ["dev", "libero", "urdf", "trt"]
@@ -4094,7 +4094,7 @@ wheels = [
 
 [[package]]
 name = "wandb"
-version = "0.24.1"
+version = "0.27.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -4108,17 +4108,17 @@ dependencies = [
     { name = "sentry-sdk" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3b/db/65fea14155118fa6c793716c1b9f26aba5993c0d462656a23047ea86629e/wandb-0.24.1.tar.gz", hash = "sha256:3ae74cb4fb0d90dca65c96541e8b75740737a7ad99406b283750fc0d58847095", size = 44232291, upload-time = "2026-01-29T23:37:47.037Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/31/fe53d06b75ef0a7f2f0ee5931a89f7aedc27d233840b1839616860fed256/wandb-0.27.0.tar.gz", hash = "sha256:579e75300173059f9334e1f513a79ef15f6d9ea5c74e20d695633648cdd02031", size = 41090732, upload-time = "2026-05-14T03:44:08.894Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/ff/8c8cd41a83599ad3f035871f4e47f11aea24db77a25fe0c8bf643dca760b/wandb-0.24.1-py3-none-macosx_12_0_arm64.whl", hash = "sha256:7bce30ca1e0fb1edea1958fc9139f64b20a5370f7896100dc8d1fef90fe9005f", size = 21609164, upload-time = "2026-01-29T23:37:18.361Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/82/4179e1869409c8d8248f67a7932311ce99a962f25899c65d91fcdc4f68ca/wandb-0.24.1-py3-none-macosx_12_0_x86_64.whl", hash = "sha256:5fcbc63108db711d70c25ed80ff3d9cf1612ffe95e06104da70bb5d80f3711cc", size = 22872511, upload-time = "2026-01-29T23:37:21.743Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/a7/137de743ce6f48c42c4996256a98d9d29e20b51ddb1816a07dee6ed1fdee/wandb-0.24.1-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:747b2056845bf4a4f1060a614384c78922990052c04bdcd14f53182bf7c96a17", size = 21271822, upload-time = "2026-01-29T23:37:24.256Z" },
-    { url = "https://files.pythonhosted.org/packages/be/55/455ff610afdc99aea26417fa5cd303f0792d568431218c56eb9b7616d871/wandb-0.24.1-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:2a9859a6008bad296a205adfee22b1ca78f3520bc96704302d8578e3758c2e20", size = 23007982, upload-time = "2026-01-29T23:37:27.657Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/4e/7a70bd90b90d511d06589fc0154bc5e153e2956c233635385ca0c4f241c8/wandb-0.24.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:9d504e3cb4cbc7072066404b307ff608db16c86d4c0f621a4ff3932562f1183c", size = 21326037, upload-time = "2026-01-29T23:37:30.886Z" },
-    { url = "https://files.pythonhosted.org/packages/64/98/d8cc33ef8dfab4e59891be4bd622a7147f81fb8f82591a9984d2b73983a3/wandb-0.24.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5bc53163f946b94ae6deb331cdfb115f50bc6f998be671ed1805cd03f5446518", size = 23100607, upload-time = "2026-01-29T23:37:33.627Z" },
-    { url = "https://files.pythonhosted.org/packages/74/f7/fa7669db1059b506bfce77cc938a70f83c6078a57aeede53ecbabdbd8242/wandb-0.24.1-py3-none-win32.whl", hash = "sha256:e08e56385e74fd56fc0473a95c223bf23b4fef838ce2008ba3fb1a8c4f41086d", size = 22278840, upload-time = "2026-01-29T23:37:36.975Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/7a/8688d51cac7850c3b275f86eec66d7e1f43b341f0d63526c643416f0da73/wandb-0.24.1-py3-none-win_amd64.whl", hash = "sha256:dfe2d713dea319e58a4e90c5ceb6f7f5d93482f2ce98e9f595eff0e40c09f840", size = 22278845, upload-time = "2026-01-29T23:37:40.209Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/55/d87faa7251e8e11e24cd8b8269152e1e46593bc694c2d3716dc2b1ee9f75/wandb-0.24.1-py3-none-win_arm64.whl", hash = "sha256:6b57755c0257d3f0f5bed0d3e390167aba363258e9b608fc465a87934507fc07", size = 20240702, upload-time = "2026-01-29T23:37:43.577Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/5e/2c199e70e636ecfd217cde0bc7469f4511e1d03d0685eb92bfdfce391430/wandb-0.27.0-py3-none-macosx_12_0_arm64.whl", hash = "sha256:c156be4851485f3c4160cb6eb2e8991b4cdeffbccefc5636d33cf5e254847365", size = 24886476, upload-time = "2026-05-14T03:43:27.569Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/cd/a617c871cd304a9804e56a7ec2ec2c65685bf0091a2b9f91910175a149e2/wandb-0.27.0-py3-none-macosx_12_0_x86_64.whl", hash = "sha256:20179f38afb0158859a4141d29ac650d3fdbd0cf801a74ce25565c934f03776c", size = 26045779, upload-time = "2026-05-14T03:43:31.999Z" },
+    { url = "https://files.pythonhosted.org/packages/10/0a/d3f159a201530b84b72ca5f98c68d1f351c2d9a1864558ed76c811407fae/wandb-0.27.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:626497d7975fa898d0a4a239da7a510483495ca3514510dbe75004a25963af4d", size = 25480764, upload-time = "2026-05-14T03:43:35.922Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/6a/8721fcdf71d42639191040a77a585d2982402b1754700cb2ecfc2ca1470a/wandb-0.27.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:f772da7005cc26a2a32b729a16982a583dc68b3d493df6a09d0aa5c5ca5a2060", size = 27256204, upload-time = "2026-05-14T03:43:39.765Z" },
+    { url = "https://files.pythonhosted.org/packages/00/5e/279d167ba79fb7a8a43401c9f25efd0f6663ee9bd1eaf5a8578530198888/wandb-0.27.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:63acfc5b994e4a90e4a2fbdee6d45e664da3dd865bb1419942c8995c06c41cf1", size = 25647469, upload-time = "2026-05-14T03:43:44.817Z" },
+    { url = "https://files.pythonhosted.org/packages/94/51/a69ac59300e3c813939d0764348959ed2a21e14c668cb1cebcb04010da6a/wandb-0.27.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:17aae6e4a88cd05c00ea8f546220918e3ebb6f8c1c36b70ef04a5ac75f0d7160", size = 27599005, upload-time = "2026-05-14T03:43:50.926Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/40/bf510c8758727df020f83b717ebc1fcc1739ed7f6ae1796ebef60bf6f592/wandb-0.27.0-py3-none-win32.whl", hash = "sha256:0bd5659417e386bf6538b5e2ffe6885774c6197f0e4853bfed517d5b0db457f1", size = 25036164, upload-time = "2026-05-14T03:43:54.839Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ff/69f88e7d90c22b79bcb911143c13e59742ee192080b21015ff83a5a1f60a/wandb-0.27.0-py3-none-win_amd64.whl", hash = "sha256:89d584b73166eecee96fb446f18d0e45b1aa45aba6a3696296f3f06d7454516b", size = 25036170, upload-time = "2026-05-14T03:43:59.227Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/38/f7efd7a87297a55c7e9a331a1dbb5b19e54aeacc11fe6f43f8636a73987c/wandb-0.27.0-py3-none-win_arm64.whl", hash = "sha256:a6c129c311edf210a2b4f2f4acc557eff522628125f5f28ed27df19c16c07079", size = 22972710, upload-time = "2026-05-14T03:44:03.275Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What this does
When LIBERO eval videos are generated during training, log the per-task `grid_summary.mp4` files to wandb via `accelerator.log(...)` when wandb is enabled. Individual `eval_episode_*.mp4` clips are intentionally skipped.

- New helper `collect_grid_summary_videos(videos_dir)` in `src/opentau/scripts/eval.py` globs the per-task `grid_summary.mp4` files, strips the trailing `_rank{N}` from the task subdir name (so wandb keys stay stable across GPU counts), and excludes individual episode clips.
- `src/opentau/scripts/train.py` logs the grid videos under `Eval Videos/{suite}_{task_id}` in the main-process eval block, guarded by `cfg.wandb.enable and cfg.eval.max_episodes_rendered > 0`.
- Bumps the `wandb` floor `0.16.3 → 0.27.0` (relock). **Intentional** — a deliberate modernization to standardize on a current wandb instead of the ~2-year-old floor; not strictly required by `wandb.Video` (which has accepted mp4 paths for many releases), bundled here as the change that touches wandb.

🗃️ Feature

## How it was tested
- Added `test_collect_grid_summary_videos_*` in `tests/scripts/test_eval.py` (CPU): verifies rank-stripping, sorted ordering, exclusion of episode clips, and the missing-dir case. `pytest -m "not gpu" tests/scripts/test_eval.py` → 2 passed.
- Verified the logging path itself: ran the exact `accelerator.log({f"Eval Videos/{name}": wandb.Video(path)}, step=step)` code against a generated `grid_summary.mp4` (plus a dummy episode clip) with wandb 0.27.0 + accelerate, in offline mode — both grid videos were staged under `media/videos/Eval Videos/...` and the clip was not logged.
- `pre-commit run --all-files` passes. `uv sync` verified on macOS and Linux with the bumped wandb.
- Not a policy change; the LIBERO sim / GPU eval path is unchanged, so GPU and regression tests were not run.

## How to checkout & try? (for the reviewer)
```bash
pytest -sx tests/scripts/test_eval.py
```
The logging fires automatically during a training run with eval + rendering enabled; grid videos then appear in wandb under `Eval Videos/*`:
```bash
opentau-train --config_path=configs/examples/pi05_libero_eval_config.json --wandb.enable=true
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).