### PR TITLE
fix(pi07_paligemma): decouple n_action_steps from chunk_size

### DIFF
--- a/src/opentau/policies/pi07_paligemma/low_level/configuration_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/configuration_pi07_low_level.py
@@ -43,8 +43,11 @@ class PI07PaligemmaLowLevelConfig(PreTrainedConfig):
         n_obs_steps: Number of observation steps to use. Defaults to 6.
         history_interval: Temporal stride between the ``n_obs_steps`` stacked
             frames in the inference buffer, in environment steps. Defaults to 1.
-        chunk_size: Size of the action chunk. The upper bound for n_action_steps. Defaults to 50.
-        n_action_steps: Number of action steps to predict. Defaults to 50.
+        chunk_size: Trained action-chunk length, i.e. the prediction horizon the model
+            always decodes at inference. Upper bound for n_action_steps. Defaults to 50.
+        n_action_steps: Inference execution horizon -- how many actions from each
+            predicted chunk are executed before the policy re-queries with fresh
+            observations. Must be <= chunk_size. Defaults to 50.
         normalization_mapping: Mapping of feature names to normalization modes.
             Defaults to identity for visual features and mean-std for state and action.
         max_state_dim: Maximum dimension for state vectors. Shorter vectors are padded. Defaults to 32.
@@ -196,6 +199,15 @@ class PI07PaligemmaLowLevelConfig(PreTrainedConfig):
         if self.max_delay > self.chunk_size:
             raise ValueError(
                 f"The max delay must be less than or equal to the chunk size. Got {self.max_delay} for `max_delay` and {self.chunk_size} for `chunk_size`."
+            )
+
+        if self.n_action_steps < self.chunk_size and self.max_delay != 0:
+            raise ValueError(
+                "A shortened execution horizon (n_action_steps < chunk_size) is not yet "
+                "supported together with real-time inference delay (max_delay > 0); they "
+                "would entangle the action-queue prefix logic. Got "
+                f"n_action_steps={self.n_action_steps}, chunk_size={self.chunk_size}, "
+                f"max_delay={self.max_delay}."
             )
 
     def validate_features(self) -> None:

--- a/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
@@ -1998,6 +1998,12 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
 
         Factored out so that :meth:`forward`, :meth:`sample_actions`, and
         :meth:`denoise_step` share one definition of what's in the suffix.
+
+        Invariant: the action block must stay the *trailing* ``chunk_size``
+        tokens of the suffix. :meth:`forward` and :meth:`denoise_step` recover
+        the action outputs with ``suffix_out[:, -chunk_size:]``; if a future
+        block is appended after the actions, that slice (and those call sites)
+        must be updated accordingly.
         """
         bsize = x_t.shape[0]
         action_mask = torch.ones(bsize, x_t.shape[1], dtype=torch.bool, device=x_t.device)

--- a/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
@@ -660,7 +660,12 @@ class PI07PaligemmaLowLevelPolicy(PreTrainedPolicy):
             delay = torch.tensor(delay, dtype=torch.long, device=batch["state"].device)
             actions = self.sample_actions(batch, noise=noise, action_prefix=action_prefix, delay=delay)
             actions = rearrange(actions, "b c d -> c b d")
-            self._action_queue.extend(actions[delay:])
+            # Execute only the first n_action_steps of the predicted chunk, then
+            # re-query with fresh observations (receding horizon). The config guard
+            # (n_action_steps < chunk_size => max_delay == 0 => delay == 0) keeps this
+            # slice in range and exactly n_action_steps long; when n_action_steps ==
+            # chunk_size it clamps to actions[delay:] (unchanged behaviour).
+            self._action_queue.extend(actions[delay : delay + self.config.n_action_steps])
             assert len(self._action_queue) == self.config.n_action_steps, (
                 f"Action queue must have {self.config.n_action_steps} actions"
             )
@@ -1932,7 +1937,10 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
         )
 
         # compute mse loss for velocity
-        suffix_out = suffix_out[:, -self.config.n_action_steps :]
+        # Supervise the whole chunk the model was trained to predict. n_action_steps
+        # is the inference-time execution horizon only and must not truncate the
+        # training target (chunk_size is the prediction horizon).
+        suffix_out = suffix_out[:, -self.config.chunk_size :]
         # Original openpi code, upcast attention output
         v_t = self.action_out_proj(suffix_out)
         v_t = v_t.to(dtype=torch.float32)
@@ -2114,7 +2122,10 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
             adarms_cond=[None, adarms_cond],
         )
         suffix_out = outputs_embeds[1]
-        suffix_out = suffix_out[:, -self.config.n_action_steps :]
+        # Denoise the full chunk_size chunk so v_t matches x_t in the Euler step.
+        # n_action_steps (execution horizon) is applied later in select_action, not
+        # at decode time.
+        suffix_out = suffix_out[:, -self.config.chunk_size :]
         v_t = self.action_out_proj(suffix_out)
         v_t = v_t.to(dtype=torch.float32)
         return v_t

--- a/tests/policies/test_pi07_paligemma_low_level.py
+++ b/tests/policies/test_pi07_paligemma_low_level.py
@@ -2181,3 +2181,75 @@ class TestPI07PaligemmaLowLevelSubgoalEmbedding:
         assert len(image_calls) == len(sg_images)
         for shape in image_calls:
             assert shape == (bsz, 3, 224, 224), shape
+
+
+class TestPI07PaligemmaLowLevelExecutionHorizon:
+    """Regression coverage for ``n_action_steps`` as a short execution horizon.
+
+    ``chunk_size`` is the trained prediction horizon (always decoded);
+    ``n_action_steps`` (<= chunk_size) is how many actions are executed before
+    re-querying. ``n_action_steps < chunk_size`` used to broadcast-crash the
+    denoise/MSE paths and trip the queue assert; these CPU tests guard that
+    path (the GPU pipeline test only exercises ``n_action_steps == chunk_size``).
+    """
+
+    @staticmethod
+    def _config(chunk_size=10, n_action_steps=3, max_delay=0):
+        return PI07PaligemmaLowLevelConfig(
+            n_obs_steps=1,
+            chunk_size=chunk_size,
+            n_action_steps=n_action_steps,
+            max_delay=max_delay,
+            max_state_dim=MAX_STATE_DIM,
+            max_action_dim=MAX_ACTION_DIM,
+        )
+
+    def test_guard_rejects_short_horizon_with_delay(self):
+        # A shortened execution horizon is not compatible with the real-time
+        # delay prefix path; the config must reject it loudly.
+        with pytest.raises(ValueError, match="max_delay"):
+            self._config(chunk_size=10, n_action_steps=3, max_delay=2)
+
+    def test_guard_allows_short_horizon_without_delay(self):
+        cfg = self._config(chunk_size=10, n_action_steps=3, max_delay=0)
+        assert (cfg.chunk_size, cfg.n_action_steps, cfg.max_delay) == (10, 3, 0)
+
+    def test_guard_allows_full_horizon_with_delay(self):
+        # n_action_steps == chunk_size keeps the real-time-delay path available.
+        cfg = self._config(chunk_size=10, n_action_steps=10, max_delay=2)
+        assert cfg.max_delay == 2
+
+    def test_select_action_executes_first_n_then_requeries(self):
+        """Model decodes the full ``chunk_size`` chunk, but ``select_action``
+        executes only the first ``n_action_steps`` before re-querying.
+        """
+        chunk_size, n_steps, bsz = 10, 3, 2
+        cfg = self._config(chunk_size=chunk_size, n_action_steps=n_steps, max_delay=0)
+
+        policy = object.__new__(PI07PaligemmaLowLevelPolicy)
+        policy.config = cfg
+        policy.eval = lambda: None  # bypass nn.Module.eval (no __init__ was run)
+        PI07PaligemmaLowLevelPolicy.reset(policy)
+
+        calls = {"n": 0}
+
+        def fake_sample_actions(batch, noise=None, action_prefix=None, delay=None):
+            # Return a full chunk_size chunk; element value encodes
+            # (call_index * 1000 + timestep) so we can assert which timesteps run.
+            calls["n"] += 1
+            ts = torch.arange(chunk_size, dtype=torch.float32).reshape(1, chunk_size, 1)
+            return (calls["n"] * 1000 + ts).expand(bsz, chunk_size, MAX_ACTION_DIM).clone()
+
+        policy.sample_actions = fake_sample_actions
+        batch = {"state": torch.zeros(bsz, MAX_STATE_DIM)}
+
+        # First n_steps actions all come from a single decode (call 1), in order.
+        acts = [PI07PaligemmaLowLevelPolicy.select_action(policy, batch) for _ in range(n_steps)]
+        assert calls["n"] == 1
+        assert [tuple(a.shape) for a in acts] == [(bsz, MAX_ACTION_DIM)] * n_steps
+        assert [a[0, 0].item() for a in acts] == [1000.0, 1001.0, 1002.0]
+
+        # Queue drained after n_action_steps -> next call re-queries (call 2).
+        a_next = PI07PaligemmaLowLevelPolicy.select_action(policy, batch)
+        assert calls["n"] == 2
+        assert a_next[0, 0].item() == 2000.0


### PR DESCRIPTION
## What this does

`n_action_steps` is meant to be the inference-time **execution horizon** (how many actions from each predicted chunk are executed before the policy re-queries with fresh observations), while `chunk_size` is the **prediction horizon** the flow-matching model is trained to decode. The `pi07_paligemma_low_level` policy conflated the two: both the training loss and the inference denoise loop sliced the action-expert output to `n_action_steps`, so any `n_action_steps < chunk_size` would:

- crash inference — the Euler step `x_t += dt * v_t` broadcast `v_t` (length `n_action_steps`) against `x_t` (length `chunk_size`); and
- mis-shape the training MSE target (`v_t` vs `u_t = noise - actions`, which is length `chunk_size`).

That effectively forced `n_action_steps == chunk_size`, so the policy could only ever execute the *entire* predicted chunk open-loop before re-planning.

Changes (in `policies/pi07_paligemma/low_level/`):
- `modeling_pi07_low_level.py`: decode/supervise the full `chunk_size` chunk in the training forward and the denoise step (slice by `chunk_size`, not `n_action_steps`); in `select_action`, push only the first `n_action_steps` actions onto the queue so it drains and re-queries after `n_action_steps` steps (receding horizon).
- `configuration_pi07_low_level.py`: guard that a shortened execution horizon (`n_action_steps < chunk_size`) requires `max_delay == 0` (the real-time-delay prefix path is not yet compatible), and clarify the `chunk_size` / `n_action_steps` docstrings.

This is a **no-op for existing configs** where `n_action_steps == chunk_size` (the slices are identical and the queue fill is unchanged), so trained checkpoints and in-flight training runs are unaffected.

🐛 Bug

## How it was tested

- Added CPU regression tests (`tests/policies/test_pi07_paligemma_low_level.py::TestPI07PaligemmaLowLevelExecutionHorizon`) that run on the `cpu_test.yml` merge gate:
  - the new `__post_init__` guard rejects `n_action_steps < chunk_size` with `max_delay > 0`, and allows the valid combinations;
  - `select_action` with `n_action_steps < chunk_size` executes only the first `n_action_steps` of the decoded chunk and re-queries afterwards (the path that tripped the queue-length assert before the fix).
- `pytest -m "not gpu"` passes (1194 + the new tests; the only failures locally are pre-existing LIBERO-asset / stdin-capture env issues unrelated to this change).
- `pytest -m "gpu" tests/policies/test_pi07_paligemma_low_level.py` is green. Note: the heavy forward + `select_action` pipeline test is `@gpu`/`@slow` and currently skipped for memory, and it only ever ran at `n_action_steps == chunk_size` — so it does **not** by itself guard the shortened-horizon path; the CPU tests above do.
- No-op verification: when `n_action_steps == chunk_size` the edited slices are identical and the queue fill is unchanged, so existing checkpoints and in-flight training are unaffected.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/policies/test_pi07_paligemma_low_level.py
```

```bash
# Eval a trained pi07_paligemma_low_level checkpoint executing only the first 10 of the
# 30 predicted actions before re-planning (previously crashed; now works):
opentau-eval --config_path=<checkpoint>/train_config.json \
  --policy.n_action_steps=10 --eval.batch_size=4
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [x] My PR includes policy-related changes.
  - [x] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.
