### PR TITLE
fix(scripts): support action_freq=None in fit_fast_tokenizer manual sampler

### DIFF
--- a/src/opentau/scripts/fit_fast_tokenizer.py
+++ b/src/opentau/scripts/fit_fast_tokenizer.py
@@ -405,7 +405,7 @@ def _compute_budgets_weighted(mixture_cfg: DatasetMixtureConfig, total_chunks: i
 
 
 def _sample_chunks_for_dataset_manual(
-    args: tuple[int, Any, int, int, float, int],
+    args: tuple[int, Any, int, int, float | None, int],
 ) -> tuple[int, list[np.ndarray], str | None]:
     """Worker: sample ``n_chunks`` action chunks of shape ``(chunk_size, native_dim)``
     resampled to ``action_freq`` via ``scipy.interpolate.interp1d``.
@@ -414,6 +414,11 @@ def _sample_chunks_for_dataset_manual(
     overhead. The interp matches LeRobot's vector_resample_strategy="nearest"
     closely enough for tokenizer fitting (``kind="linear"`` here is actually
     slightly more accurate; we don't need the strict step-resample behavior).
+
+    When ``action_freq is None`` (mixed-frequency mixture), each dataset is
+    sampled at its own native fps -- mirrors ``factory.resolve_delta_timestamps``
+    substituting ``ds_meta.fps`` so the chunk is ``chunk_size`` consecutive
+    native frames and the interp lands exactly on native frame boundaries.
     """
     idx, cfg, n_chunks, chunk_size, action_freq, seed = args
     if n_chunks <= 0:
@@ -426,6 +431,8 @@ def _sample_chunks_for_dataset_manual(
 
         meta = LeRobotDatasetMetadata(cfg.repo_id, root=cfg.root, revision=cfg.revision)
         native_fps = float(meta.info["fps"])
+        if action_freq is None:
+            action_freq = native_fps
         target_dt = 1.0 / action_freq
         chunk_duration = (chunk_size - 1) * target_dt  # seconds spanned by a chunk
         # Need at least ceil(chunk_duration * native_fps) + 1 native frames per chunk.
@@ -513,7 +520,7 @@ def _sample_via_manual(
     mixture_cfg: DatasetMixtureConfig,
     total_chunks: int,
     chunk_size: int,
-    action_freq: float,
+    action_freq: float | None,
     seed: int,
     num_workers: int,
 ) -> tuple[list[np.ndarray], list[int], dict[int, str]]:
@@ -1016,10 +1023,12 @@ def main() -> int:
     logger.info("Parsing mixture JSON: %s", args.mixture_json)
     mixture_cfg, mixture_hash = _parse_mixture(args.mixture_json)
     logger.info(
-        "Mixture has %d datasets (hash=%s); action_freq=%g",
+        "Mixture has %d datasets (hash=%s); action_freq=%s",
         len(mixture_cfg.datasets),
         mixture_hash[:12],
-        mixture_cfg.action_freq,
+        "None (mixed-frequency, per-dataset native fps)"
+        if mixture_cfg.action_freq is None
+        else f"{mixture_cfg.action_freq:g}",
     )
 
     # --- Phase 2: build mixture & gather chunks ---
@@ -1077,7 +1086,7 @@ def main() -> int:
             mixture_cfg,
             args.total_chunks,
             args.chunk_size,
-            float(mixture_cfg.action_freq),
+            mixture_cfg.action_freq,
             args.seed,
             args.num_workers,
         )

--- a/src/opentau/scripts/fit_fast_tokenizer.py
+++ b/src/opentau/scripts/fit_fast_tokenizer.py
@@ -38,8 +38,9 @@ Pipeline (all CPU):
        will see.
     3. Drain the weighted dataloader until ``--total-chunks`` action
        chunks have been collected; each batch yields chunks already
-       resampled to ``mixture.action_freq`` and right-padded to
-       ``max_action_dim``.
+       resampled to ``mixture.action_freq`` (or to each dataset's native
+       fps when ``action_freq is None`` -- mixed-frequency mixtures) and
+       right-padded to ``max_action_dim``.
     4. Min-max-normalize each chunk to ``[-1, 1]`` using
        ``mixture.meta.stats["actions"]`` -- the same min/max the policy
        will use at training via
@@ -191,8 +192,10 @@ def parse_args() -> argparse.Namespace:
             "standardization). Default: a hand-rolled equivalent that "
             "weight-allocates a budget per dataset, reads action+timestamp "
             "columns directly from parquet, and resamples to "
-            "mixture.action_freq via scipy.interp1d. Both paths respect "
-            "the mixture's weights and global FPS."
+            "mixture.action_freq via scipy.interp1d -- or to each dataset's "
+            "native fps when mixture.action_freq is None (mixed-frequency "
+            "mode). Both paths respect the mixture's weights and the same "
+            "fps convention."
         ),
     )
     p.add_argument(

--- a/tests/scripts/test_fit_fast_tokenizer.py
+++ b/tests/scripts/test_fit_fast_tokenizer.py
@@ -74,9 +74,10 @@ class TestSampleChunksManualActionFreq:
         _, chunks_native, err_native = self._run(root, action_freq=float(DEFAULT_FPS))
         assert err_native is None
         assert len(chunks_native) == len(chunks_none)
-        # ``assert_allclose`` (not ``assert_array_equal``) because the
-        # interpolator targets ``t0 + k*(1/fps)`` floats which are not
-        # bit-equal to the native timestamps for general ``t0``; the
-        # rounding error stays well below 1e-6 in float32.
+        # ``assert_array_equal`` (not ``assert_allclose``): empirically, with
+        # both calls hitting the same parquet and the same rng-seeded episode /
+        # start picks, the interp's target timestamps land on native frame
+        # boundaries closely enough that ``scipy.interpolate.interp1d`` returns
+        # bit-equal output. A future divergence would surface here immediately.
         for c_none, c_native in zip(chunks_none, chunks_native, strict=True):
-            np.testing.assert_allclose(c_none, c_native, rtol=1e-6, atol=1e-6)
+            np.testing.assert_array_equal(c_none, c_native)

--- a/tests/scripts/test_fit_fast_tokenizer.py
+++ b/tests/scripts/test_fit_fast_tokenizer.py
@@ -1,0 +1,77 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ``opentau.scripts.fit_fast_tokenizer`` helpers.
+
+End-to-end ``main()`` runs are slow (build mixture, drain dataloader,
+fit BPE), so this file targets the small helpers whose behaviour can
+flip silently on a config edit -- especially the mixed-frequency
+``action_freq=None`` branch added alongside the ``feat(datasets):
+mixed-frequency training`` work, which the manual sampler must now
+respect by substituting each dataset's native fps (same convention as
+``factory.resolve_delta_timestamps``).
+"""
+
+from __future__ import annotations
+
+from opentau.configs.default import DatasetConfig
+from opentau.scripts.fit_fast_tokenizer import _sample_chunks_for_dataset_manual
+from tests.fixtures.constants import DEFAULT_FPS, DUMMY_REPO_ID
+
+
+class TestSampleChunksManualActionFreq:
+    """``_sample_chunks_for_dataset_manual`` accepts ``action_freq=None``.
+
+    Before mixed-frequency training landed, the manual sampler required
+    a positive float ``action_freq``. ``main`` called ``float(...)`` on
+    the mixture-level value, which crashes on ``None``. The fix
+    substitutes each dataset's native fps inside the worker so the
+    chunk is ``chunk_size`` consecutive native frames -- matching what
+    ``factory.resolve_delta_timestamps`` does at training time.
+    """
+
+    def _run(self, root, action_freq, n_chunks=8, chunk_size=10, seed=0):
+        cfg = DatasetConfig(repo_id=DUMMY_REPO_ID, root=str(root))
+        return _sample_chunks_for_dataset_manual((0, cfg, n_chunks, chunk_size, action_freq, seed))
+
+    def test_none_action_freq_uses_native_fps(self, tmp_path, lerobot_dataset_factory):
+        """``action_freq=None`` substitutes ``meta.info['fps']`` per-dataset.
+
+        With chunk_size=10 against a 30 fps synthetic dataset, the chunks
+        should match those returned when ``action_freq`` is explicitly
+        set to the native fps. They span the same wall-clock duration and
+        target the same native timestamps, so the BPE-corpus content is
+        equivalent under both call styles.
+        """
+        # Materialize a 30 fps synthetic dataset on disk via the shared
+        # fixture; the worker later constructs a fresh ``LeRobotDatasetMetadata``
+        # from ``root`` and reads the parquet directly.
+        root = tmp_path / "ds_none"
+        lerobot_dataset_factory(root=root, total_episodes=3, total_frames=150)
+
+        idx_none, chunks_none, err_none = self._run(root, action_freq=None)
+        assert err_none is None, f"action_freq=None path errored: {err_none}"
+        assert idx_none == 0
+        assert len(chunks_none) == 8, "expected n_chunks=8 chunks back"
+        for c in chunks_none:
+            assert c.shape == (10, 6), f"unexpected chunk shape {c.shape}"
+
+        # Same seed + same effective action_freq must yield identical chunks.
+        # Use a separate root to keep the deterministic per-dataset rng split
+        # from being contaminated by any caching side-effects on the first call.
+        root2 = tmp_path / "ds_native"
+        lerobot_dataset_factory(root=root2, total_episodes=3, total_frames=150)
+        _, chunks_native, err_native = self._run(root2, action_freq=float(DEFAULT_FPS))
+        assert err_native is None
+        assert len(chunks_native) == 8

--- a/tests/scripts/test_fit_fast_tokenizer.py
+++ b/tests/scripts/test_fit_fast_tokenizer.py
@@ -25,6 +25,8 @@ respect by substituting each dataset's native fps (same convention as
 
 from __future__ import annotations
 
+import numpy as np
+
 from opentau.configs.default import DatasetConfig
 from opentau.scripts.fit_fast_tokenizer import _sample_chunks_for_dataset_manual
 from tests.fixtures.constants import DEFAULT_FPS, DUMMY_REPO_ID
@@ -45,19 +47,21 @@ class TestSampleChunksManualActionFreq:
         cfg = DatasetConfig(repo_id=DUMMY_REPO_ID, root=str(root))
         return _sample_chunks_for_dataset_manual((0, cfg, n_chunks, chunk_size, action_freq, seed))
 
-    def test_none_action_freq_uses_native_fps(self, tmp_path, lerobot_dataset_factory):
-        """``action_freq=None`` substitutes ``meta.info['fps']`` per-dataset.
+    def test_none_action_freq_matches_explicit_native_fps(self, tmp_path, lerobot_dataset_factory):
+        """``action_freq=None`` produces the same chunks as ``action_freq=native_fps``.
 
-        With chunk_size=10 against a 30 fps synthetic dataset, the chunks
-        should match those returned when ``action_freq`` is explicitly
-        set to the native fps. They span the same wall-clock duration and
-        target the same native timestamps, so the BPE-corpus content is
-        equivalent under both call styles.
+        The substitution is the *only* difference between the two call
+        styles -- everything downstream of ``target_dt = 1.0 / action_freq``
+        is identical -- so on a single 30 fps dataset, with the same seed,
+        the two paths must yield byte-equivalent chunks. Re-using one root
+        (the worker is read-only on the dataset) keeps the comparison from
+        being polluted by any non-determinism in the factory's synthetic
+        data generation.
         """
         # Materialize a 30 fps synthetic dataset on disk via the shared
         # fixture; the worker later constructs a fresh ``LeRobotDatasetMetadata``
         # from ``root`` and reads the parquet directly.
-        root = tmp_path / "ds_none"
+        root = tmp_path / "ds"
         lerobot_dataset_factory(root=root, total_episodes=3, total_frames=150)
 
         idx_none, chunks_none, err_none = self._run(root, action_freq=None)
@@ -67,11 +71,12 @@ class TestSampleChunksManualActionFreq:
         for c in chunks_none:
             assert c.shape == (10, 6), f"unexpected chunk shape {c.shape}"
 
-        # Same seed + same effective action_freq must yield identical chunks.
-        # Use a separate root to keep the deterministic per-dataset rng split
-        # from being contaminated by any caching side-effects on the first call.
-        root2 = tmp_path / "ds_native"
-        lerobot_dataset_factory(root=root2, total_episodes=3, total_frames=150)
-        _, chunks_native, err_native = self._run(root2, action_freq=float(DEFAULT_FPS))
+        _, chunks_native, err_native = self._run(root, action_freq=float(DEFAULT_FPS))
         assert err_native is None
-        assert len(chunks_native) == 8
+        assert len(chunks_native) == len(chunks_none)
+        # ``assert_allclose`` (not ``assert_array_equal``) because the
+        # interpolator targets ``t0 + k*(1/fps)`` floats which are not
+        # bit-equal to the native timestamps for general ``t0``; the
+        # rounding error stays well below 1e-6 in float32.
+        for c_none, c_native in zip(chunks_none, chunks_native, strict=True):
+            np.testing.assert_allclose(c_none, c_native, rtol=1e-6, atol=1e-6)


### PR DESCRIPTION
## What this does

Fixes a crash in `opentau.scripts.fit_fast_tokenizer` when the mixture has `action_freq: null`.

The fast manual sampling path (`_sample_via_manual`, the default) calls `float(mixture_cfg.action_freq)` in `main()` before dispatch — that raises `TypeError: float() argument must be ... not 'NoneType'` on mixed-frequency mixtures. With mixed-frequency training landed in [#323](https://github.com/TensorAuto/OpenTau/pull/323), `action_freq=None` is now a first-class setting that opts every dataset out of resampling and runs each at its native fps.

This PR aligns the manual sampler with [`factory.resolve_delta_timestamps`](https://github.com/TensorAuto/OpenTau/blob/main/src/opentau/datasets/factory.py): when `action_freq is None`, each worker substitutes that dataset's `meta.info["fps"]`. The chunk then spans `chunk_size` consecutive native frames and the `scipy.interpolate.interp1d` call lands exactly on native frame boundaries (so it's effectively a no-op rather than a misaligned resample). The legacy `action_freq: float` path is unchanged.

The mixture-dataloader path (`--use-mixture-dataloader`) already worked since it routes through `factory.resolve_delta_timestamps`; only the default fast path needed the fix.

🐛 Bug

## How it was tested

- Added `tests/scripts/test_fit_fast_tokenizer.py::TestSampleChunksManualActionFreq::test_none_action_freq_uses_native_fps`. Creates a 30 fps synthetic dataset via `lerobot_dataset_factory`, calls `_sample_chunks_for_dataset_manual` with `action_freq=None`, and confirms (a) no crash, (b) chunks come back with the expected `(chunk_size, native_action_dim)` shape, and (c) the same call with `action_freq=DEFAULT_FPS` succeeds with matching chunk counts.
- Full CPU suite: `uv run pytest -m "not gpu" -n auto tests/scripts tests/configs` → 259 passed.
- Pre-commit: `uv run pre-commit run --files src/opentau/scripts/fit_fast_tokenizer.py tests/scripts/test_fit_fast_tokenizer.py` → all hooks pass.

## How to checkout & try? (for the reviewer)

```bash
uv run pytest -sx tests/scripts/test_fit_fast_tokenizer.py
```

End-to-end fit against a mixed-frequency mixture (CPU-only):

```bash
uv run python -m opentau.scripts.fit_fast_tokenizer \
    --mixture-json /path/to/mixture_with_action_freq_null.json \
    --out-dir /tmp/fast-mix-freq \
    --chunk-size 30 --pilot
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).