### PR TITLE
fix(datasets): allow action_freq=None in WeightedDatasetMixture signature

### DIFF
--- a/src/opentau/datasets/dataset_mixture.py
+++ b/src/opentau/datasets/dataset_mixture.py
@@ -53,11 +53,16 @@ Functions:
     pad_vector: Pads the last dimension of a vector to a target size with zeros.
 
 Example:
-    Create a dataset mixture with two datasets:
+    Create a dataset mixture with two datasets resampled to a shared 30 Hz:
         >>> datasets = [dataset1, dataset2]
         >>> weights = [0.7, 0.3]  # 70% from dataset1, 30% from dataset2
         >>> mixture = WeightedDatasetMixture(cfg, datasets, weights, action_freq=30.0)
         >>> dataloader = mixture.get_dataloader()
+
+    Mixed-frequency mixture (no resampling) — each dataset is sampled at its
+    own native fps, so a single batch can contain samples drawn at different
+    rates:
+        >>> mixture = WeightedDatasetMixture(cfg, datasets, weights, action_freq=None)
 """
 
 import functools
@@ -335,7 +340,7 @@ class WeightedDatasetMixture:
         cfg: TrainPipelineConfig,
         datasets: List[BaseDataset],
         dataset_weights: List[float],
-        action_freq: float,
+        action_freq: Optional[float],
     ):
         """
         Initializes the WeightedDatasetMixture.
@@ -345,6 +350,13 @@ class WeightedDatasetMixture:
             datasets (List[Dataset]): A list of PyTorch Dataset objects.
             dataset_weights (List[float]): A list of weights corresponding to each dataset.
                                           These determine the relative sampling frequency.
+            action_freq (Optional[float]): Common action frequency (Hz) the
+                mixture's datasets are resampled to. ``None`` means no
+                resampling — each dataset is sampled at its native fps, so a
+                single batch may mix samples from sources running at different
+                rates (mixed-frequency training). Stored as informational
+                state and forwarded to downstream consumers (e.g.
+                ``BaseDataset._action_freq``); not used arithmetically here.
         """
         if not datasets:
             raise ValueError("The list of datasets cannot be empty.")
@@ -362,7 +374,8 @@ class WeightedDatasetMixture:
         self.cfg = cfg
         self.datasets = datasets
         self.dataset_weights = dataset_weights
-        self.action_freq = action_freq  # Frequency used for resampling action output
+        # Common resample rate (Hz); None = mixed-frequency (native fps per dataset).
+        self.action_freq: Optional[float] = action_freq
         self.dataset_names = self._make_dataset_names(cfg, datasets)  # For logging
 
         logging.info("Initializing WeightedDatasetMixture...")

--- a/tests/datasets/test_dataset_mixture.py
+++ b/tests/datasets/test_dataset_mixture.py
@@ -226,6 +226,22 @@ class TestWeightedDatasetMixture:
         assert mixture.sample_weights is not None
         assert mixture.meta is not None
 
+    @pytest.mark.slow  # 1 sec
+    def test_init_action_freq_none(self, train_pipeline_config, datasets_factory):
+        """``action_freq=None`` is accepted (mixed-frequency mixtures) and the
+        attribute round-trips as ``None``.
+
+        Companion to the signature change made alongside PR #324: the
+        constructor previously annotated ``action_freq: float`` but
+        ``DatasetMixtureConfig.action_freq`` is ``float | None`` and
+        ``make_dataset_mixture`` forwards ``None`` through. Keep this test
+        green if the param ever gets narrowed back to ``float``.
+        """
+        datasets = datasets_factory(2)
+        dataset_weights = [1.0 / len(datasets)] * len(datasets)
+        mixture = WeightedDatasetMixture(train_pipeline_config, datasets, dataset_weights, action_freq=None)
+        assert mixture.action_freq is None
+
     def test_init_empty_datasets(self, train_pipeline_config):
         """Test initialization with empty dataset list."""
         with pytest.raises(ValueError, match="The list of datasets cannot be empty"):


### PR DESCRIPTION
## What this does

Tightens the type annotation on `WeightedDatasetMixture.__init__` so that
`action_freq` is correctly declared as `float | None` instead of `float`.

Flagged while reviewing #324: after #323 made
`DatasetMixtureConfig.action_freq` `float | None` (mixed-frequency
training, each dataset at its native fps), several call sites can legitimately
forward `None` to the mixture constructor:

- `datasets/factory.py::make_dataset_mixture` (`L376`, `L380`) already
  passes `cfg.dataset_mixture.action_freq` through.
- `scripts/fit_fast_tokenizer.py::_build_mixture_parallel` (`L714`)
  does the same for the `--use-mixture-dataloader` path covered by #324.

The attribute is stored as informational state and never used arithmetically
inside `WeightedDatasetMixture` (downstream consumers already guard the
`None` case: `lerobot_dataset.py:1038` checks `if self._action_freq is not None`,
`scripts/fit_fast_tokenizer.py` formats `None` explicitly), so there is no
runtime bug — only the signature was lying. The project doesn't run a type
checker in pre-commit, so this would otherwise land silently.

Changes:

- `WeightedDatasetMixture.__init__`: `action_freq: float` → `action_freq: Optional[float]`,
  with a docstring entry explaining the `None` semantics.
- Module-level docstring example now shows both the shared-rate
  (`action_freq=30.0`) and mixed-frequency (`action_freq=None`) cases.
- Stored attribute annotated as `Optional[float]`.

No call site needed `None`-narrowing fixes — all downstream consumers already
handle `None`.

`Optional`/`List` style matches the rest of `dataset_mixture.py` (the file
already imports both).

## How it was tested

- Added `TestWeightedDatasetMixture::test_init_action_freq_none` in
  `tests/datasets/test_dataset_mixture.py`: constructs the mixture with
  `action_freq=None` and asserts the attribute round-trips as `None`.
- The end-to-end `lerobot_dataset.py:1038` branch (`emit_fps=True` +
  `action_freq=None` → emit native `meta.fps`) is already covered by
  `tests/datasets/test_optional_keys.py::TestEmitFps::test_fps_reports_native_when_action_freq_none`
  (added in #323), so this PR's new test is intentionally scoped to the
  signature-level round-trip.
- `uv run pre-commit run --files src/opentau/datasets/dataset_mixture.py tests/datasets/test_dataset_mixture.py` — all hooks pass.
- `uv run pytest -m "not gpu" -n auto tests/datasets` — 439 passed, 8 skipped.

No policy / training-loop changes, so GPU pytests and nightly regression
tests are not required.

## How to checkout & try? (for the reviewer)

```bash
gh pr checkout 325
uv run pytest -sx tests/datasets/test_dataset_mixture.py::TestWeightedDatasetMixture::test_init_action_freq_none
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.