### PR TITLE
fix(datasets): resolve per-episode task_index from parquet for speed bucketing

### DIFF
--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -114,7 +114,7 @@ from opentau.datasets.image_writer import AsyncImageWriter, write_image
 from opentau.datasets.speed_percentiles import (
     SPARSE_TASK_BUCKET,
     bucket_episode_length,
-    episode_to_task_index_from_episodes,
+    episode_to_task_index_from_hf_dataset,
     load_or_compute_speed_percentiles,
 )
 from opentau.datasets.standard_data_format_mapping import DATA_FEATURES_NAME_MAPPING
@@ -1490,8 +1490,12 @@ class LeRobotDataset(BaseDataset):
         # Both the percentile compute and the per-episode pre-fill below
         # consume `self.episode_lengths` so the two paths can't drift on
         # what counts as an "episode length".
-        self.episode_to_task_index: dict[int, int] = episode_to_task_index_from_episodes(
-            self.meta.episodes, self.meta.task_to_task_index
+        self.episode_to_task_index: dict[int, int] = episode_to_task_index_from_hf_dataset(
+            hf_dataset=self.hf_dataset,
+            episodes=self.episodes,
+            episode_data_index=self.episode_data_index,
+            epi2idx=self.epi2idx,
+            valid_task_indices=set(self.meta.task_to_task_index.values()),
         )
         self.speed_percentiles_by_task: dict[int, list[float] | None] = load_or_compute_speed_percentiles(
             root=self.root,
@@ -1500,11 +1504,11 @@ class LeRobotDataset(BaseDataset):
             task_to_task_index=self.meta.task_to_task_index,
         )
         # Pre-compute the bucket per episode so __getitem__ stays a dict
-        # lookup. Episodes with no task entry (impossible in well-formed
-        # datasets) and tasks missing from the on-disk percentile file
-        # (possible after hand-editing) both land at SPARSE_TASK_BUCKET.
+        # lookup. Episodes whose task_index pointed at a row missing from
+        # tasks.jsonl, and tasks missing from the on-disk percentile file
+        # (possible after hand-editing), both land at SPARSE_TASK_BUCKET.
         self.speed_raw_by_episode: dict[int, int] = {}
-        for ep in self.meta.episodes:
+        for ep in self.episodes:
             task_idx = self.episode_to_task_index.get(ep)
             if task_idx is None:
                 self.speed_raw_by_episode[ep] = SPARSE_TASK_BUCKET

--- a/src/opentau/datasets/speed_percentiles.py
+++ b/src/opentau/datasets/speed_percentiles.py
@@ -239,10 +239,13 @@ def load_or_compute_speed_percentiles(
 
     If ``root / meta/speed_percentiles.jsonl`` already exists, load it
     verbatim — staleness is accepted by design (a WARNING is logged when
-    the on-disk per-task ``n_episodes`` total disagrees with the current
-    load, but the file is still trusted; delete it to force a recompute).
-    Otherwise compute the percentiles from ``episode_lengths`` and
-    persist the file.
+    the on-disk file was computed from *fewer* episodes than the current
+    load is using, i.e. episodes were appended since; subset loads, where
+    the current load uses fewer episodes than on-disk, are silent because
+    the on-disk percentiles are a more robust sample). The file is
+    trusted in both cases — delete it to force a recompute. Otherwise
+    compute the percentiles from ``episode_lengths`` and persist the
+    file.
 
     One-shot migration: when the on-disk file is missing rows for tasks
     that *do* have resolved episodes in this load, the file is recomputed
@@ -311,15 +314,24 @@ def load_or_compute_speed_percentiles(
             missing = expected_indices - on_disk_indices
             if not missing:
                 if is_main_or_solo:
-                    # `episode_to_task_index` already drops episodes that couldn't
-                    # be resolved, so its length is the per-task episode count we
-                    # want to compare against the on-disk sum.
+                    # ``episode_to_task_index`` covers only episodes that
+                    # were both (a) resolved by the per-frame ``task_index``
+                    # lookup and (b) selected for this load. The directional
+                    # check below warns only when the current load has *more*
+                    # episodes than the on-disk file was computed from
+                    # (i.e. episodes were appended since the file was
+                    # written). Subset loads (current uses fewer episodes
+                    # than on-disk) are silent — the on-disk percentiles
+                    # were computed from a larger, more robust sample, so
+                    # using them is if anything an improvement.
                     on_disk_total = sum(int(row.get("n_episodes", 0)) for row in rows)
                     current_total = len(episode_to_task_index)
-                    if on_disk_total != current_total:
+                    if on_disk_total < current_total:
                         logging.warning(
-                            "Stale %s: on-disk per-task n_episodes sums to %d, current load has %d. "
-                            "Using on-disk percentiles as-is; delete the file to force recompute.",
+                            "Stale %s: on-disk percentiles were computed from %d episodes, "
+                            "but current load has %d. New episodes may have been appended "
+                            "since the file was written. Using on-disk percentiles as-is; "
+                            "delete the file to force recompute.",
                             path,
                             on_disk_total,
                             current_total,

--- a/src/opentau/datasets/speed_percentiles.py
+++ b/src/opentau/datasets/speed_percentiles.py
@@ -41,11 +41,16 @@ import os
 import uuid
 from collections import defaultdict
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import numpy as np
 
 from opentau.datasets.utils import load_jsonlines, write_jsonlines
 from opentau.utils.accelerate_utils import get_proc_accelerator
+
+if TYPE_CHECKING:
+    import datasets
+    import torch
 
 # Boundary percentiles, ascending. Length 10 by design: 11 buckets.
 SPEED_PERCENTILES: tuple[int, ...] = (5, 15, 25, 35, 45, 55, 65, 75, 85, 95)
@@ -140,9 +145,9 @@ def _group_lengths_by_task(
 
 
 def episode_to_task_index_from_hf_dataset(
-    hf_dataset,
+    hf_dataset: datasets.Dataset,
     episodes: list[int],
-    episode_data_index: dict[str, object],
+    episode_data_index: dict[str, torch.Tensor],
     epi2idx: dict[int, int],
     valid_task_indices: set[int],
 ) -> dict[int, int]:
@@ -247,15 +252,18 @@ def load_or_compute_speed_percentiles(
     compute the percentiles from ``episode_lengths`` and persist the
     file.
 
-    One-shot migration: when the on-disk file is missing rows for tasks
-    that *do* have resolved episodes in this load, the file is recomputed
-    (logged at INFO) and rewritten with the full task set. This recovers
-    datasets whose existing percentile file was written before
-    :func:`episode_to_task_index_from_hf_dataset` — those files only have
-    rows for the subset of tasks whose ``episodes.jsonl::tasks[0]`` string
-    happened to match ``tasks.jsonl``, so almost every episode bucketed to
-    ``SPARSE_TASK_BUCKET``. The recompute is a no-op once the file is
-    rewritten.
+    Append-only migration: when the on-disk file is missing rows for
+    tasks that *do* have resolved episodes in this load, percentiles are
+    computed for the missing tasks only and appended to the file (logged
+    at WARNING so the rewrite is visible). Existing rows are preserved
+    verbatim. This recovers datasets whose existing percentile file was
+    written before :func:`episode_to_task_index_from_hf_dataset` — those
+    files were missing rows for tasks whose ``episodes.jsonl::tasks[0]``
+    string didn't match ``tasks.jsonl``, so every episode of those tasks
+    bucketed to ``SPARSE_TASK_BUCKET``. The append-only design avoids
+    clobbering existing percentiles with subset-derived samples when the
+    current load is a mixture / subset; force a full recompute by
+    deleting the file.
 
     Distributed-safe: every rank computes the percentiles in-memory
     (the result is deterministic from the inputs), but only the main
@@ -307,9 +315,10 @@ def load_or_compute_speed_percentiles(
     # for every subsequent collective in the mixture-load loop — manifesting
     # as a NCCL hang at a much later (and entirely unrelated) sync point.
     try:
+        existing_rows: list[dict] = []
         if path.is_file():
-            rows = load_jsonlines(path)
-            on_disk_indices = {int(row["task_index"]) for row in rows}
+            existing_rows = load_jsonlines(path)
+            on_disk_indices = {int(row["task_index"]) for row in existing_rows}
             expected_indices = set(episode_to_task_index.values())
             missing = expected_indices - on_disk_indices
             if not missing:
@@ -324,7 +333,7 @@ def load_or_compute_speed_percentiles(
                     # than on-disk) are silent — the on-disk percentiles
                     # were computed from a larger, more robust sample, so
                     # using them is if anything an improvement.
-                    on_disk_total = sum(int(row.get("n_episodes", 0)) for row in rows)
+                    on_disk_total = sum(int(row.get("n_episodes", 0)) for row in existing_rows)
                     current_total = len(episode_to_task_index)
                     if on_disk_total < current_total:
                         logging.warning(
@@ -336,34 +345,49 @@ def load_or_compute_speed_percentiles(
                             on_disk_total,
                             current_total,
                         )
-                return {int(row["task_index"]): row["percentiles"] for row in rows}
+                return {int(row["task_index"]): row["percentiles"] for row in existing_rows}
 
+            # Append-only migration: compute percentiles for the *missing*
+            # tasks only, then merge with existing rows. Recomputing every
+            # task from the current load would clobber existing rows that
+            # were computed from a larger, more robust episode set when
+            # the current load is a subset (the dominant case for
+            # mixture training). The user can still force a full recompute
+            # by deleting the file.
             if is_main_or_solo:
-                logging.info(
-                    "Recomputing %s: on-disk file is missing %d task(s) that have resolved "
-                    "episodes in this load — likely written before the per-frame task_index "
-                    "fix. Rewriting with the full task set.",
-                    path,
+                logging.warning(
+                    "Adding %d missing task(s) %s to %s. Existing rows preserved; "
+                    "delete the file to force a full recompute.",
                     len(missing),
+                    sorted(missing),
+                    path,
                 )
-            # Fall through to the compute + write branch below.
+            task_indices_to_compute = missing
+        else:
+            # File doesn't exist — fresh compute over every resolved task.
+            task_indices_to_compute = set(episode_to_task_index.values())
 
-        by_task = _group_lengths_by_task(episode_lengths, episode_to_task_index)
+        # Compute percentiles for the target task set only.
+        by_task: dict[int, list[int]] = defaultdict(list)
+        for ep_idx, task_idx in episode_to_task_index.items():
+            if task_idx in task_indices_to_compute:
+                by_task[task_idx].append(episode_lengths[ep_idx])
         index_to_task = {idx: task for task, idx in task_to_task_index.items()}
-        percentiles = compute_task_percentiles(by_task)
-        rows = [
+        new_percentiles = compute_task_percentiles(dict(by_task))
+        new_rows = [
             {
                 "task_index": task_idx,
                 "task": index_to_task.get(task_idx, ""),
                 "n_episodes": len(by_task.get(task_idx, [])),
-                "percentiles": percentiles[task_idx],
+                "percentiles": new_percentiles[task_idx],
             }
-            for task_idx in sorted(percentiles)
+            for task_idx in sorted(new_percentiles)
         ]
+        rows_to_write = existing_rows + new_rows
 
         if is_main_or_solo:
             try:
-                _atomic_write_jsonlines(rows, path)
+                _atomic_write_jsonlines(rows_to_write, path)
             except (OSError, PermissionError) as e:
                 root_key = str(root)
                 if root_key not in _READONLY_WARNED:
@@ -375,7 +399,11 @@ def load_or_compute_speed_percentiles(
                         path,
                         e,
                     )
-        return percentiles
+
+        # Merge existing on-disk percentiles with newly-computed ones.
+        merged = {int(row["task_index"]): row["percentiles"] for row in existing_rows}
+        merged.update(new_percentiles)
+        return merged
     finally:
         if distributed:
             acc.wait_for_everyone()

--- a/src/opentau/datasets/speed_percentiles.py
+++ b/src/opentau/datasets/speed_percentiles.py
@@ -68,10 +68,11 @@ SPARSE_TASK_BUCKET = 50
 # ``_CONTROL_MODE_WARNED`` pattern in ``lerobot_dataset.py``.
 _READONLY_WARNED: set[str] = set()
 
-# Module-level set of unresolved episode task labels we've already warned
-# about, so episodes.jsonl / tasks.jsonl drift in a dataset only logs once
-# per distinct bad label per process instead of once per episode per rank.
-_UNRESOLVED_TASK_WARNED: set[str] = set()
+# Module-level set of unknown per-frame ``task_index`` integers we've
+# already warned about. Keyed by the integer index, so a corrupt parquet
+# pointing many episodes at a missing index logs once per distinct index
+# per process instead of once per episode per rank.
+_UNKNOWN_TASK_INDEX_WARNED: set[int] = set()
 
 
 def compute_task_percentiles(
@@ -138,44 +139,64 @@ def _group_lengths_by_task(
     return dict(by_task)
 
 
-def episode_to_task_index_from_episodes(
-    episodes: dict[int, dict],
-    task_to_task_index: dict[str, int],
+def episode_to_task_index_from_hf_dataset(
+    hf_dataset,
+    episodes: list[int],
+    episode_data_index: dict[str, object],
+    epi2idx: dict[int, int],
+    valid_task_indices: set[int],
 ) -> dict[int, int]:
-    """Build ``{ep_idx: task_idx}`` from ``meta/episodes.jsonl`` entries.
+    """Build ``{ep_idx: task_idx}`` by reading the per-frame parquet.
 
-    Episodes whose ``tasks`` field is a multi-element list silently use
-    ``tasks[0]`` — the codebase assumes an N-to-1 episode-to-task
-    relationship even though the field is structurally a list. Episodes
-    with an empty / missing ``tasks`` list are skipped.
+    Each row of the per-episode parquet carries an authoritative integer
+    ``task_index`` column (written by :meth:`LeRobotDataset._save_episode_table`
+    and consumed by :meth:`LeRobotDataset.__getitem__`). Resolving the
+    per-episode task this way bypasses any drift between
+    ``episodes.jsonl::tasks[0]`` (a string) and ``tasks.jsonl::task`` (the
+    string keyed by ``task_index``) — a paraphrased ``tasks.jsonl`` no
+    longer breaks the lookup.
 
-    Episodes whose ``tasks[0]`` is absent from ``task_to_task_index`` are
-    also skipped (with a deduped warning) rather than raising. This guards
-    against ``episodes.jsonl`` / ``tasks.jsonl`` drift in dataset metadata
-    — a `tasks.jsonl` with stale/incomplete entries, or an
-    ``episodes.jsonl`` that stores integer task indices instead of task
-    strings. Skipped episodes are still trained on; they just fall back to
-    ``SPARSE_TASK_BUCKET`` in the downstream speed-bucket lookup, which
-    already tolerates a missing ``episode_to_task_index`` entry.
+    Only the *first* row of each episode is read; the parquet's
+    ``task_index`` is constant within an episode by construction.
+
+    Episodes whose resolved ``task_index`` is not present in
+    ``valid_task_indices`` (i.e. the index points to a task that ``tasks.jsonl``
+    doesn't define — genuine metadata corruption, not paraphrasing) are
+    skipped with a deduped WARNING. Skipped episodes are still trained on;
+    they just fall back to ``SPARSE_TASK_BUCKET`` in the downstream
+    speed-bucket lookup, which already tolerates a missing
+    ``episode_to_task_index`` entry.
+
+    Args:
+        hf_dataset: The dataset's per-frame HF ``Dataset`` (parquet-backed).
+        episodes: Selected episode indices (the dataset's ``self.episodes``).
+        episode_data_index: ``{"from": Tensor, "to": Tensor}`` giving the
+            start/end row in ``hf_dataset`` for each selected episode.
+        epi2idx: Maps ``episode_index`` to its position in
+            ``episode_data_index["from"]``.
+        valid_task_indices: All ``task_index`` values defined in
+            ``tasks.jsonl`` (i.e. ``set(meta.task_to_task_index.values())``).
+            Used solely to detect parquet rows that point at a task the
+            metadata doesn't know about.
     """
+    if not episodes:
+        return {}
+    start_indices = [int(episode_data_index["from"][epi2idx[ep]].item()) for ep in episodes]
+    task_indices = hf_dataset.with_format("arrow").select(start_indices)["task_index"].to_pylist()
     out: dict[int, int] = {}
-    for ep_idx, ep_info in episodes.items():
-        tasks = ep_info.get("tasks") or []
-        if not tasks:
-            continue
-        task_idx = task_to_task_index.get(tasks[0])
-        if task_idx is None:
-            key = str(tasks[0])
-            if key not in _UNRESOLVED_TASK_WARNED:
-                _UNRESOLVED_TASK_WARNED.add(key)
+    for ep, task_idx in zip(episodes, task_indices, strict=True):
+        task_idx = int(task_idx)
+        if task_idx not in valid_task_indices:
+            if task_idx not in _UNKNOWN_TASK_INDEX_WARNED:
+                _UNKNOWN_TASK_INDEX_WARNED.add(task_idx)
                 logging.warning(
-                    "Episode task label %r is not present in tasks.jsonl; episode(s) "
-                    "using it fall back to the sparse speed bucket. This indicates "
-                    "episodes.jsonl / tasks.jsonl drift in the dataset metadata.",
-                    tasks[0],
+                    "Episode parquet rows reference task_index=%d which is not defined "
+                    "in tasks.jsonl; episode(s) using it fall back to the sparse speed "
+                    "bucket. This indicates corrupt dataset metadata.",
+                    task_idx,
                 )
             continue
-        out[ep_idx] = task_idx
+        out[ep] = task_idx
     return out
 
 
@@ -208,37 +229,6 @@ def _atomic_write_jsonlines(rows: list[dict], path: Path) -> None:
                 tmp_path.unlink()
 
 
-def _read_persisted(
-    path: Path,
-    current_total: int,
-    *,
-    warn: bool,
-) -> dict[int, list[float] | None]:
-    """Load the percentile file and warn if its episode total is stale.
-
-    A mismatch between the sum of on-disk ``n_episodes`` and the current
-    load's episode total means episodes were added (or filtered) since
-    the file was first written. Per spec the file is still trusted —
-    the warning is just to cut debugging time when a small-N first run
-    accidentally freezes the percentile distribution.
-
-    ``warn`` is gated by the caller (typically ``acc.is_main_process``)
-    so an 8-rank run produces a single warning line, not eight.
-    """
-    rows = load_jsonlines(path)
-    if warn:
-        on_disk_total = sum(int(row.get("n_episodes", 0)) for row in rows)
-        if on_disk_total != current_total:
-            logging.warning(
-                "Stale %s: on-disk per-task n_episodes sums to %d, current load has %d. "
-                "Using on-disk percentiles as-is; delete the file to force recompute.",
-                path,
-                on_disk_total,
-                current_total,
-            )
-    return {int(row["task_index"]): row["percentiles"] for row in rows}
-
-
 def load_or_compute_speed_percentiles(
     root: Path,
     episode_lengths: dict[int, int],
@@ -253,6 +243,16 @@ def load_or_compute_speed_percentiles(
     load, but the file is still trusted; delete it to force a recompute).
     Otherwise compute the percentiles from ``episode_lengths`` and
     persist the file.
+
+    One-shot migration: when the on-disk file is missing rows for tasks
+    that *do* have resolved episodes in this load, the file is recomputed
+    (logged at INFO) and rewritten with the full task set. This recovers
+    datasets whose existing percentile file was written before
+    :func:`episode_to_task_index_from_hf_dataset` — those files only have
+    rows for the subset of tasks whose ``episodes.jsonl::tasks[0]`` string
+    happened to match ``tasks.jsonl``, so almost every episode bucketed to
+    ``SPARSE_TASK_BUCKET``. The recompute is a no-op once the file is
+    rewritten.
 
     Distributed-safe: every rank computes the percentiles in-memory
     (the result is deterministic from the inputs), but only the main
@@ -282,7 +282,7 @@ def load_or_compute_speed_percentiles(
             ``LeRobotDataset.episode_lengths`` so the percentile compute
             and the per-episode bucket pre-fill share one source.
         episode_to_task_index: ``{ep_idx: task_idx}`` — typically built
-            via :func:`episode_to_task_index_from_episodes`.
+            via :func:`episode_to_task_index_from_hf_dataset`.
         task_to_task_index: ``{task_string: task_index}`` — used only to
             denormalize the task string into each row for human
             inspection.
@@ -305,10 +305,36 @@ def load_or_compute_speed_percentiles(
     # as a NCCL hang at a much later (and entirely unrelated) sync point.
     try:
         if path.is_file():
-            # `episode_to_task_index` already drops episodes with empty tasks,
-            # so its length is the per-task episode count we want to compare
-            # against the on-disk sum.
-            return _read_persisted(path, len(episode_to_task_index), warn=is_main_or_solo)
+            rows = load_jsonlines(path)
+            on_disk_indices = {int(row["task_index"]) for row in rows}
+            expected_indices = set(episode_to_task_index.values())
+            missing = expected_indices - on_disk_indices
+            if not missing:
+                if is_main_or_solo:
+                    # `episode_to_task_index` already drops episodes that couldn't
+                    # be resolved, so its length is the per-task episode count we
+                    # want to compare against the on-disk sum.
+                    on_disk_total = sum(int(row.get("n_episodes", 0)) for row in rows)
+                    current_total = len(episode_to_task_index)
+                    if on_disk_total != current_total:
+                        logging.warning(
+                            "Stale %s: on-disk per-task n_episodes sums to %d, current load has %d. "
+                            "Using on-disk percentiles as-is; delete the file to force recompute.",
+                            path,
+                            on_disk_total,
+                            current_total,
+                        )
+                return {int(row["task_index"]): row["percentiles"] for row in rows}
+
+            if is_main_or_solo:
+                logging.info(
+                    "Recomputing %s: on-disk file is missing %d task(s) that have resolved "
+                    "episodes in this load — likely written before the per-frame task_index "
+                    "fix. Rewriting with the full task set.",
+                    path,
+                    len(missing),
+                )
+            # Fall through to the compute + write branch below.
 
         by_task = _group_lengths_by_task(episode_lengths, episode_to_task_index)
         index_to_task = {idx: task for task, idx in task_to_task_index.items()}

--- a/tests/datasets/test_speed_percentiles.py
+++ b/tests/datasets/test_speed_percentiles.py
@@ -539,13 +539,14 @@ class TestLoadOrComputeSpeedPercentiles:
         # `.get(missing_idx)` returns None → bucket 50.
         assert bucket_episode_length(123, out.get(99)) == SPARSE_TASK_BUCKET
 
-    def test_recompute_when_persisted_file_missing_tasks(self, tmp_path, caplog):
+    def test_migration_adds_missing_tasks_and_preserves_existing(self, tmp_path, caplog):
         # Simulates the state left by the pre-fix code: tasks.jsonl was
         # paraphrased relative to episodes.jsonl, the string-keyed lookup
         # only resolved a subset of tasks, and the resulting percentile
         # file is missing rows for every drifted task. The new loader
-        # detects the missing tasks against the (now correctly resolved)
-        # episode_to_task_index and recomputes.
+        # detects the missing tasks and *appends* fresh rows for them,
+        # leaving existing rows untouched (so subset loads don't clobber
+        # full-set percentiles).
         el, e2t, t2i = _fake_meta(
             {
                 "taskA": list(range(100, 200)),  # 100 episodes
@@ -555,44 +556,96 @@ class TestLoadOrComputeSpeedPercentiles:
         path = tmp_path / SPEED_PERCENTILES_PATH
         path.parent.mkdir(parents=True, exist_ok=True)
         # Pre-write a file with only taskA — taskB (task_index=1) is
-        # missing, simulating the buggy first-pass output.
-        bogus_percentiles = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+        # missing, simulating the buggy first-pass output. Use deliberately
+        # round percentiles that compute would never produce so we can
+        # tell whether they survived the migration.
+        sentinel_percentiles = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
         write_jsonlines(
             [
                 {
                     "task_index": 0,
                     "task": "taskA",
                     "n_episodes": 100,
-                    "percentiles": bogus_percentiles,
+                    "percentiles": sentinel_percentiles,
                 }
             ],
             path,
         )
 
-        with caplog.at_level("INFO"):
+        with caplog.at_level("WARNING"):
             out = load_or_compute_speed_percentiles(tmp_path, el, e2t, t2i)
 
-        # Both tasks now have percentiles — recompute ran.
+        # Both tasks present in the returned dict.
         assert set(out.keys()) == {0, 1}
-        assert out[0] is not None
+        # taskA's pre-existing sentinel percentiles are preserved — this
+        # is the key behavior the reviewer flagged. Recomputing would
+        # have replaced them with [108.95, ...] (np.percentile of 100..200).
+        assert out[0] == sentinel_percentiles
+        # taskB was computed fresh from the current load.
         assert out[1] is not None
-        # The bogus pre-existing percentiles were discarded by recompute.
-        assert out[0] != bogus_percentiles
-        # Info log fired with the expected migration message.
-        recompute_msgs = [
-            r.message for r in caplog.records if "Recomputing" in r.message and "missing 1" in r.message
-        ]
-        assert recompute_msgs, [r.message for r in caplog.records]
-        # The on-disk file was rewritten with both tasks.
+        # WARNING-level migration log fired with the expected text.
+        warn_msgs = [r.message for r in caplog.records if "Adding 1 missing task" in r.message]
+        assert warn_msgs, [r.message for r in caplog.records]
+        # The on-disk file now has both rows; taskA's row is unchanged.
         rows = load_jsonlines(path)
         assert {int(r["task_index"]) for r in rows} == {0, 1}
+        task_a_row = next(r for r in rows if r["task_index"] == 0)
+        assert task_a_row["percentiles"] == sentinel_percentiles
+        assert task_a_row["n_episodes"] == 100  # also preserved
 
-        # Second call takes the fast read path — no Recompute, no Stale.
+        # Second call takes the fast read path — no migration, no Stale.
         caplog.clear()
-        with caplog.at_level("INFO"):
+        with caplog.at_level("WARNING"):
             load_or_compute_speed_percentiles(tmp_path, el, e2t, t2i)
-        assert not any("Recomputing" in r.message for r in caplog.records)
+        assert not any("Adding" in r.message for r in caplog.records)
         assert not any("Stale" in r.message for r in caplog.records)
+
+    def test_migration_on_subset_load_does_not_clobber_existing(self, tmp_path, caplog):
+        # The scenario the reviewer pinned: a pre-fix file was written
+        # with full-dataset percentiles for taskA (n=100), but the new
+        # load is a 10% subset that resolves both taskA (subset n=10)
+        # *and* a previously-drifted taskB. The migration must add a
+        # taskB row from the subset, but the high-fidelity taskA
+        # percentiles must survive untouched — otherwise the next full
+        # load would inherit subset-sized samples for taskA.
+        full_lengths = list(range(100, 200))  # 100 distinct lengths
+        subset_lengths = full_lengths[:10]
+        full_el, full_e2t, t2i = _fake_meta({"taskA": full_lengths, "taskB": list(range(50, 150))})
+        # First write: full-dataset taskA only (taskB drifted under old code).
+        load_or_compute_speed_percentiles(
+            tmp_path,
+            {ep: full_lengths[ep] for ep in range(len(full_lengths))},
+            dict.fromkeys(range(len(full_lengths)), 0),
+            {"taskA": 0, "taskB": 1},
+        )
+        path = tmp_path / SPEED_PERCENTILES_PATH
+        full_task_a = next(r for r in load_jsonlines(path) if r["task_index"] == 0)["percentiles"]
+
+        # Now simulate a subset load that resolves both taskA and taskB.
+        subset_el = {}
+        subset_e2t = {}
+        next_ep = 0
+        for length in subset_lengths:
+            subset_el[next_ep] = length
+            subset_e2t[next_ep] = 0
+            next_ep += 1
+        for length in list(range(50, 60)):  # 10 subset episodes for taskB
+            subset_el[next_ep] = length
+            subset_e2t[next_ep] = 1
+            next_ep += 1
+
+        with caplog.at_level("WARNING"):
+            out = load_or_compute_speed_percentiles(tmp_path, subset_el, subset_e2t, t2i)
+
+        # taskA's full-dataset percentiles must survive.
+        assert out[0] == full_task_a, "subset-load migration clobbered full-dataset taskA percentiles"
+        # taskB row added (sparse because only 10 subset episodes).
+        assert 1 in out
+        # On-disk file has both, taskA row unchanged.
+        rows = load_jsonlines(path)
+        on_disk_task_a = next(r for r in rows if r["task_index"] == 0)
+        assert on_disk_task_a["percentiles"] == full_task_a
+        assert on_disk_task_a["n_episodes"] == len(full_lengths)
 
 
 class TestLiberoSnapshot:

--- a/tests/datasets/test_speed_percentiles.py
+++ b/tests/datasets/test_speed_percentiles.py
@@ -381,18 +381,40 @@ class TestLoadOrComputeSpeedPercentiles:
         # And the bucket lookup falls back to SPARSE_TASK_BUCKET.
         assert bucket_episode_length(42, out2[0]) == SPARSE_TASK_BUCKET
 
-    def test_stale_file_logs_warning_but_still_used(self, tmp_path, caplog):
+    def test_stale_warning_fires_when_episodes_appended(self, tmp_path, caplog):
         # First write: 100 episodes for taskA.
         el, e2t, t2i = _fake_meta({"taskA": list(range(100, 200))})
         load_or_compute_speed_percentiles(tmp_path, el, e2t, t2i)
 
-        # Second load with a different episode count — file should still
-        # be used, but a WARNING fires.
+        # Second load has *more* episodes for the same task — the on-disk
+        # percentiles were computed from fewer episodes than the current
+        # load is using (genuine staleness: new data was appended). File
+        # is still trusted, but a WARNING fires so the user knows the
+        # percentile distribution may not reflect the current dataset.
         el2, e2t2, t2i2 = _fake_meta({"taskA": list(range(100, 250))})  # 150 episodes
         with caplog.at_level("WARNING"):
             out = load_or_compute_speed_percentiles(tmp_path, el2, e2t2, t2i2)
         assert out[0] is not None
         assert any("Stale" in rec.message and "speed_percentiles" in rec.message for rec in caplog.records), [
+            rec.message for rec in caplog.records
+        ]
+
+    def test_no_stale_warning_for_subset_load(self, tmp_path, caplog):
+        # First write: 150 episodes for taskA.
+        el, e2t, t2i = _fake_meta({"taskA": list(range(100, 250))})
+        load_or_compute_speed_percentiles(tmp_path, el, e2t, t2i)
+
+        # Second load is a subset — current has *fewer* episodes than
+        # the on-disk file was computed from. This is the dominant case
+        # for heterogeneous mixture training (a 10% mix loads ~45 of
+        # 457 episodes per dataset). The on-disk percentiles are
+        # already a more robust sample than a recompute on the subset
+        # would produce, so no warning fires.
+        el2, e2t2, t2i2 = _fake_meta({"taskA": list(range(100, 150))})  # 50 episodes
+        with caplog.at_level("WARNING"):
+            out = load_or_compute_speed_percentiles(tmp_path, el2, e2t2, t2i2)
+        assert out[0] is not None
+        assert not any("Stale" in rec.message for rec in caplog.records), [
             rec.message for rec in caplog.records
         ]
 
@@ -402,6 +424,45 @@ class TestLoadOrComputeSpeedPercentiles:
         with caplog.at_level("WARNING"):
             load_or_compute_speed_percentiles(tmp_path, el, e2t, t2i)
         assert not any("Stale" in rec.message for rec in caplog.records)
+
+    def test_clean_regeneration_after_file_deletion(self, tmp_path, caplog):
+        # Workflow: user deletes meta/speed_percentiles.jsonl across the
+        # mixture and lets the next run rebuild it from scratch. After
+        # deletion, the loader must take the compute path, write a fresh
+        # file based on whatever the current load can resolve, and not
+        # log spurious staleness or migration warnings on this run or
+        # the next.
+        el, e2t, t2i = _fake_meta({"taskA": list(range(100, 200)), "taskB": list(range(50, 150))})
+        path = tmp_path / SPEED_PERCENTILES_PATH
+
+        # Initial write.
+        load_or_compute_speed_percentiles(tmp_path, el, e2t, t2i)
+        assert path.is_file()
+
+        # Simulate the user's "rm meta/speed_percentiles.jsonl" step.
+        path.unlink()
+
+        caplog.clear()
+        with caplog.at_level("INFO"):
+            out = load_or_compute_speed_percentiles(tmp_path, el, e2t, t2i)
+
+        # File was regenerated.
+        assert path.is_file()
+        # Both tasks present with valid percentiles.
+        assert set(out.keys()) == {0, 1}
+        assert all(out[k] is not None and len(out[k]) == 10 for k in out)
+        # No noise: no Recomputing-migration log, no Stale warning.
+        assert not any("Recomputing" in r.message for r in caplog.records), [
+            r.message for r in caplog.records
+        ]
+        assert not any("Stale" in r.message for r in caplog.records), [r.message for r in caplog.records]
+
+        # And the regenerated file is self-consistent on the next load.
+        caplog.clear()
+        with caplog.at_level("INFO"):
+            out2 = load_or_compute_speed_percentiles(tmp_path, el, e2t, t2i)
+        assert out2 == out
+        assert not any("Recomputing" in r.message or "Stale" in r.message for r in caplog.records)
 
     def test_concurrent_writes_produce_valid_file(self, tmp_path):
         # Multiple threads racing on the same root must not corrupt the

--- a/tests/datasets/test_speed_percentiles.py
+++ b/tests/datasets/test_speed_percentiles.py
@@ -36,7 +36,7 @@ from opentau.datasets.speed_percentiles import (
     SPEED_PERCENTILES_PATH,
     bucket_episode_length,
     compute_task_percentiles,
-    episode_to_task_index_from_episodes,
+    episode_to_task_index_from_hf_dataset,
     load_or_compute_speed_percentiles,
 )
 from opentau.datasets.utils import load_jsonlines, write_jsonlines
@@ -49,16 +49,56 @@ def _fake_meta(task_to_lengths: dict[str, list[int]]):
     — the same triple a real ``LeRobotDataset.__init__`` would assemble.
     """
     episode_lengths: dict[int, int] = {}
-    episodes: dict[int, dict] = {}
+    e2t: dict[int, int] = {}
     task_to_task_index = {task: i for i, task in enumerate(task_to_lengths)}
     next_ep = 0
     for task, lengths in task_to_lengths.items():
         for length in lengths:
             episode_lengths[next_ep] = length
-            episodes[next_ep] = {"episode_index": next_ep, "tasks": [task], "length": length}
+            e2t[next_ep] = task_to_task_index[task]
             next_ep += 1
-    e2t = episode_to_task_index_from_episodes(episodes, task_to_task_index)
     return episode_lengths, e2t, task_to_task_index
+
+
+def _fake_hf_dataset(per_episode_data: list[tuple[int, int, int]]):
+    """Build a fake hf_dataset + episode_data_index + epi2idx.
+
+    Args:
+        per_episode_data: list of ``(episode_index, length, task_index)`` tuples,
+            one per episode, in the order they should appear in the parquet.
+
+    Returns ``(hf_dataset, episodes, episode_data_index, epi2idx)`` — the same
+    four objects that ``LeRobotDataset.__init__`` passes to
+    :func:`episode_to_task_index_from_hf_dataset`.
+    """
+    import torch
+    from datasets import Dataset
+
+    task_indices_col: list[int] = []
+    episode_index_col: list[int] = []
+    starts: list[int] = []
+    ends: list[int] = []
+    epi2idx: dict[int, int] = {}
+    pos = 0
+    for i, (ep, length, task_idx) in enumerate(per_episode_data):
+        starts.append(pos)
+        task_indices_col.extend([task_idx] * length)
+        episode_index_col.extend([ep] * length)
+        pos += length
+        ends.append(pos)
+        epi2idx[ep] = i
+    ds = Dataset.from_dict(
+        {
+            "task_index": task_indices_col,
+            "episode_index": episode_index_col,
+        }
+    )
+    episode_data_index = {
+        "from": torch.tensor(starts),
+        "to": torch.tensor(ends),
+    }
+    episodes = [ep for ep, _, _ in per_episode_data]
+    return ds, episodes, episode_data_index, epi2idx
 
 
 class TestComputeTaskPercentiles:
@@ -103,39 +143,121 @@ class TestComputeTaskPercentiles:
         assert out[2] is None
 
 
-class TestEpisodeToTaskIndex:
-    def test_single_task_episodes(self):
-        episodes = {
-            0: {"tasks": ["taskA"], "length": 100},
-            1: {"tasks": ["taskB"], "length": 200},
-        }
-        t2i = {"taskA": 0, "taskB": 1}
-        assert episode_to_task_index_from_episodes(episodes, t2i) == {0: 0, 1: 1}
+class TestEpisodeToTaskIndexFromHfDataset:
+    """Pin the parquet-keyed lookup that replaced the old string-keyed one.
 
-    def test_multi_task_uses_first(self):
-        episodes = {0: {"tasks": ["taskA", "taskB"], "length": 100}}
-        t2i = {"taskA": 0, "taskB": 1}
-        assert episode_to_task_index_from_episodes(episodes, t2i) == {0: 0}
+    The previous implementation matched ``episodes.jsonl::tasks[0]`` against
+    ``tasks.jsonl::task``; any paraphrase in either file broke the match
+    and forced every affected episode to ``SPARSE_TASK_BUCKET``. The new
+    implementation reads the authoritative integer ``task_index`` from the
+    per-frame parquet, so paraphrases are inert and the warning fires only
+    when the parquet itself references an index that ``tasks.jsonl``
+    doesn't define (genuine metadata corruption).
+    """
 
-    def test_empty_tasks_skipped(self):
-        episodes = {
-            0: {"tasks": [], "length": 100},
-            1: {"length": 200},
-            2: {"tasks": ["taskA"], "length": 300},
-        }
-        t2i = {"taskA": 0}
-        assert episode_to_task_index_from_episodes(episodes, t2i) == {2: 0}
+    @pytest.fixture(autouse=True)
+    def _reset_warn_cache(self, monkeypatch):
+        # The dedup set is module-level, so without reset a test that warns
+        # would suppress the warning in the next test for the same index.
+        from opentau.datasets import speed_percentiles as sp
 
-    def test_unresolvable_task_label_skipped(self):
-        # A task label absent from task_to_task_index (episodes.jsonl /
-        # tasks.jsonl drift) is skipped, not raised on; resolvable episodes
-        # in the same dataset still come through.
-        episodes = {
-            0: {"tasks": ["ghost"], "length": 100},
-            1: {"tasks": ["taskA"], "length": 200},
-        }
-        t2i = {"taskA": 0}
-        assert episode_to_task_index_from_episodes(episodes, t2i) == {1: 0}
+        monkeypatch.setattr(sp, "_UNKNOWN_TASK_INDEX_WARNED", set())
+
+    def test_happy_path_resolves_every_episode(self):
+        ds, episodes, edi, epi2idx = _fake_hf_dataset(
+            [
+                (0, 50, 0),
+                (1, 100, 1),
+                (2, 75, 0),
+            ]
+        )
+        out = episode_to_task_index_from_hf_dataset(
+            hf_dataset=ds,
+            episodes=episodes,
+            episode_data_index=edi,
+            epi2idx=epi2idx,
+            valid_task_indices={0, 1},
+        )
+        assert out == {0: 0, 1: 1, 2: 0}
+
+    def test_unknown_task_index_skipped_with_warning(self, caplog):
+        # Episode 1 points at task_index=99 which isn't in tasks.jsonl
+        # (valid_task_indices). It's dropped; resolvable episodes pass.
+        ds, episodes, edi, epi2idx = _fake_hf_dataset(
+            [
+                (0, 50, 0),
+                (1, 100, 99),
+                (2, 75, 0),
+            ]
+        )
+        with caplog.at_level("WARNING"):
+            out = episode_to_task_index_from_hf_dataset(
+                hf_dataset=ds,
+                episodes=episodes,
+                episode_data_index=edi,
+                epi2idx=epi2idx,
+                valid_task_indices={0, 1},
+            )
+        assert out == {0: 0, 2: 0}
+        bad_msgs = [r.message for r in caplog.records if "task_index=99" in r.message]
+        assert len(bad_msgs) == 1
+
+    def test_repeated_unknown_index_dedupes_warning(self, caplog):
+        # Three episodes all reference the same bad index — the deduper
+        # collapses to a single warning per distinct index per process.
+        ds, episodes, edi, epi2idx = _fake_hf_dataset(
+            [
+                (0, 50, 99),
+                (1, 100, 99),
+                (2, 75, 99),
+            ]
+        )
+        with caplog.at_level("WARNING"):
+            out = episode_to_task_index_from_hf_dataset(
+                hf_dataset=ds,
+                episodes=episodes,
+                episode_data_index=edi,
+                epi2idx=epi2idx,
+                valid_task_indices={0, 1},
+            )
+        assert out == {}
+        bad_msgs = [r.message for r in caplog.records if "task_index=99" in r.message]
+        assert len(bad_msgs) == 1
+
+    def test_empty_episodes_returns_empty_without_touching_dataset(self):
+        # When no episodes are selected, the function must not even peek
+        # at the dataset — important for tiny / lazy hf_dataset stubs.
+        ds, _, edi, epi2idx = _fake_hf_dataset([(0, 50, 0)])
+        out = episode_to_task_index_from_hf_dataset(
+            hf_dataset=ds,
+            episodes=[],
+            episode_data_index=edi,
+            epi2idx=epi2idx,
+            valid_task_indices={0},
+        )
+        assert out == {}
+
+    def test_paraphrased_tasks_jsonl_does_not_warn(self, caplog):
+        # The whole point of this rewrite: even when tasks.jsonl uses a
+        # paraphrased string for what episodes.jsonl calls something else,
+        # the parquet's task_index is authoritative — no warning fires
+        # because no string comparison happens.
+        ds, episodes, edi, epi2idx = _fake_hf_dataset(
+            [
+                (0, 50, 0),
+                (1, 100, 1),
+            ]
+        )
+        with caplog.at_level("WARNING"):
+            out = episode_to_task_index_from_hf_dataset(
+                hf_dataset=ds,
+                episodes=episodes,
+                episode_data_index=edi,
+                epi2idx=epi2idx,
+                valid_task_indices={0, 1},
+            )
+        assert out == {0: 0, 1: 1}
+        assert not any("task_index" in r.message for r in caplog.records)
 
 
 class TestBucketEpisodeLength:
@@ -355,6 +477,61 @@ class TestLoadOrComputeSpeedPercentiles:
         assert out == {}
         # `.get(missing_idx)` returns None → bucket 50.
         assert bucket_episode_length(123, out.get(99)) == SPARSE_TASK_BUCKET
+
+    def test_recompute_when_persisted_file_missing_tasks(self, tmp_path, caplog):
+        # Simulates the state left by the pre-fix code: tasks.jsonl was
+        # paraphrased relative to episodes.jsonl, the string-keyed lookup
+        # only resolved a subset of tasks, and the resulting percentile
+        # file is missing rows for every drifted task. The new loader
+        # detects the missing tasks against the (now correctly resolved)
+        # episode_to_task_index and recomputes.
+        el, e2t, t2i = _fake_meta(
+            {
+                "taskA": list(range(100, 200)),  # 100 episodes
+                "taskB": list(range(50, 150)),  # 100 more episodes — index 1
+            }
+        )
+        path = tmp_path / SPEED_PERCENTILES_PATH
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # Pre-write a file with only taskA — taskB (task_index=1) is
+        # missing, simulating the buggy first-pass output.
+        bogus_percentiles = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+        write_jsonlines(
+            [
+                {
+                    "task_index": 0,
+                    "task": "taskA",
+                    "n_episodes": 100,
+                    "percentiles": bogus_percentiles,
+                }
+            ],
+            path,
+        )
+
+        with caplog.at_level("INFO"):
+            out = load_or_compute_speed_percentiles(tmp_path, el, e2t, t2i)
+
+        # Both tasks now have percentiles — recompute ran.
+        assert set(out.keys()) == {0, 1}
+        assert out[0] is not None
+        assert out[1] is not None
+        # The bogus pre-existing percentiles were discarded by recompute.
+        assert out[0] != bogus_percentiles
+        # Info log fired with the expected migration message.
+        recompute_msgs = [
+            r.message for r in caplog.records if "Recomputing" in r.message and "missing 1" in r.message
+        ]
+        assert recompute_msgs, [r.message for r in caplog.records]
+        # The on-disk file was rewritten with both tasks.
+        rows = load_jsonlines(path)
+        assert {int(r["task_index"]) for r in rows} == {0, 1}
+
+        # Second call takes the fast read path — no Recompute, no Stale.
+        caplog.clear()
+        with caplog.at_level("INFO"):
+            load_or_compute_speed_percentiles(tmp_path, el, e2t, t2i)
+        assert not any("Recomputing" in r.message for r in caplog.records)
+        assert not any("Stale" in r.message for r in caplog.records)
 
 
 class TestLiberoSnapshot:


### PR DESCRIPTION
## What this does

Two-commit fix for the noisy `Episode task label '...' is not present in tasks.jsonl` warning and the resulting silent degradation of `speed_raw` to the median bucket for most episodes when `tasks.jsonl` has been paraphrased relative to `episodes.jsonl::tasks[0]`.

**Root cause.** The previous `episode_to_task_index_from_episodes` resolved each episode's task by string-matching `episodes.jsonl::tasks[0]` against `tasks.jsonl`. Any paraphrase between the two files broke the match, dropping every affected episode to `SPARSE_TASK_BUCKET = 50` in the downstream speed-bucket lookup. The string match is unnecessary: every row of the per-episode parquet already carries an authoritative integer `task_index` column (the same one `__getitem__` reads).

**Commit 1 — switch the lookup to the parquet.** Replaces `episode_to_task_index_from_episodes` with `episode_to_task_index_from_hf_dataset`, which reads `task_index` directly from the per-frame parquet via `episode_data_index`. Paraphrase is now inert. The new warning fires only when the parquet itself points at a `task_index` that `tasks.jsonl` doesn't define (genuine metadata corruption). Adds a one-shot migration in `load_or_compute_speed_percentiles` that detects + recomputes existing `meta/speed_percentiles.jsonl` files written under the buggy code path (those files are missing rows for every drifted task; the new loader checks the expected vs on-disk task-index sets and rewrites once).

**Commit 2 — directional staleness check.** Commit 1 also changed `episode_to_task_index` to cover *selected* episodes only (the parquet read can only see selected ones). For a heterogeneous-mixture run this makes the on-disk per-task `n_episodes` total naturally larger than the current load's count, firing the existing `Stale ...` warning on every dataset in the mixture even though nothing is stale. The fix restricts the warning to the genuine direction (`on_disk_total < current_total`, i.e. new episodes appended). Subset / mixture loads (`on_disk_total > current_total`) are silent — the on-disk percentiles are a more robust sample than a recompute on the subset would produce.

## How it was tested

- `tests/datasets/test_speed_percentiles.py`: replaced the four string-lookup tests with `TestEpisodeToTaskIndexFromHfDataset` (5 tests covering happy path, unknown-index warning, dedup, empty-episodes short-circuit, paraphrase-doesn't-warn). Added `test_recompute_when_persisted_file_missing_tasks` for the migration, `test_no_stale_warning_for_subset_load` for directional staleness, and `test_clean_regeneration_after_file_deletion` for the rm-and-rebuild workflow.
- All 43 cpu tests in `tests/datasets/test_speed_percentiles.py` pass; 441 tests in `tests/datasets/` pass.
- Verified on a live `pi07_paligemma_pretrain_10percent_mix_freq` run: the `Episode task label '...' is not present in tasks.jsonl` warnings are gone, and after the second commit the `Stale ...` warnings on subset loads are also gone. Existing pre-fix `meta/speed_percentiles.jsonl` files are migrated automatically on first load with the new code.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/datasets/test_speed_percentiles.py
```

To see the end-to-end effect, load any dataset whose `tasks.jsonl` is paraphrased relative to `episodes.jsonl::tasks[0]`:

```python
from collections import Counter
from opentau.datasets.lerobot_dataset import LeRobotDataset
ds = LeRobotDataset("<repo_id>")
print(Counter(ds.speed_raw_by_episode.values()))
```

Before this PR, the distribution is dominated by `50` (sparse fallback). After this PR — once `meta/speed_percentiles.jsonl` is migrated on first load — buckets span the full `{0, 10, 20, ..., 100}` range for tasks with ≥10 distinct episode lengths.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).