### PR TITLE
fix(scripts): pass format="mp4" to wandb.Video for grid_summary logging

### DIFF
--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -823,7 +823,7 @@ def train(cfg: TrainPipelineConfig):
                 # videos on a multi-node run without a shared FS won't be seen).
                 if cfg.wandb.enable and cfg.eval.max_episodes_rendered > 0:
                     grid_videos = {
-                        f"Eval Videos/{task_name}": wandb.Video(grid_path)
+                        f"Eval Videos/{task_name}": wandb.Video(grid_path, format="mp4")
                         for task_name, grid_path in collect_grid_summary_videos(videos_dir)
                     }
                     if grid_videos:


### PR DESCRIPTION
## What this does

Fixes the `wandb: WARNING format argument was not provided, defaulting to gif` warning that fires on every eval step that logs a `grid_summary.mp4`. The single `wandb.Video(grid_path)` call at `src/opentau/scripts/train.py:826` now passes `format="mp4"` explicitly. `grid_path` is always a path to an mp4 file (produced by `eval.py::create_grid_summary_video` and globbed by `eval.py::collect_grid_summary_videos`), so `"mp4"` is the only correct value.

The warning also reflected a real latent bug: with no `format=` kwarg, wandb defaulted to `gif`, silently mis-classifying the artifact in the wandb UI as a gif rather than the mp4 we wrote to disk.

(🐛 Bug)

## How it was tested

- `pre-commit run --files src/opentau/scripts/train.py` — all hooks pass.
- `LIBERO_CONFIG_PATH=.github/assets/libero pytest -m "not gpu" -n auto` — 1291 passed, 14 skipped. One pre-existing unrelated failure: `tests/utils/test_libero_utils.py::test_libero2torch` (`FileNotFoundError` on LIBERO benchmark assets not present in the dev env).
- This call site is not exercised by the CPU suite — it requires wandb-enabled eval with rendered episodes. The change is a strict addition of a `format="mp4"` kwarg to a one-line constructor, with no behavior change for any other path.

## How to checkout & try? (for the reviewer)

```bash
gh pr checkout <PR#>
grep -n "wandb.Video" src/opentau/scripts/train.py
```

The line should read:

```python
f"Eval Videos/{task_name}": wandb.Video(grid_path, format="mp4")
```

Next eval step that logs a grid summary should produce no `wandb: WARNING format argument was not provided` line, and the artifact in the wandb UI should appear as an mp4 (not a gif).

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).