### PR TITLE
fix(envs): zero-fill missing camera slots at eval; libero num_cams

### DIFF
--- a/src/opentau/envs/configs.py
+++ b/src/opentau/envs/configs.py
@@ -197,16 +197,16 @@ class LiberoEnv(EnvConfig):
         episode_length: Maximum length of each episode in steps.
         obs_type: Type of observations to use (e.g., ``"pixels_agent_pos"``).
         render_mode: Rendering mode for the environment (e.g., ``"rgb_array"``).
-        num_cams: Number of LIBERO cameras to expose at eval. Must be ``1``
-            (agentview only) or ``2`` (agentview + wrist eye-in-hand);
-            defaults to ``2``. When the underlying policy was trained with a
-            larger ``cfg.num_cams`` (e.g. a multi-domain mixture with 4 camera
-            slots), ``preprocess_observation`` zero-fills the remaining
-            ``cameraN`` slots so the train↔eval input structure stays aligned.
-        camera_name: Comma-separated names of LIBERO raw cameras to render.
-            Auto-derived from ``num_cams`` when unspecified (``num_cams=1`` →
-            ``"agentview_image"``, ``num_cams=2`` → ``"agentview_image,robot0_eye_in_hand_image"``).
-            If set explicitly it must contain exactly ``num_cams`` entries.
+        camera_name: Comma-separated LIBERO raw camera names to render — both
+            count and ordering of LIBERO cameras at eval are driven by this
+            string. Defaults to ``"agentview_image,robot0_eye_in_hand_image"``
+            (agentview + wrist eye-in-hand). Set to ``"agentview_image"``
+            (single camera) for agentview-only rollouts. When the underlying
+            policy was trained with a larger ``cfg.num_cams`` (e.g. a
+            multi-domain mixture with 4 camera slots),
+            ``preprocess_observation`` zero-fills the remaining ``cameraN``
+            slots so the train↔eval input structure stays aligned —
+            independent of how many real LIBERO cameras this field renders.
         init_states: Whether to initialize states randomly.
         camera_name_mapping: Optional mapping from camera names to standardized keys.
         features: Mapping from logical feature names to :class:`~opentau.configs.types.PolicyFeature` definitions.
@@ -219,7 +219,6 @@ class LiberoEnv(EnvConfig):
     episode_length: int = 520
     obs_type: str = "pixels_agent_pos"
     render_mode: str = "rgb_array"
-    num_cams: int = 2
     camera_name: str = "agentview_image,robot0_eye_in_hand_image"
     init_states: bool = True
     camera_name_mapping: dict[str, str] | None = None
@@ -238,23 +237,6 @@ class LiberoEnv(EnvConfig):
     )
 
     def __post_init__(self):
-        if self.num_cams not in (1, 2):
-            raise ValueError(
-                f"LIBERO env.num_cams must be 1 (agentview only) or 2 (agentview + wrist), "
-                f"got {self.num_cams}. LIBERO exposes at most two cameras."
-            )
-        # Auto-derive ``camera_name`` from ``num_cams`` when the user only set
-        # ``num_cams=1`` and left ``camera_name`` at the 2-cam default. Set both
-        # explicitly to use a non-default LIBERO camera pair.
-        if self.num_cams == 1 and self.camera_name == "agentview_image,robot0_eye_in_hand_image":
-            self.camera_name = "agentview_image"
-        n_in_name = len([c for c in self.camera_name.split(",") if c.strip()])
-        if n_in_name != self.num_cams:
-            raise ValueError(
-                f"LIBERO env: num_cams={self.num_cams} but camera_name has {n_in_name} "
-                f"entries ({self.camera_name!r}). Set them consistently."
-            )
-
         if self.fps <= 0:
             raise ValueError(
                 f"LIBERO env.fps (robosuite control frequency in Hz) must be positive, got {self.fps}"

--- a/src/opentau/envs/configs.py
+++ b/src/opentau/envs/configs.py
@@ -197,7 +197,16 @@ class LiberoEnv(EnvConfig):
         episode_length: Maximum length of each episode in steps.
         obs_type: Type of observations to use (e.g., ``"pixels_agent_pos"``).
         render_mode: Rendering mode for the environment (e.g., ``"rgb_array"``).
-        camera_name: Comma-separated names of cameras to use for rendering.
+        num_cams: Number of LIBERO cameras to expose at eval. Must be ``1``
+            (agentview only) or ``2`` (agentview + wrist eye-in-hand);
+            defaults to ``2``. When the underlying policy was trained with a
+            larger ``cfg.num_cams`` (e.g. a multi-domain mixture with 4 camera
+            slots), ``preprocess_observation`` zero-fills the remaining
+            ``cameraN`` slots so the train↔eval input structure stays aligned.
+        camera_name: Comma-separated names of LIBERO raw cameras to render.
+            Auto-derived from ``num_cams`` when unspecified (``num_cams=1`` →
+            ``"agentview_image"``, ``num_cams=2`` → ``"agentview_image,robot0_eye_in_hand_image"``).
+            If set explicitly it must contain exactly ``num_cams`` entries.
         init_states: Whether to initialize states randomly.
         camera_name_mapping: Optional mapping from camera names to standardized keys.
         features: Mapping from logical feature names to :class:`~opentau.configs.types.PolicyFeature` definitions.
@@ -210,6 +219,7 @@ class LiberoEnv(EnvConfig):
     episode_length: int = 520
     obs_type: str = "pixels_agent_pos"
     render_mode: str = "rgb_array"
+    num_cams: int = 2
     camera_name: str = "agentview_image,robot0_eye_in_hand_image"
     init_states: bool = True
     camera_name_mapping: dict[str, str] | None = None
@@ -228,6 +238,23 @@ class LiberoEnv(EnvConfig):
     )
 
     def __post_init__(self):
+        if self.num_cams not in (1, 2):
+            raise ValueError(
+                f"LIBERO env.num_cams must be 1 (agentview only) or 2 (agentview + wrist), "
+                f"got {self.num_cams}. LIBERO exposes at most two cameras."
+            )
+        # Auto-derive ``camera_name`` from ``num_cams`` when the user only set
+        # ``num_cams=1`` and left ``camera_name`` at the 2-cam default. Set both
+        # explicitly to use a non-default LIBERO camera pair.
+        if self.num_cams == 1 and self.camera_name == "agentview_image,robot0_eye_in_hand_image":
+            self.camera_name = "agentview_image"
+        n_in_name = len([c for c in self.camera_name.split(",") if c.strip()])
+        if n_in_name != self.num_cams:
+            raise ValueError(
+                f"LIBERO env: num_cams={self.num_cams} but camera_name has {n_in_name} "
+                f"entries ({self.camera_name!r}). Set them consistently."
+            )
+
         if self.fps <= 0:
             raise ValueError(
                 f"LIBERO env.fps (robosuite control frequency in Hz) must be positive, got {self.fps}"

--- a/src/opentau/envs/utils.py
+++ b/src/opentau/envs/utils.py
@@ -71,9 +71,21 @@ def preprocess_observation(np_observations: dict, cfg: TrainPipelineConfig) -> d
     return_observations["state"] = agent_pos
 
     batch_size = agent_pos.shape[0]
-    # add padding flags for cameras if needed
+    # Mirror training-time ``BaseDataset._standardize_images``: when the env exposes
+    # fewer cameras than the policy was trained with (e.g. LIBERO emits only
+    # ``camera0``/``camera1`` but the policy was trained with ``num_cams=4``),
+    # zero-fill the missing ``cameraN`` slots and flag them in ``img_is_pad``.
+    # Without this the eval batch has fewer image keys than any training batch,
+    # so the VLM sees a strictly shorter visual prefix than at training and
+    # ``Normalize`` prints a missing-key warning for every absent slot every step.
     if cfg.num_cams > 0:
-        return_observations["img_is_pad"] = torch.zeros((batch_size, cfg.num_cams), dtype=torch.bool)
+        img_is_pad = torch.zeros((batch_size, cfg.num_cams), dtype=torch.bool)
+        for i in range(cfg.num_cams):
+            key = f"camera{i}"
+            if key not in return_observations:
+                return_observations[key] = torch.zeros((batch_size, 3, *cfg.resolution), dtype=torch.float32)
+                img_is_pad[:, i] = True
+        return_observations["img_is_pad"] = img_is_pad
 
     # convert all floating point tensors to bfloat16 to save memory
     acc = get_proc_accelerator()

--- a/tests/envs/test_configs.py
+++ b/tests/envs/test_configs.py
@@ -21,6 +21,7 @@ import pytest
 
 from opentau.configs.types import FeatureType, PolicyFeature
 from opentau.envs.configs import EnvConfig, EnvMetadataConfig
+from opentau.envs.configs import LiberoEnv as LiberoEnvConfig
 
 
 class TestEnvConfig:
@@ -259,6 +260,59 @@ class TestEnvMetadataConfig:
     def test_control_mode_must_be_joint_or_ee(self, bad_mode):
         with pytest.raises(ValueError, match=r"control_mode must be one of"):
             EnvMetadataConfig(control_mode=bad_mode)
+
+
+class TestLiberoEnvNumCams:
+    """Pin the LIBERO ``num_cams`` field contract.
+
+    LIBERO exposes at most two cameras (``agentview_image`` + wrist
+    ``robot0_eye_in_hand_image``). The eval-time policy may have been
+    trained with a larger ``cfg.num_cams`` against a multi-domain mixture;
+    in that case ``preprocess_observation`` zero-fills the remaining slots,
+    so this field only constrains how many *real* LIBERO cameras to render
+    — not how many ``cameraN`` slots the policy sees.
+    """
+
+    def test_default_is_two_cams(self):
+        cfg = LiberoEnvConfig()
+        assert cfg.num_cams == 2
+        assert cfg.camera_name == "agentview_image,robot0_eye_in_hand_image"
+
+    def test_num_cams_one_auto_derives_camera_name(self):
+        """``num_cams=1`` with the default ``camera_name`` rewrites it to
+        ``"agentview_image"`` — users don't have to restate the camera list."""
+        cfg = LiberoEnvConfig(num_cams=1)
+        assert cfg.num_cams == 1
+        assert cfg.camera_name == "agentview_image"
+
+    def test_num_cams_one_with_explicit_one_cam_name(self):
+        cfg = LiberoEnvConfig(num_cams=1, camera_name="agentview_image")
+        assert cfg.num_cams == 1
+        assert cfg.camera_name == "agentview_image"
+
+    @pytest.mark.parametrize("bad", [0, 3, 4, -1])
+    def test_num_cams_out_of_range_raises(self, bad):
+        with pytest.raises(ValueError, match=r"num_cams must be 1 .* or 2"):
+            LiberoEnvConfig(num_cams=bad)
+
+    def test_default_two_cam_name_auto_collapses_when_num_cams_one(self):
+        """Setting ``num_cams=1`` while leaving ``camera_name`` at the 2-cam
+        default string (whether explicitly typed or just inherited) collapses
+        to the 1-cam name. Anything else is treated as a true mismatch and
+        raises — see the next test."""
+        cfg = LiberoEnvConfig(num_cams=1, camera_name="agentview_image,robot0_eye_in_hand_image")
+        assert cfg.camera_name == "agentview_image"
+
+    def test_inconsistent_non_default_camera_name_raises(self):
+        """A non-default 2-cam name with ``num_cams=1`` is a real mismatch —
+        the auto-rewrite only catches the exact default string, not arbitrary
+        2-cam pairs."""
+        with pytest.raises(ValueError, match=r"camera_name has 2 entries"):
+            LiberoEnvConfig(num_cams=1, camera_name="agentview_image,frontview_image")
+
+    def test_num_cams_two_with_one_cam_name_raises(self):
+        with pytest.raises(ValueError, match=r"camera_name has 1 entries"):
+            LiberoEnvConfig(num_cams=2, camera_name="agentview_image")
 
 
 class TestEnvConfigMetadataField:

--- a/tests/envs/test_configs.py
+++ b/tests/envs/test_configs.py
@@ -21,7 +21,6 @@ import pytest
 
 from opentau.configs.types import FeatureType, PolicyFeature
 from opentau.envs.configs import EnvConfig, EnvMetadataConfig
-from opentau.envs.configs import LiberoEnv as LiberoEnvConfig
 
 
 class TestEnvConfig:
@@ -260,59 +259,6 @@ class TestEnvMetadataConfig:
     def test_control_mode_must_be_joint_or_ee(self, bad_mode):
         with pytest.raises(ValueError, match=r"control_mode must be one of"):
             EnvMetadataConfig(control_mode=bad_mode)
-
-
-class TestLiberoEnvNumCams:
-    """Pin the LIBERO ``num_cams`` field contract.
-
-    LIBERO exposes at most two cameras (``agentview_image`` + wrist
-    ``robot0_eye_in_hand_image``). The eval-time policy may have been
-    trained with a larger ``cfg.num_cams`` against a multi-domain mixture;
-    in that case ``preprocess_observation`` zero-fills the remaining slots,
-    so this field only constrains how many *real* LIBERO cameras to render
-    — not how many ``cameraN`` slots the policy sees.
-    """
-
-    def test_default_is_two_cams(self):
-        cfg = LiberoEnvConfig()
-        assert cfg.num_cams == 2
-        assert cfg.camera_name == "agentview_image,robot0_eye_in_hand_image"
-
-    def test_num_cams_one_auto_derives_camera_name(self):
-        """``num_cams=1`` with the default ``camera_name`` rewrites it to
-        ``"agentview_image"`` — users don't have to restate the camera list."""
-        cfg = LiberoEnvConfig(num_cams=1)
-        assert cfg.num_cams == 1
-        assert cfg.camera_name == "agentview_image"
-
-    def test_num_cams_one_with_explicit_one_cam_name(self):
-        cfg = LiberoEnvConfig(num_cams=1, camera_name="agentview_image")
-        assert cfg.num_cams == 1
-        assert cfg.camera_name == "agentview_image"
-
-    @pytest.mark.parametrize("bad", [0, 3, 4, -1])
-    def test_num_cams_out_of_range_raises(self, bad):
-        with pytest.raises(ValueError, match=r"num_cams must be 1 .* or 2"):
-            LiberoEnvConfig(num_cams=bad)
-
-    def test_default_two_cam_name_auto_collapses_when_num_cams_one(self):
-        """Setting ``num_cams=1`` while leaving ``camera_name`` at the 2-cam
-        default string (whether explicitly typed or just inherited) collapses
-        to the 1-cam name. Anything else is treated as a true mismatch and
-        raises — see the next test."""
-        cfg = LiberoEnvConfig(num_cams=1, camera_name="agentview_image,robot0_eye_in_hand_image")
-        assert cfg.camera_name == "agentview_image"
-
-    def test_inconsistent_non_default_camera_name_raises(self):
-        """A non-default 2-cam name with ``num_cams=1`` is a real mismatch —
-        the auto-rewrite only catches the exact default string, not arbitrary
-        2-cam pairs."""
-        with pytest.raises(ValueError, match=r"camera_name has 2 entries"):
-            LiberoEnvConfig(num_cams=1, camera_name="agentview_image,frontview_image")
-
-    def test_num_cams_two_with_one_cam_name_raises(self):
-        with pytest.raises(ValueError, match=r"camera_name has 1 entries"):
-            LiberoEnvConfig(num_cams=2, camera_name="agentview_image")
 
 
 class TestEnvConfigMetadataField:

--- a/tests/envs/test_utils.py
+++ b/tests/envs/test_utils.py
@@ -18,6 +18,7 @@ import warnings
 from types import SimpleNamespace
 
 import gymnasium as gym
+import numpy as np
 import pytest
 import torch
 
@@ -26,6 +27,7 @@ from opentau.envs.utils import (
     add_eval_metadata,
     are_all_envs_same_type,
     check_env_attributes_and_types,
+    preprocess_observation,
 )
 
 
@@ -388,3 +390,98 @@ class TestAddEvalMetadata:
         # Existing user-set fields still flow.
         assert "speed" in obs
         assert obs["robot_type"] == ["UR5", "UR5"]
+
+
+class TestPreprocessObservationCameraPadding:
+    """Pin the train↔eval input parity contract for ``preprocess_observation``.
+
+    Training-time ``BaseDataset._standardize_images`` (in
+    ``opentau.datasets.lerobot_dataset``) always emits a ``num_cams``-wide
+    camera stack with zero-fill for missing slots and a matching
+    ``img_is_pad`` mask. Eval-time observations from an env that exposes
+    fewer cameras (e.g. LIBERO with 2 cameras while a checkpoint was
+    trained on a 4-camera mixture) must be padded the same way, otherwise
+    the VLM prefix at eval is strictly shorter than at any training step
+    and ``Normalize`` emits a missing-key warning every forward call.
+    """
+
+    @staticmethod
+    def _make_cfg(num_cams: int, resolution: tuple[int, int] = (224, 224), max_state_dim: int = 8):
+        return SimpleNamespace(
+            num_cams=num_cams,
+            resolution=resolution,
+            max_state_dim=max_state_dim,
+        )
+
+    @staticmethod
+    def _make_pixel_obs(
+        *,
+        batch_size: int = 2,
+        height: int = 224,
+        width: int = 224,
+        n_present_cams: int = 2,
+        state_dim: int = 8,
+    ) -> dict:
+        rng = np.random.default_rng(0)
+        pixels = {
+            f"camera{i}": rng.integers(0, 256, size=(batch_size, height, width, 3), dtype=np.uint8)
+            for i in range(n_present_cams)
+        }
+        agent_pos = np.zeros((batch_size, state_dim), dtype=np.float32)
+        return {"pixels": pixels, "agent_pos": agent_pos}
+
+    def test_missing_cameras_are_zero_filled(self):
+        """``num_cams=4`` with 2 present cameras → ``camera2``/``camera3``
+        are added as zero tensors and ``img_is_pad[:, 2:] == True``."""
+        cfg = self._make_cfg(num_cams=4)
+        obs = self._make_pixel_obs(batch_size=2, n_present_cams=2)
+        out = preprocess_observation(obs, cfg)
+
+        for i in range(4):
+            assert f"camera{i}" in out, f"camera{i} missing from preprocessed output"
+            assert out[f"camera{i}"].shape == (2, 3, 224, 224)
+
+        # Real cameras: derived from random uint8 input, so non-zero.
+        assert out["camera0"].float().abs().sum().item() > 0
+        assert out["camera1"].float().abs().sum().item() > 0
+        # Padded cameras: exactly zero.
+        assert out["camera2"].float().abs().sum().item() == 0
+        assert out["camera3"].float().abs().sum().item() == 0
+
+        expected_pad = torch.tensor(
+            [[False, False, True, True], [False, False, True, True]],
+            dtype=torch.bool,
+        )
+        assert torch.equal(out["img_is_pad"].cpu(), expected_pad)
+
+    def test_all_cameras_present_no_padding(self):
+        """``num_cams=2`` with 2 present cameras → no zero-fill, ``img_is_pad`` all False."""
+        cfg = self._make_cfg(num_cams=2)
+        out = preprocess_observation(self._make_pixel_obs(batch_size=3, n_present_cams=2), cfg)
+
+        assert {"camera0", "camera1"}.issubset(out)
+        assert "camera2" not in out
+        assert torch.equal(out["img_is_pad"].cpu(), torch.zeros((3, 2), dtype=torch.bool))
+
+    def test_img_is_pad_shape_matches_num_cams(self):
+        """``img_is_pad`` is always ``(B, num_cams)``; ``num_cams=4`` with 1
+        present camera → padded for slots 1/2/3."""
+        cfg = self._make_cfg(num_cams=4)
+        out = preprocess_observation(self._make_pixel_obs(batch_size=5, n_present_cams=1), cfg)
+
+        assert out["img_is_pad"].shape == (5, 4)
+        expected = torch.tensor([[False, True, True, True]] * 5, dtype=torch.bool)
+        assert torch.equal(out["img_is_pad"].cpu(), expected)
+
+    def test_zero_filled_camera_shape_uses_cfg_resolution(self):
+        """Zero-filled cameras use ``cfg.resolution``, not the env's raw HxW.
+        Mirrors the training contract where ``_standardize_images`` allocates
+        ``torch.zeros((3, *self.resolution))``."""
+        cfg = self._make_cfg(num_cams=3, resolution=(96, 128))
+        out = preprocess_observation(
+            self._make_pixel_obs(batch_size=2, height=240, width=320, n_present_cams=2),
+            cfg,
+        )
+
+        assert out["camera0"].shape == (2, 3, 96, 128)
+        assert out["camera2"].shape == (2, 3, 96, 128)


### PR DESCRIPTION
## What this does

Fixes a train↔eval mismatch in LIBERO eval rollouts when the policy was trained with `cfg.num_cams > 2` against a heterogeneous (multi-domain) mixture but the env exposes fewer cameras.

At training time, `BaseDataset._standardize_images` (`src/opentau/datasets/lerobot_dataset.py`) always emits a `cfg.num_cams`-wide image stack — when a dataset has fewer cameras than `cfg.num_cams`, the missing `cameraN` slots are zero-filled and `img_is_pad[i]=True` is set for those slots. The eval-side `preprocess_observation` did *neither*: missing keys stayed absent in the batch and `img_is_pad` was created as all-`False` regardless of how many cameras the env actually produced. With e.g. a `num_cams=4` policy evaluated on 2-camera LIBERO, the downstream effect is a strictly shorter VLM visual prefix at eval than at any training step, plus a `Warning: cameraN was missing from the batch during normalization` line from `Normalize` for every absent slot, every forward, every env, every step.

**Fix:** `preprocess_observation` now mirrors `_standardize_images` (`src/opentau/envs/utils.py`). Missing `cameraN` slots are zero-filled to `(B, 3, *cfg.resolution)` and the matching `img_is_pad[:, i]=True` is set. Since the keys are now present, `Normalize.warn_missing_keys` stops firing for them. To use a single-camera LIBERO rollout, set `env.camera_name="agentview_image"` directly — `camera_name.split(",")` already encodes both count and ordering of LIBERO render cameras, so no separate `num_cams` knob is needed on `LiberoEnv` (an earlier revision of this PR added one and was reverted after review).

## How it was tested

- `TestPreprocessObservationCameraPadding` (4 cases, `tests/envs/test_utils.py`): pins shape/pad-pattern parity for the zero-fill path — `num_cams=4` with 2 present cameras zero-fills `camera2`/`camera3` and sets `img_is_pad=[F,F,T,T]`; all-present case sets no pads; shape is always `(B, num_cams)`; zero-filled cameras use `cfg.resolution`, not the env's raw HxW.
- `pre-commit run` on all modified files: clean.
- `pytest tests/envs/ tests/scripts/test_eval.py -m "not gpu" -n auto`: all passing.
- Full CPU subset (`pytest -m "not gpu" -n auto`): 1299 passed, 14 skipped. The 2 local failures (`test_deferred_video_multi_episode`, `test_libero2torch`) are pre-existing flakes / missing-asset issues unrelated to this change.

## How to checkout & try? (for the reviewer)

```bash
LIBERO_CONFIG_PATH="$(pwd)/.github/assets/libero" \
    pytest -sx tests/envs/test_utils.py::TestPreprocessObservationCameraPadding
```

For an end-to-end LIBERO eval rollout with a policy whose `cfg.num_cams > 2`: no config change required — the next LIBERO eval should stop emitting `cameraN was missing` warnings and the policy receives a fully-padded camera stack matching the training-time `_standardize_images` shape contract. To run an agentview-only LIBERO rollout (single render camera, remaining slots zero-padded by `preprocess_observation`), set `env.camera_name="agentview_image"`.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.