### PR TITLE
fix(datasets): dedup v2.0 dataset format warning across mixture loads

### DIFF
--- a/src/opentau/datasets/utils.py
+++ b/src/opentau/datasets/utils.py
@@ -602,6 +602,33 @@ def is_valid_version(version: str) -> bool:
         return False
 
 
+_V21_WARNED_REPOS: set[str] = set()
+_V21_FULL_MESSAGE_SHOWN: bool = False
+
+
+def _warn_v21_global_stats(repo_id: str, version: packaging.version.Version) -> None:
+    """Emit the global-stats upgrade warning, deduplicated across the process.
+
+    The first v2.0 repo triggers the full V21_MESSAGE so the user sees how to
+    convert. Subsequent unique repo_ids only get a one-liner naming the repo,
+    so a mixture with hundreds of v2.0 datasets doesn't drown the log.
+    Re-warns for the same repo_id are suppressed entirely.
+    """
+    global _V21_FULL_MESSAGE_SHOWN
+    if repo_id in _V21_WARNED_REPOS:
+        return
+    _V21_WARNED_REPOS.add(repo_id)
+    if not _V21_FULL_MESSAGE_SHOWN:
+        logging.warning(V21_MESSAGE.format(repo_id=repo_id, version=version))
+        _V21_FULL_MESSAGE_SHOWN = True
+    else:
+        logging.warning(
+            f"Dataset {repo_id} is in v{version} format (uses global stats); "
+            f"run `python src/opentau/datasets/v21/convert_dataset_v20_to_v21.py "
+            f"--repo-id={repo_id}` to upgrade. See the first v2.0 warning above for details."
+        )
+
+
 def check_version_compatibility(
     repo_id: str,
     version_to_check: str | packaging.version.Version,
@@ -633,7 +660,7 @@ def check_version_compatibility(
     if v_check.major < v_current.major and enforce_breaking_major:
         raise BackwardCompatibilityError(repo_id, v_check)
     elif v_check.minor < v_current.minor:
-        logging.warning(V21_MESSAGE.format(repo_id=repo_id, version=v_check))
+        _warn_v21_global_stats(repo_id, v_check)
 
 
 def get_repo_versions(repo_id: str) -> list[packaging.version.Version]:

--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -17,6 +17,7 @@
 
 import logging
 
+import pytest
 import torch
 from datasets import Dataset
 from huggingface_hub import DatasetCard
@@ -63,11 +64,18 @@ def test_calculate_episode_data_index():
     assert torch.equal(episode_data_index["to"], torch.tensor([2, 3, 6]))
 
 
-def test_v21_warning_dedup(caplog):
+@pytest.fixture
+def reset_v21_warning_state():
+    """Reset module-global v2.0 warning dedup state around a test so a failed
+    assert doesn't leak polluted state to later tests in the same worker."""
     datasets_utils._V21_WARNED_REPOS.clear()
     datasets_utils._V21_FULL_MESSAGE_SHOWN = False
-    caplog.set_level(logging.WARNING, logger=datasets_utils.__name__)
+    yield
+    datasets_utils._V21_WARNED_REPOS.clear()
+    datasets_utils._V21_FULL_MESSAGE_SHOWN = False
 
+
+def test_v21_warning_dedup(caplog, reset_v21_warning_state):
     with caplog.at_level(logging.WARNING):
         check_version_compatibility("org/first", "2.0", "2.1")
         check_version_compatibility("org/second", "2.0", "2.1")
@@ -87,6 +95,3 @@ def test_v21_warning_dedup(caplog):
         assert repo_id in msg
         assert "convert_dataset_v20_to_v21.py" in msg
         assert "discord.com/invite" not in msg
-
-    datasets_utils._V21_WARNED_REPOS.clear()
-    datasets_utils._V21_FULL_MESSAGE_SHOWN = False

--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -15,12 +15,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+
 import torch
 from datasets import Dataset
 from huggingface_hub import DatasetCard
 
+from opentau.datasets import utils as datasets_utils
 from opentau.datasets.push_dataset_to_hub.utils import calculate_episode_data_index
-from opentau.datasets.utils import create_lerobot_dataset_card, hf_transform_to_torch
+from opentau.datasets.utils import (
+    check_version_compatibility,
+    create_lerobot_dataset_card,
+    hf_transform_to_torch,
+)
 
 
 def test_default_parameters():
@@ -54,3 +61,32 @@ def test_calculate_episode_data_index():
     episode_data_index = calculate_episode_data_index(dataset)
     assert torch.equal(episode_data_index["from"], torch.tensor([0, 2, 3]))
     assert torch.equal(episode_data_index["to"], torch.tensor([2, 3, 6]))
+
+
+def test_v21_warning_dedup(caplog):
+    datasets_utils._V21_WARNED_REPOS.clear()
+    datasets_utils._V21_FULL_MESSAGE_SHOWN = False
+    caplog.set_level(logging.WARNING, logger=datasets_utils.__name__)
+
+    with caplog.at_level(logging.WARNING):
+        check_version_compatibility("org/first", "2.0", "2.1")
+        check_version_compatibility("org/second", "2.0", "2.1")
+        check_version_compatibility("org/third", "2.0", "2.1")
+        check_version_compatibility("org/first", "2.0", "2.1")  # dup: silent
+
+    warning_messages = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warning_messages) == 3, warning_messages
+
+    # First message is the long-form V21_MESSAGE for the first repo (contains
+    # the Discord help link which only appears in the long form).
+    assert "org/first" in warning_messages[0]
+    assert "discord.com/invite" in warning_messages[0]
+
+    # Subsequent messages are the one-liner naming the repo and the convert script.
+    for repo_id, msg in zip(["org/second", "org/third"], warning_messages[1:], strict=True):
+        assert repo_id in msg
+        assert "convert_dataset_v20_to_v21.py" in msg
+        assert "discord.com/invite" not in msg
+
+    datasets_utils._V21_WARNED_REPOS.clear()
+    datasets_utils._V21_FULL_MESSAGE_SHOWN = False


### PR DESCRIPTION
## What this does

Training on a mixture of hundreds of datasets where many are still in v2.0 format floods the log with the full 10-line `V21_MESSAGE` blurb once per dataset (`logging.warning(V21_MESSAGE...)` in `check_version_compatibility`, called from every `LeRobotDatasetMetadata.load_metadata()`). With ~50 v2.0 repos in a mixture, that's ~500 lines of nearly identical warning text.

This change deduplicates by `repo_id` at the `check_version_compatibility` call site in `src/opentau/datasets/utils.py`:

- The **first** v2.0 repo still emits the full `V21_MESSAGE` so the user sees the convert command and the help link.
- Each **subsequent unique** v2.0 repo emits a single-line warning that names the repo and the exact `convert_dataset_v20_to_v21.py --repo-id=<repo>` command to run.
- The **same** `repo_id` re-checked (e.g. reloaded) stays silent.

For a mixture with 50 v2.0 repos this drops the log from ~500 lines to ~59 while still surfacing every affected repo by name. v2.x → v1.x backward-compat *errors* (`BackwardCompatibilityError`) and the v2.x → v2.x+1 dedup logic are unchanged otherwise.

Bug.

## How it was tested

- Added `test_v21_warning_dedup` in `tests/datasets/test_utils.py` that calls `check_version_compatibility` four times (three unique repos + one duplicate), asserts exactly 3 warnings, that the first is the long-form `V21_MESSAGE` (contains the Discord help link), and that the subsequent two are one-liners naming the convert command.
- `pre-commit run --files src/opentau/datasets/utils.py tests/datasets/test_utils.py` clean.
- `pytest tests/datasets/test_utils.py -m "not gpu"` — 4 passed.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/datasets/test_utils.py::test_v21_warning_dedup
```

Or exercise it end-to-end by loading a mixture containing several `physical-intelligence/*` v2.0 datasets and inspecting the warning lines emitted at the start of training — only the first should be the long form.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.