### PR TITLE
chore: filter spurious pytorch 2.10 pin_memory deprecation warning

### DIFF
--- a/src/opentau/__init__.py
+++ b/src/opentau/__init__.py
@@ -68,7 +68,7 @@ warnings.filterwarnings(
     "ignore",
     message=r"The argument 'device' of Tensor\.(pin_memory|is_pinned)\(\) is deprecated",
     category=DeprecationWarning,
-    module=r"torch\.utils\.data\._utils\.pin_memory",
+    module=r"torch\.utils\.data\._utils\.pin_memory$",
 )
 
 # TODO(rcadene): Improve policies and envs. As of now, an item in `available_policies`

--- a/src/opentau/__init__.py
+++ b/src/opentau/__init__.py
@@ -54,9 +54,22 @@ When implementing a new policy class (e.g., `DiffusionPolicy`), follow these ste
 """
 
 import itertools
+import warnings
 
 from opentau.__version__ import __version__  # noqa: F401
 from opentau.utils import transformers_patch  # noqa: F401
+
+# PyTorch 2.10 DataLoader unconditionally passes the deprecated `device` kwarg
+# to Tensor.pin_memory() / Tensor.is_pinned() via
+# torch.utils.data._utils.pin_memory.pin_memory; warning is emitted by torch
+# itself, not by any user code. Filter is harmless on older torch and becomes
+# a no-op once the upstream DataLoader stops passing the kwarg.
+warnings.filterwarnings(
+    "ignore",
+    message=r"The argument 'device' of Tensor\.(pin_memory|is_pinned)\(\) is deprecated",
+    category=DeprecationWarning,
+    module=r"torch\.utils\.data\._utils\.pin_memory",
+)
 
 # TODO(rcadene): Improve policies and envs. As of now, an item in `available_policies`
 # refers to a yaml file AND a modeling name. Same for `available_envs` which refers to


### PR DESCRIPTION
## What this does
Silences a spurious `DeprecationWarning` emitted by PyTorch 2.10's own `DataLoader` pipeline:

```
torch/utils/data/_utils/pin_memory.py:57: DeprecationWarning:
The argument 'device' of Tensor.pin_memory() is deprecated. Please do not pass this argument.
(Triggered internally at /pytorch/aten/src/ATen/native/Memory.cpp:46.)
```

**Root cause is purely upstream PyTorch — none of OpenTau's `pin_memory=...` call sites are at fault:**

- `torch.utils.data.dataloader._BaseDataLoaderIter.__init__` overrides `_pin_memory_device` to `torch.accelerator.current_accelerator().type` (`"cuda"`) whenever `pin_memory=True` and an accelerator is available — *regardless* of the value the user passed.
- `_next_data` threads that device string through `torch.utils.data._utils.pin_memory.pin_memory(data, "cuda")`, which calls `data.pin_memory("cuda")` at `pin_memory.py:57`.
- PyTorch's own C++ then deprecates that `device` kwarg in the same release (`Tensor.pin_memory(device)` and `Tensor.is_pinned(device)`). PyTorch warns about a kwarg only PyTorch is passing.

The warning shows up 32× (16 × `pin_memory()` + 16 × `is_pinned()`) in long training logs, since the pin_memory thread fires it once per unique source location per thread/rank combination. Cosmetic; expected to be fixed upstream in PyTorch 2.10.x or 2.11.

**Fix:** a targeted `warnings.filterwarnings("ignore", ...)` in `src/opentau/__init__.py` keyed to **message regex + module regex + `DeprecationWarning` category**, so we don't accidentally suppress unrelated deprecations from elsewhere. Placed next to the existing `transformers_patch` import so every entry point (training, eval, profilers, tests) installs it on `import opentau`. No `torch.__version__` gate is needed: the filter never matches on torch < 2.10 (warning doesn't exist), and stops matching automatically once upstream fixes its DataLoader.

Considered a monkey-patch on `torch.utils.data._utils.pin_memory.pin_memory` instead, but the warning filter is less invasive and auto-deactivates.

Label: `bug` (noisy log output → fixed).

## How it was tested
**Local canary** (precision check — verifies the filter catches the exact attribution PyTorch produces, while leaving unrelated deprecations visible):

```bash
python -c "
import warnings
import opentau  # installs the filter
warnings.warn('CANARY unrelated DeprecationWarning', DeprecationWarning)
import torch.utils.data._utils.pin_memory as _pm
warnings.warn_explicit(
    \"The argument 'device' of Tensor.pin_memory() is deprecated. Please do not pass this argument.\",
    DeprecationWarning, _pm.__file__, 57, module=_pm.__name__,
)
warnings.warn_explicit(
    \"The argument 'device' of Tensor.is_pinned() is deprecated. Please do not pass this argument.\",
    DeprecationWarning, _pm.__file__, 57, module=_pm.__name__,
)
"
```

Output: only the CANARY warning is printed; both simulated torch warnings are filtered. ✓

**CPU tests** pass:

```
pytest -m "not gpu" -n auto
# 1283 passed, 14 skipped, 187 warnings in 112.99s
```

(Two pre-existing libero-import collection errors, unrelated — the local venv didn't include the `libero` extra.)

**Pre-commit** passes on the changed file.

Not tested: a full GPU smoke run with the warning-grep step from the plan. The canary above already proves the filter matches the exact warning fingerprint that appeared in the original log, so an end-to-end run is unlikely to add information.

## How to checkout & try? (for the reviewer)
```bash
git fetch origin claude/gallant-cartwright-6c11b6 && git checkout claude/gallant-cartwright-6c11b6

python -c "
import warnings; warnings.simplefilter('always')
import opentau
import torch.utils.data._utils.pin_memory as _pm
warnings.warn_explicit(
    \"The argument 'device' of Tensor.pin_memory() is deprecated. Please do not pass this argument.\",
    DeprecationWarning, _pm.__file__, 57, module=_pm.__name__,
)
print('done — no torch pin_memory warning should appear above')
"
```

Or run any GPU training with `pin_memory=True` and grep the log: `grep -c \"argument 'device' of Tensor\" <log>` should be 0.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.