### PR TITLE
ci: skip redundant PR runs when push covered the same tree

### DIFF
--- a/.github/workflows/cpu_test.yml
+++ b/.github/workflows/cpu_test.yml
@@ -32,14 +32,55 @@ env:
   PRE_COMMIT_HOME: "/pre-commit-cache"
 
 jobs:
-  cpu-tests:
-    # Block PRs from non-org accounts to keep fork code off our runners.
-    # `push` and `workflow_dispatch` already require write access, so the
-    # short-circuit lets them through unchanged.
+  precheck:
+    # Decide whether the `pull_request` run is redundant with the `push` run.
+    # If the PR branch already contains every commit on the base ref, the
+    # merge would fast-forward and the merge tree equals the head tree that
+    # `push` already tested. For `push` / `workflow_dispatch`, always run.
     if: >-
       github.event_name != 'pull_request'
       || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
       || github.event.pull_request.user.login == 'claude[bot]'
+    name: Pre-check
+    runs-on: ubuntu-latest
+    outputs:
+      run-tests: ${{ steps.decide.outputs.run-tests }}
+    steps:
+      - name: Decide whether to run tests
+        id: decide
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            echo "Event=$EVENT_NAME; always run tests."
+            echo "run-tests=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          status=$(curl -fsSL \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${REPO}/compare/${BASE_SHA}...${HEAD_SHA}" \
+            | jq -r '.status' || echo "unknown")
+          echo "Compare status: $status"
+          case "$status" in
+            identical|ahead)
+              echo "Head contains base; push run already covered this tree. Skipping."
+              echo "run-tests=false" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Head does not strictly contain base; running tests."
+              echo "run-tests=true" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+  cpu-tests:
+    needs: precheck
+    if: needs.precheck.outputs.run-tests == 'true'
     name: CPU Tests
     runs-on: ubuntu-latest
     steps:
@@ -120,3 +161,28 @@ jobs:
           flags: cpu
           name: cpu-coverage
           fail_ci_if_error: false
+
+  status:
+    # Stable status check for branch protection. Passes when `cpu-tests`
+    # succeeded OR was skipped because `precheck` determined the push run
+    # already covered this tree. Point required-status-checks at this job.
+    needs: [precheck, cpu-tests]
+    if: always()
+    name: CPU Tests Status
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report aggregated result
+        env:
+          PRECHECK_RESULT: ${{ needs.precheck.result }}
+          TESTS_RESULT: ${{ needs.cpu-tests.result }}
+        run: |
+          set -euo pipefail
+          echo "precheck=$PRECHECK_RESULT cpu-tests=$TESTS_RESULT"
+          if [ "$PRECHECK_RESULT" != "success" ]; then
+            echo "Pre-check did not succeed."
+            exit 1
+          fi
+          case "$TESTS_RESULT" in
+            success|skipped) echo "OK" ;;
+            *) exit 1 ;;
+          esac

--- a/.github/workflows/cpu_test.yml
+++ b/.github/workflows/cpu_test.yml
@@ -37,10 +37,16 @@ jobs:
     # If the PR branch already contains every commit on the base ref, the
     # merge would fast-forward and the merge tree equals the head tree that
     # `push` already tested. For `push` / `workflow_dispatch`, always run.
-    if: >-
-      github.event_name != 'pull_request'
-      || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
-      || github.event.pull_request.user.login == 'claude[bot]'
+    #
+    # Safe to run on any author: this job only hits the GitHub compare API,
+    # it does not check out fork code. The author-association gate is on
+    # `cpu-tests` below so fork PRs still skip the runner-heavy job.
+    #
+    # Note: we infer "push covered this tree" purely from the FF compare
+    # status; we don't query the push workflow's actual conclusion for the
+    # same SHA. In practice push lands after the PR's skip-path status job,
+    # so branch protection sees push's real result. If `push` is ever
+    # gated/filtered so it doesn't fire for a SHA, revisit this assumption.
     name: Pre-check
     runs-on: ubuntu-latest
     outputs:
@@ -80,7 +86,15 @@ jobs:
 
   cpu-tests:
     needs: precheck
-    if: needs.precheck.outputs.run-tests == 'true'
+    # Block PRs from non-org accounts to keep fork code off our runners.
+    # `push` and `workflow_dispatch` already require write access, so the
+    # short-circuit lets them through unchanged. A skipped job counts as a
+    # passing required check, which preserves the pre-PR behaviour for forks.
+    if: >-
+      needs.precheck.outputs.run-tests == 'true'
+      && (github.event_name != 'pull_request'
+          || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+          || github.event.pull_request.user.login == 'claude[bot]')
     name: CPU Tests
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -22,14 +22,55 @@ permissions:
   contents: read
 
 jobs:
-  pre-commit:
-    # Block PRs from non-org accounts to keep fork code off our runners.
-    # `push` already requires write access, so the short-circuit lets it
-    # through unchanged.
+  precheck:
+    # Decide whether the `pull_request` run is redundant with the `push` run.
+    # If the PR branch already contains every commit on the base ref, the
+    # merge would fast-forward and the merge tree equals the head tree that
+    # `push` already linted. For `push`, always run.
     if: >-
       github.event_name != 'pull_request'
       || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
       || github.event.pull_request.user.login == 'claude[bot]'
+    name: Pre-check
+    runs-on: ubuntu-latest
+    outputs:
+      run-tests: ${{ steps.decide.outputs.run-tests }}
+    steps:
+      - name: Decide whether to run pre-commit
+        id: decide
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            echo "Event=$EVENT_NAME; always run."
+            echo "run-tests=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          status=$(curl -fsSL \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${REPO}/compare/${BASE_SHA}...${HEAD_SHA}" \
+            | jq -r '.status' || echo "unknown")
+          echo "Compare status: $status"
+          case "$status" in
+            identical|ahead)
+              echo "Head contains base; push run already covered this tree. Skipping."
+              echo "run-tests=false" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Head does not strictly contain base; running."
+              echo "run-tests=true" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+  pre-commit:
+    needs: precheck
+    if: needs.precheck.outputs.run-tests == 'true'
     name: Pre-commit Hooks
     runs-on: ubuntu-latest
     steps:
@@ -59,3 +100,28 @@ jobs:
       - name: Run pre-commit
         run: |
           pre-commit run --all-files
+
+  status:
+    # Stable status check for branch protection. Passes when `pre-commit`
+    # succeeded OR was skipped because `precheck` determined the push run
+    # already covered this tree. Point required-status-checks at this job.
+    needs: [precheck, pre-commit]
+    if: always()
+    name: Pre-commit Status
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report aggregated result
+        env:
+          PRECHECK_RESULT: ${{ needs.precheck.result }}
+          HOOKS_RESULT: ${{ needs.pre-commit.result }}
+        run: |
+          set -euo pipefail
+          echo "precheck=$PRECHECK_RESULT pre-commit=$HOOKS_RESULT"
+          if [ "$PRECHECK_RESULT" != "success" ]; then
+            echo "Pre-check did not succeed."
+            exit 1
+          fi
+          case "$HOOKS_RESULT" in
+            success|skipped) echo "OK" ;;
+            *) exit 1 ;;
+          esac

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -27,10 +27,16 @@ jobs:
     # If the PR branch already contains every commit on the base ref, the
     # merge would fast-forward and the merge tree equals the head tree that
     # `push` already linted. For `push`, always run.
-    if: >-
-      github.event_name != 'pull_request'
-      || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
-      || github.event.pull_request.user.login == 'claude[bot]'
+    #
+    # Safe to run on any author: this job only hits the GitHub compare API,
+    # it does not check out fork code. The author-association gate is on
+    # `pre-commit` below so fork PRs still skip the runner-heavy job.
+    #
+    # Note: we infer "push covered this tree" purely from the FF compare
+    # status; we don't query the push workflow's actual conclusion for the
+    # same SHA. In practice push lands after the PR's skip-path status job,
+    # so branch protection sees push's real result. If `push` is ever
+    # gated/filtered so it doesn't fire for a SHA, revisit this assumption.
     name: Pre-check
     runs-on: ubuntu-latest
     outputs:
@@ -70,7 +76,15 @@ jobs:
 
   pre-commit:
     needs: precheck
-    if: needs.precheck.outputs.run-tests == 'true'
+    # Block PRs from non-org accounts to keep fork code off our runners.
+    # `push` already requires write access, so the short-circuit lets it
+    # through unchanged. A skipped job counts as a passing required check,
+    # which preserves the pre-PR behaviour for forks.
+    if: >-
+      needs.precheck.outputs.run-tests == 'true'
+      && (github.event_name != 'pull_request'
+          || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+          || github.event.pull_request.user.login == 'claude[bot]')
     name: Pre-commit Hooks
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## What this does
On every PR push, both `push` and `pull_request` events fire and we currently run the CPU test suite and pre-commit hooks twice against the same tree. This PR adds a `precheck` job to `cpu_test.yml` and `pre-commit.yml` that calls the GitHub compare API; when the PR head already contains every commit on the base ref (`status` is `identical` or `ahead`), merging would fast-forward and the merge tree equals the head tree that the `push` run already validated, so the test job is skipped.

A new `status` job (`CPU Tests Status` / `Pre-commit Status`) always runs and aggregates the result — it passes when the underlying job succeeded or was skipped because of the precheck, and fails otherwise. Branch-protection required checks should be flipped from `CPU Tests` / `Pre-commit Hooks` to `CPU Tests Status` / `Pre-commit Status` so the skip path doesn't block merges.

When the PR branch is behind base (`status` is `behind` or `diverged`), the `pull_request` run still executes — it's the only one that exercises the merge commit's tree.

Label: ⚡️ Performance.

## How it was tested
- `pre-commit run --files .github/workflows/cpu_test.yml .github/workflows/pre-commit.yml` — all hooks pass, including `zizmor` (GHA security linter) and `check yaml`.
- Logic walk-through:
  - `push` / `workflow_dispatch` → precheck short-circuits with `run-tests=true` → test job runs → status passes.
  - PR up-to-date with base → compare returns `ahead`/`identical` → `run-tests=false` → test job skipped → status passes (skipped is treated as success).
  - PR behind base → compare returns `behind`/`diverged` → `run-tests=true` → test job runs → status reflects its result.
  - Compare API failure or unknown status → defaults to `run-tests=true` (fail-safe).
- End-to-end verification will land on this PR itself once CI runs: the first push triggers the `push` workflow; opening the PR triggers the `pull_request` workflow, which should hit the `ahead`/`identical` skip path on subsequent in-sync syncs.

## How to checkout & try? (for the reviewer)
```bash
git fetch origin claude/youthful-allen-HJFwj
git checkout claude/youthful-allen-HJFwj
# Inspect the two workflow files:
git diff main -- .github/workflows/cpu_test.yml .github/workflows/pre-commit.yml
```
Then watch this PR's Actions tab — the `Pre-check` job should report `Compare status: ahead` (or `identical`) and the downstream `CPU Tests` / `Pre-commit Hooks` jobs should be skipped, while the `push`-triggered runs should execute normally.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_012owBv9nE5Y5K7iHWqTwYuQ)_