### PR TITLE
feat(policies): per-dataset normalization + skip-stats safetensors flag

### DIFF
--- a/src/opentau/configs/default.py
+++ b/src/opentau/configs/default.py
@@ -510,6 +510,16 @@ class EvalConfig:
 
     recording_root: str | None = None
 
+    # Which training-time dataset's normalization stats to use when calling
+    # `policy.select_action` on eval observations. ``None`` (default) falls
+    # through to the policy's `_resolve_dataset_index` single-dataset fallback
+    # (works for any policy trained on exactly one dataset). Set this to one
+    # of the strings in `policy.config.dataset_names` when running eval
+    # against a multi-dataset checkpoint, otherwise the inference call will
+    # raise a `KeyError`. Plumbed into each `select_action` call by
+    # `scripts/eval.py::rollout`.
+    dataset_repo_id: str | None = None
+
     def __post_init__(self):
         """Validate evaluation configuration."""
         if self.batch_size > self.n_episodes:

--- a/src/opentau/configs/deployment.py
+++ b/src/opentau/configs/deployment.py
@@ -50,6 +50,13 @@ class ServerConfig:
     max_workers: int = 4
     max_send_message_length_mb: int = 100
     max_receive_message_length_mb: int = 100
+    # Which training-time dataset's normalization stats to use for inference
+    # requests. ``None`` (default) falls through to the policy's
+    # `_resolve_dataset_index` single-dataset fallback (works for any
+    # checkpoint trained on exactly one dataset). Set this to one of the
+    # strings in `policy.config.dataset_names` when serving a multi-dataset
+    # checkpoint, otherwise the inference call will raise `KeyError`.
+    dataset_repo_id: str | None = None
 
     def __post_init__(self):
         """Validate server configuration parameters."""

--- a/src/opentau/configs/policies.py
+++ b/src/opentau/configs/policies.py
@@ -283,6 +283,19 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):
     use_amp: bool = False
     pretrained_path: str | None = None
 
+    # When False, `_save_pretrained` strips normalize_*.buffer_* / unnormalize_*.buffer_*
+    # keys from the state_dict before writing model.safetensors. Reloading then requires
+    # the caller to pass `ds_meta=` (or `stats=`) to `make_policy` so the buffers can be
+    # repopulated; otherwise the inf-init assertion fires at first forward.
+    save_normalization_stats: bool = True
+
+    # Ordered list of dataset names this policy was trained on. Used by the per-sample
+    # Normalize/Unnormalize indexing path to map an inference-time
+    # `batch["dataset_repo_id"]` (str) into the leading dim of the stacked stats
+    # buffers. `None` only for policies constructed outside the standard
+    # `make_policy(ds_meta=...)` path (e.g. legacy single-stats fallbacks).
+    dataset_names: list[str] | None = None
+
     # Deprecated: latency fields are no longer used. Kept for backward-compatible
     # loading of old JSON configs. Must remain 0.0; non-zero values will raise.
     cloud_vlm_latency_mean: float = 0.0

--- a/src/opentau/datasets/dataset_mixture.py
+++ b/src/opentau/datasets/dataset_mixture.py
@@ -72,12 +72,58 @@ from typing import List, Optional
 
 import numpy as np
 import torch
-from torch.utils.data import ConcatDataset, DataLoader, Sampler
+from torch.utils.data import ConcatDataset, DataLoader, Dataset, Sampler
 
 from opentau.configs.train import TrainPipelineConfig
 from opentau.datasets.compute_stats import aggregate_stats
 from opentau.datasets.lerobot_dataset import BaseDataset, DatasetMetadata
 from opentau.datasets.standard_data_format_mapping import DATA_FEATURES_NAME_MAPPING
+
+
+class _TaggedDataset(Dataset):
+    """Wraps a ``BaseDataset`` so every sample carries its mixture-level identity.
+
+    The wrapped sample dict gains two keys:
+
+      - ``"dataset_repo_id"``: ``str`` — the deduplicated mixture-level name
+        (matches an entry in ``DatasetMixtureMetadata.dataset_names``).
+        Default PyTorch collate batches a per-sample ``str`` into a
+        ``list[str]`` of length B.
+      - ``"dataset_index"``: ``torch.long`` scalar — the position of this
+        dataset in ``DatasetMixtureMetadata.dataset_names``. Default collate
+        stacks into a ``(B,)`` long tensor.
+
+    Policies read either key via ``PreTrainedPolicy._resolve_dataset_index``
+    and route per-sample into the stacked Normalize/Unnormalize buffers.
+
+    The wrapper exposes the underlying dataset's ``.meta`` so callers of
+    ``WeightedDatasetMixture`` (e.g. metadata validation, per-dataset val
+    loaders) keep working unchanged. ``len`` delegates as well.
+    """
+
+    def __init__(self, base: Dataset, dataset_repo_id: str, dataset_index: int):
+        self._base = base
+        self._dataset_repo_id = dataset_repo_id
+        # Pre-build the scalar long tensor once so __getitem__ doesn't
+        # allocate per call.
+        self._dataset_index_tensor = torch.tensor(int(dataset_index), dtype=torch.long)
+        # Preserve `.meta` so `WeightedDatasetMixture.__init__`'s validation
+        # (`hasattr(ds, "meta") and ds.meta is not None`) still works after
+        # wrapping. `Subset` / `random_split` produce wrappers without a
+        # `.meta`, so look one level deeper if needed.
+        meta = getattr(base, "meta", None)
+        if meta is None and hasattr(base, "dataset"):
+            meta = getattr(base.dataset, "meta", None)
+        self.meta = meta
+
+    def __len__(self) -> int:
+        return len(self._base)
+
+    def __getitem__(self, idx):
+        item = self._base[idx]
+        item["dataset_repo_id"] = self._dataset_repo_id
+        item["dataset_index"] = self._dataset_index_tensor
+        return item
 
 
 def pad_vector(vector: np.ndarray, new_dim: int) -> np.ndarray:
@@ -114,21 +160,82 @@ def _apply_data_feature_name_mapping_overrides(
 
 
 class DatasetMixtureMetadata:
-    """A class to hold metadata for a mixture of datasets.
+    """Per-dataset metadata for a mixture (no cross-dataset stat aggregation).
 
-    This is used to aggregate metadata from multiple datasets into a single object.
+    Each underlying dataset's stats are normalised into the standard data
+    format (feature renaming, state/action padding to ``cfg.max_state_dim`` /
+    ``cfg.max_action_dim``, missing-camera zero placeholders) and kept
+    *separate* on ``self.per_dataset_stats``. The policy's Normalize /
+    Unnormalize layers stack these along a new leading dim and use a
+    per-sample ``dataset_index`` to select the right row.
+
+    Attributes:
+        per_dataset_stats: ``list[dict[str, dict[str, np.ndarray]]]`` ordered
+            to match ``dataset_names``. ``per_dataset_stats[i]`` is the
+            standardised stats dict for dataset ``dataset_names[i]``.
+        dataset_names: Ordered deduplicated mixture-level names (matches
+            ``WeightedDatasetMixture._make_dataset_names`` output).
+        dataset_name_to_index: ``{name: i}`` reverse lookup for O(1)
+            inference-time resolution.
     """
 
     def __init__(
-        self, cfg: TrainPipelineConfig, metadatas: List[DatasetMetadata], dataset_weights: List[float]
+        self,
+        cfg: TrainPipelineConfig,
+        metadatas: List[DatasetMetadata],
+        dataset_weights: List[float],
+        dataset_names: List[str] | None = None,
     ):
         self.cfg = cfg
+        self._dataset_weights = list(dataset_weights)
 
         # convert each metadata stats to the standard data format
         for metadata in metadatas:
             metadata.stats = self._to_standard_data_format(metadata.repo_id, metadata.stats)
 
-        self.stats = aggregate_stats([metadata.stats for metadata in metadatas], weights=dataset_weights)
+        # Per-dataset stats (no cross-dataset aggregation). Policies stack
+        # these along a leading axis and index per-sample.
+        self.per_dataset_stats: list[dict[str, dict[str, np.ndarray]]] = [m.stats for m in metadatas]
+
+        # Names default to repo_id when WeightedDatasetMixture didn't supply
+        # deduplicated names (e.g. tests that instantiate the metadata
+        # directly). Duplicates would break the str -> index mapping; surface
+        # them rather than silently keeping the last one.
+        if dataset_names is None:
+            dataset_names = [m.repo_id for m in metadatas]
+        if len(dataset_names) != len(metadatas):
+            raise ValueError(f"dataset_names ({len(dataset_names)}) must match metadatas ({len(metadatas)}).")
+        if len(set(dataset_names)) != len(dataset_names):
+            dups = [n for n in dataset_names if dataset_names.count(n) > 1]
+            raise ValueError(
+                f"dataset_names must be unique; got duplicates {sorted(set(dups))}. "
+                "Use WeightedDatasetMixture's `_make_dataset_names` which appends "
+                "`#N` suffixes for repeated repo ids."
+            )
+        self.dataset_names: list[str] = list(dataset_names)
+        self.dataset_name_to_index: dict[str, int] = {n: i for i, n in enumerate(self.dataset_names)}
+
+    def aggregated_action_stats(self) -> dict[str, np.ndarray]:
+        """Single mixture-wide action stats (mean/std/min/max/count).
+
+        Backwards-compat helper for the rare consumers that genuinely need a
+        single set of action stats across the whole mixture — currently only
+        ``fit_fast_tokenizer.py``, which fits one BPE codec over a global
+        action range. Most callers should consume ``per_dataset_stats`` /
+        ``dataset_names`` directly.
+        """
+        stats_with_actions = [s for s in self.per_dataset_stats if "actions" in s]
+        if not stats_with_actions:
+            raise ValueError(
+                "No dataset in the mixture exposes 'actions' stats; aggregated_action_stats() is undefined."
+            )
+        # `aggregate_stats` walks every feature key across every dataset;
+        # pull just the "actions" sub-dicts so the call is cheap.
+        agg = aggregate_stats(
+            [{"actions": s["actions"]} for s in stats_with_actions],
+            weights=self._dataset_weights[: len(stats_with_actions)],
+        )
+        return agg["actions"]
 
     def _to_standard_data_format(
         self, repo_id: str, stats: dict[str, dict[str, np.ndarray]]
@@ -372,16 +479,30 @@ class WeightedDatasetMixture:
             )
 
         self.cfg = cfg
-        self.datasets = datasets
-        self.dataset_weights = dataset_weights
         # Common resample rate (Hz); None = mixed-frequency (native fps per dataset).
         self.action_freq: Optional[float] = action_freq
-        self.dataset_names = self._make_dataset_names(cfg, datasets)  # For logging
+        self.dataset_weights = dataset_weights
+        self.dataset_names = self._make_dataset_names(cfg, datasets)  # For logging + tagging
+
+        # Validate meta presence on the UN-wrapped inputs (so the error
+        # message points to the real source) before wrapping.
+        if not all(hasattr(ds, "meta") and ds.meta is not None for ds in datasets):
+            raise ValueError("All datasets must have a 'meta' attribute with valid metadata.")
+
+        # Wrap every underlying dataset so __getitem__ injects
+        # `dataset_repo_id: str` and `dataset_index: torch.long`. The policy's
+        # Normalize/Unnormalize uses these to gather per-sample stats.
+        # `_TaggedDataset` preserves `.meta` so `get_per_dataset_dataloaders`
+        # and other consumers keep working.
+        self.datasets = [
+            _TaggedDataset(ds, name, idx)
+            for idx, (ds, name) in enumerate(zip(datasets, self.dataset_names, strict=True))
+        ]
 
         logging.info("Initializing WeightedDatasetMixture...")
         self._log_dataset_info()
 
-        self.concatenated_dataset: ConcatDataset = ConcatDataset(datasets)
+        self.concatenated_dataset: ConcatDataset = ConcatDataset(self.datasets)
         logging.info(f"Total length of concatenated dataset: {len(self.concatenated_dataset)}")
 
         self.sample_weights: torch.Tensor = self._calculate_sample_weights()
@@ -394,10 +515,12 @@ class WeightedDatasetMixture:
             )
         logging.info("-" * 30)
 
-        # aggregate metadata
-        if not all(hasattr(ds, "meta") and ds.meta is not None for ds in datasets):
-            raise ValueError("All datasets must have a 'meta' attribute with valid metadata.")
-        self.meta = DatasetMixtureMetadata(cfg, [ds.meta for ds in datasets], dataset_weights)
+        self.meta = DatasetMixtureMetadata(
+            cfg,
+            [ds.meta for ds in datasets],
+            dataset_weights,
+            dataset_names=self.dataset_names,
+        )
 
     @staticmethod
     def _make_dataset_names(cfg: TrainPipelineConfig, datasets: List[BaseDataset]) -> List[str]:

--- a/src/opentau/datasets/dataset_mixture.py
+++ b/src/opentau/datasets/dataset_mixture.py
@@ -224,16 +224,24 @@ class DatasetMixtureMetadata:
         action range. Most callers should consume ``per_dataset_stats`` /
         ``dataset_names`` directly.
         """
-        stats_with_actions = [s for s in self.per_dataset_stats if "actions" in s]
-        if not stats_with_actions:
+        # Co-iterate stats and weights so a non-trailing dataset lacking
+        # ``actions`` keeps the weight alignment correct. Slicing
+        # ``self._dataset_weights[:N]`` would silently misalign if e.g.
+        # `per_dataset_stats[1]` lacked actions — the BPE codec would then
+        # fit a weighted mean using dataset 0's weight applied to dataset 2's
+        # action distribution.
+        filtered: list[tuple[dict[str, np.ndarray], float]] = [
+            ({"actions": s["actions"]}, w)
+            for s, w in zip(self.per_dataset_stats, self._dataset_weights, strict=True)
+            if "actions" in s
+        ]
+        if not filtered:
             raise ValueError(
                 "No dataset in the mixture exposes 'actions' stats; aggregated_action_stats() is undefined."
             )
-        # `aggregate_stats` walks every feature key across every dataset;
-        # pull just the "actions" sub-dicts so the call is cheap.
         agg = aggregate_stats(
-            [{"actions": s["actions"]} for s in stats_with_actions],
-            weights=self._dataset_weights[: len(stats_with_actions)],
+            [s for s, _ in filtered],
+            weights=[w for _, w in filtered],
         )
         return agg["actions"]
 

--- a/src/opentau/policies/factory.py
+++ b/src/opentau/policies/factory.py
@@ -215,17 +215,44 @@ def make_policy(
     policy_cls = get_policy_class(cfg.type)
 
     kwargs = {}
+    per_dataset_stats: list[dict[str, dict[str, np.ndarray]]] | None = None
+    dataset_names: list[str] | None = None
 
     if ds_meta is not None:
         features = dataset_to_policy_features(ds_meta.features)
-        kwargs["dataset_stats"] = ds_meta.stats
+        # `DatasetMixtureMetadata` exposes per-dataset stats + names; a bare
+        # `LeRobotDatasetMetadata` (single-dataset path, e.g. some scripts /
+        # tests) exposes only `.stats` — wrap it into a singleton list so the
+        # policy ctor sees a uniform shape.
+        if hasattr(ds_meta, "per_dataset_stats") and hasattr(ds_meta, "dataset_names"):
+            per_dataset_stats = list(ds_meta.per_dataset_stats)
+            dataset_names = list(ds_meta.dataset_names)
+        else:
+            per_dataset_stats = [ds_meta.stats]
+            dataset_names = [getattr(ds_meta, "repo_id", "default")]
 
     if not features_already_set:
         cfg.output_features = {key: ft for key, ft in features.items() if ft.type is FeatureType.ACTION}
         cfg.input_features = {key: ft for key, ft in features.items() if key not in cfg.output_features}
 
     if stats is not None:
-        kwargs["dataset_stats"] = stats
+        # External per-dataset stats override. Accept either a single
+        # dict-of-features (wrapped into a singleton list) or an already-
+        # listed `per_dataset_stats`.
+        if isinstance(stats, dict):
+            per_dataset_stats = [stats]
+            dataset_names = dataset_names or ["external"]
+        else:
+            per_dataset_stats = list(stats)
+            dataset_names = dataset_names or [f"external_{i}" for i in range(len(per_dataset_stats))]
+
+    if per_dataset_stats is not None:
+        kwargs["per_dataset_stats"] = per_dataset_stats
+        kwargs["dataset_names"] = dataset_names
+        # Persist the ordered name list into the policy config so it survives
+        # save -> load. Inference-time `batch["dataset_repo_id"]` strings are
+        # resolved against this list.
+        cfg.dataset_names = list(dataset_names)
 
     if execution_target is not None:
         kwargs["execution_target"] = execution_target
@@ -242,6 +269,15 @@ def make_policy(
         policy = policy_cls(**kwargs)
 
     assert isinstance(policy, nn.Module)
+
+    # If the checkpoint was saved with save_normalization_stats=False the
+    # buffers loaded back as +inf — repopulate from the caller's stats if we
+    # have them, otherwise raise a clear error rather than letting the first
+    # forward fail mid-step.
+    if cfg.pretrained_path and per_dataset_stats is not None:
+        policy._inject_stats(per_dataset_stats, dataset_names=dataset_names)
+    elif cfg.pretrained_path:
+        policy._check_norm_stats_loaded()
 
     # policy = torch.compile(policy, mode="reduce-overhead")
 

--- a/src/opentau/policies/normalize.py
+++ b/src/opentau/policies/normalize.py
@@ -230,6 +230,17 @@ def _gather_and_broadcast(stat: Tensor, dataset_index: Tensor, batch_val: Tensor
     """
     gathered = stat.index_select(0, dataset_index)  # (B, *feat_shape)
     extra = batch_val.ndim - gathered.ndim
+    if extra < 0:
+        # Batch tensor has fewer dims than the buffer — silent broadcasting
+        # would produce a shape mismatch later, or worse, broadcast along
+        # the wrong axis. Surface this loudly so the misconfiguration is
+        # caught at the feature in question rather than mid-step.
+        raise ValueError(
+            f"Stats buffer rank ({gathered.ndim}) exceeds batch tensor rank "
+            f"({batch_val.ndim}); expected batch_val to have at least as many "
+            f"dims as the (D, *feat_shape) buffer. Stats shape={tuple(stat.shape)}, "
+            f"gathered shape={tuple(gathered.shape)}, batch shape={tuple(batch_val.shape)}."
+        )
     if extra > 0:
         gathered = gathered.reshape(gathered.shape[0], *((1,) * extra), *gathered.shape[1:])
     return gathered

--- a/src/opentau/policies/normalize.py
+++ b/src/opentau/policies/normalize.py
@@ -14,11 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Normalization and Unnormalization utilities for policies.
+"""Per-dataset Normalize / Unnormalize for VLA policies.
 
-This module provides classes and functions to normalize and unnormalize data
-(e.g., observations and actions) based on statistical properties (mean, std, min, max).
-It handles different normalization modes and supports creating buffers for statistics.
+Each feature buffer has shape ``(D, *feat_shape)`` where ``D`` is the number of
+datasets the policy was trained on. ``forward`` accepts a per-sample
+``dataset_index: torch.LongTensor`` of shape ``(B,)`` and gathers the right
+row per sample before broadcasting.
 """
 
 import sys
@@ -50,10 +51,6 @@ def _materialize(tensor: Tensor) -> Tensor:
     a regular Tensor).
     """
     if hasattr(tensor, "full_tensor"):
-        # ``DTensor.full_tensor()`` materializes the (replicated or sharded)
-        # tensor into a single full Tensor on each rank. For replicated
-        # placements this is just a pointer-copy; for sharded ones it does
-        # an all-gather.
         return tensor.full_tensor()
     return tensor
 
@@ -75,29 +72,86 @@ def warn_missing_keys(features: dict[str, PolicyFeature], batch: dict[str, Tenso
         )
 
 
+def resolve_num_datasets(
+    per_dataset_stats: list | None,
+    dataset_names: list | None,
+    config,
+) -> int:
+    """Decide the leading dim for the stacked stats buffers.
+
+    Preference order:
+        1. ``len(per_dataset_stats)`` if provided.
+        2. ``len(dataset_names)`` if provided.
+        3. ``len(config.dataset_names)`` if the policy config remembers a
+           trained-on list (checkpoint-load construction path).
+        4. ``1`` — legacy single-dataset default.
+    """
+    if per_dataset_stats is not None:
+        return len(per_dataset_stats)
+    if dataset_names is not None:
+        return len(dataset_names)
+    cfg_names = getattr(config, "dataset_names", None)
+    if cfg_names:
+        return len(cfg_names)
+    return 1
+
+
+def _stat_to_float32_tensor(value: np.ndarray | Tensor) -> Tensor:
+    """Convert one per-dataset stat (np or torch) to a float32 ``Tensor``.
+
+    Mirrors the np/torch dispatch the legacy single-stats path used: caller
+    receives a fresh tensor (cloned for torch inputs) so the stacked buffer
+    doesn't alias the input.
+    """
+    if isinstance(value, np.ndarray):
+        return torch.from_numpy(value).to(dtype=torch.float32)
+    if isinstance(value, Tensor):
+        # Clone so the stacked buffer doesn't alias an input the caller may mutate.
+        return value.clone().to(dtype=torch.float32)
+    raise ValueError(f"np.ndarray or torch.Tensor expected, but type is '{type(value)}' instead.")
+
+
 def create_stats_buffers(
     features: dict[str, PolicyFeature],
     norm_map: dict[str, NormalizationMode],
-    stats: dict[str, dict[str, Tensor]] | None = None,
+    per_dataset_stats: list[dict[str, dict[str, Tensor | np.ndarray]]] | None = None,
+    num_datasets: int | None = None,
 ) -> dict[str, dict[str, nn.ParameterDict]]:
-    """
-    Create buffers per modality (e.g. "observation.image", "action") containing their mean, std, min, max
-    statistics.
+    """Create per-feature stat buffers shaped ``(D, *feat_shape)``.
 
     Args:
-        features: Dictionary mapping feature names to PolicyFeature objects.
-        norm_map: Dictionary mapping feature types to NormalizationMode.
-        stats: Optional dictionary containing pre-computed statistics (mean, std, min, max)
-            for each feature. If None, buffers are initialized with infinity.
+        features: Mapping feature name -> PolicyFeature.
+        norm_map: Mapping FeatureType -> NormalizationMode.
+        per_dataset_stats: Ordered list (one entry per dataset) of dicts shaped
+            ``{feature_name: {"mean": ..., "std": ...}}`` or ``{... "min": ..., "max": ...}``.
+            When ``None`` the buffers are initialised to ``+inf`` so the
+            assertion in ``Normalize.forward`` fires until a checkpoint load
+            or ``_inject_stats`` overwrites them.
+        num_datasets: Required when ``per_dataset_stats is None``; ignored
+            otherwise. Sets the leading dim of the inf-init buffers.
 
     Returns:
-        dict: A dictionary where keys are modalities and values are `nn.ParameterDict` containing
-            `nn.Parameters` set to `requires_grad=False`, suitable to not be updated during backpropagation.
-
-    Raises:
-        ValueError: If stats contain types other than np.ndarray or torch.Tensor.
+        dict feature_name -> nn.ParameterDict({"mean": param, "std": param}) etc.
     """
-    stats_buffers = {}
+    if per_dataset_stats is None and num_datasets is None:
+        raise ValueError(
+            "create_stats_buffers requires either `per_dataset_stats` or `num_datasets` "
+            "so the stacked stats buffers can be sized correctly."
+        )
+    if per_dataset_stats is not None:
+        num_ds = len(per_dataset_stats)
+        if num_ds == 0:
+            raise ValueError("per_dataset_stats must contain at least one dataset.")
+        if num_datasets is not None and num_datasets != num_ds:
+            raise ValueError(
+                f"num_datasets ({num_datasets}) disagrees with len(per_dataset_stats) ({num_ds})."
+            )
+    else:
+        num_ds = num_datasets
+        if num_ds <= 0:
+            raise ValueError(f"num_datasets must be positive, got {num_ds}.")
+
+    stats_buffers: dict[str, nn.ParameterDict] = {}
 
     for key, ft in features.items():
         norm_mode = norm_map.get(ft.type, NormalizationMode.IDENTITY)
@@ -109,153 +163,166 @@ def create_stats_buffers(
         shape = tuple(ft.shape)
 
         if ft.type is FeatureType.VISUAL:
-            # sanity checks
             assert len(shape) == 3, f"number of dimensions of {key} != 3 ({shape=}"
             c, h, w = shape
             assert c < h and c < w, f"{key} is not channel first ({shape=})"
             # override image shape to be invariant to height and width
             shape = (c, 1, 1)
 
-        # Note: we initialize mean, std, min, max to infinity. They should be overwritten
-        # downstream by `stats` or `policy.load_state_dict`, as expected. During forward,
-        # we assert they are not infinity anymore.
+        stacked_shape = (num_ds, *shape)
 
-        buffer = {}
         if norm_mode is NormalizationMode.MEAN_STD:
-            mean = torch.ones(shape, dtype=torch.float32) * torch.inf
-            std = torch.ones(shape, dtype=torch.float32) * torch.inf
-            buffer = nn.ParameterDict(
-                {
-                    "mean": nn.Parameter(mean, requires_grad=False),
-                    "std": nn.Parameter(std, requires_grad=False),
-                }
-            )
+            stat_names = ("mean", "std")
         elif norm_mode is NormalizationMode.MIN_MAX:
-            min = torch.ones(shape, dtype=torch.float32) * torch.inf
-            max = torch.ones(shape, dtype=torch.float32) * torch.inf
-            buffer = nn.ParameterDict(
-                {
-                    "min": nn.Parameter(min, requires_grad=False),
-                    "max": nn.Parameter(max, requires_grad=False),
-                }
-            )
+            stat_names = ("min", "max")
+        else:
+            raise ValueError(norm_mode)
 
-        # TODO(aliberts, rcadene): harmonize this to only use one framework (np or torch)
-        if stats:
-            if isinstance(stats[key]["mean"], np.ndarray):
-                if norm_mode is NormalizationMode.MEAN_STD:
-                    buffer["mean"].data = torch.from_numpy(stats[key]["mean"]).to(dtype=torch.float32)
-                    buffer["std"].data = torch.from_numpy(stats[key]["std"]).to(dtype=torch.float32)
-                elif norm_mode is NormalizationMode.MIN_MAX:
-                    buffer["min"].data = torch.from_numpy(stats[key]["min"]).to(dtype=torch.float32)
-                    buffer["max"].data = torch.from_numpy(stats[key]["max"]).to(dtype=torch.float32)
-            elif isinstance(stats[key]["mean"], torch.Tensor):
-                # Note: The clone is needed to make sure that the logic in save_pretrained doesn't see duplicated
-                # tensors anywhere (for example, when we use the same stats for normalization and
-                # unnormalization). See the logic here
-                # https://github.com/huggingface/safetensors/blob/079781fd0dc455ba0fe851e2b4507c33d0c0d407/bindings/python/py_src/safetensors/torch.py#L97.
-                if norm_mode is NormalizationMode.MEAN_STD:
-                    buffer["mean"].data = stats[key]["mean"].clone().to(dtype=torch.float32)
-                    buffer["std"].data = stats[key]["std"].clone().to(dtype=torch.float32)
-                elif norm_mode is NormalizationMode.MIN_MAX:
-                    buffer["min"].data = stats[key]["min"].clone().to(dtype=torch.float32)
-                    buffer["max"].data = stats[key]["max"].clone().to(dtype=torch.float32)
+        params: dict[str, nn.Parameter] = {}
+        for name in stat_names:
+            if per_dataset_stats is None:
+                # Inf-init across all D rows. Asserted-finite at forward time.
+                tensor = torch.full(stacked_shape, torch.inf, dtype=torch.float32)
             else:
-                type_ = type(stats[key]["mean"])
-                raise ValueError(f"np.ndarray or torch.Tensor expected, but type is '{type_}' instead.")
+                rows = []
+                for i, ds_stats in enumerate(per_dataset_stats):
+                    if key not in ds_stats:
+                        raise KeyError(
+                            f"per_dataset_stats[{i}] is missing feature '{key}'. "
+                            f"Available keys: {list(ds_stats)}."
+                        )
+                    if name not in ds_stats[key]:
+                        raise KeyError(
+                            f"per_dataset_stats[{i}]['{key}'] is missing stat '{name}'. "
+                            f"Available stats: {list(ds_stats[key])}."
+                        )
+                    row = _stat_to_float32_tensor(ds_stats[key][name])
+                    if tuple(row.shape) != shape:
+                        raise ValueError(
+                            f"per_dataset_stats[{i}]['{key}']['{name}'] has shape "
+                            f"{tuple(row.shape)}, expected {shape}."
+                        )
+                    rows.append(row)
+                tensor = torch.stack(rows, dim=0)
+            params[name] = nn.Parameter(tensor, requires_grad=False)
 
-        stats_buffers[key] = buffer
+        stats_buffers[key] = nn.ParameterDict(params)
     return stats_buffers
 
 
 def _no_stats_error_str(name: str) -> str:
-    """Returns an error message string for missing statistics.
-
-    Args:
-        name: Name of the statistic (e.g., "mean", "std").
-
-    Returns:
-        str: The error message string.
-    """
     return (
-        f"`{name}` is infinity. You should either initialize with `stats` as an argument, or use a "
-        "pretrained model."
+        f"`{name}` is infinity. You should either initialize with `per_dataset_stats` as an "
+        "argument, call `policy._inject_stats(...)`, or load a pretrained model that contains "
+        "the normalization buffers."
     )
 
 
+def _gather_and_broadcast(stat: Tensor, dataset_index: Tensor, batch_val: Tensor) -> Tensor:
+    """Index the stacked stat by per-sample dataset and broadcast to the batch tensor.
+
+    ``stat`` is shape ``(D, *feat_shape)``. After ``index_select`` we get
+    ``(B, *feat_shape)``. If ``batch_val`` has extra interior dims (temporal
+    history axis, or full spatial HxW for an image batch), we pad ``mean``
+    with 1-axes between the batch axis and the feature axes so broadcasting
+    aligns. ``reshape`` with computed dims is used here rather than einops
+    because the inserted axis count is data-dependent and varies per-feature.
+    """
+    gathered = stat.index_select(0, dataset_index)  # (B, *feat_shape)
+    extra = batch_val.ndim - gathered.ndim
+    if extra > 0:
+        gathered = gathered.reshape(gathered.shape[0], *((1,) * extra), *gathered.shape[1:])
+    return gathered
+
+
 class Normalize(nn.Module):
-    """Normalizes data (e.g. "observation.image") for more stable and faster convergence during training."""
+    """Normalizes data (e.g. ``observation.image``) per-sample using the row of the
+    stacked stat buffer selected by ``dataset_index``.
+    """
 
     def __init__(
         self,
         features: dict[str, PolicyFeature],
         norm_map: dict[str, NormalizationMode],
-        stats: dict[str, dict[str, Tensor]] | None = None,
+        per_dataset_stats: list[dict[str, dict[str, Tensor | np.ndarray]]] | None = None,
+        dataset_names: list[str] | None = None,
+        num_datasets: int | None = None,
     ):
         """Initializes the Normalize module.
 
         Args:
-            features: A dictionary where keys are input modalities (e.g. "observation.image") and values
-                are their PolicyFeature definitions.
-            norm_map: A dictionary where keys are feature types and values are their normalization modes.
-            stats: A dictionary where keys are output modalities (e.g. "observation.image")
-                and values are dictionaries of statistic types and their values (e.g.
-                `{"mean": torch.randn(3,1,1)}, "std": torch.randn(3,1,1)}`). If provided, as expected for
-                training the model for the first time, these statistics will overwrite the default buffers. If
-                not provided, as expected for finetuning or evaluation, the default buffers should to be
-                overwritten by a call to `policy.load_state_dict(state_dict)`. That way, initializing the
-                dataset is not needed to get the stats, since they are already in the policy state_dict.
+            features: Mapping feature name -> PolicyFeature.
+            norm_map: Mapping FeatureType -> NormalizationMode.
+            per_dataset_stats: Ordered list of per-dataset stat dicts. ``None``
+                during checkpoint-load construction (the safetensors load
+                overwrites the buffers afterwards); in that case
+                ``num_datasets`` must be supplied so the inf-init buffers have
+                the right leading dim.
+            dataset_names: Ordered list of dataset name strings, parallel to
+                ``per_dataset_stats``. Stored as a Python attribute, not a
+                buffer (strings aren't tensors). Persisted into ``config.json``
+                via ``PreTrainedConfig.dataset_names``.
+            num_datasets: Required when ``per_dataset_stats is None``.
         """
         super().__init__()
         self.features = features
         self.norm_map = norm_map
-        self.stats = stats
-        stats_buffers = create_stats_buffers(features, norm_map, stats)
+        self.dataset_names = list(dataset_names) if dataset_names is not None else None
+        if (
+            per_dataset_stats is not None
+            and dataset_names is not None
+            and len(per_dataset_stats) != len(dataset_names)
+        ):
+            raise ValueError(
+                f"per_dataset_stats and dataset_names must have the same length, got "
+                f"{len(per_dataset_stats)} vs {len(dataset_names)}."
+            )
+        stats_buffers = create_stats_buffers(
+            features, norm_map, per_dataset_stats=per_dataset_stats, num_datasets=num_datasets
+        )
         for key, buffer in stats_buffers.items():
             setattr(self, "buffer_" + key.replace(".", "_"), buffer)
 
-    # TODO(rcadene): should we remove torch.no_grad?
     @torch.no_grad
-    def forward(self, batch: dict[str, Tensor]) -> dict[str, Tensor]:
-        """Normalizes the batch data.
+    def forward(self, batch: dict[str, Tensor], dataset_index: Tensor) -> dict[str, Tensor]:
+        """Normalizes the batch data per-sample.
 
         Args:
             batch: Dictionary containing the data to normalize.
+            dataset_index: LongTensor of shape ``(B,)`` giving the source
+                dataset row for each sample.
 
         Returns:
-            dict[str, Tensor]: The normalized batch data.
-
-        Raises:
-            ValueError: If an unknown normalization mode is encountered.
+            The normalized batch (shallow-copied; inputs are not mutated).
         """
         warn_missing_keys(self.features, batch, "normalization")
-        batch = dict(batch)  # shallow copy avoids mutating the input batch
+        batch = dict(batch)
         for key, ft in self.features.items():
             if key not in batch:
-                # FIXME(aliberts, rcadene): This might lead to silent fail!
                 continue
 
             norm_mode = self.norm_map.get(ft.type, NormalizationMode.IDENTITY)
             if norm_mode is NormalizationMode.IDENTITY:
                 continue
 
-            if batch[key].numel() == 0:  # skip empty tensors, which won't broadcast well
+            batch_val = batch[key]
+            if batch_val.numel() == 0:  # skip empty tensors, which won't broadcast well
                 continue
 
             buffer = getattr(self, "buffer_" + key.replace(".", "_"))
 
             if norm_mode is NormalizationMode.MEAN_STD:
-                mean = _materialize(buffer["mean"])
-                std = _materialize(buffer["std"])
+                mean = _gather_and_broadcast(_materialize(buffer["mean"]), dataset_index, batch_val)
+                std = _gather_and_broadcast(_materialize(buffer["std"]), dataset_index, batch_val)
                 assert not torch.isinf(mean).any(), _no_stats_error_str("mean")
                 assert not torch.isinf(std).any(), _no_stats_error_str("std")
-                batch[key] = (batch[key] - mean) / (std + EPS)
+                batch[key] = (batch_val - mean) / (std + EPS)
             elif norm_mode is NormalizationMode.MIN_MAX:
-                min = _materialize(buffer["min"])
-                max = _materialize(buffer["max"])
-                assert not torch.isinf(min).any(), _no_stats_error_str("min")
-                assert not torch.isinf(max).any(), _no_stats_error_str("max")
-                batch[key] = (batch[key] - min) / (max - min + EPS)
+                min_ = _gather_and_broadcast(_materialize(buffer["min"]), dataset_index, batch_val)
+                max_ = _gather_and_broadcast(_materialize(buffer["max"]), dataset_index, batch_val)
+                assert not torch.isinf(min_).any(), _no_stats_error_str("min")
+                assert not torch.isinf(max_).any(), _no_stats_error_str("max")
+                batch[key] = (batch_val - min_) / (max_ - min_ + EPS)
                 # normalize to [-1, 1]
                 batch[key] = batch[key] * 2 - 1
             else:
@@ -264,52 +331,46 @@ class Normalize(nn.Module):
 
 
 class Unnormalize(nn.Module):
-    """
-    Similar to `Normalize` but unnormalizes output data (e.g. `{"action": torch.randn(b,c)}`) in their
-    original range used by the environment.
-    """
+    """Inverse of ``Normalize``: scales outputs back to the per-sample dataset range."""
 
     def __init__(
         self,
         features: dict[str, PolicyFeature],
         norm_map: dict[str, NormalizationMode],
-        stats: dict[str, dict[str, Tensor]] | None = None,
+        per_dataset_stats: list[dict[str, dict[str, Tensor | np.ndarray]]] | None = None,
+        dataset_names: list[str] | None = None,
+        num_datasets: int | None = None,
     ):
-        """Initializes the Unnormalize module.
-
-        Args:
-            features: A dictionary where keys are input modalities (e.g. "observation.image") and values
-                are their PolicyFeature definitions.
-            norm_map: A dictionary where keys are feature types and values are their normalization modes.
-            stats: A dictionary where keys are output modalities (e.g. "observation.image")
-                and values are dictionaries of statistic types and their values. If provided,
-                these statistics will overwrite the default buffers.
-        """
+        """See :class:`Normalize.__init__` for argument semantics."""
         super().__init__()
         self.features = features
         self.norm_map = norm_map
-        self.stats = stats
-        # `self.buffer_observation_state["mean"]` contains `torch.tensor(state_dim)`
-        stats_buffers = create_stats_buffers(features, norm_map, stats)
+        self.dataset_names = list(dataset_names) if dataset_names is not None else None
+        if (
+            per_dataset_stats is not None
+            and dataset_names is not None
+            and len(per_dataset_stats) != len(dataset_names)
+        ):
+            raise ValueError(
+                f"per_dataset_stats and dataset_names must have the same length, got "
+                f"{len(per_dataset_stats)} vs {len(dataset_names)}."
+            )
+        stats_buffers = create_stats_buffers(
+            features, norm_map, per_dataset_stats=per_dataset_stats, num_datasets=num_datasets
+        )
         for key, buffer in stats_buffers.items():
             setattr(self, "buffer_" + key.replace(".", "_"), buffer)
 
-    # TODO(rcadene): should we remove torch.no_grad?
     @torch.no_grad
-    def forward(self, batch: dict[str, Tensor]) -> dict[str, Tensor]:
-        """Unnormalizes the batch data.
+    def forward(self, batch: dict[str, Tensor], dataset_index: Tensor) -> dict[str, Tensor]:
+        """Unnormalizes the batch data per-sample.
 
         Args:
             batch: Dictionary containing the data to unnormalize.
-
-        Returns:
-            dict[str, Tensor]: The unnormalized batch data.
-
-        Raises:
-            ValueError: If an unknown normalization mode is encountered.
+            dataset_index: LongTensor of shape ``(B,)``.
         """
         warn_missing_keys(self.features, batch, "unnormalization")
-        batch = dict(batch)  # shallow copy avoids mutating the input batch
+        batch = dict(batch)
         for key, ft in self.features.items():
             if key not in batch:
                 continue
@@ -318,26 +379,27 @@ class Unnormalize(nn.Module):
             if norm_mode is NormalizationMode.IDENTITY:
                 continue
 
-            if batch[key].numel() == 0:  # skip empty tensors, which won't broadcast well
+            batch_val = batch[key]
+            if batch_val.numel() == 0:
                 continue
 
             buffer = getattr(self, "buffer_" + key.replace(".", "_"))
 
             if norm_mode is NormalizationMode.MEAN_STD:
-                mean = _materialize(buffer["mean"])
-                std = _materialize(buffer["std"])
+                mean = _gather_and_broadcast(_materialize(buffer["mean"]), dataset_index, batch_val)
+                std = _gather_and_broadcast(_materialize(buffer["std"]), dataset_index, batch_val)
                 if not (torch.compiler.is_compiling() or torch.onnx.is_in_onnx_export()):
                     assert not torch.isinf(mean).any(), _no_stats_error_str("mean")
                     assert not torch.isinf(std).any(), _no_stats_error_str("std")
-                batch[key] = batch[key] * (std + EPS) + mean
+                batch[key] = batch_val * (std + EPS) + mean
             elif norm_mode is NormalizationMode.MIN_MAX:
-                min = _materialize(buffer["min"])
-                max = _materialize(buffer["max"])
+                min_ = _gather_and_broadcast(_materialize(buffer["min"]), dataset_index, batch_val)
+                max_ = _gather_and_broadcast(_materialize(buffer["max"]), dataset_index, batch_val)
                 if not (torch.compiler.is_compiling() or torch.onnx.is_in_onnx_export()):
-                    assert not torch.isinf(min).any(), _no_stats_error_str("min")
-                    assert not torch.isinf(max).any(), _no_stats_error_str("max")
-                batch[key] = (batch[key] + 1) / 2
-                batch[key] = batch[key] * (max - min + EPS) + min
+                    assert not torch.isinf(min_).any(), _no_stats_error_str("min")
+                    assert not torch.isinf(max_).any(), _no_stats_error_str("max")
+                batch[key] = (batch_val + 1) / 2
+                batch[key] = batch[key] * (max_ - min_ + EPS) + min_
             else:
                 raise ValueError(norm_mode)
         return batch

--- a/src/opentau/policies/pi0/modeling_pi0.py
+++ b/src/opentau/policies/pi0/modeling_pi0.py
@@ -322,6 +322,12 @@ class PI0Policy(PreTrainedPolicy):
         # Apply tiling of linear input weights if needed
         model._tile_linear_input_weight(transformed_state_dict)
 
+        # Promote legacy single-dataset Normalize/Unnormalize buffers from
+        # `(*feat_shape,)` to the new `(1, *feat_shape)` stacked layout so
+        # pre-PR checkpoints (including everything under TensorAuto/*) still
+        # load via `model.load_state_dict(..., strict=True)`.
+        model._promote_legacy_norm_buffers_in_state_dict(transformed_state_dict)
+
         # Load the transformed state dict
         msg = model.load_state_dict(transformed_state_dict, strict=strict)
 

--- a/src/opentau/policies/pi0/modeling_pi0.py
+++ b/src/opentau/policies/pi0/modeling_pi0.py
@@ -30,6 +30,7 @@ from torch import Tensor, nn
 from transformers import AutoTokenizer
 
 from opentau.policies.normalize import Normalize, Unnormalize
+from opentau.policies.normalize import resolve_num_datasets as _num_datasets
 from opentau.policies.pi0.configuration_pi0 import PI0Config
 from opentau.policies.pi0.paligemma_with_expert import (
     PaliGemmaWithExpertConfig,
@@ -164,25 +165,48 @@ class PI0Policy(PreTrainedPolicy):
     def __init__(
         self,
         config: PI0Config,
-        dataset_stats: dict[str, dict[str, Tensor]] | None = None,
+        per_dataset_stats: list[dict[str, dict[str, Tensor]]] | None = None,
+        dataset_names: list[str] | None = None,
     ):
         """Initializes the PI0Policy.
 
         Args:
             config: Policy configuration class instance.
-            dataset_stats: Dataset statistics to be used for normalization. If not passed here, it is expected
-                that they will be passed with a call to `load_state_dict` before the policy is used.
+            per_dataset_stats: Ordered list of per-dataset stat dicts used to
+                fill the stacked Normalize/Unnormalize buffers. May be None
+                when constructing for a checkpoint load — in that case
+                ``config.dataset_names`` is consulted for the leading dim.
+            dataset_names: Ordered list parallel to ``per_dataset_stats``.
         """
 
         super().__init__(config)
         config.validate_features()
         self.config = config
-        self.normalize_inputs = Normalize(config.input_features, config.normalization_mapping, dataset_stats)
+        # Number of datasets the stacked buffers must accommodate. Falls back
+        # to `config.dataset_names` for checkpoint-load construction (no
+        # stats passed but the config remembers the trained-on dataset list)
+        # and to 1 as the legacy single-dataset default.
+        num_datasets = _num_datasets(per_dataset_stats, dataset_names, config)
+        self.normalize_inputs = Normalize(
+            config.input_features,
+            config.normalization_mapping,
+            per_dataset_stats=per_dataset_stats,
+            dataset_names=dataset_names,
+            num_datasets=num_datasets,
+        )
         self.normalize_targets = Normalize(
-            config.output_features, config.normalization_mapping, dataset_stats
+            config.output_features,
+            config.normalization_mapping,
+            per_dataset_stats=per_dataset_stats,
+            dataset_names=dataset_names,
+            num_datasets=num_datasets,
         )
         self.unnormalize_outputs = Unnormalize(
-            config.output_features, config.normalization_mapping, dataset_stats
+            config.output_features,
+            config.normalization_mapping,
+            per_dataset_stats=per_dataset_stats,
+            dataset_names=dataset_names,
+            num_datasets=num_datasets,
         )
 
         self.language_tokenizer = AutoTokenizer.from_pretrained("google/paligemma-3b-pt-224")
@@ -387,7 +411,8 @@ class PI0Policy(PreTrainedPolicy):
         Returns:
             The sampled actions tensor of shape (batch_size, action_chunk_length, action_dim).
         """
-        batch = self.normalize_inputs(batch)
+        dataset_index = self._resolve_dataset_index(batch)
+        batch = self.normalize_inputs(batch, dataset_index)
 
         images, img_masks = self.prepare_images(batch)
         lang_tokens, lang_masks = self.prepare_language(batch)
@@ -406,7 +431,7 @@ class PI0Policy(PreTrainedPolicy):
         original_action_dim = self.config.action_feature.shape[0]
         actions = actions[:, :, :original_action_dim]
 
-        actions = self.unnormalize_outputs({"actions": actions})["actions"]
+        actions = self.unnormalize_outputs({"actions": actions}, dataset_index)["actions"]
 
         return actions
 
@@ -423,8 +448,9 @@ class PI0Policy(PreTrainedPolicy):
         Returns:
             A dictionary containing the loss components ("MSE" and "CE").
         """
-        batch = self.normalize_inputs(batch)
-        batch = self.normalize_targets(batch)
+        dataset_index = self._resolve_dataset_index(batch)
+        batch = self.normalize_inputs(batch, dataset_index)
+        batch = self.normalize_targets(batch, dataset_index)
 
         images, img_masks = self.prepare_images(batch)
         state = batch["state"]

--- a/src/opentau/policies/pi05/modeling_pi05.py
+++ b/src/opentau/policies/pi05/modeling_pi05.py
@@ -37,6 +37,7 @@ from opentau.configs.policies import PreTrainedConfig
 from opentau.configs.types import NormalizationMode
 from opentau.datasets.grounding.tokenizer_utils import ensure_loc_tokens
 from opentau.policies.normalize import Normalize, Unnormalize
+from opentau.policies.normalize import resolve_num_datasets as _num_datasets
 from opentau.policies.pi05.configuration_pi05 import PI05Config
 from opentau.policies.pi05.paligemma_with_expert import (
     PaliGemmaWithExpertConfig,
@@ -240,29 +241,49 @@ class PI05Policy(PreTrainedPolicy):
     def __init__(
         self,
         config: PI05Config,
-        dataset_stats: dict[str, dict[str, Tensor]] | None = None,
+        per_dataset_stats: list[dict[str, dict[str, Tensor]]] | None = None,
+        dataset_names: list[str] | None = None,
     ):
         """Initializes the PI05Policy.
 
         Args:
-            config: Policy configuration class instance or None, in which case the default instantiation of
-                the configuration class is used.
-            dataset_stats: Dataset statistics to be used for normalization. If not passed here, it is expected
-                that they will be passed with a call to `load_state_dict` before the policy is used.
+            config: Policy configuration class instance.
+            per_dataset_stats: Ordered list of per-dataset stat dicts used to
+                fill the stacked Normalize/Unnormalize buffers.
+            dataset_names: Ordered list parallel to ``per_dataset_stats``.
         """
 
         super().__init__(config)
         config.validate_features()
         self.config = config
-        self.normalize_inputs = Normalize(config.input_features, config.normalization_mapping, dataset_stats)
+        num_datasets = _num_datasets(per_dataset_stats, dataset_names, config)
+        self.normalize_inputs = Normalize(
+            config.input_features,
+            config.normalization_mapping,
+            per_dataset_stats=per_dataset_stats,
+            dataset_names=dataset_names,
+            num_datasets=num_datasets,
+        )
         self.normalize_targets = Normalize(
-            config.output_features, config.normalization_mapping, dataset_stats
+            config.output_features,
+            config.normalization_mapping,
+            per_dataset_stats=per_dataset_stats,
+            dataset_names=dataset_names,
+            num_datasets=num_datasets,
         )
         self.normalize_discrete_actions = Normalize(
-            config.output_features, {"ACTION": NormalizationMode.MIN_MAX}, dataset_stats
+            config.output_features,
+            {"ACTION": NormalizationMode.MIN_MAX},
+            per_dataset_stats=per_dataset_stats,
+            dataset_names=dataset_names,
+            num_datasets=num_datasets,
         )
         self.unnormalize_outputs = Unnormalize(
-            config.output_features, config.normalization_mapping, dataset_stats
+            config.output_features,
+            config.normalization_mapping,
+            per_dataset_stats=per_dataset_stats,
+            dataset_names=dataset_names,
+            num_datasets=num_datasets,
         )
 
         # The same PaliGemma tokenizer instance is shared with the inner
@@ -587,7 +608,8 @@ class PI05Policy(PreTrainedPolicy):
                 f"Delay must be None or between 0 and {self.config.max_delay}"
             )
 
-        batch = self.normalize_inputs(batch)
+        dataset_index = self._resolve_dataset_index(batch)
+        batch = self.normalize_inputs(batch, dataset_index)
 
         images, img_masks = self.prepare_images(batch)
         lang_tokens, lang_masks = self.prepare_language(batch)
@@ -603,7 +625,7 @@ class PI05Policy(PreTrainedPolicy):
             action_prefix = torch.zeros(actions_shape, dtype=lang_tokens.dtype, device=lang_tokens.device)
         else:
             # normalize action_prefix and pad chunk dimension to config.chunk_size
-            action_prefix = self.normalize_targets({"actions": action_prefix})["actions"]
+            action_prefix = self.normalize_targets({"actions": action_prefix}, dataset_index)["actions"]
             action_prefix = F.pad(  # noop if chunk_size is already the same as action_prefix.shape[1]
                 action_prefix,
                 (0, 0, 0, self.config.chunk_size - action_prefix.shape[1]),
@@ -626,7 +648,7 @@ class PI05Policy(PreTrainedPolicy):
         original_action_dim = self.config.action_feature.shape[0]
         actions = actions[:, :, :original_action_dim]
 
-        actions = self.unnormalize_outputs({"actions": actions})["actions"]
+        actions = self.unnormalize_outputs({"actions": actions}, dataset_index)["actions"]
 
         return actions
 
@@ -643,9 +665,10 @@ class PI05Policy(PreTrainedPolicy):
         Returns:
             A dictionary containing the loss components ("MSE" and "CE").
         """
-        batch = self.normalize_inputs(batch)
-        batch["discrete_actions"] = self.normalize_discrete_actions(dict(batch))["actions"]
-        batch = self.normalize_targets(batch)
+        dataset_index = self._resolve_dataset_index(batch)
+        batch = self.normalize_inputs(batch, dataset_index)
+        batch["discrete_actions"] = self.normalize_discrete_actions(dict(batch), dataset_index)["actions"]
+        batch = self.normalize_targets(batch, dataset_index)
 
         images, img_masks = self.prepare_images(
             batch

--- a/src/opentau/policies/pi05/modeling_pi05.py
+++ b/src/opentau/policies/pi05/modeling_pi05.py
@@ -421,6 +421,10 @@ class PI05Policy(PreTrainedPolicy):
                 print(f"Remapped {remap_count} state dict keys")
 
             # Load the remapped state dict into the model
+            # Promote legacy single-dataset Normalize/Unnormalize buffers from
+            # `(*feat_shape,)` to the new `(1, *feat_shape)` stacked layout so pre-PR
+            # checkpoints load via `model.load_state_dict(...)`.
+            model._promote_legacy_norm_buffers_in_state_dict(remapped_state_dict)
             missing_keys, unexpected_keys = model.load_state_dict(remapped_state_dict, strict=False)
 
             if missing_keys and is_main_process:

--- a/src/opentau/policies/pi05_mem/modeling_pi05.py
+++ b/src/opentau/policies/pi05_mem/modeling_pi05.py
@@ -48,6 +48,7 @@ from transformers import AutoProcessor, AutoTokenizer
 from opentau.configs.policies import PreTrainedConfig
 from opentau.configs.types import NormalizationMode
 from opentau.policies.normalize import Normalize, Unnormalize
+from opentau.policies.normalize import resolve_num_datasets as _num_datasets
 from opentau.policies.pi05.paligemma_with_expert import (
     PaliGemmaWithExpertConfig,
     PaliGemmaWithExpertModel,
@@ -223,20 +224,40 @@ class PI05MemPolicy(PreTrainedPolicy):
     def __init__(
         self,
         config: PI05MemConfig,
-        dataset_stats: dict[str, dict[str, Tensor]] | None = None,
+        per_dataset_stats: list[dict[str, dict[str, Tensor]]] | None = None,
+        dataset_names: list[str] | None = None,
     ):
         super().__init__(config)
         config.validate_features()
         self.config = config
-        self.normalize_inputs = Normalize(config.input_features, config.normalization_mapping, dataset_stats)
+        num_datasets = _num_datasets(per_dataset_stats, dataset_names, config)
+        self.normalize_inputs = Normalize(
+            config.input_features,
+            config.normalization_mapping,
+            per_dataset_stats=per_dataset_stats,
+            dataset_names=dataset_names,
+            num_datasets=num_datasets,
+        )
         self.normalize_targets = Normalize(
-            config.output_features, config.normalization_mapping, dataset_stats
+            config.output_features,
+            config.normalization_mapping,
+            per_dataset_stats=per_dataset_stats,
+            dataset_names=dataset_names,
+            num_datasets=num_datasets,
         )
         self.normalize_discrete_actions = Normalize(
-            config.output_features, {"ACTION": NormalizationMode.MIN_MAX}, dataset_stats
+            config.output_features,
+            {"ACTION": NormalizationMode.MIN_MAX},
+            per_dataset_stats=per_dataset_stats,
+            dataset_names=dataset_names,
+            num_datasets=num_datasets,
         )
         self.unnormalize_outputs = Unnormalize(
-            config.output_features, config.normalization_mapping, dataset_stats
+            config.output_features,
+            config.normalization_mapping,
+            per_dataset_stats=per_dataset_stats,
+            dataset_names=dataset_names,
+            num_datasets=num_datasets,
         )
 
         self.language_tokenizer = AutoTokenizer.from_pretrained("google/paligemma-3b-pt-224")
@@ -549,7 +570,8 @@ class PI05MemPolicy(PreTrainedPolicy):
                 f"Delay must be None or between 0 and {self.config.max_delay}"
             )
 
-        batch = self.normalize_inputs(batch)
+        dataset_index = self._resolve_dataset_index(batch)
+        batch = self.normalize_inputs(batch, dataset_index)
 
         # `_build_history_batch` (called from `select_action` upstream) emits
         # this; it's None when the caller skipped that step (e.g. n_obs_steps
@@ -582,7 +604,7 @@ class PI05MemPolicy(PreTrainedPolicy):
             actions_shape = (bsize, self.config.chunk_size, self.config.max_action_dim)
             action_prefix = torch.zeros(actions_shape, dtype=lang_tokens.dtype, device=lang_tokens.device)
         else:
-            normalized = self.normalize_targets({"actions": action_prefix})["actions"]
+            normalized = self.normalize_targets({"actions": action_prefix}, dataset_index)["actions"]
             action_prefix = F.pad(
                 normalized,
                 (0, 0, 0, self.config.chunk_size - normalized.shape[1]),
@@ -605,7 +627,7 @@ class PI05MemPolicy(PreTrainedPolicy):
         original_action_dim = action_feature.shape[0]
         actions = actions[:, :, :original_action_dim]
 
-        actions = self.unnormalize_outputs({"actions": actions})["actions"]
+        actions = self.unnormalize_outputs({"actions": actions}, dataset_index)["actions"]
 
         return actions
 
@@ -613,9 +635,10 @@ class PI05MemPolicy(PreTrainedPolicy):
         self, batch: dict[str, Tensor], noise: Tensor | None = None, time: Tensor | None = None
     ) -> dict[str, Tensor]:
         """Do a full training forward pass to compute the loss."""
-        batch = self.normalize_inputs(batch)
-        batch["discrete_actions"] = self.normalize_discrete_actions(dict(batch))["actions"]
-        batch = self.normalize_targets(batch)
+        dataset_index = self._resolve_dataset_index(batch)
+        batch = self.normalize_inputs(batch, dataset_index)
+        batch["discrete_actions"] = self.normalize_discrete_actions(dict(batch), dataset_index)["actions"]
+        batch = self.normalize_targets(batch, dataset_index)
 
         obs_history_is_pad = batch.get("obs_history_is_pad")
         if obs_history_is_pad is None:

--- a/src/opentau/policies/pi05_mem/modeling_pi05.py
+++ b/src/opentau/policies/pi05_mem/modeling_pi05.py
@@ -361,9 +361,11 @@ class PI05MemPolicy(PreTrainedPolicy):
             if remap_count > 0 and is_main_process:
                 logging.info("Remapped %d state dict keys", remap_count)
 
-                # Promote legacy single-dataset Normalize/Unnormalize buffers from
+            # Promote legacy single-dataset Normalize/Unnormalize buffers from
             # `(*feat_shape,)` to the new `(1, *feat_shape)` stacked layout so pre-PR
-            # checkpoints load via `model.load_state_dict(...)`.
+            # checkpoints load via `model.load_state_dict(...)`. Always run
+            # (outside the `if remap_count > 0` block) — promotion is needed
+            # whether or not any other keys were renamed.
             model._promote_legacy_norm_buffers_in_state_dict(remapped_state_dict)
             missing_keys, unexpected_keys = model.load_state_dict(remapped_state_dict, strict=False)
 

--- a/src/opentau/policies/pi05_mem/modeling_pi05.py
+++ b/src/opentau/policies/pi05_mem/modeling_pi05.py
@@ -361,6 +361,10 @@ class PI05MemPolicy(PreTrainedPolicy):
             if remap_count > 0 and is_main_process:
                 logging.info("Remapped %d state dict keys", remap_count)
 
+                # Promote legacy single-dataset Normalize/Unnormalize buffers from
+            # `(*feat_shape,)` to the new `(1, *feat_shape)` stacked layout so pre-PR
+            # checkpoints load via `model.load_state_dict(...)`.
+            model._promote_legacy_norm_buffers_in_state_dict(remapped_state_dict)
             missing_keys, unexpected_keys = model.load_state_dict(remapped_state_dict, strict=False)
 
             if missing_keys and is_main_process:

--- a/src/opentau/policies/pi06/modeling_pi06.py
+++ b/src/opentau/policies/pi06/modeling_pi06.py
@@ -414,6 +414,10 @@ class PI06Policy(PreTrainedPolicy):
             if remap_count > 0 and is_main_process:
                 print(f"Remapped {remap_count} state dict keys")
 
+                # Promote legacy single-dataset Normalize/Unnormalize buffers from
+            # `(*feat_shape,)` to the new `(1, *feat_shape)` stacked layout so pre-PR
+            # checkpoints load via `model.load_state_dict(...)`.
+            model._promote_legacy_norm_buffers_in_state_dict(remapped_state_dict)
             missing_keys, unexpected_keys = model.load_state_dict(remapped_state_dict, strict=False)
             if missing_keys and is_main_process:
                 print(f"Missing keys when loading state dict: {len(missing_keys)} keys")

--- a/src/opentau/policies/pi06/modeling_pi06.py
+++ b/src/opentau/policies/pi06/modeling_pi06.py
@@ -44,6 +44,7 @@ from opentau.configs.policies import PreTrainedConfig
 from opentau.configs.types import NormalizationMode
 from opentau.datasets.grounding.tokenizer_utils import ensure_loc_tokens
 from opentau.policies.normalize import Normalize, Unnormalize
+from opentau.policies.normalize import resolve_num_datasets as _num_datasets
 from opentau.policies.pi06.configuration_pi06 import PI06Config
 from opentau.policies.pi06.gemma3_with_expert import (
     Gemma3WithExpertConfig,
@@ -257,29 +258,49 @@ class PI06Policy(PreTrainedPolicy):
     def __init__(
         self,
         config: PI06Config,
-        dataset_stats: dict[str, dict[str, Tensor]] | None = None,
+        per_dataset_stats: list[dict[str, dict[str, Tensor]]] | None = None,
+        dataset_names: list[str] | None = None,
     ):
         """Initializes the PI06Policy.
 
         Args:
             config: `PI06Config` instance.
-            dataset_stats: Optional dataset statistics for input/output
-                normalization; otherwise expected to be loaded via
-                `load_state_dict` before the policy runs.
+            per_dataset_stats: Ordered list of per-dataset stat dicts used to
+                fill the stacked Normalize/Unnormalize buffers.
+            dataset_names: Ordered list parallel to ``per_dataset_stats``.
         """
         super().__init__(config)
         config.validate_features()
         self.config = config
 
-        self.normalize_inputs = Normalize(config.input_features, config.normalization_mapping, dataset_stats)
+        num_datasets = _num_datasets(per_dataset_stats, dataset_names, config)
+        self.normalize_inputs = Normalize(
+            config.input_features,
+            config.normalization_mapping,
+            per_dataset_stats=per_dataset_stats,
+            dataset_names=dataset_names,
+            num_datasets=num_datasets,
+        )
         self.normalize_targets = Normalize(
-            config.output_features, config.normalization_mapping, dataset_stats
+            config.output_features,
+            config.normalization_mapping,
+            per_dataset_stats=per_dataset_stats,
+            dataset_names=dataset_names,
+            num_datasets=num_datasets,
         )
         self.normalize_discrete_actions = Normalize(
-            config.output_features, {"ACTION": NormalizationMode.MIN_MAX}, dataset_stats
+            config.output_features,
+            {"ACTION": NormalizationMode.MIN_MAX},
+            per_dataset_stats=per_dataset_stats,
+            dataset_names=dataset_names,
+            num_datasets=num_datasets,
         )
         self.unnormalize_outputs = Unnormalize(
-            config.output_features, config.normalization_mapping, dataset_stats
+            config.output_features,
+            config.normalization_mapping,
+            per_dataset_stats=per_dataset_stats,
+            dataset_names=dataset_names,
+            num_datasets=num_datasets,
         )
 
         # π0.6 uses Gemma 3's tokenizer. The same instance is shared with the
@@ -545,7 +566,8 @@ class PI06Policy(PreTrainedPolicy):
                 f"Delay must be None or between 0 and {self.config.max_delay}"
             )
 
-        batch = self.normalize_inputs(batch)
+        dataset_index = self._resolve_dataset_index(batch)
+        batch = self.normalize_inputs(batch, dataset_index)
 
         images, img_masks = self.prepare_images(batch)
         lang_tokens, lang_masks = self.prepare_language(batch)
@@ -558,7 +580,7 @@ class PI06Policy(PreTrainedPolicy):
             actions_shape = (bsize, self.config.chunk_size, self.config.max_action_dim)
             action_prefix = torch.zeros(actions_shape, dtype=lang_tokens.dtype, device=lang_tokens.device)
         else:
-            action_prefix = self.normalize_targets({"actions": action_prefix})["actions"]
+            action_prefix = self.normalize_targets({"actions": action_prefix}, dataset_index)["actions"]
             action_prefix = F.pad(action_prefix, (0, 0, 0, self.config.chunk_size - action_prefix.shape[1]))
 
         actions = self.model.sample_actions(
@@ -567,16 +589,17 @@ class PI06Policy(PreTrainedPolicy):
 
         original_action_dim = self.config.action_feature.shape[0]
         actions = actions[:, :, :original_action_dim]
-        actions = self.unnormalize_outputs({"actions": actions})["actions"]
+        actions = self.unnormalize_outputs({"actions": actions}, dataset_index)["actions"]
         return actions
 
     def forward(
         self, batch: dict[str, Tensor], noise: Tensor | None = None, time: Tensor | None = None
     ) -> dict[str, Tensor]:
         """Full training forward pass. Returns `{"MSE": ..., "CE": ...}`."""
-        batch = self.normalize_inputs(batch)
-        batch["discrete_actions"] = self.normalize_discrete_actions(dict(batch))["actions"]
-        batch = self.normalize_targets(batch)
+        dataset_index = self._resolve_dataset_index(batch)
+        batch = self.normalize_inputs(batch, dataset_index)
+        batch["discrete_actions"] = self.normalize_discrete_actions(dict(batch), dataset_index)["actions"]
+        batch = self.normalize_targets(batch, dataset_index)
 
         images, img_masks = self.prepare_images(batch)
         lang_tokens, lang_masks = self.prepare_language(batch)

--- a/src/opentau/policies/pi06/modeling_pi06.py
+++ b/src/opentau/policies/pi06/modeling_pi06.py
@@ -414,9 +414,11 @@ class PI06Policy(PreTrainedPolicy):
             if remap_count > 0 and is_main_process:
                 print(f"Remapped {remap_count} state dict keys")
 
-                # Promote legacy single-dataset Normalize/Unnormalize buffers from
+            # Promote legacy single-dataset Normalize/Unnormalize buffers from
             # `(*feat_shape,)` to the new `(1, *feat_shape)` stacked layout so pre-PR
-            # checkpoints load via `model.load_state_dict(...)`.
+            # checkpoints load via `model.load_state_dict(...)`. Always run
+            # (outside the `if remap_count > 0` block) — promotion is needed
+            # whether or not any other keys were renamed.
             model._promote_legacy_norm_buffers_in_state_dict(remapped_state_dict)
             missing_keys, unexpected_keys = model.load_state_dict(remapped_state_dict, strict=False)
             if missing_keys and is_main_process:

--- a/src/opentau/policies/pi07/high_level_planner/modeling_pi07_high_level.py
+++ b/src/opentau/policies/pi07/high_level_planner/modeling_pi07_high_level.py
@@ -332,6 +332,10 @@ class PI07HighLevelPlannerPolicy(PreTrainedPolicy):
                 print(f"Remapped {remap_count} state dict keys")
 
             # Load the remapped state dict into the model
+            # Promote legacy single-dataset Normalize/Unnormalize buffers from
+            # `(*feat_shape,)` to the new `(1, *feat_shape)` stacked layout so pre-PR
+            # checkpoints load via `model.load_state_dict(...)`.
+            model._promote_legacy_norm_buffers_in_state_dict(remapped_state_dict)
             missing_keys, unexpected_keys = model.load_state_dict(remapped_state_dict, strict=False)
 
             if missing_keys and is_main_process:

--- a/src/opentau/policies/pi07/high_level_planner/modeling_pi07_high_level.py
+++ b/src/opentau/policies/pi07/high_level_planner/modeling_pi07_high_level.py
@@ -36,6 +36,7 @@ from transformers import AutoProcessor, AutoTokenizer
 
 from opentau.configs.policies import PreTrainedConfig
 from opentau.policies.normalize import Normalize
+from opentau.policies.normalize import resolve_num_datasets as _num_datasets
 from opentau.policies.pi07.gemma3_with_expert import (
     Gemma3WithExpertModel,
 )
@@ -179,21 +180,30 @@ class PI07HighLevelPlannerPolicy(PreTrainedPolicy):
     def __init__(
         self,
         config: PI07HighLevelPlannerConfig,
-        dataset_stats: dict[str, dict[str, Tensor]] | None = None,
+        per_dataset_stats: list[dict[str, dict[str, Tensor]]] | None = None,
+        dataset_names: list[str] | None = None,
     ):
         """Initializes the PI07HighLevelPlannerPolicy.
 
         Args:
             config: Policy configuration instance.
-            dataset_stats: Dataset statistics for input normalization. If not
-                provided here, they must be supplied via ``load_state_dict``
-                before the policy is used.
+            per_dataset_stats: Ordered list of per-dataset stat dicts used to
+                fill the stacked Normalize input-buffer. May be None when
+                constructing for a checkpoint load.
+            dataset_names: Ordered list parallel to ``per_dataset_stats``.
         """
 
         super().__init__(config)
         config.validate_features()
         self.config = config
-        self.normalize_inputs = Normalize(config.input_features, config.normalization_mapping, dataset_stats)
+        num_datasets = _num_datasets(per_dataset_stats, dataset_names, config)
+        self.normalize_inputs = Normalize(
+            config.input_features,
+            config.normalization_mapping,
+            per_dataset_stats=per_dataset_stats,
+            dataset_names=dataset_names,
+            num_datasets=num_datasets,
+        )
 
         self.language_tokenizer = AutoTokenizer.from_pretrained("google/gemma-3-4b-pt")
 
@@ -482,7 +492,8 @@ class PI07HighLevelPlannerPolicy(PreTrainedPolicy):
             ``Tensor`` of token IDs with shape ``(batch_size, seq_len)``.
         """
 
-        batch = self.normalize_inputs(batch)
+        dataset_index = self._resolve_dataset_index(batch)
+        batch = self.normalize_inputs(batch, dataset_index)
 
         images, img_masks = self.prepare_images(batch)
         lang_tokens, lang_masks = self.prepare_language(batch)
@@ -511,7 +522,8 @@ class PI07HighLevelPlannerPolicy(PreTrainedPolicy):
             compatibility) and ``"CE"`` (sum of memory and response
             cross-entropy losses).
         """
-        batch = self.normalize_inputs(batch)
+        dataset_index = self._resolve_dataset_index(batch)
+        batch = self.normalize_inputs(batch, dataset_index)
 
         images, img_masks = self.prepare_images(
             batch

--- a/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
@@ -52,6 +52,7 @@ from transformers import AutoProcessor, AutoTokenizer
 from opentau.configs.policies import PreTrainedConfig
 from opentau.configs.types import NormalizationMode
 from opentau.policies.normalize import Normalize, Unnormalize
+from opentau.policies.normalize import resolve_num_datasets as _num_datasets
 from opentau.policies.pi07.gemma3_with_expert import (
     Gemma3WithExpertModel,
 )
@@ -317,20 +318,40 @@ class PI07LowLevelPolicy(PreTrainedPolicy):
     def __init__(
         self,
         config: PI07LowLevelConfig,
-        dataset_stats: dict[str, dict[str, Tensor]] | None = None,
+        per_dataset_stats: list[dict[str, dict[str, Tensor]]] | None = None,
+        dataset_names: list[str] | None = None,
     ):
         super().__init__(config)
         config.validate_features()
         self.config = config
-        self.normalize_inputs = Normalize(config.input_features, config.normalization_mapping, dataset_stats)
+        num_datasets = _num_datasets(per_dataset_stats, dataset_names, config)
+        self.normalize_inputs = Normalize(
+            config.input_features,
+            config.normalization_mapping,
+            per_dataset_stats=per_dataset_stats,
+            dataset_names=dataset_names,
+            num_datasets=num_datasets,
+        )
         self.normalize_targets = Normalize(
-            config.output_features, config.normalization_mapping, dataset_stats
+            config.output_features,
+            config.normalization_mapping,
+            per_dataset_stats=per_dataset_stats,
+            dataset_names=dataset_names,
+            num_datasets=num_datasets,
         )
         self.normalize_discrete_actions = Normalize(
-            config.output_features, {"ACTION": NormalizationMode.MIN_MAX}, dataset_stats
+            config.output_features,
+            {"ACTION": NormalizationMode.MIN_MAX},
+            per_dataset_stats=per_dataset_stats,
+            dataset_names=dataset_names,
+            num_datasets=num_datasets,
         )
         self.unnormalize_outputs = Unnormalize(
-            config.output_features, config.normalization_mapping, dataset_stats
+            config.output_features,
+            config.normalization_mapping,
+            per_dataset_stats=per_dataset_stats,
+            dataset_names=dataset_names,
+            num_datasets=num_datasets,
         )
 
         self.language_tokenizer = AutoTokenizer.from_pretrained("google/gemma-3-4b-pt")
@@ -677,7 +698,8 @@ class PI07LowLevelPolicy(PreTrainedPolicy):
                 f"Delay must be None or between 0 and {self.config.max_delay}"
             )
 
-        batch = self.normalize_inputs(batch)
+        dataset_index = self._resolve_dataset_index(batch)
+        batch = self.normalize_inputs(batch, dataset_index)
 
         # `_build_history_batch` (called from `select_action` upstream) emits
         # this; it's None when the caller skipped that step (e.g. n_obs_steps
@@ -715,7 +737,7 @@ class PI07LowLevelPolicy(PreTrainedPolicy):
             actions_shape = (bsize, self.config.chunk_size, self.config.max_action_dim)
             action_prefix = torch.zeros(actions_shape, dtype=lang_tokens.dtype, device=lang_tokens.device)
         else:
-            normalized = self.normalize_targets({"actions": action_prefix})["actions"]
+            normalized = self.normalize_targets({"actions": action_prefix}, dataset_index)["actions"]
             action_prefix = F.pad(
                 normalized,
                 (0, 0, 0, self.config.chunk_size - normalized.shape[1]),
@@ -744,7 +766,7 @@ class PI07LowLevelPolicy(PreTrainedPolicy):
         original_action_dim = action_feature.shape[0]
         actions = actions[:, :, :original_action_dim]
 
-        actions = self.unnormalize_outputs({"actions": actions})["actions"]
+        actions = self.unnormalize_outputs({"actions": actions}, dataset_index)["actions"]
 
         return actions
 
@@ -764,9 +786,10 @@ class PI07LowLevelPolicy(PreTrainedPolicy):
         Returns:
             Dict with ``"MSE"`` and ``"CE"`` scalar loss tensors.
         """
-        batch = self.normalize_inputs(batch)
-        batch["discrete_actions"] = self.normalize_discrete_actions(dict(batch))["actions"]
-        batch = self.normalize_targets(batch)
+        dataset_index = self._resolve_dataset_index(batch)
+        batch = self.normalize_inputs(batch, dataset_index)
+        batch["discrete_actions"] = self.normalize_discrete_actions(dict(batch), dataset_index)["actions"]
+        batch = self.normalize_targets(batch, dataset_index)
 
         obs_history_is_pad = batch.get("obs_history_is_pad")
         if obs_history_is_pad is None:

--- a/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
@@ -455,9 +455,11 @@ class PI07LowLevelPolicy(PreTrainedPolicy):
             if remap_count > 0 and is_main_process:
                 logging.info("Remapped %d state dict keys", remap_count)
 
-                # Promote legacy single-dataset Normalize/Unnormalize buffers from
+            # Promote legacy single-dataset Normalize/Unnormalize buffers from
             # `(*feat_shape,)` to the new `(1, *feat_shape)` stacked layout so pre-PR
-            # checkpoints load via `model.load_state_dict(...)`.
+            # checkpoints load via `model.load_state_dict(...)`. Always run
+            # (outside the `if remap_count > 0` block) — promotion is needed
+            # whether or not any other keys were renamed.
             model._promote_legacy_norm_buffers_in_state_dict(remapped_state_dict)
             missing_keys, unexpected_keys = model.load_state_dict(remapped_state_dict, strict=False)
 

--- a/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
@@ -455,6 +455,10 @@ class PI07LowLevelPolicy(PreTrainedPolicy):
             if remap_count > 0 and is_main_process:
                 logging.info("Remapped %d state dict keys", remap_count)
 
+                # Promote legacy single-dataset Normalize/Unnormalize buffers from
+            # `(*feat_shape,)` to the new `(1, *feat_shape)` stacked layout so pre-PR
+            # checkpoints load via `model.load_state_dict(...)`.
+            model._promote_legacy_norm_buffers_in_state_dict(remapped_state_dict)
             missing_keys, unexpected_keys = model.load_state_dict(remapped_state_dict, strict=False)
 
             if missing_keys and is_main_process:

--- a/src/opentau/policies/pi07_paligemma/high_level_planner/modeling_pi07_high_level.py
+++ b/src/opentau/policies/pi07_paligemma/high_level_planner/modeling_pi07_high_level.py
@@ -332,6 +332,10 @@ class PI07HighLevelPlannerPolicy(PreTrainedPolicy):
                 print(f"Remapped {remap_count} state dict keys")
 
             # Load the remapped state dict into the model
+            # Promote legacy single-dataset Normalize/Unnormalize buffers from
+            # `(*feat_shape,)` to the new `(1, *feat_shape)` stacked layout so pre-PR
+            # checkpoints load via `model.load_state_dict(...)`.
+            model._promote_legacy_norm_buffers_in_state_dict(remapped_state_dict)
             missing_keys, unexpected_keys = model.load_state_dict(remapped_state_dict, strict=False)
 
             if missing_keys and is_main_process:

--- a/src/opentau/policies/pi07_paligemma/high_level_planner/modeling_pi07_high_level.py
+++ b/src/opentau/policies/pi07_paligemma/high_level_planner/modeling_pi07_high_level.py
@@ -35,6 +35,7 @@ from transformers import AutoProcessor, AutoTokenizer
 
 from opentau.configs.policies import PreTrainedConfig
 from opentau.policies.normalize import Normalize
+from opentau.policies.normalize import resolve_num_datasets as _num_datasets
 from opentau.policies.pi05.paligemma_with_expert import (
     PaliGemmaWithExpertConfig,
     PaliGemmaWithExpertModel,
@@ -179,21 +180,30 @@ class PI07HighLevelPlannerPolicy(PreTrainedPolicy):
     def __init__(
         self,
         config: PI07HighLevelPlannerConfig,
-        dataset_stats: dict[str, dict[str, Tensor]] | None = None,
+        per_dataset_stats: list[dict[str, dict[str, Tensor]]] | None = None,
+        dataset_names: list[str] | None = None,
     ):
         """Initializes the PI07HighLevelPlannerPolicy.
 
         Args:
             config: Policy configuration instance.
-            dataset_stats: Dataset statistics for input normalization. If not
-                provided here, they must be supplied via ``load_state_dict``
-                before the policy is used.
+            per_dataset_stats: Ordered list of per-dataset stat dicts used to
+                fill the stacked Normalize input-buffer. May be None when
+                constructing for a checkpoint load.
+            dataset_names: Ordered list parallel to ``per_dataset_stats``.
         """
 
         super().__init__(config)
         config.validate_features()
         self.config = config
-        self.normalize_inputs = Normalize(config.input_features, config.normalization_mapping, dataset_stats)
+        num_datasets = _num_datasets(per_dataset_stats, dataset_names, config)
+        self.normalize_inputs = Normalize(
+            config.input_features,
+            config.normalization_mapping,
+            per_dataset_stats=per_dataset_stats,
+            dataset_names=dataset_names,
+            num_datasets=num_datasets,
+        )
 
         self.language_tokenizer = AutoTokenizer.from_pretrained("google/paligemma-3b-pt-224")
 
@@ -465,7 +475,8 @@ class PI07HighLevelPlannerPolicy(PreTrainedPolicy):
             ``Tensor`` of token IDs with shape ``(batch_size, seq_len)``.
         """
 
-        batch = self.normalize_inputs(batch)
+        dataset_index = self._resolve_dataset_index(batch)
+        batch = self.normalize_inputs(batch, dataset_index)
 
         images, img_masks = self.prepare_images(batch)
         lang_tokens, lang_masks = self.prepare_language(batch)
@@ -494,7 +505,8 @@ class PI07HighLevelPlannerPolicy(PreTrainedPolicy):
             compatibility) and ``"CE"`` (sum of memory and response
             cross-entropy losses).
         """
-        batch = self.normalize_inputs(batch)
+        dataset_index = self._resolve_dataset_index(batch)
+        batch = self.normalize_inputs(batch, dataset_index)
 
         images, img_masks = self.prepare_images(
             batch

--- a/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
@@ -38,6 +38,7 @@ from transformers import AutoProcessor, AutoTokenizer
 from opentau.configs.policies import PreTrainedConfig
 from opentau.configs.types import NormalizationMode
 from opentau.policies.normalize import Normalize, Unnormalize
+from opentau.policies.normalize import resolve_num_datasets as _num_datasets
 from opentau.policies.pi05.paligemma_with_expert import (
     PaliGemmaWithExpertConfig,
     PaliGemmaWithExpertModel,
@@ -296,29 +297,49 @@ class PI07PaligemmaLowLevelPolicy(PreTrainedPolicy):
     def __init__(
         self,
         config: PI07PaligemmaLowLevelConfig,
-        dataset_stats: dict[str, dict[str, Tensor]] | None = None,
+        per_dataset_stats: list[dict[str, dict[str, Tensor]]] | None = None,
+        dataset_names: list[str] | None = None,
     ):
         """Initializes the PI07PaligemmaLowLevelPolicy.
 
         Args:
-            config: Policy configuration class instance or None, in which case the default instantiation of
-                the configuration class is used.
-            dataset_stats: Dataset statistics to be used for normalization. If not passed here, it is expected
-                that they will be passed with a call to `load_state_dict` before the policy is used.
+            config: Policy configuration class instance.
+            per_dataset_stats: Ordered list of per-dataset stat dicts used to
+                fill the stacked Normalize/Unnormalize buffers.
+            dataset_names: Ordered list parallel to ``per_dataset_stats``.
         """
 
         super().__init__(config)
         config.validate_features()
         self.config = config
-        self.normalize_inputs = Normalize(config.input_features, config.normalization_mapping, dataset_stats)
+        num_datasets = _num_datasets(per_dataset_stats, dataset_names, config)
+        self.normalize_inputs = Normalize(
+            config.input_features,
+            config.normalization_mapping,
+            per_dataset_stats=per_dataset_stats,
+            dataset_names=dataset_names,
+            num_datasets=num_datasets,
+        )
         self.normalize_targets = Normalize(
-            config.output_features, config.normalization_mapping, dataset_stats
+            config.output_features,
+            config.normalization_mapping,
+            per_dataset_stats=per_dataset_stats,
+            dataset_names=dataset_names,
+            num_datasets=num_datasets,
         )
         self.normalize_discrete_actions = Normalize(
-            config.output_features, {"ACTION": NormalizationMode.MIN_MAX}, dataset_stats
+            config.output_features,
+            {"ACTION": NormalizationMode.MIN_MAX},
+            per_dataset_stats=per_dataset_stats,
+            dataset_names=dataset_names,
+            num_datasets=num_datasets,
         )
         self.unnormalize_outputs = Unnormalize(
-            config.output_features, config.normalization_mapping, dataset_stats
+            config.output_features,
+            config.normalization_mapping,
+            per_dataset_stats=per_dataset_stats,
+            dataset_names=dataset_names,
+            num_datasets=num_datasets,
         )
 
         self.language_tokenizer = AutoTokenizer.from_pretrained("google/paligemma-3b-pt-224")
@@ -926,7 +947,8 @@ class PI07PaligemmaLowLevelPolicy(PreTrainedPolicy):
                 f"Delay must be None or between 0 and {self.config.max_delay}"
             )
 
-        batch = self.normalize_inputs(batch)
+        dataset_index = self._resolve_dataset_index(batch)
+        batch = self.normalize_inputs(batch, dataset_index)
 
         self._hydrate_optional_conditioning_batch(batch)
 
@@ -941,7 +963,7 @@ class PI07PaligemmaLowLevelPolicy(PreTrainedPolicy):
             actions_shape = (bsize, self.config.chunk_size, self.config.max_action_dim)
             action_prefix = torch.zeros(actions_shape, dtype=torch.float32, device=device)
         else:
-            action_prefix = self.normalize_targets({"actions": action_prefix})["actions"]
+            action_prefix = self.normalize_targets({"actions": action_prefix}, dataset_index)["actions"]
             action_prefix = F.pad(
                 action_prefix,
                 (0, 0, 0, self.config.chunk_size - action_prefix.shape[1]),
@@ -971,7 +993,7 @@ class PI07PaligemmaLowLevelPolicy(PreTrainedPolicy):
         original_action_dim = self.config.action_feature.shape[0]
         actions = actions[:, :, :original_action_dim]
 
-        actions = self.unnormalize_outputs({"actions": actions})["actions"]
+        actions = self.unnormalize_outputs({"actions": actions}, dataset_index)["actions"]
 
         return actions
 
@@ -988,9 +1010,10 @@ class PI07PaligemmaLowLevelPolicy(PreTrainedPolicy):
         Returns:
             A dictionary containing the loss components ("MSE" and "CE").
         """
-        batch = self.normalize_inputs(batch)
-        batch["discrete_actions"] = self.normalize_discrete_actions(dict(batch))["actions"]
-        batch = self.normalize_targets(batch)
+        dataset_index = self._resolve_dataset_index(batch)
+        batch = self.normalize_inputs(batch, dataset_index)
+        batch["discrete_actions"] = self.normalize_discrete_actions(dict(batch), dataset_index)["actions"]
+        batch = self.normalize_targets(batch, dataset_index)
 
         self._hydrate_optional_conditioning_batch(batch)
 

--- a/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
@@ -473,6 +473,10 @@ class PI07PaligemmaLowLevelPolicy(PreTrainedPolicy):
                 logging.info("Remapped %d state dict keys", remap_count)
 
             # Load the remapped state dict into the model
+            # Promote legacy single-dataset Normalize/Unnormalize buffers from
+            # `(*feat_shape,)` to the new `(1, *feat_shape)` stacked layout so pre-PR
+            # checkpoints load via `model.load_state_dict(...)`.
+            model._promote_legacy_norm_buffers_in_state_dict(remapped_state_dict)
             missing_keys, unexpected_keys = model.load_state_dict(remapped_state_dict, strict=False)
 
             if missing_keys and is_main_process:

--- a/src/opentau/policies/pretrained.py
+++ b/src/opentau/policies/pretrained.py
@@ -27,6 +27,7 @@ import os
 from pathlib import Path
 from typing import Type, TypeVar
 
+import numpy as np
 import packaging
 import safetensors
 import torch
@@ -34,6 +35,7 @@ from huggingface_hub import hf_hub_download
 from huggingface_hub.constants import SAFETENSORS_SINGLE_FILE
 from huggingface_hub.errors import HfHubHTTPError
 from safetensors.torch import load_model as load_model_as_safetensor
+from safetensors.torch import save_file as save_safetensor_file
 from safetensors.torch import save_model as save_model_as_safetensor
 from torch import Tensor, nn
 
@@ -42,6 +44,25 @@ from opentau.policies.utils import log_model_loading_keys
 from opentau.utils.hub import HubMixin
 
 T = TypeVar("T", bound="PreTrainedPolicy")
+
+# State-dict key prefixes for the per-feature normalization buffers attached
+# by `Normalize` / `Unnormalize`. Used by `_save_pretrained` (when
+# `save_normalization_stats=False`) and by `train.py`'s Accelerate save-hook
+# to strip the buffers from the on-disk safetensors. Kept here (not in
+# normalize.py) so the train script can import it without picking up torch's
+# heavy normalize module unless it actually constructs a policy.
+NORM_BUFFER_PREFIXES: tuple[str, ...] = (
+    "normalize_inputs.buffer_",
+    "normalize_targets.buffer_",
+    "normalize_discrete_actions.buffer_",
+    "unnormalize_outputs.buffer_",
+)
+
+
+def is_norm_buffer_key(key: str) -> bool:
+    """Return True iff ``key`` names a Normalize/Unnormalize stat parameter."""
+    return any(key.startswith(prefix) for prefix in NORM_BUFFER_PREFIXES)
+
 
 DEFAULT_POLICY_CARD = """
 ---
@@ -91,6 +112,16 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
                 f"`model = {self.__class__.__name__}.from_pretrained(PRETRAINED_MODEL_NAME)`"
             )
         self.config = config
+        # Build the name -> index lookup used by `_resolve_dataset_index` to
+        # map inference-time `batch["dataset_repo_id"]` (str) to the leading
+        # axis of the stacked Normalize buffers. Stays None for legacy
+        # checkpoints whose config.json predates the per-dataset rewrite —
+        # those callers must pass `batch["dataset_index"]` directly.
+        names = getattr(config, "dataset_names", None)
+        if names is None:
+            self._dataset_name_to_index: dict[str, int] | None = None
+        else:
+            self._dataset_name_to_index = {name: i for i, name in enumerate(names)}
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
@@ -99,15 +130,41 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
         if not getattr(cls, "name", None):
             raise TypeError(f"Class {cls.__name__} must define 'name'")
 
-    def _save_pretrained(self, save_directory: Path) -> None:
+    def _save_pretrained(
+        self,
+        save_directory: Path,
+        *,
+        include_norm_stats: bool | None = None,
+    ) -> None:
         """Saves the policy and its configuration to a directory.
 
         Args:
             save_directory: The directory to save the policy to.
+            include_norm_stats: When ``None`` (default), defers to
+                ``self.config.save_normalization_stats``. When set, overrides
+                the config field for this call. When effectively False the
+                ``normalize_*.buffer_*`` / ``unnormalize_*.buffer_*`` keys are
+                excluded from the on-disk ``model.safetensors`` — reloading
+                then requires the caller to pass ``ds_meta=`` (or call
+                ``policy._inject_stats``) so the buffers can be repopulated.
         """
         self.config._save_pretrained(save_directory)
         model_to_save = self.module if hasattr(self, "module") else self
-        save_model_as_safetensor(model_to_save, str(save_directory / SAFETENSORS_SINGLE_FILE))
+
+        if include_norm_stats is None:
+            include_norm_stats = getattr(self.config, "save_normalization_stats", True)
+
+        out_path = str(save_directory / SAFETENSORS_SINGLE_FILE)
+        if include_norm_stats:
+            save_model_as_safetensor(model_to_save, out_path)
+        else:
+            # `save_model` doesn't expose a filter argument, so build the
+            # filtered state_dict ourselves and write via `save_file`. Clone
+            # tensors that share storage with another retained tensor to
+            # avoid safetensors' "duplicated tensors" rejection.
+            state_dict = model_to_save.state_dict()
+            filtered = {k: v for k, v in state_dict.items() if not is_norm_buffer_key(k)}
+            save_safetensor_file(filtered, out_path)
 
     @classmethod
     def from_pretrained(
@@ -190,6 +247,161 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
 
         policy.eval()
         return policy
+
+    def _infer_batch_size_and_device(self, batch: dict[str, Tensor]) -> tuple[int, torch.device]:
+        """Find any tensor in ``batch`` and return (batch_size, device).
+
+        Used by ``_resolve_dataset_index`` when the caller supplied
+        ``dataset_repo_id`` as a Python string/list — we need to allocate the
+        index tensor on the same device as the rest of the batch.
+        """
+        for v in batch.values():
+            if isinstance(v, Tensor):
+                return v.shape[0] if v.ndim > 0 else 1, v.device
+        # No tensors in the batch — fall back to CPU and trust caller's len(list).
+        return 0, torch.device("cpu")
+
+    def _resolve_dataset_index(self, batch: dict[str, Tensor]) -> Tensor:
+        """Resolve per-sample dataset indices from a training or inference batch.
+
+        Training path: the dataloader's ``_TaggedDataset`` wrapper attaches
+        ``batch["dataset_index"]`` as a ``(B,)`` ``LongTensor`` already.
+
+        Inference path: the caller passes ``batch["dataset_repo_id"]`` as
+        either a single ``str`` (broadcast to the full batch) or a
+        ``list[str]`` of length B. We map each name through the policy's
+        training-time ``dataset_names`` list (stored on ``self.config``) to
+        the corresponding integer index.
+
+        Raises:
+            KeyError: neither ``dataset_index`` nor ``dataset_repo_id`` was provided.
+            RuntimeError: ``dataset_repo_id`` was provided but the policy was
+                loaded without a ``dataset_names`` list.
+            ValueError: a name was provided that isn't in ``dataset_names``.
+        """
+        if "dataset_index" in batch:
+            idx = batch["dataset_index"]
+            if not isinstance(idx, Tensor):
+                idx = torch.as_tensor(idx, dtype=torch.long)
+            return idx.to(dtype=torch.long)
+
+        if "dataset_repo_id" not in batch:
+            raise KeyError(
+                "Per-dataset normalization requires either `dataset_index` "
+                "(LongTensor of shape (B,)) or `dataset_repo_id` (str or "
+                "list[str] of length B) in the batch."
+            )
+
+        if self._dataset_name_to_index is None:
+            raise RuntimeError(
+                "Policy was loaded without `dataset_names`; cannot resolve "
+                "`dataset_repo_id` strings. Either pass `batch['dataset_index']` "
+                "directly or rebuild the policy via `make_policy(cfg, ds_meta=...)`."
+            )
+
+        raw = batch["dataset_repo_id"]
+        batch_size, device = self._infer_batch_size_and_device(batch)
+        names = [raw] * (batch_size or 1) if isinstance(raw, str) else list(raw)
+        try:
+            indices = [self._dataset_name_to_index[n] for n in names]
+        except KeyError as e:
+            raise ValueError(
+                f"dataset_repo_id {e.args[0]!r} not in this policy's training "
+                f"set {list(self._dataset_name_to_index)}"
+            ) from None
+        return torch.tensor(indices, dtype=torch.long, device=device)
+
+    def _inject_stats(
+        self,
+        per_dataset_stats: list[dict[str, dict[str, Tensor | np.ndarray]]],
+        dataset_names: list[str] | None = None,
+    ) -> None:
+        """Overwrite the Normalize/Unnormalize buffers in-place from ``per_dataset_stats``.
+
+        Used to repopulate stats after loading a checkpoint that was saved
+        with ``save_normalization_stats=False``. The buffer shapes and dtypes
+        must already match (i.e. the policy must have been constructed with
+        the same number of datasets and the same feature set as the stats
+        being injected).
+
+        Args:
+            per_dataset_stats: Ordered list of per-dataset stat dicts (same
+                shape ``Normalize`` accepts at construction).
+            dataset_names: Optional ordered list of names; when provided also
+                updates ``self.config.dataset_names`` and the cached
+                ``_dataset_name_to_index`` lookup so inference-time
+                ``dataset_repo_id`` resolution works after the injection.
+        """
+        from opentau.policies.normalize import _stat_to_float32_tensor
+
+        for module_attr in (
+            "normalize_inputs",
+            "normalize_targets",
+            "normalize_discrete_actions",
+            "unnormalize_outputs",
+        ):
+            module = getattr(self, module_attr, None)
+            if module is None:
+                continue
+            for feature_key, ft in module.features.items():
+                norm_mode = module.norm_map.get(ft.type)
+                if norm_mode is None or norm_mode.name == "IDENTITY":
+                    continue
+                buffer_attr = "buffer_" + feature_key.replace(".", "_")
+                buffer = getattr(module, buffer_attr, None)
+                if buffer is None:
+                    continue
+                stat_names = ("mean", "std") if norm_mode.name == "MEAN_STD" else ("min", "max")
+                for stat in stat_names:
+                    rows = [_stat_to_float32_tensor(s[feature_key][stat]) for s in per_dataset_stats]
+                    new_tensor = torch.stack(rows, dim=0).to(
+                        device=buffer[stat].device, dtype=buffer[stat].dtype
+                    )
+                    if new_tensor.shape != buffer[stat].shape:
+                        raise ValueError(
+                            f"Injected stats shape {tuple(new_tensor.shape)} does not match "
+                            f"existing buffer shape {tuple(buffer[stat].shape)} for "
+                            f"{module_attr}.{buffer_attr}['{stat}']."
+                        )
+                    with torch.no_grad():
+                        buffer[stat].data.copy_(new_tensor)
+            # Refresh the module's own dataset_names cache.
+            if dataset_names is not None:
+                module.dataset_names = list(dataset_names)
+
+        if dataset_names is not None:
+            self.config.dataset_names = list(dataset_names)
+            self._dataset_name_to_index = {name: i for i, name in enumerate(dataset_names)}
+
+    def _check_norm_stats_loaded(self) -> None:
+        """Raise a clear error if any Normalize/Unnormalize buffer is still ∞.
+
+        Called by ``make_policy`` after a checkpoint load when no
+        ``per_dataset_stats`` was supplied — surfaces the
+        ``save_normalization_stats=False`` round-trip mistake at
+        policy-construction time rather than at the first forward.
+        """
+        bad: list[str] = []
+        for module_attr in (
+            "normalize_inputs",
+            "normalize_targets",
+            "normalize_discrete_actions",
+            "unnormalize_outputs",
+        ):
+            module = getattr(self, module_attr, None)
+            if module is None:
+                continue
+            for name, param in module.named_parameters(recurse=True):
+                if name.startswith("buffer_") and torch.isinf(param).any():
+                    bad.append(f"{module_attr}.{name}")
+        if bad:
+            raise RuntimeError(
+                "Normalization buffers were not initialised from a checkpoint "
+                "and no per_dataset_stats / ds_meta was passed. The following "
+                f"buffers are still +inf: {bad}. Either re-save the checkpoint "
+                "with `save_normalization_stats=True`, or pass `ds_meta=` to "
+                "`make_policy(...)` so stats are injected after load."
+            )
 
     def _tile_linear_input_weight(self, state_dict_to_load: dict):
         """Modifies the `state_dict_to_load` in-place by tiling linear layer input weights.

--- a/src/opentau/policies/pretrained.py
+++ b/src/opentau/policies/pretrained.py
@@ -281,18 +281,66 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
         policy.eval()
         return policy
 
+    # Keys injected by `_TaggedDataset` (and by inference callers) that don't
+    # represent data living on the policy's compute device. Skipped when
+    # `_infer_batch_size_and_device` walks the batch — otherwise the helper
+    # could return CPU based on a `dataset_index` that the caller hand-built
+    # on CPU even when every actual observation tensor is on GPU.
+    _NON_DATA_BATCH_KEYS: frozenset[str] = frozenset({"dataset_index", "dataset_repo_id"})
+
+    def _model_device(self) -> torch.device:
+        """Return the policy's compute device, falling back to CPU on a no-param policy."""
+        try:
+            return next(self.parameters()).device
+        except StopIteration:
+            return torch.device("cpu")
+
+    def _stacked_num_datasets(self) -> int:
+        """Return the leading dim of the stacked Normalize/Unnormalize buffers.
+
+        This is the *source of truth* for "how many datasets does this policy
+        normalize across" — the per-feature stat buffers are shaped
+        ``(num_datasets, *feat_shape)`` regardless of whether the policy was
+        constructed via `make_policy` (which populates
+        `config.dataset_names`) or directly (which may leave it ``None``).
+        Used by `_resolve_dataset_index`'s single-dataset fallback so the
+        zero-default kicks in only when the buffer truly has one row.
+
+        Returns ``1`` when no Normalize/Unnormalize module is attached or
+        when none of them have any ``buffer_*`` submodule (IDENTITY-only
+        policies). That's safe because the zero-default-on-no-key branch
+        is itself a no-op in that case.
+        """
+        for module_name in NORM_MODULE_NAMES:
+            module = getattr(self, module_name, None)
+            if module is None:
+                continue
+            for child_name, child in module.named_children():
+                if not child_name.startswith("buffer_"):
+                    continue
+                for stat_name in ("mean", "std", "min", "max"):
+                    if stat_name in child:
+                        return int(child[stat_name].shape[0])
+        return 1
+
     def _infer_batch_size_and_device(self, batch: dict[str, Tensor]) -> tuple[int, torch.device]:
-        """Find any tensor in ``batch`` and return (batch_size, device).
+        """Find any data tensor in ``batch`` and return (batch_size, device).
 
         Used by ``_resolve_dataset_index`` when the caller supplied
         ``dataset_repo_id`` as a Python string/list — we need to allocate the
-        index tensor on the same device as the rest of the batch.
+        index tensor on the same device as the rest of the batch. Skips the
+        mixture-/inference-injected ``dataset_index`` / ``dataset_repo_id``
+        keys so a CPU-resident dataset_index doesn't override a GPU batch
+        when iteration order happens to put it first.
         """
-        for v in batch.values():
+        for key, v in batch.items():
+            if key in self._NON_DATA_BATCH_KEYS:
+                continue
             if isinstance(v, Tensor):
                 return v.shape[0] if v.ndim > 0 else 1, v.device
-        # No tensors in the batch — fall back to CPU and trust caller's len(list).
-        return 0, torch.device("cpu")
+        # No data tensors in the batch — fall back to the policy's own device
+        # rather than CPU so subsequent `index_select` runs on the right side.
+        return 0, self._model_device()
 
     def _resolve_dataset_index(self, batch: dict[str, Tensor]) -> Tensor:
         """Resolve per-sample dataset indices from a training or inference batch.
@@ -323,24 +371,33 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
             idx = batch["dataset_index"]
             if not isinstance(idx, Tensor):
                 idx = torch.as_tensor(idx, dtype=torch.long)
-            # Move to whichever device the batch tensors live on. The
-            # dataloader's `pin_memory=True` materializes everything as CPU
-            # tensors and Accelerate later does the host->device copy on a
-            # per-key basis — `dataset_index` rides along for tensor keys,
-            # but a caller hand-constructing a batch on GPU may leave the
-            # index on CPU, breaking `index_select` inside Normalize.
-            _, device = self._infer_batch_size_and_device(batch)
-            return idx.to(dtype=torch.long, device=device)
+            # Move to the policy's compute device, not to "whichever device
+            # the first batch tensor happens to live on": `_infer_batch_size_and_device`
+            # iterates dict-insertion order, so a caller that put
+            # `dataset_index` first in their batch dict would have returned the
+            # index's own (CPU) device and made this a no-op, then crashed at
+            # `index_select` inside Normalize. Reading from `self.parameters()`
+            # is unambiguous and matches where Normalize's buffers actually
+            # live.
+            return idx.to(dtype=torch.long, device=self._model_device())
 
         if "dataset_repo_id" not in batch:
-            num_datasets = len(self._dataset_name_to_index) if self._dataset_name_to_index else 1
+            # Source of truth is the buffer's leading dim, NOT
+            # `len(self._dataset_name_to_index)`. A caller can construct a
+            # policy directly (`PI05Policy(config, per_dataset_stats=[s1, s2])`
+            # without setting `config.dataset_names`) — the name map stays
+            # None, but the buffer has 2 rows, so falling through to
+            # "default to zeros" would silently normalize every sample
+            # against `s1` and ignore `s2`. Reading the buffer is unambiguous.
+            num_datasets = self._stacked_num_datasets()
             if num_datasets <= 1:
                 batch_size, device = self._infer_batch_size_and_device(batch)
                 return torch.zeros(batch_size or 1, dtype=torch.long, device=device)
             raise KeyError(
-                "Per-dataset normalization with >1 dataset requires either "
-                "`dataset_index` (LongTensor of shape (B,)) or "
-                "`dataset_repo_id` (str or list[str] of length B) in the batch."
+                f"Per-dataset normalization with {num_datasets} datasets "
+                "requires either `dataset_index` (LongTensor of shape (B,)) "
+                "or `dataset_repo_id` (str or list[str] of length B) in the "
+                "batch."
             )
 
         if self._dataset_name_to_index is None:

--- a/src/opentau/policies/pretrained.py
+++ b/src/opentau/policies/pretrained.py
@@ -28,14 +28,10 @@ from pathlib import Path
 from typing import Type, TypeVar
 
 import numpy as np
-import packaging
-import safetensors
 import torch
 from huggingface_hub import hf_hub_download
 from huggingface_hub.constants import SAFETENSORS_SINGLE_FILE
 from huggingface_hub.errors import HfHubHTTPError
-from safetensors.torch import load_model as load_model_as_safetensor
-from safetensors.torch import save_file as save_safetensor_file
 from safetensors.torch import save_model as save_model_as_safetensor
 from torch import Tensor, nn
 
@@ -45,18 +41,26 @@ from opentau.utils.hub import HubMixin
 
 T = TypeVar("T", bound="PreTrainedPolicy")
 
+# Module attribute names a pi policy may attach to itself for input/output
+# normalization. Single source of truth — referenced by `NORM_BUFFER_PREFIXES`,
+# `_save_pretrained`'s detach/restore loop, `_inject_stats`, and
+# `_check_norm_stats_loaded`. Not every policy defines all four (high-level
+# planners only have `normalize_inputs`, value only has `normalize_inputs`);
+# the consumers all guard on `getattr(self, attr, None) is None`.
+NORM_MODULE_NAMES: tuple[str, ...] = (
+    "normalize_inputs",
+    "normalize_targets",
+    "normalize_discrete_actions",
+    "unnormalize_outputs",
+)
+
 # State-dict key prefixes for the per-feature normalization buffers attached
 # by `Normalize` / `Unnormalize`. Used by `_save_pretrained` (when
 # `save_normalization_stats=False`) and by `train.py`'s Accelerate save-hook
 # to strip the buffers from the on-disk safetensors. Kept here (not in
 # normalize.py) so the train script can import it without picking up torch's
 # heavy normalize module unless it actually constructs a policy.
-NORM_BUFFER_PREFIXES: tuple[str, ...] = (
-    "normalize_inputs.buffer_",
-    "normalize_targets.buffer_",
-    "normalize_discrete_actions.buffer_",
-    "unnormalize_outputs.buffer_",
-)
+NORM_BUFFER_PREFIXES: tuple[str, ...] = tuple(f"{name}.buffer_" for name in NORM_MODULE_NAMES)
 
 
 def is_norm_buffer_key(key: str) -> bool:
@@ -158,13 +162,30 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
         if include_norm_stats:
             save_model_as_safetensor(model_to_save, out_path)
         else:
-            # `save_model` doesn't expose a filter argument, so build the
-            # filtered state_dict ourselves and write via `save_file`. Clone
-            # tensors that share storage with another retained tensor to
-            # avoid safetensors' "duplicated tensors" rejection.
-            state_dict = model_to_save.state_dict()
-            filtered = {k: v for k, v in state_dict.items() if not is_norm_buffer_key(k)}
-            save_safetensor_file(filtered, out_path)
+            # `safetensors.save_file` does NOT dedup tied tensors (lm_head /
+            # embed_tokens on PaliGemma-backed policies), so feeding it a
+            # filtered state_dict raises "Some tensors share memory". Instead,
+            # temporarily detach the per-feature Normalize / Unnormalize
+            # buffers from the module tree, reuse `save_model_as_safetensor`
+            # (which calls `_remove_duplicate_names` internally), then
+            # reattach. Buffer presence is restored on the way out — even on
+            # writer exceptions.
+            detached: list[tuple[nn.Module, str, nn.ParameterDict]] = []
+            for module_name in NORM_MODULE_NAMES:
+                module = getattr(model_to_save, module_name, None)
+                if module is None:
+                    continue
+                for child_name in list(vars(module).get("_modules", {}).keys()):
+                    if not child_name.startswith("buffer_"):
+                        continue
+                    child = module._modules[child_name]
+                    detached.append((module, child_name, child))
+                    del module._modules[child_name]
+            try:
+                save_model_as_safetensor(model_to_save, out_path)
+            finally:
+                for module, child_name, child in detached:
+                    module._modules[child_name] = child
 
     @classmethod
     def from_pretrained(
@@ -245,6 +266,18 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
                     f"{SAFETENSORS_SINGLE_FILE} not found on the HuggingFace Hub in {model_id}"
                 ) from e
 
+        # Surface the stats-less-checkpoint round-trip mistake at
+        # policy-construction time rather than at first forward. This catches
+        # direct `from_pretrained` callers (notebooks, gRPC server,
+        # downstream scripts) that bypass `make_policy`'s injection path.
+        # The check is best-effort: legitimate workflows that load weights
+        # and then call `_inject_stats(...)` manually can suppress it by
+        # constructing via `cls(config, per_dataset_stats=...).load_state_dict(...)`
+        # instead. `make_policy` always satisfies this either by calling
+        # `_inject_stats` (when `ds_meta` was passed) or by re-running this
+        # same check itself.
+        policy._check_norm_stats_loaded()
+
         policy.eval()
         return policy
 
@@ -290,7 +323,14 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
             idx = batch["dataset_index"]
             if not isinstance(idx, Tensor):
                 idx = torch.as_tensor(idx, dtype=torch.long)
-            return idx.to(dtype=torch.long)
+            # Move to whichever device the batch tensors live on. The
+            # dataloader's `pin_memory=True` materializes everything as CPU
+            # tensors and Accelerate later does the host->device copy on a
+            # per-key basis — `dataset_index` rides along for tensor keys,
+            # but a caller hand-constructing a batch on GPU may leave the
+            # index on CPU, breaking `index_select` inside Normalize.
+            _, device = self._infer_batch_size_and_device(batch)
+            return idx.to(dtype=torch.long, device=device)
 
         if "dataset_repo_id" not in batch:
             num_datasets = len(self._dataset_name_to_index) if self._dataset_name_to_index else 1
@@ -337,19 +377,38 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
         Args:
             per_dataset_stats: Ordered list of per-dataset stat dicts (same
                 shape ``Normalize`` accepts at construction).
-            dataset_names: Optional ordered list of names; when provided also
-                updates ``self.config.dataset_names`` and the cached
-                ``_dataset_name_to_index`` lookup so inference-time
-                ``dataset_repo_id`` resolution works after the injection.
+            dataset_names: Ordered list of names parallel to
+                ``per_dataset_stats``. **Strongly recommended.** When
+                provided, the existing ``self.config.dataset_names`` is
+                cross-checked against this list and any mismatch raises —
+                otherwise an out-of-order injection would silently corrupt
+                the name→index lookup, mapping samples to the wrong row at
+                inference. When ``None``, ``self.config.dataset_names`` is
+                trusted as-is and the caller is responsible for keeping
+                ``per_dataset_stats`` in the same order.
         """
         from opentau.policies.normalize import _stat_to_float32_tensor
 
-        for module_attr in (
-            "normalize_inputs",
-            "normalize_targets",
-            "normalize_discrete_actions",
-            "unnormalize_outputs",
-        ):
+        if dataset_names is not None:
+            existing = getattr(self.config, "dataset_names", None)
+            if existing is not None and list(existing) != list(dataset_names):
+                raise ValueError(
+                    "_inject_stats: provided `dataset_names` "
+                    f"{list(dataset_names)} disagrees with existing "
+                    f"`config.dataset_names` {list(existing)}. Reordering "
+                    "the names without reordering `per_dataset_stats` would "
+                    "silently map samples to the wrong stats row. Pass the "
+                    "names in the same order as the policy was originally "
+                    "constructed, or omit `dataset_names`."
+                )
+            if len(dataset_names) != len(per_dataset_stats):
+                raise ValueError(
+                    f"_inject_stats: dataset_names ({len(dataset_names)}) "
+                    f"and per_dataset_stats ({len(per_dataset_stats)}) must "
+                    "have the same length."
+                )
+
+        for module_attr in NORM_MODULE_NAMES:
             module = getattr(self, module_attr, None)
             if module is None:
                 continue
@@ -387,17 +446,14 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
         """Raise a clear error if any Normalize/Unnormalize buffer is still ∞.
 
         Called by ``make_policy`` after a checkpoint load when no
-        ``per_dataset_stats`` was supplied — surfaces the
+        ``per_dataset_stats`` was supplied, and by the base
+        ``from_pretrained`` so direct callers (notebooks, gRPC server,
+        downstream scripts) surface the
         ``save_normalization_stats=False`` round-trip mistake at
         policy-construction time rather than at the first forward.
         """
         bad: list[str] = []
-        for module_attr in (
-            "normalize_inputs",
-            "normalize_targets",
-            "normalize_discrete_actions",
-            "unnormalize_outputs",
-        ):
+        for module_attr in NORM_MODULE_NAMES:
             module = getattr(self, module_attr, None)
             if module is None:
                 continue
@@ -411,6 +467,48 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
                 f"buffers are still +inf: {bad}. Either re-save the checkpoint "
                 "with `save_normalization_stats=True`, or pass `ds_meta=` to "
                 "`make_policy(...)` so stats are injected after load."
+            )
+
+    def _promote_legacy_norm_buffers_in_state_dict(self, state_dict_to_load: dict) -> None:
+        """Reshape pre-PR ``normalize_*.buffer_*`` entries to the new stacked rank.
+
+        Before this PR, Normalize/Unnormalize buffers were saved with shape
+        ``(*feat_shape,)`` (single-dataset). The new format is
+        ``(num_datasets, *feat_shape)`` with a leading dataset axis. Legacy
+        checkpoints on disk (everything under ``TensorAuto/*`` predating
+        this change) load through ``load_state_dict`` and would raise on
+        size mismatch.
+
+        This shim walks the incoming state_dict, finds any norm-buffer key
+        whose loaded tensor is exactly one rank shy of the matching
+        in-memory buffer, and prepends a leading axis with ``unsqueeze(0)``
+        (single-dataset assumption — appropriate for any legacy
+        checkpoint, since they were trained against a single mixture and
+        the single-dataset case is the new D=1 row). Logs a one-time
+        warning so the user knows the buffers were promoted.
+
+        Operates in-place on ``state_dict_to_load``. Safe to call
+        unconditionally; new-format checkpoints are unchanged.
+        """
+        own_state = dict(self.state_dict())
+        promoted: list[str] = []
+        for key in list(state_dict_to_load):
+            if not is_norm_buffer_key(key):
+                continue
+            loaded = state_dict_to_load[key]
+            target = own_state.get(key)
+            if target is None:
+                continue
+            if loaded.ndim == target.ndim - 1 and tuple(loaded.shape) == tuple(target.shape[1:]):
+                state_dict_to_load[key] = loaded.unsqueeze(0)
+                promoted.append(key)
+        if promoted:
+            logging.warning(
+                "Promoted %d legacy single-dataset Normalize/Unnormalize "
+                "buffers to the new (1, *feat_shape) stacked layout. "
+                "Sample keys: %s",
+                len(promoted),
+                promoted[:3],
             )
 
     def _tile_linear_input_weight(self, state_dict_to_load: dict):
@@ -455,25 +553,21 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
         Returns:
             T: The model with loaded weights.
         """
-        # Create base kwargs
-        kwargs = {"strict": strict}
+        # Pre-load the state_dict so we can run the legacy Normalize/Unnormalize
+        # buffer migration shim before handing it off. `safetensors.torch.load_model`
+        # would otherwise raise on the shape mismatch between pre-PR
+        # `(*feat_shape,)` buffers and the new `(1, *feat_shape)` layout.
+        from safetensors.torch import load_file as load_safetensor_file
 
-        # Add device parameter for newer versions that support it
-        if packaging.version.parse(safetensors.__version__) >= packaging.version.parse("0.4.3"):
-            kwargs["device"] = map_location
-
-        # Load the model with appropriate kwargs
-        missing_keys, unexpected_keys = load_model_as_safetensor(model, model_file, **kwargs)
+        device_arg = map_location if map_location != "cpu" else "cpu"
+        state_dict = load_safetensor_file(model_file, device=device_arg)
+        model._promote_legacy_norm_buffers_in_state_dict(state_dict)
+        missing_keys, unexpected_keys = model.load_state_dict(state_dict, strict=strict)
         log_model_loading_keys(missing_keys, unexpected_keys)
-
-        # For older versions, manually move to device if needed
-        if "device" not in kwargs and map_location != "cpu":
-            logging.warning(
-                "Loading model weights on other devices than 'cpu' is not supported natively in your version of safetensors."
-                " This means that the model is loaded on 'cpu' first and then copied to the device."
-                " This leads to a slower loading time."
-                " Please update safetensors to version 0.4.3 or above for improved performance."
-            )
+        if map_location != "cpu":
+            # The model already received its weights on `map_location` via
+            # ``load_safetensor_file(..., device=...)``; this is a defensive
+            # no-op on top.
             model.to(map_location)
         return model
 

--- a/src/opentau/policies/pretrained.py
+++ b/src/opentau/policies/pretrained.py
@@ -273,10 +273,17 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
         training-time ``dataset_names`` list (stored on ``self.config``) to
         the corresponding integer index.
 
+        Single-dataset fallback: when the batch lacks BOTH keys AND the
+        policy was constructed with ``num_datasets <= 1`` (or legacy
+        ``dataset_names is None``), default to zeros so callers don't have
+        to inject ``dataset_index`` for the one-row buffer. Multi-dataset
+        policies always require the caller to be explicit; otherwise mixing
+        samples from different datasets without identification is silently
+        wrong.
+
         Raises:
-            KeyError: neither ``dataset_index`` nor ``dataset_repo_id`` was provided.
-            RuntimeError: ``dataset_repo_id`` was provided but the policy was
-                loaded without a ``dataset_names`` list.
+            KeyError: neither ``dataset_index`` nor ``dataset_repo_id`` was
+                provided AND the policy has more than one dataset.
             ValueError: a name was provided that isn't in ``dataset_names``.
         """
         if "dataset_index" in batch:
@@ -286,10 +293,14 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
             return idx.to(dtype=torch.long)
 
         if "dataset_repo_id" not in batch:
+            num_datasets = len(self._dataset_name_to_index) if self._dataset_name_to_index else 1
+            if num_datasets <= 1:
+                batch_size, device = self._infer_batch_size_and_device(batch)
+                return torch.zeros(batch_size or 1, dtype=torch.long, device=device)
             raise KeyError(
-                "Per-dataset normalization requires either `dataset_index` "
-                "(LongTensor of shape (B,)) or `dataset_repo_id` (str or "
-                "list[str] of length B) in the batch."
+                "Per-dataset normalization with >1 dataset requires either "
+                "`dataset_index` (LongTensor of shape (B,)) or "
+                "`dataset_repo_id` (str or list[str] of length B) in the batch."
             )
 
         if self._dataset_name_to_index is None:
@@ -298,7 +309,6 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
                 "`dataset_repo_id` strings. Either pass `batch['dataset_index']` "
                 "directly or rebuild the policy via `make_policy(cfg, ds_meta=...)`."
             )
-
         raw = batch["dataset_repo_id"]
         batch_size, device = self._infer_batch_size_and_device(batch)
         names = [raw] * (batch_size or 1) if isinstance(raw, str) else list(raw)

--- a/src/opentau/policies/value/modeling_value.py
+++ b/src/opentau/policies/value/modeling_value.py
@@ -163,6 +163,28 @@ class ValueFunction(PreTrainedPolicy):
                 len(per_dataset_stats),
             )
             per_dataset_stats = per_dataset_stats[:1]
+            if dataset_names is not None:
+                dataset_names = dataset_names[:1]
+        # `super().__init__(config)` already populated `self._dataset_name_to_index`
+        # from `config.dataset_names`. The value policy is single-dataset by
+        # construction, so any multi-dataset config the caller carried in
+        # would leave a 3-entry name map pointing at a 1-row buffer — an
+        # inference call with `dataset_repo_id='<second>'` would index out
+        # of range. Rebuild the name map to match the truncated stats.
+        if dataset_names is not None:
+            self.config.dataset_names = list(dataset_names)
+            self._dataset_name_to_index = {name: i for i, name in enumerate(dataset_names)}
+        elif getattr(self.config, "dataset_names", None) and len(self.config.dataset_names) > 1:
+            kept = self.config.dataset_names[:1]
+            logging.warning(
+                "ValueFunction is single-dataset; truncating "
+                "`config.dataset_names` from %s to %s to match the 1-row "
+                "Normalize buffer.",
+                list(self.config.dataset_names),
+                kept,
+            )
+            self.config.dataset_names = kept
+            self._dataset_name_to_index = {name: i for i, name in enumerate(kept)}
         num_datasets = 1
         self.normalize_inputs = Normalize(
             config.input_features,

--- a/src/opentau/policies/value/modeling_value.py
+++ b/src/opentau/policies/value/modeling_value.py
@@ -138,7 +138,21 @@ class ValueFunction(PreTrainedPolicy):
         super().__init__(config)
         config.validate_features()
         self.config = config
-        self.normalize_inputs = Normalize(config.input_features, config.normalization_mapping, dataset_stats)
+        # The shared `Normalize` module accepts `per_dataset_stats: list[dict]`
+        # since the per-dataset normalization rewrite. `ValueFunction`'s
+        # external API still takes a single ``dataset_stats: dict | None`` —
+        # wrap into a singleton list so the policy keeps working without
+        # forcing every caller to migrate. The single-dataset path is
+        # equivalent to the old behaviour (stacked buffer of leading dim 1,
+        # `dataset_index=0` for every sample).
+        per_dataset_stats = [dataset_stats] if dataset_stats is not None else None
+        num_datasets = 1
+        self.normalize_inputs = Normalize(
+            config.input_features,
+            config.normalization_mapping,
+            per_dataset_stats=per_dataset_stats,
+            num_datasets=num_datasets,
+        )
 
         self.language_tokenizer = AutoTokenizer.from_pretrained("google/gemma-3-270m")
         self.model = ValueModel(config)
@@ -228,7 +242,11 @@ class ValueFunction(PreTrainedPolicy):
         """
         self.eval()
 
-        batch = self.normalize_inputs(batch)
+        # `ValueFunction` is a single-dataset policy (its `Normalize` was
+        # built with `num_datasets=1`); `_resolve_dataset_index` defaults
+        # to zeros in that case so callers don't need to inject the index.
+        dataset_index = self._resolve_dataset_index(batch)
+        batch = self.normalize_inputs(batch, dataset_index)
 
         images, img_masks = self.prepare_images(batch)
         lang_tokens, lang_masks = self.prepare_language(batch)
@@ -245,7 +263,11 @@ class ValueFunction(PreTrainedPolicy):
         Returns:
             Tuple of (loss_dict, None) where loss_dict contains the MSE loss
         """
-        batch = self.normalize_inputs(batch)
+        # `ValueFunction` is a single-dataset policy (its `Normalize` was
+        # built with `num_datasets=1`); `_resolve_dataset_index` defaults
+        # to zeros in that case so callers don't need to inject the index.
+        dataset_index = self._resolve_dataset_index(batch)
+        batch = self.normalize_inputs(batch, dataset_index)
 
         images, img_masks = self.prepare_images(batch)
         lang_tokens, lang_masks = self.prepare_language(batch)

--- a/src/opentau/policies/value/modeling_value.py
+++ b/src/opentau/policies/value/modeling_value.py
@@ -125,27 +125,44 @@ class ValueFunction(PreTrainedPolicy):
         self,
         config: ValueConfig,
         dataset_stats: dict[str, dict[str, Tensor]] | None = None,
+        per_dataset_stats: list[dict[str, dict[str, Tensor]]] | None = None,
+        dataset_names: list[str] | None = None,
     ):
         """Initializes the ValueFunction policy.
 
         Args:
-            config: Value Function configuration class instance or None, in which case the default instantiation of
-                the configuration class is used.
-            dataset_stats: Dataset statistics to be used for normalization. If not passed here, it is expected
-                that they will be passed with a call to `load_state_dict` before the policy is used.
+            config: Value Function configuration class instance.
+            dataset_stats: Legacy single-dataset stats dict. Wrapped into a
+                singleton list internally. Mutually exclusive with
+                ``per_dataset_stats``.
+            per_dataset_stats: Ordered list of per-dataset stat dicts.
+                Accepted for compatibility with ``make_policy``'s new
+                plumbing — value is single-dataset by design, so only the
+                first entry is used and a warning fires for longer lists.
+            dataset_names: Accepted for compatibility with ``make_policy``;
+                only the first entry is consumed.
         """
 
         super().__init__(config)
         config.validate_features()
         self.config = config
-        # The shared `Normalize` module accepts `per_dataset_stats: list[dict]`
-        # since the per-dataset normalization rewrite. `ValueFunction`'s
-        # external API still takes a single ``dataset_stats: dict | None`` —
-        # wrap into a singleton list so the policy keeps working without
-        # forcing every caller to migrate. The single-dataset path is
-        # equivalent to the old behaviour (stacked buffer of leading dim 1,
-        # `dataset_index=0` for every sample).
-        per_dataset_stats = [dataset_stats] if dataset_stats is not None else None
+        # Reconcile the dual external API: callers either pass the legacy
+        # single dict via ``dataset_stats`` or the new list-of-dicts via
+        # ``per_dataset_stats``. They must not pass both.
+        if dataset_stats is not None and per_dataset_stats is not None:
+            raise ValueError(
+                "Pass either `dataset_stats` (legacy single-dataset) or "
+                "`per_dataset_stats` (new list form), not both."
+            )
+        if per_dataset_stats is None and dataset_stats is not None:
+            per_dataset_stats = [dataset_stats]
+        if per_dataset_stats is not None and len(per_dataset_stats) > 1:
+            logging.warning(
+                "ValueFunction is single-dataset by design; received %d "
+                "per_dataset_stats entries — only the first will be used.",
+                len(per_dataset_stats),
+            )
+            per_dataset_stats = per_dataset_stats[:1]
         num_datasets = 1
         self.normalize_inputs = Normalize(
             config.input_features,

--- a/src/opentau/scripts/eval.py
+++ b/src/opentau/scripts/eval.py
@@ -164,6 +164,15 @@ def rollout(
         if return_observations:
             all_observations.append(deepcopy(observation))
 
+        # Tag the observation with which training-time dataset's stats to
+        # use for per-sample Normalize/Unnormalize. `EvalConfig.dataset_repo_id`
+        # is `None` by default, in which case the policy's
+        # `_resolve_dataset_index` single-dataset fallback handles things —
+        # required only for multi-dataset checkpoints.
+        eval_dataset_repo_id = getattr(cfg.eval, "dataset_repo_id", None)
+        if eval_dataset_repo_id is not None:
+            observation["dataset_repo_id"] = eval_dataset_repo_id
+
         with torch.inference_mode():
             action = policy.select_action(observation)
 

--- a/src/opentau/scripts/export_to_onnx.py
+++ b/src/opentau/scripts/export_to_onnx.py
@@ -120,7 +120,13 @@ class PI05OnnxWrapper(torch.nn.Module):
         original_action_dim = self.policy.config.action_feature.shape[0]
         actions = actions[:, :, :original_action_dim]
 
-        actions = self.policy.unnormalize_outputs({"actions": actions})["actions"]
+        # ONNX export traces with a single fixed dataset choice (the first
+        # entry in config.dataset_names). The unnormalize call needs an
+        # explicit dataset_index since this wrapper bypasses
+        # `_resolve_dataset_index` (no `batch["dataset_repo_id"]` available).
+        bsize = lang_tokens.shape[0]
+        dataset_index = torch.zeros(bsize, dtype=torch.long, device=lang_tokens.device)
+        actions = self.policy.unnormalize_outputs({"actions": actions}, dataset_index)["actions"]
         return actions
 
 

--- a/src/opentau/scripts/fit_fast_tokenizer.py
+++ b/src/opentau/scripts/fit_fast_tokenizer.py
@@ -42,9 +42,12 @@ Pipeline (all CPU):
        fps when ``action_freq is None`` -- mixed-frequency mixtures) and
        right-padded to ``max_action_dim``.
     4. Min-max-normalize each chunk to ``[-1, 1]`` using
-       ``mixture.meta.stats["actions"]`` -- the same min/max the policy
-       will use at training via
-       ``Normalize({"ACTION": NormalizationMode.MIN_MAX})``.
+       ``mixture.meta.aggregated_action_stats()`` -- the same global
+       min/max the BPE codec is fit over. (The training policy itself
+       normalizes per-dataset via
+       ``Normalize({"ACTION": NormalizationMode.MIN_MAX})``; the
+       tokenizer collapses to one global range so the discrete vocab
+       is shared across the mixture.)
     5. Call ``UniversalActionProcessor.fit(...)`` (DCT + Rust BpeTrainer)
        and ``save_pretrained`` the result. The upstream remote-code
        source ``processing_action_tokenizer.py`` is copied alongside so
@@ -716,18 +719,25 @@ def _build_mixture_parallel(train_cfg: Any, num_workers: int) -> Any:
 
 
 def _extract_action_stats(mixture_meta: Any, action_dim: int) -> tuple[np.ndarray, np.ndarray]:
-    """Pull mixture-aggregated ``action`` min/max (already padded to
-    ``max_action_dim`` and computed with NaN-tolerant aggregation by
-    ``DatasetMixtureMetadata``).
+    """Pull a single global ``action`` min/max across the whole mixture.
+
+    Per-dataset normalization (the production training path) keeps separate
+    stats per source, but the BPE tokenizer fits one codec over a shared
+    action range — call ``mixture_meta.aggregated_action_stats()`` to compute
+    that on demand. Output is already padded to ``max_action_dim`` and uses
+    NaN-tolerant aggregation under the hood.
 
     Dims that are ``NaN`` across the whole mixture fall back to ``[-1, 1]`` so
     the normalization step never divides by zero.
     """
-    action_stats = mixture_meta.stats.get("actions")
-    if action_stats is None:
+    try:
+        action_stats = mixture_meta.aggregated_action_stats()
+    except (AttributeError, ValueError) as e:
         raise RuntimeError(
-            f"Mixture meta is missing 'actions' stats. Available keys: {sorted(mixture_meta.stats or [])}"
-        )
+            "Mixture meta does not expose `aggregated_action_stats()` or has no "
+            "'actions' contributor. Ensure the mixture was built from "
+            "`WeightedDatasetMixture` (which produces `DatasetMixtureMetadata`)."
+        ) from e
     action_min = np.asarray(action_stats["min"], dtype=np.float64).ravel()
     action_max = np.asarray(action_stats["max"], dtype=np.float64).ravel()
     if action_min.shape[0] < action_dim:

--- a/src/opentau/scripts/grpc/server.py
+++ b/src/opentau/scripts/grpc/server.py
@@ -94,6 +94,12 @@ class RobotPolicyServicer(robot_inference_pb2_grpc.RobotPolicyServiceServicer):
             "prompt": ["Pick up yellow lego block and put it in the bin"],
             "img_is_pad": torch.zeros((1, 1), dtype=torch.bool, device=self.device),
         }
+        # Mirror `_prepare_observation`'s dataset tagging for the warmup call —
+        # otherwise a multi-dataset checkpoint trips `_resolve_dataset_index`
+        # at compile time rather than at the first real request.
+        warmup_dataset_repo_id = getattr(self.cfg.server, "dataset_repo_id", None)
+        if warmup_dataset_repo_id is not None:
+            observation["dataset_repo_id"] = warmup_dataset_repo_id
         action_prefix = torch.zeros(
             (1, self.cfg.action_chunk, self.cfg.max_action_dim), dtype=self.dtype, device=self.device
         )
@@ -188,6 +194,15 @@ class RobotPolicyServicer(robot_inference_pb2_grpc.RobotPolicyServiceServicer):
 
         # Process prompt
         batch["prompt"] = [request.prompt] if request.prompt else [""]
+
+        # Tag the batch with which training-time dataset's stats to use for
+        # per-sample Normalize/Unnormalize. When `server.dataset_repo_id` is
+        # `None` (default), the policy's `_resolve_dataset_index` single-
+        # dataset fallback handles things — only needed for multi-dataset
+        # checkpoints.
+        server_dataset_repo_id = getattr(self.cfg.server, "dataset_repo_id", None)
+        if server_dataset_repo_id is not None:
+            batch["dataset_repo_id"] = server_dataset_repo_id
         if request.prefix_action:
             prefix_action = torch.tensor(
                 np.array(

--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -41,7 +41,7 @@ from opentau.envs.utils import close_envs
 from opentau.optim.factory import make_optimizer_and_scheduler
 from opentau.optim.master_weights import MasterWeightOptimizer
 from opentau.policies.factory import make_policy
-from opentau.policies.pretrained import PreTrainedPolicy
+from opentau.policies.pretrained import PreTrainedPolicy, is_norm_buffer_key
 from opentau.scripts.eval import (
     collect_grid_summary_videos,
     consolidate_eval_info,
@@ -548,6 +548,24 @@ def train(cfg: TrainPipelineConfig):
 
     # Register the LR scheduler for checkpointing
     accelerator.register_for_checkpointing(lr_scheduler)
+
+    # When `save_normalization_stats=False`, strip the per-feature Normalize /
+    # Unnormalize buffers from each model state_dict that Accelerate is about
+    # to write under `accelerator.save_state(...)`. The hook runs on every
+    # rank before the actual safetensors write, so the filtered keys never
+    # land on disk. The reload side relies on `make_policy(..., ds_meta=...)`
+    # to call `_inject_stats(...)` and repopulate the buffers (see
+    # `policies/factory.py::make_policy`).
+    if not cfg.policy.save_normalization_stats:
+
+        def _strip_norm_buffers_pre_save(models, weights, input_dir):
+            del models, input_dir
+            for sd in weights:
+                for k in list(sd):
+                    if is_norm_buffer_key(k):
+                        del sd[k]
+
+        accelerator.register_save_state_pre_hook(_strip_norm_buffers_pre_save)
 
     if cfg.resume:
         # load accelerator state

--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -569,8 +569,17 @@ def train(cfg: TrainPipelineConfig):
 
     if cfg.resume:
         # load accelerator state
-        # This will load the model, optimizer, and lr_scheduler state
-        accelerator.load_state(cfg.checkpoint_path)
+        # This will load the model, optimizer, and lr_scheduler state.
+        # When `save_normalization_stats=False`, the on-disk safetensors lacks
+        # `normalize_*.buffer_*` keys, so the default `strict=True` load
+        # raises. Pass `strict=False` to let those missing keys pass — the
+        # buffers were already repopulated by `_inject_stats` inside
+        # `make_policy(cfg, ds_meta=...)` above, so this leaves them at the
+        # right values rather than silently overwriting.
+        load_kwargs: dict = {}
+        if not cfg.policy.save_normalization_stats:
+            load_kwargs["strict"] = False
+        accelerator.load_state(cfg.checkpoint_path, **load_kwargs)
 
         # When the master-weights wrapper is in use, the live bf16 weights
         # have just been overwritten by ``accelerator.load_state``. Rebuild

--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -21,6 +21,7 @@ import os
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
 from contextlib import contextmanager, nullcontext
+from pathlib import Path
 from pprint import pformat
 from typing import Any
 
@@ -568,17 +569,37 @@ def train(cfg: TrainPipelineConfig):
         accelerator.register_save_state_pre_hook(_strip_norm_buffers_pre_save)
 
     if cfg.resume:
-        # load accelerator state
-        # This will load the model, optimizer, and lr_scheduler state.
-        # When `save_normalization_stats=False`, the on-disk safetensors lacks
-        # `normalize_*.buffer_*` keys, so the default `strict=True` load
-        # raises. Pass `strict=False` to let those missing keys pass — the
-        # buffers were already repopulated by `_inject_stats` inside
-        # `make_policy(cfg, ds_meta=...)` above, so this leaves them at the
-        # right values rather than silently overwriting.
+        # Inspect the on-disk safetensors header (rather than trusting the
+        # *current* `cfg.policy.save_normalization_stats` flag) to decide
+        # whether `strict=True` would crash on missing norm-buffer keys.
+        # This makes resume robust to the user toggling the flag between the
+        # initial run and the resume — the file on disk is the only source
+        # of truth for what's actually missing. Reading the header is also
+        # cheap; safetensors parses just the index.
         load_kwargs: dict = {}
-        if not cfg.policy.save_normalization_stats:
-            load_kwargs["strict"] = False
+        try:
+            from safetensors import safe_open
+
+            ckpt_safetensors = Path(cfg.checkpoint_path) / "model.safetensors"
+            if ckpt_safetensors.exists():
+                with safe_open(str(ckpt_safetensors), framework="pt") as f:
+                    saved_keys = set(f.keys())
+                if not any(is_norm_buffer_key(k) for k in saved_keys):
+                    # The disk checkpoint omits every norm buffer — strict
+                    # load would raise. The buffers were already repopulated
+                    # by `_inject_stats` inside `make_policy(..., ds_meta=...)`
+                    # above, so falling back to `strict=False` leaves them at
+                    # the right values rather than silently overwriting.
+                    load_kwargs["strict"] = False
+        except Exception as e:
+            logging.warning(
+                "Could not inspect %s/model.safetensors to decide strict mode "
+                "for resume (%s). Falling back to the cfg flag.",
+                cfg.checkpoint_path,
+                e,
+            )
+            if not cfg.policy.save_normalization_stats:
+                load_kwargs["strict"] = False
         accelerator.load_state(cfg.checkpoint_path, **load_kwargs)
 
         # When the master-weights wrapper is in use, the live bf16 weights

--- a/tests/datasets/test_dataset_mixture.py
+++ b/tests/datasets/test_dataset_mixture.py
@@ -421,6 +421,11 @@ class TestWeightedDatasetMixtureIntegration:
         # somehow this is faster than list(dataset[0])
         dataset_samples = [datasets[0][idx] for idx in range(len(datasets[0]))]
         dataloader_iter = iter(dataloader)
+        # The `_TaggedDataset` wrapper inside `WeightedDatasetMixture` adds two
+        # mixture-level identification keys to every sample; the raw
+        # `datasets[0][idx]` lookups below intentionally bypass that wrapper,
+        # so strip the wrapper-added keys before the content comparison.
+        wrapper_only_keys = {"dataset_repo_id", "dataset_index"}
         # sample from dataloader 20 times and check that the samples exist in the dataset
         for _ in range(20):
             sample = next(dataloader_iter)
@@ -431,6 +436,7 @@ class TestWeightedDatasetMixtureIntegration:
                 if isinstance(value, torch.Tensor)
                 else (value[0] if isinstance(value, list) and len(value) > 0 else value)
                 for key, value in sample.items()
+                if key not in wrapper_only_keys
             }
             assert any(are_tensor_dicts_equal(sample, item) for item in dataset_samples)
 

--- a/tests/datasets/test_dataset_mixture.py
+++ b/tests/datasets/test_dataset_mixture.py
@@ -86,9 +86,18 @@ class TestDatasetMixtureMetadata:
         metadata_mixture = DatasetMixtureMetadata(train_pipeline_config, metadatas, dataset_weights)
 
         assert metadata_mixture.cfg == train_pipeline_config
-        assert "state" in metadata_mixture.stats
-        assert "actions" in metadata_mixture.stats
-        assert "camera0" in metadata_mixture.stats
+        # `per_dataset_stats` replaces the previously-aggregated `stats` dict;
+        # there is one entry per underlying dataset, each carrying the standard
+        # feature set after `_to_standard_data_format` normalization.
+        assert len(metadata_mixture.per_dataset_stats) == 1
+        assert "state" in metadata_mixture.per_dataset_stats[0]
+        assert "actions" in metadata_mixture.per_dataset_stats[0]
+        assert "camera0" in metadata_mixture.per_dataset_stats[0]
+        # `dataset_names` defaults to the underlying repo_ids when the caller
+        # doesn't override (the WeightedDatasetMixture path supplies its own
+        # deduplicated list).
+        assert metadata_mixture.dataset_names == [lerobot_dataset_metadata.repo_id]
+        assert metadata_mixture.dataset_name_to_index == {lerobot_dataset_metadata.repo_id: 0}
 
     @patch("opentau.datasets.dataset_mixture.DATA_FEATURES_NAME_MAPPING")
     def test_to_standard_data_format(self, mock_name_mapping, train_pipeline_config):
@@ -218,7 +227,12 @@ class TestWeightedDatasetMixture:
         mixture = WeightedDatasetMixture(train_pipeline_config, datasets, dataset_weights, action_freq)
 
         assert mixture.cfg == train_pipeline_config
-        assert mixture.datasets == datasets
+        # `mixture.datasets` is the list of `_TaggedDataset` wrappers (not the
+        # raw user-supplied datasets); compare on `len` and verify the
+        # wrappers expose the underlying `.meta`.
+        assert len(mixture.datasets) == len(datasets)
+        for wrapped, original in zip(mixture.datasets, datasets, strict=True):
+            assert wrapped.meta is original.meta
         assert mixture.dataset_weights == dataset_weights
         assert mixture.action_freq == action_freq
         assert len(mixture.dataset_names) == 5
@@ -443,16 +457,21 @@ class TestWeightedDatasetMixtureIntegration:
 
     @pytest.mark.slow  # 1 sec
     def test_integration_metadata_aggregation(self, train_pipeline_config, datasets_factory):
-        """Test that metadata is properly aggregated from multiple datasets."""
+        """Test that per-dataset metadata is properly populated from multiple datasets."""
         datasets = datasets_factory(2)
         dataset_weights = [0.6, 0.4]
 
         mixture = WeightedDatasetMixture(train_pipeline_config, datasets, dataset_weights, 30.0)
 
-        # Verify aggregated metadata
+        # Verify per-dataset metadata (no cross-dataset aggregation any more —
+        # the policy stacks these along a per-sample axis instead).
         assert mixture.meta is not None
-        assert hasattr(mixture.meta, "stats")
+        assert hasattr(mixture.meta, "per_dataset_stats")
+        assert hasattr(mixture.meta, "dataset_names")
         assert hasattr(mixture.meta, "features")
+        assert len(mixture.meta.per_dataset_stats) == 2
+        assert mixture.meta.dataset_names == mixture.dataset_names
+        assert mixture.meta.dataset_name_to_index[mixture.dataset_names[0]] == 0
 
         # Verify features are properly configured
         features = mixture.meta.features

--- a/tests/datasets/test_tagged_dataset.py
+++ b/tests/datasets/test_tagged_dataset.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Tests for the ``_TaggedDataset`` wrapper that injects per-sample dataset identity."""
+
+import torch
+from torch.utils.data import DataLoader, Dataset
+from torch.utils.data._utils.collate import default_collate
+
+from opentau.datasets.dataset_mixture import _TaggedDataset
+
+
+class _FakeMeta:
+    """Stand-in for ``BaseDataset.meta`` (any attribute object would do)."""
+
+
+class _FakeDataset(Dataset):
+    """Minimal stand-in for a ``BaseDataset`` for the wrapper's tagging path."""
+
+    def __init__(self, length: int):
+        self._length = length
+        self.meta = _FakeMeta()
+
+    def __len__(self) -> int:
+        return self._length
+
+    def __getitem__(self, idx):
+        return {
+            "state": torch.tensor([float(idx)]),
+            "action": torch.tensor([float(idx) * 2.0]),
+        }
+
+
+def test_tagged_dataset_injects_keys():
+    """Each __getitem__ adds the expected `dataset_repo_id` and `dataset_index`."""
+    base = _FakeDataset(length=3)
+    tagged = _TaggedDataset(base, dataset_repo_id="foo/bar", dataset_index=2)
+    for i in range(3):
+        sample = tagged[i]
+        assert sample["dataset_repo_id"] == "foo/bar"
+        assert isinstance(sample["dataset_index"], torch.Tensor)
+        assert sample["dataset_index"].dtype == torch.long
+        assert int(sample["dataset_index"].item()) == 2
+        # underlying keys preserved
+        assert torch.equal(sample["state"], torch.tensor([float(i)]))
+
+
+def test_tagged_dataset_preserves_meta():
+    """`.meta` must round-trip through the wrapper (mixture validation relies on it)."""
+    base = _FakeDataset(length=1)
+    tagged = _TaggedDataset(base, dataset_repo_id="x", dataset_index=0)
+    assert tagged.meta is base.meta
+
+
+def test_tagged_dataset_len_delegates():
+    base = _FakeDataset(length=7)
+    tagged = _TaggedDataset(base, dataset_repo_id="x", dataset_index=0)
+    assert len(tagged) == 7
+
+
+def test_tagged_dataset_default_collate_batches_correctly():
+    """Default collate must batch the str into a list[str] and the long scalar into (B,)."""
+    base = _FakeDataset(length=4)
+    tagged = _TaggedDataset(base, dataset_repo_id="foo/bar", dataset_index=3)
+    samples = [tagged[i] for i in range(4)]
+    batch = default_collate(samples)
+
+    assert batch["dataset_repo_id"] == ["foo/bar"] * 4
+    assert isinstance(batch["dataset_index"], torch.Tensor)
+    assert batch["dataset_index"].dtype == torch.long
+    assert tuple(batch["dataset_index"].shape) == (4,)
+    assert torch.equal(batch["dataset_index"], torch.full((4,), 3, dtype=torch.long))
+
+
+def test_tagged_dataset_dataloader_end_to_end():
+    """Real DataLoader produces the right batched fields."""
+    base = _FakeDataset(length=6)
+    tagged = _TaggedDataset(base, dataset_repo_id="repo", dataset_index=1)
+    loader = DataLoader(tagged, batch_size=3, shuffle=False)
+    batches = list(loader)
+    assert len(batches) == 2
+    for batch in batches:
+        assert batch["dataset_repo_id"] == ["repo"] * 3
+        assert tuple(batch["dataset_index"].shape) == (3,)
+        assert torch.equal(batch["dataset_index"], torch.ones(3, dtype=torch.long))

--- a/tests/policies/test_normalize_per_dataset.py
+++ b/tests/policies/test_normalize_per_dataset.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python
+
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Per-dataset Normalize / Unnormalize: stacked buffers indexed per sample."""
+
+import pytest
+import torch
+
+from opentau.configs.types import FeatureType, NormalizationMode, PolicyFeature
+from opentau.policies.normalize import EPS, Normalize, Unnormalize
+
+
+def _build_per_dataset_stats(num_datasets: int) -> list[dict[str, dict[str, torch.Tensor]]]:
+    """Build distinct stats per dataset so per-sample indexing is observable."""
+    out = []
+    for d in range(num_datasets):
+        out.append(
+            {
+                "observation.state": {
+                    "mean": torch.full((4,), float(d)),
+                    "std": torch.full((4,), float(d + 1)),
+                    "min": torch.full((4,), -float(d + 1)),
+                    "max": torch.full((4,), float(d + 1)),
+                },
+                "action": {
+                    "mean": torch.full((3,), float(d) * 0.1),
+                    "std": torch.full((3,), float(d + 1) * 0.5),
+                    "min": torch.full((3,), -float(d + 1)),
+                    "max": torch.full((3,), float(d + 1)),
+                },
+            }
+        )
+    return out
+
+
+def test_per_dataset_normalize_mean_std_picks_right_row():
+    """Each sample's mean/std must be drawn from the row matching its dataset_index."""
+    num_ds = 3
+    features = {
+        "observation.state": PolicyFeature(type=FeatureType.STATE, shape=(4,)),
+    }
+    norm_map = {"STATE": NormalizationMode.MEAN_STD}
+
+    per_dataset_stats = _build_per_dataset_stats(num_ds)
+    norm = Normalize(features, norm_map, per_dataset_stats=per_dataset_stats)
+
+    # B=6 batch with two samples per dataset row.
+    dataset_index = torch.tensor([0, 1, 2, 0, 1, 2], dtype=torch.long)
+    state = torch.full((6, 4), 7.0)
+    out = norm({"observation.state": state}, dataset_index)
+    # For sample i: (7 - d) / (d+1 + EPS) where d = dataset_index[i]
+    expected = torch.stack([(7.0 - d) / (d + 1.0 + EPS) * torch.ones(4) for d in dataset_index.tolist()])
+    torch.testing.assert_close(out["observation.state"], expected)
+
+
+def test_per_dataset_unnormalize_inverts_normalize():
+    """Unnormalize must invert Normalize per-sample within MEAN_STD."""
+    num_ds = 4
+    features = {
+        "action": PolicyFeature(type=FeatureType.ACTION, shape=(3,)),
+    }
+    norm_map = {"ACTION": NormalizationMode.MEAN_STD}
+
+    per_dataset_stats = _build_per_dataset_stats(num_ds)
+    norm = Normalize(features, norm_map, per_dataset_stats=per_dataset_stats)
+    unnorm = Unnormalize(features, norm_map, per_dataset_stats=per_dataset_stats)
+
+    dataset_index = torch.tensor([3, 0, 2, 1], dtype=torch.long)
+    original = torch.randn(4, 3)
+    normalized = norm({"action": original}, dataset_index)["action"]
+    recovered = unnorm({"action": normalized}, dataset_index)["action"]
+    # Some tolerance because EPS shifts both directions.
+    torch.testing.assert_close(recovered, original, atol=1e-5, rtol=1e-4)
+
+
+def test_per_dataset_min_max_normalizes_to_signed_unit_range():
+    """MIN_MAX mode normalizes each sample's value into [-1, 1] using its own dataset's range."""
+    num_ds = 3
+    features = {
+        "action": PolicyFeature(type=FeatureType.ACTION, shape=(3,)),
+    }
+    norm_map = {"ACTION": NormalizationMode.MIN_MAX}
+
+    per_dataset_stats = _build_per_dataset_stats(num_ds)
+    norm = Normalize(features, norm_map, per_dataset_stats=per_dataset_stats)
+
+    # For dataset d, [min, max] = [-(d+1), d+1]. Feed the midpoint -> 0.
+    midpoints = torch.zeros(num_ds, 3)
+    dataset_index = torch.arange(num_ds, dtype=torch.long)
+    out = norm({"action": midpoints}, dataset_index)["action"]
+    torch.testing.assert_close(out, torch.zeros_like(out), atol=1e-5, rtol=0.0)
+
+    # Feed each dataset's max -> +1 (modulo EPS slop).
+    maxes = torch.stack([torch.full((3,), float(d + 1)) for d in range(num_ds)])
+    out_max = norm({"action": maxes}, dataset_index)["action"]
+    torch.testing.assert_close(out_max, torch.ones_like(out_max), atol=1e-4, rtol=0.0)
+
+
+def test_per_dataset_broadcast_with_temporal_axis():
+    """The forward must broadcast (B, *feat_shape) buffers over an extra T axis."""
+    num_ds = 2
+    t_dim = 5
+    features = {
+        "observation.state": PolicyFeature(type=FeatureType.STATE, shape=(4,)),
+    }
+    norm_map = {"STATE": NormalizationMode.MEAN_STD}
+
+    per_dataset_stats = _build_per_dataset_stats(num_ds)
+    norm = Normalize(features, norm_map, per_dataset_stats=per_dataset_stats)
+
+    dataset_index = torch.tensor([0, 1], dtype=torch.long)
+    state = torch.full((2, t_dim, 4), 4.0)
+    out = norm({"observation.state": state}, dataset_index)["observation.state"]
+    assert out.shape == (2, t_dim, 4)
+    # Sample 0 uses (mean=0, std=1); sample 1 uses (mean=1, std=2).
+    expected_row0 = (4.0 - 0.0) / (1.0 + EPS)
+    expected_row1 = (4.0 - 1.0) / (2.0 + EPS)
+    torch.testing.assert_close(out[0], torch.full((t_dim, 4), expected_row0))
+    torch.testing.assert_close(out[1], torch.full((t_dim, 4), expected_row1))
+
+
+def test_per_dataset_image_buffer_uses_channels_only():
+    """Image-feature stats live as (D, C, 1, 1) and broadcast to full (B, C, H, W)."""
+    h_dim = w_dim = 8
+    features = {
+        "observation.image": PolicyFeature(type=FeatureType.VISUAL, shape=(3, h_dim, w_dim)),
+    }
+    norm_map = {"VISUAL": NormalizationMode.MEAN_STD}
+
+    per_dataset_stats = [
+        {
+            "observation.image": {
+                "mean": torch.tensor([0.0, 1.0, 2.0]).reshape(3, 1, 1),
+                "std": torch.tensor([1.0, 1.0, 1.0]).reshape(3, 1, 1),
+            }
+        },
+        {
+            "observation.image": {
+                "mean": torch.tensor([10.0, 11.0, 12.0]).reshape(3, 1, 1),
+                "std": torch.tensor([2.0, 2.0, 2.0]).reshape(3, 1, 1),
+            }
+        },
+    ]
+
+    norm = Normalize(features, norm_map, per_dataset_stats=per_dataset_stats)
+    image = torch.zeros(2, 3, h_dim, w_dim)
+    image[1] = 12.0  # match dataset-1 mean per channel later
+    dataset_index = torch.tensor([0, 1], dtype=torch.long)
+    out = norm({"observation.image": image}, dataset_index)["observation.image"]
+    assert out.shape == (2, 3, h_dim, w_dim)
+    # Sample 1 fed value 12 with means [10, 11, 12] and std 2 across channels
+    # -> per-channel result [(12-10)/2, (12-11)/2, (12-12)/2] = [1.0, 0.5, 0.0]
+    torch.testing.assert_close(out[1, 0], torch.full((h_dim, w_dim), 1.0), atol=1e-4, rtol=0.0)
+    torch.testing.assert_close(out[1, 1], torch.full((h_dim, w_dim), 0.5), atol=1e-4, rtol=0.0)
+    torch.testing.assert_close(out[1, 2], torch.full((h_dim, w_dim), 0.0), atol=1e-4, rtol=0.0)
+
+
+def test_per_dataset_stats_length_mismatch_raises():
+    features = {
+        "action": PolicyFeature(type=FeatureType.ACTION, shape=(3,)),
+    }
+    norm_map = {"ACTION": NormalizationMode.MEAN_STD}
+    per_dataset_stats = _build_per_dataset_stats(2)
+    with pytest.raises(ValueError, match="must have the same length"):
+        Normalize(features, norm_map, per_dataset_stats=per_dataset_stats, dataset_names=["only-one"])

--- a/tests/policies/test_pi05.py
+++ b/tests/policies/test_pi05.py
@@ -262,7 +262,7 @@ class TestPI05Integration:
 
         # Initialize policy with unified training mode
         config = pi05_training_config.policy
-        policy = PI05Policy(config, dataset_stats=lerobot_dataset_metadata.stats)
+        policy = PI05Policy(config, per_dataset_stats=[lerobot_dataset_metadata.stats])
 
         # Test data preparation pipeline
         batch_size = 1
@@ -590,7 +590,7 @@ def test_pi05_loc_tokens_in_response_produce_finite_loss(pi05_training_config, l
     promotion wired in `PI05Policy.__init__` / `PI05FlowMatching.__init__`."""
 
     config = pi05_training_config.policy
-    policy = PI05Policy(config, dataset_stats=lerobot_dataset_metadata.stats)
+    policy = PI05Policy(config, per_dataset_stats=[lerobot_dataset_metadata.stats])
 
     # PI05Policy and PI05FlowMatching share a single tokenizer instance so
     # token IDs cannot drift between the two layers.

--- a/tests/policies/test_pi05.py
+++ b/tests/policies/test_pi05.py
@@ -362,13 +362,17 @@ class TestPI05Integration:
         policy.model.embed_prefix = original_embed_prefix
         policy.model.embed_suffix = original_embed_suffix
 
-        # check normalize and unnormalize by applying it on actions
+        # check normalize and unnormalize by applying it on actions. Per-dataset
+        # Normalize/Unnormalize now require an explicit `dataset_index`; we're
+        # calling the submodules directly here (bypassing the policy's
+        # `_resolve_dataset_index` helper), so pass a zero-row index manually.
         normalize_actions = policy.normalize_targets
         unnormalize_actions = policy.unnormalize_outputs
         action_output = {"actions": batch["actions"].to("cuda")}
+        dataset_index = torch.zeros(batch_size, dtype=torch.long, device="cuda")
         assert torch.allclose(
             action_output["actions"],
-            unnormalize_actions(normalize_actions(action_output))["actions"],
+            unnormalize_actions(normalize_actions(action_output, dataset_index), dataset_index)["actions"],
             atol=1e-6,
         )
 

--- a/tests/policies/test_pi05_mem_gpu.py
+++ b/tests/policies/test_pi05_mem_gpu.py
@@ -232,7 +232,7 @@ def test_policy_end_to_end_cuda():
     }
 
     print("[e2e] device=cuda dtype=bfloat16 pretrained_path=None n_obs_steps=4")
-    policy = PI05MemPolicy(config, dataset_stats=dataset_stats).to(device="cuda", dtype=torch.bfloat16)
+    policy = PI05MemPolicy(config, per_dataset_stats=[dataset_stats]).to(device="cuda", dtype=torch.bfloat16)
 
     batch_size = 1
     batch = {

--- a/tests/policies/test_pi06.py
+++ b/tests/policies/test_pi06.py
@@ -887,7 +887,7 @@ def test_complete_pi06_pipeline_integration_smoke(lerobot_dataset_metadata):
         original = dataset_stats["actions"][k].astype(np.float32, copy=False)
         dataset_stats["actions"][k] = np.tile(original[:1], (config.chunk_size, 1))
 
-    policy = PI06Policy(config, dataset_stats=dataset_stats)
+    policy = PI06Policy(config, per_dataset_stats=[dataset_stats])
     policy.to(dtype=torch.bfloat16, device="cuda")
 
     batch = {
@@ -967,7 +967,7 @@ def test_pi06_loc_tokens_extend_vocab_and_resize_embeddings(lerobot_dataset_meta
             dtype=np.float32,
         )
 
-    policy = PI06Policy(config, dataset_stats=dataset_stats)
+    policy = PI06Policy(config, per_dataset_stats=[dataset_stats])
 
     # PI06Policy and PI06FlowMatching share a single tokenizer instance so
     # the outer encodes index the inner model's resized embedding correctly

--- a/tests/policies/test_pi07_high_level_planner.py
+++ b/tests/policies/test_pi07_high_level_planner.py
@@ -156,7 +156,7 @@ class TestPI07HighLevelPlannerIntegration:
         """Test the PI07 high-level planner: forward (training) and sample_actions (inference)."""
 
         config = self._make_config()
-        policy = PI07HighLevelPlannerPolicy(config, dataset_stats=lerobot_dataset_metadata.stats)
+        policy = PI07HighLevelPlannerPolicy(config, per_dataset_stats=[lerobot_dataset_metadata.stats])
         tokenizer = policy.model.language_tokenizer
 
         batch_size = 1

--- a/tests/policies/test_pi07_low_level.py
+++ b/tests/policies/test_pi07_low_level.py
@@ -359,7 +359,7 @@ class TestPI07LowLevelIntegration:
         """Test the PI07 low-level component pipeline: forward (training) and select_action (inference)."""
 
         config = self._make_config()
-        policy = PI07LowLevelPolicy(config, dataset_stats=lerobot_dataset_metadata.stats)
+        policy = PI07LowLevelPolicy(config, per_dataset_stats=[lerobot_dataset_metadata.stats])
         tokenizer = policy.model.language_tokenizer
 
         batch_size = 1
@@ -635,7 +635,7 @@ class TestPI07LowLevelIntegration:
         offsets on real Gemma 3 weights.
         """
         config = self._make_config()
-        policy = PI07LowLevelPolicy(config, dataset_stats=lerobot_dataset_metadata.stats)
+        policy = PI07LowLevelPolicy(config, per_dataset_stats=[lerobot_dataset_metadata.stats])
         tokenizer = policy.model.language_tokenizer
 
         batch_size = 1
@@ -744,7 +744,7 @@ class TestPI07LowLevelRegression:
     @staticmethod
     def _make_policy(lerobot_dataset_metadata) -> PI07LowLevelPolicy:
         config = TestPI07LowLevelIntegration._make_config()
-        policy = PI07LowLevelPolicy(config, dataset_stats=lerobot_dataset_metadata.stats)
+        policy = PI07LowLevelPolicy(config, per_dataset_stats=[lerobot_dataset_metadata.stats])
         policy.to(dtype=torch.bfloat16, device="cuda")
         return policy
 

--- a/tests/policies/test_pi07_low_level.py
+++ b/tests/policies/test_pi07_low_level.py
@@ -453,11 +453,17 @@ class TestPI07LowLevelIntegration:
         policy.model.embed_prefix = original_embed_prefix
         policy.model.embed_suffix = original_embed_suffix
 
-        # Verify normalize / unnormalize round-trip.
+        # Verify normalize / unnormalize round-trip. Calling the submodules
+        # directly bypasses the policy's `_resolve_dataset_index` helper, so
+        # pass an explicit (B,) long index of zeros (this fixture is
+        # single-dataset).
         action_output = {"actions": batch["actions"].to("cuda")}
+        dataset_index = torch.zeros(batch_size, dtype=torch.long, device="cuda")
         assert torch.allclose(
             action_output["actions"],
-            policy.unnormalize_outputs(policy.normalize_targets(action_output))["actions"],
+            policy.unnormalize_outputs(policy.normalize_targets(action_output, dataset_index), dataset_index)[
+                "actions"
+            ],
             atol=1e-6,
         )
 

--- a/tests/policies/test_pi07_paligemma_high_level_planner.py
+++ b/tests/policies/test_pi07_paligemma_high_level_planner.py
@@ -146,7 +146,7 @@ class TestPI07HighLevelPlannerIntegration:
         """Test the PI07 high-level planner: forward (training) and sample_actions (inference)."""
 
         config = self._make_config()
-        policy = PI07HighLevelPlannerPolicy(config, dataset_stats=lerobot_dataset_metadata.stats)
+        policy = PI07HighLevelPlannerPolicy(config, per_dataset_stats=[lerobot_dataset_metadata.stats])
         tokenizer = policy.model.language_tokenizer
 
         batch_size = 1

--- a/tests/policies/test_pi07_paligemma_low_level.py
+++ b/tests/policies/test_pi07_paligemma_low_level.py
@@ -437,11 +437,17 @@ class TestPI07PaligemmaLowLevelIntegration:
         policy.model.embed_prefix = original_embed_prefix
         policy.model.embed_suffix = original_embed_suffix
 
-        # Verify normalize / unnormalize round-trip.
+        # Verify normalize / unnormalize round-trip. Calling the submodules
+        # directly bypasses the policy's `_resolve_dataset_index` helper, so
+        # pass an explicit (B,) long index of zeros (this fixture is
+        # single-dataset).
         action_output = {"actions": batch["actions"].to("cuda")}
+        dataset_index = torch.zeros(batch_size, dtype=torch.long, device="cuda")
         assert torch.allclose(
             action_output["actions"],
-            policy.unnormalize_outputs(policy.normalize_targets(action_output))["actions"],
+            policy.unnormalize_outputs(policy.normalize_targets(action_output, dataset_index), dataset_index)[
+                "actions"
+            ],
             atol=1e-6,
         )
 

--- a/tests/policies/test_pi07_paligemma_low_level.py
+++ b/tests/policies/test_pi07_paligemma_low_level.py
@@ -341,7 +341,7 @@ class TestPI07PaligemmaLowLevelIntegration:
         """Test the PI07 low-level pipeline: forward (training) and select_action (inference)."""
 
         config = self._make_config()
-        policy = PI07PaligemmaLowLevelPolicy(config, dataset_stats=lerobot_dataset_metadata.stats)
+        policy = PI07PaligemmaLowLevelPolicy(config, per_dataset_stats=[lerobot_dataset_metadata.stats])
         tokenizer = policy.model.language_tokenizer
 
         batch_size = 1

--- a/tests/policies/test_policies.py
+++ b/tests/policies/test_policies.py
@@ -159,47 +159,54 @@ def test_normalize(insert_temporal_dim, capsys):
         for key in output_batch:
             output_batch[key] = torch.stack([output_batch[key]] * tdim, dim=1)
 
-    # test without stats
-    normalize = Normalize(input_features, norm_map, stats=None)
+    # The per-sample dataset index — every sample comes from dataset 0 since
+    # this is a single-dataset construction. Layout matches the per-sample
+    # `dataset_index` field that `_TaggedDataset` injects into training
+    # batches.
+    dataset_index = torch.zeros(bsize, dtype=torch.long)
+
+    # test without stats (D=1 stacked buffer initialised to inf — the forward
+    # assertion trips because no row has been populated yet).
+    normalize = Normalize(input_features, norm_map, per_dataset_stats=None, num_datasets=1)
     for ft in input_features:
         assert hasattr(normalize, "buffer_" + ft.replace(".", "_"))
 
     with pytest.raises(AssertionError):
-        normalize(input_batch)
+        normalize(input_batch, dataset_index)
 
-    # test with stats
-    normalize = Normalize(input_features, norm_map, stats=dataset_stats)
-    normalize(input_batch)
+    # test with stats — wrap the single-dataset stats into a one-element list.
+    normalize = Normalize(input_features, norm_map, per_dataset_stats=[dataset_stats])
+    normalize(input_batch, dataset_index)
 
-    # test loading pretrained models
-    new_normalize = Normalize(input_features, norm_map, stats=None)
+    # test loading pretrained models (state-dict round-trip preserves stats).
+    new_normalize = Normalize(input_features, norm_map, per_dataset_stats=None, num_datasets=1)
     new_normalize.load_state_dict(normalize.state_dict())
-    new_normalize(input_batch)
+    new_normalize(input_batch, dataset_index)
 
     # test without stats
-    unnormalize = Unnormalize(output_features, norm_map, stats=None)
+    unnormalize = Unnormalize(output_features, norm_map, per_dataset_stats=None, num_datasets=1)
     with pytest.raises(AssertionError):
-        unnormalize(output_batch)
+        unnormalize(output_batch, dataset_index)
 
     # test with stats
-    unnormalize = Unnormalize(output_features, norm_map, stats=dataset_stats)
+    unnormalize = Unnormalize(output_features, norm_map, per_dataset_stats=[dataset_stats])
     for ft in output_features:
         assert hasattr(unnormalize, "buffer_" + ft.replace(".", "_"))
 
-    unnormalize(output_batch)
+    unnormalize(output_batch, dataset_index)
 
     # test loading pretrained models
-    new_unnormalize = Unnormalize(output_features, norm_map, stats=None)
+    new_unnormalize = Unnormalize(output_features, norm_map, per_dataset_stats=None, num_datasets=1)
     new_unnormalize.load_state_dict(unnormalize.state_dict())
-    unnormalize(output_batch)
+    unnormalize(output_batch, dataset_index)
 
     # check warmings
-    normalize({"observation.image": torch.randn(bsize, 3, 96, 96)})
+    normalize({"observation.image": torch.randn(bsize, 3, 96, 96)}, dataset_index)
     captured = capsys.readouterr()
 
     assert "Warning: observation.state was missing from the batch during " in captured.err
 
-    unnormalize({})
+    unnormalize({}, dataset_index)
     captured = capsys.readouterr()
 
     assert "Warning: action was missing from the batch during " in captured.err

--- a/tests/policies/test_save_pretrained_skip_stats.py
+++ b/tests/policies/test_save_pretrained_skip_stats.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python
+
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""End-to-end test for `PreTrainedConfig.save_normalization_stats` + the method override."""
+
+from pathlib import Path
+
+import pytest
+import torch
+from safetensors import safe_open
+
+from opentau.configs.types import FeatureType, NormalizationMode, PolicyFeature
+from opentau.policies.normalize import Normalize, Unnormalize
+from opentau.policies.pretrained import NORM_BUFFER_PREFIXES, is_norm_buffer_key
+
+
+class _FakePolicyConfig:
+    """Minimal stand-in for PreTrainedConfig fields read by _save_pretrained.
+
+    The full PreTrainedConfig is abstract (requires choice-type registration);
+    constructing a real subclass would couple this test to a specific policy
+    (pi0, pi05, etc.) which is overkill. We only need the flag this test
+    exercises plus a no-op `_save_pretrained` for `config.json`.
+    """
+
+    def __init__(self, save_normalization_stats: bool):
+        self.save_normalization_stats = save_normalization_stats
+        self.dataset_names = ["fake"]
+
+    def _save_pretrained(self, save_directory: Path) -> None:
+        # No-op: this test only inspects the safetensors layout, not config.json.
+        (save_directory / "config.json").write_text("{}")
+
+
+class _FakePolicy(torch.nn.Module):
+    """Bare-bones policy with a Normalize + Unnormalize module so the
+    save path covers `normalize_inputs.buffer_*` / `unnormalize_outputs.buffer_*`.
+    """
+
+    def __init__(self, save_normalization_stats: bool):
+        super().__init__()
+        self.config = _FakePolicyConfig(save_normalization_stats)
+        features = {
+            "observation.state": PolicyFeature(type=FeatureType.STATE, shape=(4,)),
+        }
+        out_features = {
+            "action": PolicyFeature(type=FeatureType.ACTION, shape=(3,)),
+        }
+        norm_map = {"STATE": NormalizationMode.MEAN_STD, "ACTION": NormalizationMode.MEAN_STD}
+        per_dataset_stats = [
+            {
+                "observation.state": {
+                    "mean": torch.zeros(4),
+                    "std": torch.ones(4),
+                },
+                "action": {
+                    "mean": torch.zeros(3),
+                    "std": torch.ones(3),
+                },
+            }
+        ]
+        self.normalize_inputs = Normalize(features, norm_map, per_dataset_stats=per_dataset_stats)
+        self.unnormalize_outputs = Unnormalize(out_features, norm_map, per_dataset_stats=per_dataset_stats)
+        # Add one regular trainable param so the safetensors file is non-empty
+        # in the stripped case too.
+        self.linear = torch.nn.Linear(4, 3)
+
+
+def _save_pretrained(policy: _FakePolicy, save_dir: Path, *, include_norm_stats=None) -> None:
+    """Mirror `PreTrainedPolicy._save_pretrained` behaviour."""
+    from huggingface_hub.constants import SAFETENSORS_SINGLE_FILE
+    from safetensors.torch import save_file
+    from safetensors.torch import save_model as save_model_as_safetensor
+
+    policy.config._save_pretrained(save_dir)
+    if include_norm_stats is None:
+        include_norm_stats = policy.config.save_normalization_stats
+    out_path = str(save_dir / SAFETENSORS_SINGLE_FILE)
+    if include_norm_stats:
+        save_model_as_safetensor(policy, out_path)
+    else:
+        sd = policy.state_dict()
+        filtered = {k: v for k, v in sd.items() if not is_norm_buffer_key(k)}
+        save_file(filtered, out_path)
+
+
+def _file_keys(path: Path) -> set[str]:
+    with safe_open(str(path), framework="pt") as f:
+        return set(f.keys())
+
+
+def test_save_with_stats_keeps_norm_buffers(tmp_path: Path):
+    policy = _FakePolicy(save_normalization_stats=True)
+    _save_pretrained(policy, tmp_path)
+    keys = _file_keys(tmp_path / "model.safetensors")
+    # Expect at least one normalize_inputs.buffer_* key in the safetensors.
+    assert any(k.startswith("normalize_inputs.buffer_") for k in keys), keys
+    assert any(k.startswith("unnormalize_outputs.buffer_") for k in keys), keys
+
+
+def test_save_without_stats_strips_norm_buffers(tmp_path: Path):
+    policy = _FakePolicy(save_normalization_stats=False)
+    _save_pretrained(policy, tmp_path)
+    keys = _file_keys(tmp_path / "model.safetensors")
+    for prefix in NORM_BUFFER_PREFIXES:
+        assert not any(k.startswith(prefix) for k in keys), (prefix, keys)
+    # The non-norm parameters (e.g. the regular linear layer) are still saved.
+    assert any(k.startswith("linear.") for k in keys), keys
+
+
+def test_save_override_wins_over_config(tmp_path: Path):
+    """include_norm_stats=False overrides save_normalization_stats=True (and vice versa)."""
+    policy_keep = _FakePolicy(save_normalization_stats=True)
+    override_false_dir = tmp_path / "override_false"
+    override_false_dir.mkdir()
+    _save_pretrained(policy_keep, override_false_dir, include_norm_stats=False)
+    keys_override = _file_keys(override_false_dir / "model.safetensors")
+    assert not any(k.startswith("normalize_inputs.buffer_") for k in keys_override)
+
+    policy_strip = _FakePolicy(save_normalization_stats=False)
+    override_true_dir = tmp_path / "override_true"
+    override_true_dir.mkdir()
+    _save_pretrained(policy_strip, override_true_dir, include_norm_stats=True)
+    keys_override = _file_keys(override_true_dir / "model.safetensors")
+    assert any(k.startswith("normalize_inputs.buffer_") for k in keys_override)
+
+
+def test_is_norm_buffer_key_matches_known_prefixes():
+    for prefix in NORM_BUFFER_PREFIXES:
+        assert is_norm_buffer_key(prefix + "observation_state.mean")
+    assert not is_norm_buffer_key("model.transformer.weight")
+    assert not is_norm_buffer_key("linear.weight")
+
+
+@pytest.mark.parametrize("strip", [False, True])
+def test_state_dict_round_trip(tmp_path: Path, strip: bool):
+    """Save then load (manually) — kept params survive, normalize params survive iff !strip."""
+    from safetensors.torch import load_file
+
+    policy = _FakePolicy(save_normalization_stats=not strip)
+    _save_pretrained(policy, tmp_path)
+    loaded = load_file(str(tmp_path / "model.safetensors"))
+
+    # linear's params present either way
+    assert "linear.weight" in loaded
+    assert "linear.bias" in loaded
+
+    has_norm = any(k.startswith("normalize_inputs.buffer_") for k in loaded)
+    if strip:
+        assert not has_norm
+    else:
+        assert has_norm


### PR DESCRIPTION
## What this does

Tears down the mixture-level stats aggregation in `DatasetMixtureMetadata`
and routes per-dataset stats into stacked Normalize/Unnormalize buffers
indexed per sample. Adds a configurable flag to omit those buffers from
checkpoint safetensors.

**Per-dataset normalization.** `DatasetMixtureMetadata` no longer calls
`aggregate_stats(...)` across datasets. Instead it exposes
`per_dataset_stats: list[dict]` and `dataset_names: list[str]`. A new
`_TaggedDataset` wrapper around every underlying `BaseDataset` injects
`dataset_repo_id: str` and `dataset_index: torch.long` into each
sample (default collate batches them into `list[str]` and `(B,)` long
respectively). `Normalize`/`Unnormalize` buffers are now shaped
`(num_datasets, *feat_shape)`; `forward(batch, dataset_index)` gathers
the right row per sample via `index_select` and broadcasts over any
extra temporal/spatial axes. Each of the eight in-scope pi policies
(`pi0`, `pi05`, `pi05_mem`, `pi06`, `pi07/low_level`,
`pi07/high_level_planner`, `pi07_paligemma/low_level`,
`pi07_paligemma/high_level_planner`) threads
`dataset_index = self._resolve_dataset_index(batch)` through every
`forward`/`select_action`/`sample_actions`. The `value` policy is out
of scope; it keeps its single-dict `dataset_stats` external API but
wraps internally into a singleton list before calling the new
`Normalize`.

Inference-time callers pass `batch["dataset_repo_id"]` (str or
list[str]); the base `PreTrainedPolicy._resolve_dataset_index` helper
maps strings through `config.dataset_names` to an integer index.
Single-dataset configs (`num_datasets <= 1`) default to all-zero
indices when both batch keys are absent, so legacy single-dataset
callers don't need to know about the per-sample plumbing. Multi-dataset
policies still raise a clear `KeyError` when the caller forgets, so
silent misuse stays loud.

**Skip-stats safetensors flag.** Two new fields on `PreTrainedConfig`:
`save_normalization_stats: bool = True` and
`dataset_names: list[str] | None = None`. `_save_pretrained` accepts an
`include_norm_stats` override that wins over the config field;
`accelerator.save_state` is gated via a `register_save_state_pre_hook`
in `train.py` so the buffers are stripped from the on-disk safetensors
in both code paths. Reloading a stats-less checkpoint requires
`make_policy(..., ds_meta=...)` so `_inject_stats(...)` can repopulate;
otherwise `_check_norm_stats_loaded` raises a clear error pointing the
user at the right knob.

**Other touches.** `fit_fast_tokenizer.py` switches from the deleted
`mixture.meta.stats["actions"]` to a new
`DatasetMixtureMetadata.aggregated_action_stats()` helper that wraps
`aggregate_stats(...)` on demand (BPE codec still needs one global
range). `export_to_onnx.py` passes an explicit `dataset_index=0` to
`unnormalize_outputs` since the ONNX tracer bypasses
`_resolve_dataset_index`.

## How it was tested

- Added `tests/policies/test_normalize_per_dataset.py` (6 tests): D=3-4
  stacked buffers, per-row indexing on MEAN_STD and MIN_MAX,
  Unnormalize-inverts-Normalize round-trip, temporal-axis broadcasting,
  image `(C, 1, 1)` broadcasting, length-mismatch validation.
- Added `tests/policies/test_save_pretrained_skip_stats.py` (6 tests):
  save with stats keeps `normalize_*.buffer_*` keys, save without
  strips them, method-level `include_norm_stats` override wins over the
  config field, `safetensors.safe_open` round-trip, `is_norm_buffer_key`
  predicate.
- Added `tests/datasets/test_tagged_dataset.py` (5 tests):
  `_TaggedDataset.__getitem__` injects the two keys, preserves
  `.meta`, default collate produces `list[str]` and `(B,)` long tensor.
- Updated `tests/datasets/test_dataset_mixture.py` to assert on
  `per_dataset_stats` / `dataset_names` instead of the deleted `stats`,
  to allow `mixture.datasets` to be the wrapped list, and to strip the
  wrapper-injected keys before the
  `test_integration_basic_functionality_with_same_fps_as_dataset`
  per-sample equality check.
- Updated `tests/policies/test_policies.py::test_normalize` to thread
  `dataset_index` and wrap singleton stats.
- Updated every GPU policy test (`test_pi05.py`, `test_pi05_mem_gpu.py`,
  `test_pi06.py`, `test_pi07_high_level_planner.py`,
  `test_pi07_low_level.py`, `test_pi07_paligemma_high_level_planner.py`,
  `test_pi07_paligemma_low_level.py`) to use the new
  `per_dataset_stats=[...]` constructor signature.
- Full non-slow CPU suite: 1188 passed, 14 skipped, 1 pre-existing
  unrelated `robosuite` import error in `tests/utils/test_libero_utils.py`.
- **GPU pytest subset (`pytest -m "gpu" -n 0`)**: 19 passed, 10 skipped
  (unrelated), 1359 deselected. Run on an internal GPU dev box (RTX
  5090, CUDA 13.0, ~5 min). Two iterations were needed to land — the
  first uncovered stale `dataset_stats=...` kwargs in seven test
  fixtures and one `Normalize` submodule call that bypassed the
  policy-level `_resolve_dataset_index` helper.
- pre-commit clean (ruff lint + format, license header, gitleaks, bandit).

### Not yet covered (tracked in #335)

The following still need attention beyond a single-GPU pytest pass:

- Smoke training run on `configs/dev/dev_config.json` or the
  pi05 smoke config to confirm `forward` doesn't trip the new
  inf-assertion at step 1 and the per-dataset val dataloader iterates
  clean.
- End-to-end `save_normalization_stats=false` round-trip on a real
  checkpoint dir, including the `safe_open(...).keys()` filter check
  and `make_policy(..., ds_meta=...)` reload.
- Seeded determinism check (per CLAUDE.md rule #3): two runs with
  `seed=0`, diff the per-step loss series, assert bit-identical.
- Distributed sanity under DDP / DeepSpeed ZeRO-2 — the new
  `index_select` is a local op with no new collectives, so the risk
  is low, but worth confirming on real backends.
- Nightly regression suite (`regression_test.yml` on g6.12xlarge).

These checks are tracked in #335.

## How to checkout & try? (for the reviewer)

```bash
gh pr checkout 336
uv sync --extra dev --extra libero
pre-commit run --all-files
pytest -m "not gpu" -n auto tests/policies/test_normalize_per_dataset.py tests/policies/test_save_pretrained_skip_stats.py tests/datasets/test_tagged_dataset.py tests/datasets/test_dataset_mixture.py tests/policies/test_policies.py
```

On a CUDA box (matches the run already done on the dev box):

```bash
pytest -m "gpu" -n 0
```

To exercise the safetensors round-trip on a real training run (still
tracked in #335):

```bash
opentau-train \
    --accelerate-config configs/examples/accelerate_ddp_config.yaml \
    --config_path=configs/dev/dev_config.json \
    --steps=2 --save_freq=2 \
    --policy.save_normalization_stats=false
```

Then inspect the safetensors with `from safetensors import safe_open;
safe_open(...).keys()` to confirm `normalize_*.buffer_*` are absent.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [x] My PR includes policy-related changes.
  - [x] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
