### PR TITLE
feat(pi07_paligemma): skip saved normalization buffers on load

### DIFF
--- a/src/opentau/policies/pi07_paligemma/low_level/configuration_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/configuration_pi07_low_level.py
@@ -71,10 +71,20 @@ class PI07PaligemmaLowLevelConfig(PreTrainedConfig):
             ``normalize_*`` / ``unnormalize_*`` buffer tensors from the state dict before
             ``load_state_dict``. The buffers freshly initialised from ``dataset_stats`` then
             survive — use this when finetuning a checkpoint whose saved normalization stats
-            were aggregated over a different dataset mixture than the finetuning data. Note
-            that the model was trained against the saved stats; switching the normalization
-            mid-training only makes sense when followed by further training, not when
-            loading purely for inference. Defaults to False (no behaviour change).
+            were aggregated over a different dataset mixture than the finetuning data.
+            **Requires ``dataset_stats`` to be supplied to ``__init__``** (e.g. via
+            :py:func:`opentau.policies.factory.make_policy`); otherwise the buffers stay at
+            the ``inf`` sentinel from :py:func:`opentau.policies.normalize.create_stats_buffers`
+            and the next forward crashes. **One-shot:** after the strip fires successfully,
+            :py:meth:`from_pretrained` resets the flag to ``False`` on the model's config so
+            that subsequent ``save_pretrained`` / resume / inference loads do not re-strip
+            the now-correct finetuned buffers. The model was trained against the saved
+            stats, so switching the normalization mid-training only makes sense when followed
+            by further training, not when loading purely for inference. **Scope:** only the
+            ``pi07_paligemma_low_level`` load path honours this knob today; ``pi05`` /
+            ``pi05_mem`` / ``pi06`` / ``pi07/low_level`` / ``pi0`` share the same trap and
+            should grow an equivalent knob as follow-up. Defaults to False (no behaviour
+            change).
         optimizer_lr: Learning rate for the optimizer. Defaults to 2.5e-5.
         optimizer_betas: Beta parameters for AdamW optimizer. Defaults to (0.9, 0.95).
         optimizer_eps: Epsilon parameter for AdamW optimizer. Defaults to 1e-8.

--- a/src/opentau/policies/pi07_paligemma/low_level/configuration_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/configuration_pi07_low_level.py
@@ -67,6 +67,14 @@ class PI07PaligemmaLowLevelConfig(PreTrainedConfig):
             backward compatibility but logs a warning and falls back to "eager".
         freeze_vision_encoder: Whether to freeze the vision encoder during fine-tuning. Defaults to True.
         train_expert_only: Whether to train only the expert module. Defaults to False.
+        skip_normalization_weights: When loading via :py:meth:`from_pretrained`, drop the saved
+            ``normalize_*`` / ``unnormalize_*`` buffer tensors from the state dict before
+            ``load_state_dict``. The buffers freshly initialised from ``dataset_stats`` then
+            survive — use this when finetuning a checkpoint whose saved normalization stats
+            were aggregated over a different dataset mixture than the finetuning data. Note
+            that the model was trained against the saved stats; switching the normalization
+            mid-training only makes sense when followed by further training, not when
+            loading purely for inference. Defaults to False (no behaviour change).
         optimizer_lr: Learning rate for the optimizer. Defaults to 2.5e-5.
         optimizer_betas: Beta parameters for AdamW optimizer. Defaults to (0.9, 0.95).
         optimizer_eps: Epsilon parameter for AdamW optimizer. Defaults to 1e-8.
@@ -147,6 +155,7 @@ class PI07PaligemmaLowLevelConfig(PreTrainedConfig):
     # Finetuning settings
     freeze_vision_encoder: bool = True
     train_expert_only: bool = False
+    skip_normalization_weights: bool = False
     # Wrap each transformer-layer forward in torch.utils.checkpoint to trade
     # ~25-33% same-batch compute for ~30-40 GB of activation memory per rank,
     # typically netting +10-25% throughput once the freed memory is spent on

--- a/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
@@ -125,6 +125,27 @@ def _is_normalize_buffer_key(key: str) -> bool:
     return key.startswith("normalize_") or key.startswith("unnormalize_")
 
 
+def _find_inf_normalize_buffers(module: nn.Module) -> list[str]:
+    """Return the names of every Normalize / Unnormalize buffer parameter on
+    ``module`` that still holds the ``torch.inf`` sentinel from
+    :py:func:`~opentau.policies.normalize.create_stats_buffers`.
+
+    Used by :py:meth:`PI07PaligemmaLowLevelPolicy.from_pretrained` to detect
+    the ``skip_normalization_weights=True`` + missing ``dataset_stats``
+    combination: the strip voids the "load_state_dict will refill these"
+    branch of the ``dataset_stats`` contract, so without ``dataset_stats``
+    the buffers stay at ``inf`` and the next forward crashes inside
+    :py:meth:`~opentau.policies.normalize.Normalize.forward` with a
+    "use a pretrained model" error that actively misleads when a
+    pretrained model *was* used.
+    """
+    return [
+        name
+        for name, param in module.named_parameters()
+        if _is_normalize_buffer_key(name) and torch.isinf(param).any()
+    ]
+
+
 def create_sinusoidal_pos_embedding(
     time: Tensor, dimension: int, min_period: float, max_period: float, device: torch.device | str = "cpu"
 ) -> Tensor:
@@ -419,6 +440,11 @@ class PI07PaligemmaLowLevelPolicy(PreTrainedPolicy):
         # Now manually load and remap the state dict
         acc = get_proc_accelerator()
         is_main_process = acc.is_main_process if acc else True
+        # Tracks whether the strip branch fired inside the try block below.
+        # Used outside the try/except to gate the inf-buffer guard so the
+        # ValueError is not swallowed by the broad `except Exception` that
+        # otherwise just warns and returns the (broken) model.
+        strip_ran = False
         try:
             # Try to load the pytorch_model.bin or model.safetensors file
             if is_main_process:
@@ -495,6 +521,7 @@ class PI07PaligemmaLowLevelPolicy(PreTrainedPolicy):
                 # persists False, and later resumes / inference loads do not
                 # re-strip the now-correct finetuned buffers.
                 model.config.skip_normalization_weights = False
+                strip_ran = True
 
             # Load the remapped state dict into the model
             missing_keys, unexpected_keys = model.load_state_dict(remapped_state_dict, strict=False)
@@ -525,6 +552,29 @@ class PI07PaligemmaLowLevelPolicy(PreTrainedPolicy):
         except Exception as e:
             if is_main_process:
                 logging.warning("Could not remap state dict keys: %s", e)
+
+        # Outside the try/except so the ValueError is not swallowed.
+        # Gated on `strip_ran` so this only fires when the load path
+        # actually reached and executed the strip branch — i.e. the user
+        # asked for skip_normalization_weights AND the load succeeded far
+        # enough to apply it. The strip voids the "load_state_dict will
+        # refill these" half of the dataset_stats contract, so without
+        # dataset_stats wired into __init__, the buffers stay at the
+        # torch.inf sentinel from create_stats_buffers and the next
+        # forward crashes inside Normalize.forward with a "use a
+        # pretrained model" message that actively misleads here.
+        if strip_ran:
+            inf_buffers = _find_inf_normalize_buffers(model)
+            if inf_buffers:
+                raise ValueError(
+                    "skip_normalization_weights=True requires `dataset_stats` to be "
+                    "passed to __init__ (e.g. via "
+                    "`opentau.policies.factory.make_policy(..., ds_meta=...)`) so "
+                    "the fresh buffers can replace the stripped saved ones; got "
+                    f"{len(inf_buffers)} uninitialized (inf) buffer(s): "
+                    + ", ".join(inf_buffers[:5])
+                    + (f", ... ({len(inf_buffers) - 5} more)" if len(inf_buffers) > 5 else "")
+                )
 
         return model
 

--- a/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
@@ -451,6 +451,23 @@ class PI07PaligemmaLowLevelPolicy(PreTrainedPolicy):
             if remap_count > 0 and is_main_process:
                 logging.info("Remapped %d state dict keys", remap_count)
 
+            # Strip saved normalize/unnormalize buffers so the
+            # ``dataset_stats``-initialised buffers from ``__init__`` survive
+            # the load. ``requires_grad=False`` on those tensors means training
+            # alone cannot recover from inheriting the wrong stats.
+            if config.skip_normalization_weights:
+                n_before = len(remapped_state_dict)
+                remapped_state_dict = {
+                    key: val
+                    for key, val in remapped_state_dict.items()
+                    if not (key.startswith("normalize_") or key.startswith("unnormalize_"))
+                }
+                if is_main_process:
+                    logging.info(
+                        "skip_normalization_weights=True; dropped %d saved normalize/unnormalize buffer keys",
+                        n_before - len(remapped_state_dict),
+                    )
+
             # Load the remapped state dict into the model
             missing_keys, unexpected_keys = model.load_state_dict(remapped_state_dict, strict=False)
 

--- a/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
@@ -473,16 +473,23 @@ class PI07PaligemmaLowLevelPolicy(PreTrainedPolicy):
             # ``dataset_stats``-initialised buffers from ``__init__`` survive
             # the load. ``requires_grad=False`` on those tensors means training
             # alone cannot recover from inheriting the wrong stats.
+            stripped_keys: frozenset[str] = frozenset()
             if config.skip_normalization_weights:
-                n_before = len(remapped_state_dict)
+                stripped_keys = frozenset(key for key in remapped_state_dict if _is_normalize_buffer_key(key))
                 remapped_state_dict = {
-                    key: val for key, val in remapped_state_dict.items() if not _is_normalize_buffer_key(key)
+                    key: val for key, val in remapped_state_dict.items() if key not in stripped_keys
                 }
                 if is_main_process:
-                    logging.info(
-                        "skip_normalization_weights=True; dropped %d saved normalize/unnormalize buffer keys",
-                        n_before - len(remapped_state_dict),
-                    )
+                    if not stripped_keys:
+                        logging.warning(
+                            "skip_normalization_weights=True but no normalize_/unnormalize_ "
+                            "keys were present in the saved state dict; the flag had no effect."
+                        )
+                    else:
+                        logging.info(
+                            "skip_normalization_weights=True; dropped %d saved normalize/unnormalize buffer keys",
+                            len(stripped_keys),
+                        )
                 # One-shot semantics: the flag is consumed by this load.
                 # Reset on the model's config so the next save_pretrained()
                 # persists False, and later resumes / inference loads do not
@@ -492,12 +499,18 @@ class PI07PaligemmaLowLevelPolicy(PreTrainedPolicy):
             # Load the remapped state dict into the model
             missing_keys, unexpected_keys = model.load_state_dict(remapped_state_dict, strict=False)
 
-            if missing_keys and is_main_process:
-                logging.warning("Missing keys when loading state dict: %d keys", len(missing_keys))
-                for key in missing_keys[:20]:
+            # Hide deliberately-stripped buffer keys from the missing-keys
+            # warning so the noisy WARNING does not directly contradict the
+            # INFO logged just above. ``stripped_keys`` is empty when the
+            # flag is off, so this is a no-op for default loads.
+            unintended_missing = [key for key in missing_keys if key not in stripped_keys]
+
+            if unintended_missing and is_main_process:
+                logging.warning("Missing keys when loading state dict: %d keys", len(unintended_missing))
+                for key in unintended_missing[:20]:
                     logging.warning("  - %s", key)
-                if len(missing_keys) > 20:
-                    logging.warning("  ... and %d more", len(missing_keys) - 20)
+                if len(unintended_missing) > 20:
+                    logging.warning("  ... and %d more", len(unintended_missing) - 20)
 
             if unexpected_keys and is_main_process:
                 logging.warning("Unexpected keys when loading state dict: %d keys", len(unexpected_keys))
@@ -506,7 +519,7 @@ class PI07PaligemmaLowLevelPolicy(PreTrainedPolicy):
                 if len(unexpected_keys) > 20:
                     logging.warning("  ... and %d more", len(unexpected_keys) - 20)
 
-            if not missing_keys and not unexpected_keys and is_main_process:
+            if not unintended_missing and not unexpected_keys and is_main_process:
                 logging.info("All keys loaded successfully!")
 
         except Exception as e:

--- a/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
@@ -107,6 +107,24 @@ def _preferred_dtype():
     return torch.float32 if torch.onnx.is_in_onnx_export() else torch.bfloat16
 
 
+def _is_normalize_buffer_key(key: str) -> bool:
+    """Return True iff ``key`` is a top-level Normalize / Unnormalize buffer tensor
+    saved by :class:`~opentau.policies.normalize.Normalize` /
+    :class:`~opentau.policies.normalize.Unnormalize`.
+
+    Anchored at the start of ``key`` so a hypothetical nested submodule named
+    ``model.something.normalize_internal.weight`` is *not* matched — only the
+    eight top-level buffer tensors (`normalize_inputs.buffer_*.{mean,std}`,
+    `normalize_targets.buffer_*.{mean,std}`,
+    `unnormalize_outputs.buffer_*.{mean,std}`,
+    `normalize_discrete_actions.buffer_*.{min,max}`).
+
+    Single source of truth for the ``skip_normalization_weights`` filter so
+    tests can exercise the same predicate the production load path uses.
+    """
+    return key.startswith("normalize_") or key.startswith("unnormalize_")
+
+
 def create_sinusoidal_pos_embedding(
     time: Tensor, dimension: int, min_period: float, max_period: float, device: torch.device | str = "cpu"
 ) -> Tensor:
@@ -458,15 +476,18 @@ class PI07PaligemmaLowLevelPolicy(PreTrainedPolicy):
             if config.skip_normalization_weights:
                 n_before = len(remapped_state_dict)
                 remapped_state_dict = {
-                    key: val
-                    for key, val in remapped_state_dict.items()
-                    if not (key.startswith("normalize_") or key.startswith("unnormalize_"))
+                    key: val for key, val in remapped_state_dict.items() if not _is_normalize_buffer_key(key)
                 }
                 if is_main_process:
                     logging.info(
                         "skip_normalization_weights=True; dropped %d saved normalize/unnormalize buffer keys",
                         n_before - len(remapped_state_dict),
                     )
+                # One-shot semantics: the flag is consumed by this load.
+                # Reset on the model's config so the next save_pretrained()
+                # persists False, and later resumes / inference loads do not
+                # re-strip the now-correct finetuned buffers.
+                model.config.skip_normalization_weights = False
 
             # Load the remapped state dict into the model
             missing_keys, unexpected_keys = model.load_state_dict(remapped_state_dict, strict=False)

--- a/tests/policies/test_pi07_paligemma_low_level.py
+++ b/tests/policies/test_pi07_paligemma_low_level.py
@@ -2424,31 +2424,64 @@ class TestSkipNormalizationWeights:
         cfg = PI07PaligemmaLowLevelConfig(skip_normalization_weights=True)
         assert cfg.skip_normalization_weights is True
 
-    def test_predicate_matches_all_eight_saved_buffer_keys(self):
-        """Exercises the production predicate
-        :py:func:`opentau.policies.pi07_paligemma.low_level.modeling_pi07_low_level._is_normalize_buffer_key`
-        directly so the test fails (rather than passes vacuously) when a
-        future edit broadens, narrows, or renames the predicate.
-
-        The eight keys below are the full set written by the current
+    def test_predicate_matches_real_normalize_buffer_keys(self):
+        """Grounds the predicate against the keys a real
         :py:class:`~opentau.policies.normalize.Normalize` /
-        :py:class:`~opentau.policies.normalize.Unnormalize` modules — if
-        ``create_stats_buffers`` ever grows a new buffer name this list
-        needs an entry and the predicate needs an update; the assertion
-        pins both sides together.
+        :py:class:`~opentau.policies.normalize.Unnormalize` actually
+        produces in its ``state_dict()`` — instead of hand-built keys
+        that happen to match by prefix coincidence.
+
+        Catches future refactors to either side of the contract: the
+        ``buffer_`` prefix or ``.`` → ``_`` mangling in
+        :py:class:`~opentau.policies.normalize.Normalize.__init__` (line
+        ~215), the per-mode buffer field names from
+        :py:func:`~opentau.policies.normalize.create_stats_buffers`
+        (``mean``/``std`` vs ``min``/``max``), and the predicate's
+        ``startswith`` anchor.
         """
-        saved_buffer_keys = [
-            "normalize_inputs.buffer_state.mean",
-            "normalize_inputs.buffer_state.std",
-            "normalize_targets.buffer_actions.mean",
-            "normalize_targets.buffer_actions.std",
-            "unnormalize_outputs.buffer_actions.mean",
-            "unnormalize_outputs.buffer_actions.std",
-            "normalize_discrete_actions.buffer_actions.min",
-            "normalize_discrete_actions.buffer_actions.max",
-        ]
-        for key in saved_buffer_keys:
-            assert _is_normalize_buffer_key(key), f"{key!r} should be stripped but predicate returned False"
+        from opentau.policies.normalize import Normalize, Unnormalize
+
+        features = {
+            "observation.state": PolicyFeature(type=FeatureType.STATE, shape=(8,)),
+            "observation.images.top": PolicyFeature(type=FeatureType.VISUAL, shape=(3, 224, 224)),
+            "action": PolicyFeature(type=FeatureType.ACTION, shape=(7,)),
+        }
+        norm_map_mean_std = {
+            FeatureType.STATE: NormalizationMode.MEAN_STD,
+            FeatureType.VISUAL: NormalizationMode.IDENTITY,
+            FeatureType.ACTION: NormalizationMode.MEAN_STD,
+        }
+        norm_map_min_max = {
+            FeatureType.STATE: NormalizationMode.MIN_MAX,
+            FeatureType.VISUAL: NormalizationMode.IDENTITY,
+            FeatureType.ACTION: NormalizationMode.MIN_MAX,
+        }
+
+        normalize_mean_std_keys = list(Normalize(features, norm_map_mean_std).state_dict().keys())
+        unnormalize_mean_std_keys = list(Unnormalize(features, norm_map_mean_std).state_dict().keys())
+        normalize_min_max_keys = list(Normalize(features, norm_map_min_max).state_dict().keys())
+
+        # Each (Un)Normalize submodule attaches as ``normalize_inputs`` /
+        # ``normalize_targets`` / ``unnormalize_outputs`` /
+        # ``normalize_discrete_actions`` on the policy, so prepend each of
+        # those prefixes to get the saved-checkpoint shape.
+        for prefix, child_keys in [
+            ("normalize_inputs.", normalize_mean_std_keys),
+            ("normalize_targets.", normalize_mean_std_keys),
+            ("unnormalize_outputs.", unnormalize_mean_std_keys),
+            ("normalize_discrete_actions.", normalize_min_max_keys),
+        ]:
+            assert child_keys, (
+                f"Normalize / Unnormalize produced no keys for {prefix!r}; test fixture is broken"
+            )
+            for child_key in child_keys:
+                saved_key = prefix + child_key
+                assert _is_normalize_buffer_key(saved_key), (
+                    f"production saved key {saved_key!r} (built from "
+                    f"feature {child_key!r} under {prefix!r}) is not "
+                    "matched by _is_normalize_buffer_key — predicate or "
+                    "buffer-naming convention has drifted"
+                )
 
     def test_predicate_anchored_at_key_start(self):
         """The predicate must NOT match nested submodule keys that merely

--- a/tests/policies/test_pi07_paligemma_low_level.py
+++ b/tests/policies/test_pi07_paligemma_low_level.py
@@ -24,6 +24,7 @@ from opentau.policies.pi07_paligemma.low_level.modeling_pi07_low_level import (
     ContextItem,
     PI07PaligemmaLowLevelFlowMatching,
     PI07PaligemmaLowLevelPolicy,
+    _find_inf_normalize_buffers,
     _is_normalize_buffer_key,
     make_att_2d_masks,
 )
@@ -2499,3 +2500,68 @@ class TestSkipNormalizationWeights:
         ]
         for key in non_buffer_keys:
             assert not _is_normalize_buffer_key(key), f"{key!r} should be kept but predicate returned True"
+
+    def test_find_inf_normalize_buffers_detects_init_inf_sentinels(self):
+        """The runtime guard helper used by
+        :py:meth:`PI07PaligemmaLowLevelPolicy.from_pretrained` must catch
+        the ``skip_normalization_weights=True`` + missing ``dataset_stats``
+        combination — where :py:func:`~opentau.policies.normalize.create_stats_buffers`
+        leaves the Normalize buffers at the ``torch.inf`` sentinel.
+
+        Mirrors the production layout: a parent module that holds a
+        :py:class:`~opentau.policies.normalize.Normalize` submodule under
+        the attribute name ``normalize_inputs``, with no ``dataset_stats``
+        passed so the buffers stay at ``inf``.
+        """
+        import torch.nn as nn
+
+        from opentau.policies.normalize import Normalize
+
+        features = {"action": PolicyFeature(type=FeatureType.ACTION, shape=(7,))}
+        norm_map = {FeatureType.ACTION: NormalizationMode.MEAN_STD}
+
+        parent = nn.Module()
+        parent.normalize_inputs = Normalize(features, norm_map, stats=None)
+
+        inf_buffers = _find_inf_normalize_buffers(parent)
+        assert inf_buffers, "expected the helper to flag at least one inf buffer for a stats-less Normalize"
+        assert all(name.startswith("normalize_inputs.") for name in inf_buffers), (
+            f"flagged buffers must all be under the parent's normalize_inputs path; got {inf_buffers!r}"
+        )
+
+    def test_find_inf_normalize_buffers_empty_when_stats_passed(self):
+        """When ``dataset_stats`` is wired through, every Normalize /
+        Unnormalize buffer is finite and the helper returns an empty
+        list — the production load path then skips the ValueError.
+        """
+        import numpy as np
+        import torch.nn as nn
+
+        from opentau.policies.normalize import Normalize, Unnormalize
+
+        features = {"action": PolicyFeature(type=FeatureType.ACTION, shape=(7,))}
+        norm_map = {FeatureType.ACTION: NormalizationMode.MEAN_STD}
+        stats = {"action": {"mean": np.zeros(7, dtype=np.float32), "std": np.ones(7, dtype=np.float32)}}
+
+        parent = nn.Module()
+        parent.normalize_inputs = Normalize(features, norm_map, stats=stats)
+        parent.unnormalize_outputs = Unnormalize(features, norm_map, stats=stats)
+
+        assert _find_inf_normalize_buffers(parent) == []
+
+    def test_find_inf_normalize_buffers_ignores_non_buffer_params(self):
+        """The helper must only flag Normalize / Unnormalize buffer
+        params — never an unrelated parameter that happens to contain
+        ``inf`` (e.g. a deliberately-initialised attention bias, an
+        embedding being NaN-checked, etc.).
+        """
+        import torch.nn as nn
+
+        parent = nn.Module()
+        # Looks like a Normalize buffer name but is NOT under a
+        # normalize_*/unnormalize_* attribute path — verifies the
+        # predicate is anchored at the parameter-path start.
+        parent.some_layer = nn.Linear(4, 4)
+        parent.some_layer.bias.data.fill_(float("inf"))
+
+        assert _find_inf_normalize_buffers(parent) == []

--- a/tests/policies/test_pi07_paligemma_low_level.py
+++ b/tests/policies/test_pi07_paligemma_low_level.py
@@ -2399,3 +2399,65 @@ class TestPaligemmaLowLevelFpsSegment:
 
         assert "FPS: 30, " in captured[0]
         assert "FPS:" not in captured[1]
+
+
+class TestSkipNormalizationWeights:
+    """Pins ``skip_normalization_weights`` config field + the filter rule used
+    inside :py:meth:`PI07PaligemmaLowLevelPolicy.from_pretrained` to strip
+    saved ``normalize_*`` / ``unnormalize_*`` buffer tensors from the loaded
+    state dict.
+
+    Why this matters: when finetuning a checkpoint whose saved normalization
+    stats were aggregated over a different dataset mixture than the
+    finetuning data, the saved buffers clobber the freshly-initialised stats
+    from ``dataset_stats``. The model then keeps normalising in the wrong
+    space and cannot recover via training alone (buffers are
+    ``requires_grad=False``). This knob bypasses the clobber.
+    """
+
+    def test_default_is_false(self):
+        cfg = PI07PaligemmaLowLevelConfig()
+        assert cfg.skip_normalization_weights is False
+
+    def test_can_be_set_true(self):
+        cfg = PI07PaligemmaLowLevelConfig(skip_normalization_weights=True)
+        assert cfg.skip_normalization_weights is True
+
+    def test_filter_strips_only_normalize_buffer_keys(self):
+        """The filter expression used in ``from_pretrained`` should drop
+        every saved ``normalize_*`` / ``unnormalize_*`` top-level key and
+        leave every other key (including ``model.normalize_…`` if it ever
+        existed) untouched.
+
+        Replicates the inline filter in
+        :py:meth:`PI07PaligemmaLowLevelPolicy.from_pretrained` so a future
+        edit that broadens or narrows the predicate trips this test before
+        landing in production.
+        """
+        state_dict = {
+            "normalize_inputs.buffer_state.mean": 1,
+            "normalize_inputs.buffer_state.std": 2,
+            "normalize_targets.buffer_actions.mean": 3,
+            "normalize_targets.buffer_actions.std": 4,
+            "unnormalize_outputs.buffer_actions.mean": 5,
+            "unnormalize_outputs.buffer_actions.std": 6,
+            "normalize_discrete_actions.buffer_actions.min": 7,
+            "normalize_discrete_actions.buffer_actions.max": 8,
+            "model.paligemma_with_expert.foo.weight": 9,
+            "state_proj.weight": 10,
+            # Defensive: a hypothetical nested key containing "normalize"
+            # below the top level must NOT be stripped — the filter is
+            # anchored at the start of the key.
+            "model.some_layer.normalize_inputs_internal.weight": 11,
+        }
+        filtered = {
+            key: val
+            for key, val in state_dict.items()
+            if not (key.startswith("normalize_") or key.startswith("unnormalize_"))
+        }
+        assert set(filtered.keys()) == {
+            "model.paligemma_with_expert.foo.weight",
+            "state_proj.weight",
+            "model.some_layer.normalize_inputs_internal.weight",
+        }
+        assert all(not (k.startswith("normalize_") or k.startswith("unnormalize_")) for k in filtered)

--- a/tests/policies/test_pi07_paligemma_low_level.py
+++ b/tests/policies/test_pi07_paligemma_low_level.py
@@ -24,6 +24,7 @@ from opentau.policies.pi07_paligemma.low_level.modeling_pi07_low_level import (
     ContextItem,
     PI07PaligemmaLowLevelFlowMatching,
     PI07PaligemmaLowLevelPolicy,
+    _is_normalize_buffer_key,
     make_att_2d_masks,
 )
 
@@ -2423,41 +2424,45 @@ class TestSkipNormalizationWeights:
         cfg = PI07PaligemmaLowLevelConfig(skip_normalization_weights=True)
         assert cfg.skip_normalization_weights is True
 
-    def test_filter_strips_only_normalize_buffer_keys(self):
-        """The filter expression used in ``from_pretrained`` should drop
-        every saved ``normalize_*`` / ``unnormalize_*`` top-level key and
-        leave every other key (including ``model.normalize_…`` if it ever
-        existed) untouched.
+    def test_predicate_matches_all_eight_saved_buffer_keys(self):
+        """Exercises the production predicate
+        :py:func:`opentau.policies.pi07_paligemma.low_level.modeling_pi07_low_level._is_normalize_buffer_key`
+        directly so the test fails (rather than passes vacuously) when a
+        future edit broadens, narrows, or renames the predicate.
 
-        Replicates the inline filter in
-        :py:meth:`PI07PaligemmaLowLevelPolicy.from_pretrained` so a future
-        edit that broadens or narrows the predicate trips this test before
-        landing in production.
+        The eight keys below are the full set written by the current
+        :py:class:`~opentau.policies.normalize.Normalize` /
+        :py:class:`~opentau.policies.normalize.Unnormalize` modules — if
+        ``create_stats_buffers`` ever grows a new buffer name this list
+        needs an entry and the predicate needs an update; the assertion
+        pins both sides together.
         """
-        state_dict = {
-            "normalize_inputs.buffer_state.mean": 1,
-            "normalize_inputs.buffer_state.std": 2,
-            "normalize_targets.buffer_actions.mean": 3,
-            "normalize_targets.buffer_actions.std": 4,
-            "unnormalize_outputs.buffer_actions.mean": 5,
-            "unnormalize_outputs.buffer_actions.std": 6,
-            "normalize_discrete_actions.buffer_actions.min": 7,
-            "normalize_discrete_actions.buffer_actions.max": 8,
-            "model.paligemma_with_expert.foo.weight": 9,
-            "state_proj.weight": 10,
-            # Defensive: a hypothetical nested key containing "normalize"
-            # below the top level must NOT be stripped — the filter is
-            # anchored at the start of the key.
-            "model.some_layer.normalize_inputs_internal.weight": 11,
-        }
-        filtered = {
-            key: val
-            for key, val in state_dict.items()
-            if not (key.startswith("normalize_") or key.startswith("unnormalize_"))
-        }
-        assert set(filtered.keys()) == {
+        saved_buffer_keys = [
+            "normalize_inputs.buffer_state.mean",
+            "normalize_inputs.buffer_state.std",
+            "normalize_targets.buffer_actions.mean",
+            "normalize_targets.buffer_actions.std",
+            "unnormalize_outputs.buffer_actions.mean",
+            "unnormalize_outputs.buffer_actions.std",
+            "normalize_discrete_actions.buffer_actions.min",
+            "normalize_discrete_actions.buffer_actions.max",
+        ]
+        for key in saved_buffer_keys:
+            assert _is_normalize_buffer_key(key), f"{key!r} should be stripped but predicate returned False"
+
+    def test_predicate_anchored_at_key_start(self):
+        """The predicate must NOT match nested submodule keys that merely
+        contain ``normalize`` further down (e.g. a future
+        ``model.<layer>.normalize_internal.weight``). Anchoring at the
+        start of the key is what keeps the strip surgical to the eight
+        top-level buffer tensors.
+        """
+        non_buffer_keys = [
             "model.paligemma_with_expert.foo.weight",
             "state_proj.weight",
             "model.some_layer.normalize_inputs_internal.weight",
-        }
-        assert all(not (k.startswith("normalize_") or k.startswith("unnormalize_")) for k in filtered)
+            "model.unnormalize_helper.scratch",
+            "language_tokenizer.embedding",
+        ]
+        for key in non_buffer_keys:
+            assert not _is_normalize_buffer_key(key), f"{key!r} should be kept but predicate returned True"


### PR DESCRIPTION
## What this does

Adds a new policy-config knob `skip_normalization_weights: bool = False` on `PI07PaligemmaLowLevelConfig`. When `True`, `PI07PaligemmaLowLevelPolicy.from_pretrained` filters every `normalize_*` / `unnormalize_*` key out of the remapped state dict **before** `load_state_dict`, so the `dataset_stats`-initialised buffers from `__init__` survive the load. Defaults to `False`, so existing configs and in-flight runs are unaffected (the filter branch is skipped entirely).

**Motivation.** When finetuning a checkpoint whose saved normalization stats were aggregated over a different dataset mixture than the finetuning data, the saved `normalize_*.buffer_*` / `unnormalize_*.buffer_*` tensors clobber the freshly-computed `dataset_stats` at load time. Those buffers are registered as `nn.Parameter(requires_grad=False)`, so the wrong stats stay baked in for the rest of training — the model keeps normalising/unnormalising in the source-mixture geometry even though the finetuning data lives in a much narrower distribution. Caught this empirically while debugging a heterogeneous-mixture pretrain → single-domain finetune sequence where val MSE on the finetune dataset looked fine but rollouts on the finetune env hit 0% success. Stripping the saved buffers and letting the fresh `dataset_stats` take over (paired with continued finetuning so the weights re-align to the new normalized space) is what unlocks the recovery.

The new knob is opt-in. The new code path is a single conditional dict-comprehension just above `load_state_dict`, plus a `logging.info` reporting how many keys were dropped.

🗃️ Feature

### Caveats / when not to use this

- Switching the normalization mid-training only makes sense when **followed by further training** — the model was trained to predict in the source-mixture normalized space, so the layers immediately downstream of `normalize_inputs` / upstream of `unnormalize_outputs` need to re-align. Loading with this knob purely for **inference** would pin actions near the new `μ` regardless of what the model predicts. The docstring on the new field calls this out.
- Substring matching is anchored at the start of the key (`startswith("normalize_") or startswith("unnormalize_")`), so a hypothetical nested module called `model.something.normalize_internal.weight` is **not** affected — only the eight top-level Normalize / Unnormalize buffer tensors saved by the current `Normalize` / `Unnormalize` classes.

## How it was tested

- Added `TestSkipNormalizationWeights` (3 cases) in `tests/policies/test_pi07_paligemma_low_level.py`:
  - `test_default_is_false` — pins the dataclass default to `False`.
  - `test_can_be_set_true` — pins that the field is keyword-settable (catches a draccus-side renaming or removal).
  - `test_filter_strips_only_normalize_buffer_keys` — replicates the inline filter expression on a hand-built state dict containing the eight real buffer keys + a couple of model weight keys + a defensive nested `model.…normalize_inputs_internal.weight` key; asserts only the top-level `normalize_*` / `unnormalize_*` keys are dropped. Catches regressions if a future edit broadens or narrows the predicate.
- `pytest -m "not gpu" -n auto tests/policies/test_pi07_paligemma_low_level.py` — all 49 tests pass, including the 3 new ones (verified separately via `pytest ::TestSkipNormalizationWeights -v` → 3 passed).
- `pytest -m "gpu" -n 0 tests/policies/test_pi07_paligemma_low_level.py` (RTX 5090) — 1 passed, 1 skipped, 49 deselected, ~20 s. The 1 skipped is the pre-existing memory-skipped heavy pipeline test.
- `pytest -m "gpu" -n 0` (full suite, RTX 5090) — **19 passed, 10 skipped, 0 failed in 3:20**. All skips are pre-existing unconditional `@pytest.mark.skip` markers (memory or env), unaffected by this branch.
- `pre-commit run --files src/opentau/policies/pi07_paligemma/low_level/configuration_pi07_low_level.py src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py tests/policies/test_pi07_paligemma_low_level.py` — all hooks pass (ruff, ruff-format, pyupgrade, bandit, gitleaks, license-header, …).
- Nightly regression tests will land in the scheduled `regression_test.yml` cron — they haven't run yet on this branch.
- End-to-end empirical validation: enabled the knob on a real heterogeneous-mixture pretrained checkpoint, then finetuned on a single-domain dataset. Training MSE spikes ~21× at step ~40 (model encountering different-geometry normalized targets for the first time) — the expected signature of the fresh `dataset_stats` taking effect. Without the knob the same finetune sat at the source-mixture loss landscape and could not move the rollout success rate off zero in 1000 steps; with the knob the loss curve enters a new trajectory that the weights then re-align to.

## How to checkout & try? (for the reviewer)

```bash
git checkout claude/skip-normalization-weights
uv sync --extra dev --extra libero
pytest -sx tests/policies/test_pi07_paligemma_low_level.py::TestSkipNormalizationWeights
```

To enable on a real finetune, set the field under `policy` in your training JSON:

```json
{
  "policy": {
    "type": "pi07_paligemma_low_level",
    "pretrained_path": "TensorAuto/<your-pretrained-checkpoint>",
    "skip_normalization_weights": true
  }
}
```

…and launch normally:

```bash
opentau-train --config_path=configs/your_finetune_config.json
```

The startup log will include `skip_normalization_weights=True; dropped 8 saved normalize/unnormalize buffer keys` if the filter fires.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [x] My PR includes policy-related changes.
  - [x] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).