### PR TITLE
fix(configs+tests): unblock dev_config smoke and merge-collision test failures

### DIFF
--- a/configs/dev/dev_config.json
+++ b/configs/dev/dev_config.json
@@ -31,7 +31,7 @@
         "attention_implementation": "eager",
         "freeze_vision_encoder": true,
         "train_expert_only": true,
-        "tokenizer_max_length": 256,
+        "prompt_max_length": 256,
         "discrete_action_max_length": 75,
         "optimizer_lr": 2.5e-05,
         "optimizer_betas": [

--- a/tests/policies/test_pi07_paligemma_low_level.py
+++ b/tests/policies/test_pi07_paligemma_low_level.py
@@ -2464,9 +2464,15 @@ class TestSkipNormalizationWeights:
             FeatureType.ACTION: NormalizationMode.MIN_MAX,
         }
 
-        normalize_mean_std_keys = list(Normalize(features, norm_map_mean_std).state_dict().keys())
-        unnormalize_mean_std_keys = list(Unnormalize(features, norm_map_mean_std).state_dict().keys())
-        normalize_min_max_keys = list(Normalize(features, norm_map_min_max).state_dict().keys())
+        normalize_mean_std_keys = list(
+            Normalize(features, norm_map_mean_std, num_datasets=1).state_dict().keys()
+        )
+        unnormalize_mean_std_keys = list(
+            Unnormalize(features, norm_map_mean_std, num_datasets=1).state_dict().keys()
+        )
+        normalize_min_max_keys = list(
+            Normalize(features, norm_map_min_max, num_datasets=1).state_dict().keys()
+        )
 
         # Each (Un)Normalize submodule attaches as ``normalize_inputs`` /
         # ``normalize_targets`` / ``unnormalize_outputs`` /
@@ -2527,7 +2533,7 @@ class TestSkipNormalizationWeights:
         norm_map = {FeatureType.ACTION: NormalizationMode.MEAN_STD}
 
         parent = nn.Module()
-        parent.normalize_inputs = Normalize(features, norm_map, stats=None)
+        parent.normalize_inputs = Normalize(features, norm_map, num_datasets=1)
 
         inf_buffers = _find_inf_normalize_buffers(parent)
         assert inf_buffers, "expected the helper to flag at least one inf buffer for a stats-less Normalize"
@@ -2550,8 +2556,8 @@ class TestSkipNormalizationWeights:
         stats = {"action": {"mean": np.zeros(7, dtype=np.float32), "std": np.ones(7, dtype=np.float32)}}
 
         parent = nn.Module()
-        parent.normalize_inputs = Normalize(features, norm_map, stats=stats)
-        parent.unnormalize_outputs = Unnormalize(features, norm_map, stats=stats)
+        parent.normalize_inputs = Normalize(features, norm_map, per_dataset_stats=[stats])
+        parent.unnormalize_outputs = Unnormalize(features, norm_map, per_dataset_stats=[stats])
 
         assert _find_inf_normalize_buffers(parent) == []
 


### PR DESCRIPTION
## What this does

Two small fixes uncovered while verifying [#335](https://github.com/TensorAuto/OpenTau/issues/335).

### 1. `configs/dev/dev_config.json` — stale `tokenizer_max_length`

Renamed in [#290](https://github.com/TensorAuto/OpenTau/pull/290) (FAST tokenizer support) but `dev_config.json` was not updated, so loading it raised:

```
draccus.utils.DecodingError: `policy`: The fields `tokenizer_max_length` are not valid for PI05Config
```

The issue's verification recipe explicitly suggests `configs/dev/dev_config.json` (with `steps=2`) as one of the smoke targets — that command was unrunnable today because of this stale field.

`configs/examples/pi_config.json` also has `tokenizer_max_length`, but that one targets `pi0` and `PI0Config` still has the field, so it's intentionally left alone.

### 2. `tests/policies/test_pi07_paligemma_low_level.py::TestSkipNormalizationWeights` — `#336` / `#337` API drift

`#336` (per-dataset normalization) renamed `Normalize(stats=...)` to `Normalize(per_dataset_stats=[...])` (a list, with `num_datasets=` as the inf-init path). `#337` was authored against the pre-`#336` API and merged first; `#336` then merged without updating these tests, so CPU CI now fails on every PR with:

```
ValueError: create_stats_buffers requires either `per_dataset_stats` or `num_datasets` ...
TypeError: Normalize.__init__() got an unexpected keyword argument 'stats'
```

Affected tests (all in `TestSkipNormalizationWeights`):
- `test_predicate_matches_real_normalize_buffer_keys`
- `test_find_inf_normalize_buffers_detects_init_inf_sentinels`
- `test_find_inf_normalize_buffers_empty_when_stats_passed`

Updates:
- Inf-init paths now pass `num_datasets=1` (replaces the implicit single-dataset default).
- The populated-stats path passes `per_dataset_stats=[stats]` (wrap the single stat dict in a singleton list to match the new D-row layout).

🐛 Bug

## How it was tested

`pre-commit run --all-files` clean on both files.

**Test fix (CPU-runnable):**

```bash
pytest -xvs tests/policies/test_pi07_paligemma_low_level.py::TestSkipNormalizationWeights -m "not gpu"
# 7 passed in 0.10s
```

**Config fix (end-to-end smoke on an internal single-GPU dev box):**

```bash
opentau-train \
  --accelerate-config <single-gpu-config>.yaml \
  --config_path=configs/dev/dev_config.json \
  --policy.pretrained_path=TensorAuto/pi05_base \
  --output_dir=outputs/verify/dev_smoke \
  --steps=2 --save_freq=2 --val_freq=2 \
  --wandb.enable=false
```

```
INFO ts/train.py:682 step:1(1) ... total_loss:5.554770 mse_loss:0.098065 ce_loss:4.574120
INFO ts/train.py:682 step:2(2) ... total_loss:7.446621 mse_loss:0.180828 ce_loss:5.638338
INFO ts/train.py:788 Validation/lerobot/droid_100 step:2(2) ... val_total_loss:12.691884
INFO ts/train.py:927 End of training
```

Without the config fix the same command exits with the `DecodingError` above before reaching `Creating dataset`.

## How to checkout & try? (for the reviewer)

```bash
gh pr checkout 339

# 1. Test fix:
pytest -xvs tests/policies/test_pi07_paligemma_low_level.py::TestSkipNormalizationWeights -m "not gpu"

# 2. Config fix (just confirm it parses):
python -c "
from opentau.configs import parser
from opentau.configs.train import TrainPipelineConfig
import sys
sys.argv = ['_', '--config_path=configs/dev/dev_config.json',
            '--policy.pretrained_path=TensorAuto/pi05_base',
            '--steps=2', '--wandb.enable=false']
@parser.wrap()
def main(cfg: TrainPipelineConfig):
    print('OK:', type(cfg.policy).__name__, 'prompt_max_length=', cfg.policy.prompt_max_length)
main()
"
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).