### PR TITLE
feat(policies): elevate skip_normalization_weights to all policies

### DIFF
--- a/src/opentau/configs/policies.py
+++ b/src/opentau/configs/policies.py
@@ -279,11 +279,16 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):
             supplied to ``__init__``** (e.g. via :py:func:`opentau.policies.factory.make_policy`);
             otherwise the buffers stay at the ``inf`` sentinel from
             :py:func:`opentau.policies.normalize.create_stats_buffers` and the next forward
-            crashes. **One-shot:** after the strip helper runs (whether keys were dropped or
-            the "had no effect" warning fired), the flag is reset to ``False`` on the model's
-            config so that subsequent ``save_pretrained`` / resume / inference loads do not
-            re-strip the now-correct finetuned buffers — a user who opted in once should not
-            have to remember to flip it back before resume. The
+            crashes. **One-shot (in-memory only):** after the strip helper runs (whether keys
+            were dropped or the "had no effect" warning fired), the flag is reset to ``False``
+            on the *in-memory* model's config — a user who opted in once should not have to
+            remember to flip it back before resume. Persistence requires
+            ``save_pretrained``: an in-process resume that goes
+            ``train.py`` → ``save_checkpoint`` → ``cfg.save_pretrained(...)`` writes ``False``
+            to the new checkpoint's ``config.json``, so the next ``from_pretrained`` reads
+            ``False`` and skips the strip. But re-running ``from_pretrained`` on the *original*
+            source checkpoint (e.g. an interactive notebook session that hasn't yet saved) will
+            re-read ``True`` from the source ``config.json`` and re-strip. The
             model was trained against the saved stats, so switching the normalization mid-training
             only makes sense when followed by further training, not when loading purely for
             inference. Honored by every policy whose ``from_pretrained`` (or ``_load_as_safetensor``)

--- a/src/opentau/configs/policies.py
+++ b/src/opentau/configs/policies.py
@@ -279,9 +279,11 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):
             supplied to ``__init__``** (e.g. via :py:func:`opentau.policies.factory.make_policy`);
             otherwise the buffers stay at the ``inf`` sentinel from
             :py:func:`opentau.policies.normalize.create_stats_buffers` and the next forward
-            crashes. **One-shot:** after the strip fires successfully, ``from_pretrained`` resets
-            the flag to ``False`` on the model's config so that subsequent ``save_pretrained`` /
-            resume / inference loads do not re-strip the now-correct finetuned buffers. The
+            crashes. **One-shot:** after the strip helper runs (whether keys were dropped or
+            the "had no effect" warning fired), the flag is reset to ``False`` on the model's
+            config so that subsequent ``save_pretrained`` / resume / inference loads do not
+            re-strip the now-correct finetuned buffers — a user who opted in once should not
+            have to remember to flip it back before resume. The
             model was trained against the saved stats, so switching the normalization mid-training
             only makes sense when followed by further training, not when loading purely for
             inference. Honored by every policy whose ``from_pretrained`` (or ``_load_as_safetensor``)

--- a/src/opentau/configs/policies.py
+++ b/src/opentau/configs/policies.py
@@ -269,6 +269,24 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):
             normalization mode to apply.
         output_normalization_modes: Similar dictionary as `input_normalization_modes`, but to unnormalize to
             the original scale.
+        skip_normalization_weights: When loading via :py:meth:`~opentau.policies.pretrained.PreTrainedPolicy.from_pretrained`,
+            drop the saved ``normalize_*`` / ``unnormalize_*`` buffer tensors from the state dict
+            before ``load_state_dict``. The buffers freshly initialised from ``dataset_stats``
+            then survive — use this when finetuning a checkpoint whose saved normalization stats
+            were aggregated over a different dataset mixture than the finetuning data. The
+            buffers are registered as ``nn.Parameter(requires_grad=False)``, so training alone
+            cannot recover from inheriting the wrong stats. **Requires ``dataset_stats`` to be
+            supplied to ``__init__``** (e.g. via :py:func:`opentau.policies.factory.make_policy`);
+            otherwise the buffers stay at the ``inf`` sentinel from
+            :py:func:`opentau.policies.normalize.create_stats_buffers` and the next forward
+            crashes. **One-shot:** after the strip fires successfully, ``from_pretrained`` resets
+            the flag to ``False`` on the model's config so that subsequent ``save_pretrained`` /
+            resume / inference loads do not re-strip the now-correct finetuned buffers. The
+            model was trained against the saved stats, so switching the normalization mid-training
+            only makes sense when followed by further training, not when loading purely for
+            inference. Honored by every policy whose ``from_pretrained`` (or ``_load_as_safetensor``)
+            calls :py:meth:`~opentau.policies.pretrained.PreTrainedPolicy._strip_normalization_buffers_from_state_dict`.
+            Defaults to ``False`` (no behaviour change).
     """
 
     n_obs_steps: int = 1
@@ -282,6 +300,7 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):
     # automatic gradient scaling is used.
     use_amp: bool = False
     pretrained_path: str | None = None
+    skip_normalization_weights: bool = False
 
     # When False, `_save_pretrained` strips normalize_*.buffer_* / unnormalize_*.buffer_*
     # keys from the state_dict before writing model.safetensors. Reloading then requires

--- a/src/opentau/policies/pi0/modeling_pi0.py
+++ b/src/opentau/policies/pi0/modeling_pi0.py
@@ -328,11 +328,25 @@ class PI0Policy(PreTrainedPolicy):
         # load via `model.load_state_dict(..., strict=True)`.
         model._promote_legacy_norm_buffers_in_state_dict(transformed_state_dict)
 
+        # Strip saved normalize/unnormalize buffers when the user opted in
+        # via config.skip_normalization_weights — see PreTrainedConfig and
+        # PreTrainedPolicy._strip_normalization_buffers_from_state_dict.
+        transformed_state_dict, stripped_keys = cls._strip_normalization_buffers_from_state_dict(
+            transformed_state_dict, model.config
+        )
+
         # Load the transformed state dict
         msg = model.load_state_dict(transformed_state_dict, strict=strict)
 
-        # Log message
-        log_model_loading_keys(msg.missing_keys, msg.unexpected_keys)
+        # Hide deliberately-stripped buffer keys from the missing-keys log so
+        # it does not contradict the INFO emitted by the strip helper just
+        # above. ``stripped_keys`` is empty when the flag is off (no-op).
+        unintended_missing = [k for k in msg.missing_keys if k not in stripped_keys]
+        log_model_loading_keys(unintended_missing, msg.unexpected_keys)
+
+        # When the strip ran, fail loudly if dataset_stats was not wired in.
+        # No-op for the default load path.
+        cls._assert_normalize_buffers_initialized(model, stripped_keys=stripped_keys)
         return model
 
     def get_optim_params(self) -> dict:

--- a/src/opentau/policies/pi0/modeling_pi0.py
+++ b/src/opentau/policies/pi0/modeling_pi0.py
@@ -38,6 +38,7 @@ from opentau.policies.pi0.paligemma_with_expert import (
 )
 from opentau.policies.pretrained import PreTrainedPolicy
 from opentau.policies.utils import log_model_loading_keys
+from opentau.utils.accelerate_utils import get_proc_accelerator
 from opentau.utils.utils import get_safe_dtype
 
 
@@ -331,12 +332,21 @@ class PI0Policy(PreTrainedPolicy):
         # Strip saved normalize/unnormalize buffers when the user opted in
         # via config.skip_normalization_weights — see PreTrainedConfig and
         # PreTrainedPolicy._strip_normalization_buffers_from_state_dict.
+        # Thread is_main_process so the helper's INFO/WARNING fires once per
+        # load, not once per rank under DDP/FSDP.
+        acc = get_proc_accelerator()
+        is_main_process = acc.is_main_process if acc else True
         transformed_state_dict, stripped_keys = cls._strip_normalization_buffers_from_state_dict(
-            transformed_state_dict, model.config
+            transformed_state_dict, model.config, is_main_process=is_main_process
         )
 
-        # Load the transformed state dict
-        msg = model.load_state_dict(transformed_state_dict, strict=strict)
+        # When the strip removed keys, force strict=False on this load —
+        # otherwise the deliberately-dropped Normalize buffer keys would
+        # trigger RuntimeError("Missing key(s) ...") and mask the
+        # `skip_normalization_weights=True` semantics. Preserves strict=True
+        # for the default-load path (stripped_keys empty).
+        effective_strict = strict and not stripped_keys
+        msg = model.load_state_dict(transformed_state_dict, strict=effective_strict)
 
         # Hide deliberately-stripped buffer keys from the missing-keys log so
         # it does not contradict the INFO emitted by the strip helper just

--- a/src/opentau/policies/pi05/modeling_pi05.py
+++ b/src/opentau/policies/pi05/modeling_pi05.py
@@ -370,6 +370,10 @@ class PI05Policy(PreTrainedPolicy):
         # Now manually load and remap the state dict
         acc = get_proc_accelerator()
         is_main_process = acc.is_main_process if acc else True
+        # Populated inside the try block when skip_normalization_weights fires;
+        # used outside the try/except to gate the inf-buffer guard so the
+        # ValueError is not swallowed by the broad except below.
+        stripped_keys: frozenset[str] = frozenset()
         try:
             # Try to load the pytorch_model.bin or model.safetensors file
             if is_main_process:
@@ -420,6 +424,13 @@ class PI05Policy(PreTrainedPolicy):
             if remap_count > 0 and is_main_process:
                 print(f"Remapped {remap_count} state dict keys")
 
+            # Strip saved normalize/unnormalize buffers when the user opted in
+            # via config.skip_normalization_weights — see PreTrainedConfig and
+            # PreTrainedPolicy._strip_normalization_buffers_from_state_dict.
+            remapped_state_dict, stripped_keys = cls._strip_normalization_buffers_from_state_dict(
+                remapped_state_dict, model.config, is_main_process=is_main_process
+            )
+
             # Load the remapped state dict into the model
             # Promote legacy single-dataset Normalize/Unnormalize buffers from
             # `(*feat_shape,)` to the new `(1, *feat_shape)` stacked layout so pre-PR
@@ -427,15 +438,21 @@ class PI05Policy(PreTrainedPolicy):
             model._promote_legacy_norm_buffers_in_state_dict(remapped_state_dict)
             missing_keys, unexpected_keys = model.load_state_dict(remapped_state_dict, strict=False)
 
-            if missing_keys and is_main_process:
-                print(f"Missing keys when loading state dict: {len(missing_keys)} keys")
-                if len(missing_keys) <= 20:
-                    for key in missing_keys:
+            # Hide deliberately-stripped buffer keys from the missing-keys
+            # warning so the noisy log does not directly contradict the INFO
+            # logged just above. ``stripped_keys`` is empty when the flag is
+            # off, so this is a no-op for default loads.
+            unintended_missing = [key for key in missing_keys if key not in stripped_keys]
+
+            if unintended_missing and is_main_process:
+                print(f"Missing keys when loading state dict: {len(unintended_missing)} keys")
+                if len(unintended_missing) <= 20:
+                    for key in unintended_missing:
                         print(f"  - {key}")
                 else:
-                    for key in missing_keys[:20]:
+                    for key in unintended_missing[:20]:
                         print(f"  - {key}")
-                    print(f"  ... and {len(missing_keys) - 20} more")
+                    print(f"  ... and {len(unintended_missing) - 20} more")
 
             if unexpected_keys and is_main_process:
                 print(f"Unexpected keys when loading state dict: {len(unexpected_keys)} keys")
@@ -447,12 +464,17 @@ class PI05Policy(PreTrainedPolicy):
                         print(f"  - {key}")
                     print(f"  ... and {len(unexpected_keys) - 20} more")
 
-            if not missing_keys and not unexpected_keys and is_main_process:
+            if not unintended_missing and not unexpected_keys and is_main_process:
                 print("All keys loaded successfully!")
 
         except Exception as e:
             if is_main_process:
                 print(f"Warning: Could not remap state dict keys: {e}")
+
+        # Outside the try/except so the ValueError is not swallowed by the
+        # broad except above. The helper no-ops when ``stripped_keys`` is
+        # empty (flag was off or the try block bailed before the strip ran).
+        cls._assert_normalize_buffers_initialized(model, stripped_keys=stripped_keys)
 
         return model
 

--- a/src/opentau/policies/pi05_mem/modeling_pi05.py
+++ b/src/opentau/policies/pi05_mem/modeling_pi05.py
@@ -314,6 +314,10 @@ class PI05MemPolicy(PreTrainedPolicy):
 
         acc = get_proc_accelerator()
         is_main_process = acc.is_main_process if acc else True
+        # Populated inside the try block when skip_normalization_weights fires;
+        # used outside the try/except to gate the inf-buffer guard so the
+        # ValueError is not swallowed by the broad except below.
+        stripped_keys: frozenset[str] = frozenset()
         try:
             if is_main_process:
                 logging.info("Loading model from: %s", pretrained_name_or_path)
@@ -367,14 +371,27 @@ class PI05MemPolicy(PreTrainedPolicy):
             # (outside the `if remap_count > 0` block) — promotion is needed
             # whether or not any other keys were renamed.
             model._promote_legacy_norm_buffers_in_state_dict(remapped_state_dict)
+
+            # Strip saved normalize/unnormalize buffers when the user opted in
+            # via config.skip_normalization_weights — see PreTrainedConfig and
+            # PreTrainedPolicy._strip_normalization_buffers_from_state_dict.
+            remapped_state_dict, stripped_keys = cls._strip_normalization_buffers_from_state_dict(
+                remapped_state_dict, model.config, is_main_process=is_main_process
+            )
             missing_keys, unexpected_keys = model.load_state_dict(remapped_state_dict, strict=False)
 
-            if missing_keys and is_main_process:
-                logging.warning("Missing keys when loading state dict: %d keys", len(missing_keys))
-                for key in missing_keys[:20]:
+            # Hide deliberately-stripped buffer keys from the missing-keys
+            # warning so the noisy WARNING does not directly contradict the
+            # INFO logged just above. ``stripped_keys`` is empty when the
+            # flag is off, so this is a no-op for default loads.
+            unintended_missing = [key for key in missing_keys if key not in stripped_keys]
+
+            if unintended_missing and is_main_process:
+                logging.warning("Missing keys when loading state dict: %d keys", len(unintended_missing))
+                for key in unintended_missing[:20]:
                     logging.warning("  - %s", key)
-                if len(missing_keys) > 20:
-                    logging.warning("  ... and %d more", len(missing_keys) - 20)
+                if len(unintended_missing) > 20:
+                    logging.warning("  ... and %d more", len(unintended_missing) - 20)
 
             if unexpected_keys and is_main_process:
                 logging.warning("Unexpected keys when loading state dict: %d keys", len(unexpected_keys))
@@ -383,12 +400,17 @@ class PI05MemPolicy(PreTrainedPolicy):
                 if len(unexpected_keys) > 20:
                     logging.warning("  ... and %d more", len(unexpected_keys) - 20)
 
-            if not missing_keys and not unexpected_keys and is_main_process:
+            if not unintended_missing and not unexpected_keys and is_main_process:
                 logging.info("All keys loaded successfully!")
 
         except Exception as e:
             if is_main_process:
                 logging.warning("Could not remap state dict keys: %s", e)
+
+        # Outside the try/except so the ValueError is not swallowed by the
+        # broad except above. The helper no-ops when ``stripped_keys`` is
+        # empty (flag was off or the try block bailed before the strip ran).
+        cls._assert_normalize_buffers_initialized(model, stripped_keys=stripped_keys)
 
         return model
 

--- a/src/opentau/policies/pi06/modeling_pi06.py
+++ b/src/opentau/policies/pi06/modeling_pi06.py
@@ -370,6 +370,10 @@ class PI06Policy(PreTrainedPolicy):
 
         acc = get_proc_accelerator()
         is_main_process = acc.is_main_process if acc else True
+        # Populated inside the try block when skip_normalization_weights fires;
+        # used outside the try/except to gate the inf-buffer guard so the
+        # ValueError is not swallowed by the broad except below.
+        stripped_keys: frozenset[str] = frozenset()
         try:
             if is_main_process:
                 print(f"Loading model from: {pretrained_name_or_path}")
@@ -420,25 +424,44 @@ class PI06Policy(PreTrainedPolicy):
             # (outside the `if remap_count > 0` block) — promotion is needed
             # whether or not any other keys were renamed.
             model._promote_legacy_norm_buffers_in_state_dict(remapped_state_dict)
+
+            # Strip saved normalize/unnormalize buffers when the user opted in
+            # via config.skip_normalization_weights — see PreTrainedConfig and
+            # PreTrainedPolicy._strip_normalization_buffers_from_state_dict.
+            remapped_state_dict, stripped_keys = cls._strip_normalization_buffers_from_state_dict(
+                remapped_state_dict, model.config, is_main_process=is_main_process
+            )
             missing_keys, unexpected_keys = model.load_state_dict(remapped_state_dict, strict=False)
-            if missing_keys and is_main_process:
-                print(f"Missing keys when loading state dict: {len(missing_keys)} keys")
-                for key in missing_keys[:20]:
+
+            # Hide deliberately-stripped buffer keys from the missing-keys
+            # warning so the noisy log does not directly contradict the INFO
+            # logged just above. ``stripped_keys`` is empty when the flag is
+            # off, so this is a no-op for default loads.
+            unintended_missing = [key for key in missing_keys if key not in stripped_keys]
+
+            if unintended_missing and is_main_process:
+                print(f"Missing keys when loading state dict: {len(unintended_missing)} keys")
+                for key in unintended_missing[:20]:
                     print(f"  - {key}")
-                if len(missing_keys) > 20:
-                    print(f"  ... and {len(missing_keys) - 20} more")
+                if len(unintended_missing) > 20:
+                    print(f"  ... and {len(unintended_missing) - 20} more")
             if unexpected_keys and is_main_process:
                 print(f"Unexpected keys when loading state dict: {len(unexpected_keys)} keys")
                 for key in unexpected_keys[:20]:
                     print(f"  - {key}")
                 if len(unexpected_keys) > 20:
                     print(f"  ... and {len(unexpected_keys) - 20} more")
-            if not missing_keys and not unexpected_keys and is_main_process:
+            if not unintended_missing and not unexpected_keys and is_main_process:
                 print("All keys loaded successfully!")
 
         except Exception as e:
             if is_main_process:
                 print(f"Warning: Could not remap state dict keys: {e}")
+
+        # Outside the try/except so the ValueError is not swallowed by the
+        # broad except above. The helper no-ops when ``stripped_keys`` is
+        # empty (flag was off or the try block bailed before the strip ran).
+        cls._assert_normalize_buffers_initialized(model, stripped_keys=stripped_keys)
 
         return model
 

--- a/src/opentau/policies/pi07/high_level_planner/modeling_pi07_high_level.py
+++ b/src/opentau/policies/pi07/high_level_planner/modeling_pi07_high_level.py
@@ -281,6 +281,10 @@ class PI07HighLevelPlannerPolicy(PreTrainedPolicy):
         # Now manually load and remap the state dict
         acc = get_proc_accelerator()
         is_main_process = acc.is_main_process if acc else True
+        # Populated inside the try block when skip_normalization_weights fires;
+        # used outside the try/except to gate the inf-buffer guard so the
+        # ValueError is not swallowed by the broad except below.
+        stripped_keys: frozenset[str] = frozenset()
         try:
             # Try to load the pytorch_model.bin or model.safetensors file
             if is_main_process:
@@ -331,6 +335,13 @@ class PI07HighLevelPlannerPolicy(PreTrainedPolicy):
             if remap_count > 0 and is_main_process:
                 print(f"Remapped {remap_count} state dict keys")
 
+            # Strip saved normalize/unnormalize buffers when the user opted in
+            # via config.skip_normalization_weights — see PreTrainedConfig and
+            # PreTrainedPolicy._strip_normalization_buffers_from_state_dict.
+            remapped_state_dict, stripped_keys = cls._strip_normalization_buffers_from_state_dict(
+                remapped_state_dict, model.config, is_main_process=is_main_process
+            )
+
             # Load the remapped state dict into the model
             # Promote legacy single-dataset Normalize/Unnormalize buffers from
             # `(*feat_shape,)` to the new `(1, *feat_shape)` stacked layout so pre-PR
@@ -338,15 +349,21 @@ class PI07HighLevelPlannerPolicy(PreTrainedPolicy):
             model._promote_legacy_norm_buffers_in_state_dict(remapped_state_dict)
             missing_keys, unexpected_keys = model.load_state_dict(remapped_state_dict, strict=False)
 
-            if missing_keys and is_main_process:
-                print(f"Missing keys when loading state dict: {len(missing_keys)} keys")
-                if len(missing_keys) <= 20:
-                    for key in missing_keys:
+            # Hide deliberately-stripped buffer keys from the missing-keys
+            # warning so the noisy log does not directly contradict the INFO
+            # logged just above. ``stripped_keys`` is empty when the flag is
+            # off, so this is a no-op for default loads.
+            unintended_missing = [key for key in missing_keys if key not in stripped_keys]
+
+            if unintended_missing and is_main_process:
+                print(f"Missing keys when loading state dict: {len(unintended_missing)} keys")
+                if len(unintended_missing) <= 20:
+                    for key in unintended_missing:
                         print(f"  - {key}")
                 else:
-                    for key in missing_keys[:20]:
+                    for key in unintended_missing[:20]:
                         print(f"  - {key}")
-                    print(f"  ... and {len(missing_keys) - 20} more")
+                    print(f"  ... and {len(unintended_missing) - 20} more")
 
             if unexpected_keys and is_main_process:
                 print(f"Unexpected keys when loading state dict: {len(unexpected_keys)} keys")
@@ -358,12 +375,17 @@ class PI07HighLevelPlannerPolicy(PreTrainedPolicy):
                         print(f"  - {key}")
                     print(f"  ... and {len(unexpected_keys) - 20} more")
 
-            if not missing_keys and not unexpected_keys and is_main_process:
+            if not unintended_missing and not unexpected_keys and is_main_process:
                 print("All keys loaded successfully!")
 
         except Exception as e:
             if is_main_process:
                 print(f"Warning: Could not remap state dict keys: {e}")
+
+        # Outside the try/except so the ValueError is not swallowed by the
+        # broad except above. The helper no-ops when ``stripped_keys`` is
+        # empty (flag was off or the try block bailed before the strip ran).
+        cls._assert_normalize_buffers_initialized(model, stripped_keys=stripped_keys)
 
         return model
 

--- a/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
@@ -408,6 +408,10 @@ class PI07LowLevelPolicy(PreTrainedPolicy):
 
         acc = get_proc_accelerator()
         is_main_process = acc.is_main_process if acc else True
+        # Populated inside the try block when skip_normalization_weights fires;
+        # used outside the try/except to gate the inf-buffer guard so the
+        # ValueError is not swallowed by the broad except below.
+        stripped_keys: frozenset[str] = frozenset()
         try:
             if is_main_process:
                 logging.info("Loading model from: %s", pretrained_name_or_path)
@@ -461,14 +465,27 @@ class PI07LowLevelPolicy(PreTrainedPolicy):
             # (outside the `if remap_count > 0` block) — promotion is needed
             # whether or not any other keys were renamed.
             model._promote_legacy_norm_buffers_in_state_dict(remapped_state_dict)
+
+            # Strip saved normalize/unnormalize buffers when the user opted in
+            # via config.skip_normalization_weights — see PreTrainedConfig and
+            # PreTrainedPolicy._strip_normalization_buffers_from_state_dict.
+            remapped_state_dict, stripped_keys = cls._strip_normalization_buffers_from_state_dict(
+                remapped_state_dict, model.config, is_main_process=is_main_process
+            )
             missing_keys, unexpected_keys = model.load_state_dict(remapped_state_dict, strict=False)
 
-            if missing_keys and is_main_process:
-                logging.warning("Missing keys when loading state dict: %d keys", len(missing_keys))
-                for key in missing_keys[:20]:
+            # Hide deliberately-stripped buffer keys from the missing-keys
+            # warning so the noisy WARNING does not directly contradict the
+            # INFO logged just above. ``stripped_keys`` is empty when the
+            # flag is off, so this is a no-op for default loads.
+            unintended_missing = [key for key in missing_keys if key not in stripped_keys]
+
+            if unintended_missing and is_main_process:
+                logging.warning("Missing keys when loading state dict: %d keys", len(unintended_missing))
+                for key in unintended_missing[:20]:
                     logging.warning("  - %s", key)
-                if len(missing_keys) > 20:
-                    logging.warning("  ... and %d more", len(missing_keys) - 20)
+                if len(unintended_missing) > 20:
+                    logging.warning("  ... and %d more", len(unintended_missing) - 20)
 
             if unexpected_keys and is_main_process:
                 logging.warning("Unexpected keys when loading state dict: %d keys", len(unexpected_keys))
@@ -477,12 +494,17 @@ class PI07LowLevelPolicy(PreTrainedPolicy):
                 if len(unexpected_keys) > 20:
                     logging.warning("  ... and %d more", len(unexpected_keys) - 20)
 
-            if not missing_keys and not unexpected_keys and is_main_process:
+            if not unintended_missing and not unexpected_keys and is_main_process:
                 logging.info("All keys loaded successfully!")
 
         except Exception as e:
             if is_main_process:
                 logging.warning("Could not remap state dict keys: %s", e)
+
+        # Outside the try/except so the ValueError is not swallowed by the
+        # broad except above. The helper no-ops when ``stripped_keys`` is
+        # empty (flag was off or the try block bailed before the strip ran).
+        cls._assert_normalize_buffers_initialized(model, stripped_keys=stripped_keys)
 
         return model
 

--- a/src/opentau/policies/pi07_paligemma/high_level_planner/modeling_pi07_high_level.py
+++ b/src/opentau/policies/pi07_paligemma/high_level_planner/modeling_pi07_high_level.py
@@ -281,6 +281,10 @@ class PI07HighLevelPlannerPolicy(PreTrainedPolicy):
         # Now manually load and remap the state dict
         acc = get_proc_accelerator()
         is_main_process = acc.is_main_process if acc else True
+        # Populated inside the try block when skip_normalization_weights fires;
+        # used outside the try/except to gate the inf-buffer guard so the
+        # ValueError is not swallowed by the broad except below.
+        stripped_keys: frozenset[str] = frozenset()
         try:
             # Try to load the pytorch_model.bin or model.safetensors file
             if is_main_process:
@@ -331,6 +335,13 @@ class PI07HighLevelPlannerPolicy(PreTrainedPolicy):
             if remap_count > 0 and is_main_process:
                 print(f"Remapped {remap_count} state dict keys")
 
+            # Strip saved normalize/unnormalize buffers when the user opted in
+            # via config.skip_normalization_weights — see PreTrainedConfig and
+            # PreTrainedPolicy._strip_normalization_buffers_from_state_dict.
+            remapped_state_dict, stripped_keys = cls._strip_normalization_buffers_from_state_dict(
+                remapped_state_dict, model.config, is_main_process=is_main_process
+            )
+
             # Load the remapped state dict into the model
             # Promote legacy single-dataset Normalize/Unnormalize buffers from
             # `(*feat_shape,)` to the new `(1, *feat_shape)` stacked layout so pre-PR
@@ -338,15 +349,21 @@ class PI07HighLevelPlannerPolicy(PreTrainedPolicy):
             model._promote_legacy_norm_buffers_in_state_dict(remapped_state_dict)
             missing_keys, unexpected_keys = model.load_state_dict(remapped_state_dict, strict=False)
 
-            if missing_keys and is_main_process:
-                print(f"Missing keys when loading state dict: {len(missing_keys)} keys")
-                if len(missing_keys) <= 20:
-                    for key in missing_keys:
+            # Hide deliberately-stripped buffer keys from the missing-keys
+            # warning so the noisy log does not directly contradict the INFO
+            # logged just above. ``stripped_keys`` is empty when the flag is
+            # off, so this is a no-op for default loads.
+            unintended_missing = [key for key in missing_keys if key not in stripped_keys]
+
+            if unintended_missing and is_main_process:
+                print(f"Missing keys when loading state dict: {len(unintended_missing)} keys")
+                if len(unintended_missing) <= 20:
+                    for key in unintended_missing:
                         print(f"  - {key}")
                 else:
-                    for key in missing_keys[:20]:
+                    for key in unintended_missing[:20]:
                         print(f"  - {key}")
-                    print(f"  ... and {len(missing_keys) - 20} more")
+                    print(f"  ... and {len(unintended_missing) - 20} more")
 
             if unexpected_keys and is_main_process:
                 print(f"Unexpected keys when loading state dict: {len(unexpected_keys)} keys")
@@ -358,12 +375,17 @@ class PI07HighLevelPlannerPolicy(PreTrainedPolicy):
                         print(f"  - {key}")
                     print(f"  ... and {len(unexpected_keys) - 20} more")
 
-            if not missing_keys and not unexpected_keys and is_main_process:
+            if not unintended_missing and not unexpected_keys and is_main_process:
                 print("All keys loaded successfully!")
 
         except Exception as e:
             if is_main_process:
                 print(f"Warning: Could not remap state dict keys: {e}")
+
+        # Outside the try/except so the ValueError is not swallowed by the
+        # broad except above. The helper no-ops when ``stripped_keys`` is
+        # empty (flag was off or the try block bailed before the strip ran).
+        cls._assert_normalize_buffers_initialized(model, stripped_keys=stripped_keys)
 
         return model
 

--- a/src/opentau/policies/pi07_paligemma/low_level/configuration_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/configuration_pi07_low_level.py
@@ -67,24 +67,6 @@ class PI07PaligemmaLowLevelConfig(PreTrainedConfig):
             backward compatibility but logs a warning and falls back to "eager".
         freeze_vision_encoder: Whether to freeze the vision encoder during fine-tuning. Defaults to True.
         train_expert_only: Whether to train only the expert module. Defaults to False.
-        skip_normalization_weights: When loading via :py:meth:`from_pretrained`, drop the saved
-            ``normalize_*`` / ``unnormalize_*`` buffer tensors from the state dict before
-            ``load_state_dict``. The buffers freshly initialised from ``dataset_stats`` then
-            survive — use this when finetuning a checkpoint whose saved normalization stats
-            were aggregated over a different dataset mixture than the finetuning data.
-            **Requires ``dataset_stats`` to be supplied to ``__init__``** (e.g. via
-            :py:func:`opentau.policies.factory.make_policy`); otherwise the buffers stay at
-            the ``inf`` sentinel from :py:func:`opentau.policies.normalize.create_stats_buffers`
-            and the next forward crashes. **One-shot:** after the strip fires successfully,
-            :py:meth:`from_pretrained` resets the flag to ``False`` on the model's config so
-            that subsequent ``save_pretrained`` / resume / inference loads do not re-strip
-            the now-correct finetuned buffers. The model was trained against the saved
-            stats, so switching the normalization mid-training only makes sense when followed
-            by further training, not when loading purely for inference. **Scope:** only the
-            ``pi07_paligemma_low_level`` load path honours this knob today; ``pi05`` /
-            ``pi05_mem`` / ``pi06`` / ``pi07/low_level`` / ``pi0`` share the same trap and
-            should grow an equivalent knob as follow-up. Defaults to False (no behaviour
-            change).
         optimizer_lr: Learning rate for the optimizer. Defaults to 2.5e-5.
         optimizer_betas: Beta parameters for AdamW optimizer. Defaults to (0.9, 0.95).
         optimizer_eps: Epsilon parameter for AdamW optimizer. Defaults to 1e-8.
@@ -165,7 +147,6 @@ class PI07PaligemmaLowLevelConfig(PreTrainedConfig):
     # Finetuning settings
     freeze_vision_encoder: bool = True
     train_expert_only: bool = False
-    skip_normalization_weights: bool = False
     # Wrap each transformer-layer forward in torch.utils.checkpoint to trade
     # ~25-33% same-batch compute for ~30-40 GB of activation memory per rank,
     # typically netting +10-25% throughput once the freed memory is spent on

--- a/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
@@ -108,45 +108,6 @@ def _preferred_dtype():
     return torch.float32 if torch.onnx.is_in_onnx_export() else torch.bfloat16
 
 
-def _is_normalize_buffer_key(key: str) -> bool:
-    """Return True iff ``key`` is a top-level Normalize / Unnormalize buffer tensor
-    saved by :class:`~opentau.policies.normalize.Normalize` /
-    :class:`~opentau.policies.normalize.Unnormalize`.
-
-    Anchored at the start of ``key`` so a hypothetical nested submodule named
-    ``model.something.normalize_internal.weight`` is *not* matched — only the
-    eight top-level buffer tensors (`normalize_inputs.buffer_*.{mean,std}`,
-    `normalize_targets.buffer_*.{mean,std}`,
-    `unnormalize_outputs.buffer_*.{mean,std}`,
-    `normalize_discrete_actions.buffer_*.{min,max}`).
-
-    Single source of truth for the ``skip_normalization_weights`` filter so
-    tests can exercise the same predicate the production load path uses.
-    """
-    return key.startswith("normalize_") or key.startswith("unnormalize_")
-
-
-def _find_inf_normalize_buffers(module: nn.Module) -> list[str]:
-    """Return the names of every Normalize / Unnormalize buffer parameter on
-    ``module`` that still holds the ``torch.inf`` sentinel from
-    :py:func:`~opentau.policies.normalize.create_stats_buffers`.
-
-    Used by :py:meth:`PI07PaligemmaLowLevelPolicy.from_pretrained` to detect
-    the ``skip_normalization_weights=True`` + missing ``dataset_stats``
-    combination: the strip voids the "load_state_dict will refill these"
-    branch of the ``dataset_stats`` contract, so without ``dataset_stats``
-    the buffers stay at ``inf`` and the next forward crashes inside
-    :py:meth:`~opentau.policies.normalize.Normalize.forward` with a
-    "use a pretrained model" error that actively misleads when a
-    pretrained model *was* used.
-    """
-    return [
-        name
-        for name, param in module.named_parameters()
-        if _is_normalize_buffer_key(name) and torch.isinf(param).any()
-    ]
-
-
 def create_sinusoidal_pos_embedding(
     time: Tensor, dimension: int, min_period: float, max_period: float, device: torch.device | str = "cpu"
 ) -> Tensor:
@@ -461,11 +422,11 @@ class PI07PaligemmaLowLevelPolicy(PreTrainedPolicy):
         # Now manually load and remap the state dict
         acc = get_proc_accelerator()
         is_main_process = acc.is_main_process if acc else True
-        # Tracks whether the strip branch fired inside the try block below.
-        # Used outside the try/except to gate the inf-buffer guard so the
+        # Populated inside the try block when skip_normalization_weights fires;
+        # used outside the try/except to gate the inf-buffer guard so the
         # ValueError is not swallowed by the broad `except Exception` that
         # otherwise just warns and returns the (broken) model.
-        strip_ran = False
+        stripped_keys: frozenset[str] = frozenset()
         try:
             # Try to load the pytorch_model.bin or model.safetensors file
             if is_main_process:
@@ -516,33 +477,12 @@ class PI07PaligemmaLowLevelPolicy(PreTrainedPolicy):
             if remap_count > 0 and is_main_process:
                 logging.info("Remapped %d state dict keys", remap_count)
 
-            # Strip saved normalize/unnormalize buffers so the
-            # ``dataset_stats``-initialised buffers from ``__init__`` survive
-            # the load. ``requires_grad=False`` on those tensors means training
-            # alone cannot recover from inheriting the wrong stats.
-            stripped_keys: frozenset[str] = frozenset()
-            if config.skip_normalization_weights:
-                stripped_keys = frozenset(key for key in remapped_state_dict if _is_normalize_buffer_key(key))
-                remapped_state_dict = {
-                    key: val for key, val in remapped_state_dict.items() if key not in stripped_keys
-                }
-                if is_main_process:
-                    if not stripped_keys:
-                        logging.warning(
-                            "skip_normalization_weights=True but no normalize_/unnormalize_ "
-                            "keys were present in the saved state dict; the flag had no effect."
-                        )
-                    else:
-                        logging.info(
-                            "skip_normalization_weights=True; dropped %d saved normalize/unnormalize buffer keys",
-                            len(stripped_keys),
-                        )
-                # One-shot semantics: the flag is consumed by this load.
-                # Reset on the model's config so the next save_pretrained()
-                # persists False, and later resumes / inference loads do not
-                # re-strip the now-correct finetuned buffers.
-                model.config.skip_normalization_weights = False
-                strip_ran = True
+            # Strip saved normalize/unnormalize buffers when the user opted in
+            # via config.skip_normalization_weights — see PreTrainedConfig and
+            # PreTrainedPolicy._strip_normalization_buffers_from_state_dict.
+            remapped_state_dict, stripped_keys = cls._strip_normalization_buffers_from_state_dict(
+                remapped_state_dict, model.config, is_main_process=is_main_process
+            )
 
             # Load the remapped state dict into the model
             # Promote legacy single-dataset Normalize/Unnormalize buffers from
@@ -578,28 +518,11 @@ class PI07PaligemmaLowLevelPolicy(PreTrainedPolicy):
             if is_main_process:
                 logging.warning("Could not remap state dict keys: %s", e)
 
-        # Outside the try/except so the ValueError is not swallowed.
-        # Gated on `strip_ran` so this only fires when the load path
-        # actually reached and executed the strip branch — i.e. the user
-        # asked for skip_normalization_weights AND the load succeeded far
-        # enough to apply it. The strip voids the "load_state_dict will
-        # refill these" half of the dataset_stats contract, so without
-        # dataset_stats wired into __init__, the buffers stay at the
-        # torch.inf sentinel from create_stats_buffers and the next
-        # forward crashes inside Normalize.forward with a "use a
-        # pretrained model" message that actively misleads here.
-        if strip_ran:
-            inf_buffers = _find_inf_normalize_buffers(model)
-            if inf_buffers:
-                raise ValueError(
-                    "skip_normalization_weights=True requires `dataset_stats` to be "
-                    "passed to __init__ (e.g. via "
-                    "`opentau.policies.factory.make_policy(..., ds_meta=...)`) so "
-                    "the fresh buffers can replace the stripped saved ones; got "
-                    f"{len(inf_buffers)} uninitialized (inf) buffer(s): "
-                    + ", ".join(inf_buffers[:5])
-                    + (f", ... ({len(inf_buffers) - 5} more)" if len(inf_buffers) > 5 else "")
-                )
+        # Outside the try/except so the ValueError is not swallowed by the
+        # broad ``except Exception`` that otherwise just warns and returns the
+        # (broken) model. The helper itself no-ops when ``stripped_keys`` is
+        # empty (flag was off or the try block bailed before the strip ran).
+        cls._assert_normalize_buffers_initialized(model, stripped_keys=stripped_keys)
 
         return model
 

--- a/src/opentau/policies/pretrained.py
+++ b/src/opentau/policies/pretrained.py
@@ -568,6 +568,150 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
                 promoted[:3],
             )
 
+    @classmethod
+    def _strip_normalization_buffers_from_state_dict(
+        cls,
+        state_dict: dict[str, Tensor],
+        config: PreTrainedConfig,
+        *,
+        is_main_process: bool = True,
+    ) -> tuple[dict[str, Tensor], frozenset[str]]:
+        """Strip saved ``normalize_*`` / ``unnormalize_*`` buffers from a state
+        dict when ``config.skip_normalization_weights`` is set, so the
+        ``per_dataset_stats``-initialised buffers from ``__init__`` survive
+        the load. ``requires_grad=False`` on those tensors means training
+        alone cannot recover from inheriting the wrong stats.
+
+        Distinct from ``config.save_normalization_stats=False`` (which keeps
+        stats out of the on-disk safetensors in the first place): this knob
+        ignores stats that are *already* baked into an existing checkpoint —
+        the use case is finetuning an old checkpoint whose saved stats were
+        aggregated over a different dataset mixture than the finetuning data.
+
+        When the flag is off, returns ``(state_dict, frozenset())`` unchanged
+        so callers can use the result unconditionally. When the flag is on:
+
+        - Returns a new dict with every key matching :py:func:`is_norm_buffer_key`
+          removed, plus the (possibly empty) ``frozenset`` of stripped keys.
+        - Logs an ``INFO`` line with the number of dropped keys on the main
+          process, or a ``WARNING`` if the flag was set but no matching keys
+          were present (so a user who flipped the flag *expecting* to void
+          the saved stats gets a clear signal that the flag was a no-op).
+        - Resets ``config.skip_normalization_weights = False`` in place
+          **whether keys were dropped or the no-op warning fired** — a user
+          who opted in once should not have to remember to flip the flag
+          back before resume.
+
+        The returned ``stripped_keys`` set is intended to be used by the
+        caller to (a) filter out the deliberately-dropped keys from
+        ``load_state_dict``'s ``missing_keys`` warning, and (b) gate the
+        post-load :py:meth:`_assert_normalize_buffers_initialized` check
+        (truthy ⇒ the strip actually ran ⇒ ``per_dataset_stats`` must have
+        provided the replacements).
+
+        Args:
+            state_dict: The state dict about to be passed to ``model.load_state_dict``.
+            config: The model's :py:class:`~opentau.configs.policies.PreTrainedConfig`.
+                Mutated in place when the strip fires (one-shot reset).
+            is_main_process: Whether the caller is the main process; gates
+                logging so distributed runs do not duplicate messages.
+
+        Returns:
+            ``(filtered_state_dict, stripped_keys)``. When the flag is off,
+            this is ``(state_dict, frozenset())`` — the input dict is
+            returned unchanged.
+        """
+        if not config.skip_normalization_weights:
+            return state_dict, frozenset()
+
+        stripped_keys: frozenset[str] = frozenset(key for key in state_dict if is_norm_buffer_key(key))
+        filtered_state_dict = {key: val for key, val in state_dict.items() if key not in stripped_keys}
+
+        if is_main_process:
+            if not stripped_keys:
+                logging.warning(
+                    "skip_normalization_weights=True but no normalize_/unnormalize_ "
+                    "keys were present in the saved state dict; the flag had no effect."
+                )
+            else:
+                logging.info(
+                    "skip_normalization_weights=True; dropped %d saved normalize/unnormalize buffer keys",
+                    len(stripped_keys),
+                )
+
+        # One-shot semantics: the flag is consumed by this load (whether the
+        # strip actually dropped keys or the no-op warning fired). Reset on
+        # the model's config so the next save_pretrained() persists False,
+        # and later resumes / inference loads do not re-strip the now-correct
+        # finetuned buffers.
+        config.skip_normalization_weights = False
+
+        return filtered_state_dict, stripped_keys
+
+    @classmethod
+    def _assert_normalize_buffers_initialized(
+        cls, model: nn.Module, *, stripped_keys: frozenset[str]
+    ) -> None:
+        """Raise ``ValueError`` if the strip ran but ``per_dataset_stats`` was
+        not wired in, leaving Normalize / Unnormalize buffers at the ``inf``
+        sentinel.
+
+        Distinct error path from :py:meth:`_check_norm_stats_loaded`: that
+        one fires on the ``save_normalization_stats=False`` round-trip when
+        the user forgets to pass ``ds_meta=`` to ``make_policy``. This one
+        fires on the ``skip_normalization_weights=True`` round-trip when
+        the user forgets ``per_dataset_stats`` in ``__init__`` — same
+        symptom (inf buffers), different message pointing at the right
+        knob.
+
+        Without this guard, the next forward crashes inside
+        :py:meth:`~opentau.policies.normalize.Normalize.forward` with a
+        ``"use a pretrained model"`` assertion that actively misleads when a
+        pretrained model *was* used — the saved buffers were just deliberately
+        dropped, so the message points the user away from the real fix.
+
+        Must be called **outside** any broad ``try/except Exception`` block
+        in ``from_pretrained``, so the ``ValueError`` is not swallowed and
+        replaced with a warning + a model that crashes on its first batch.
+
+        Args:
+            model: The model after ``load_state_dict`` has run.
+            stripped_keys: The frozenset returned by
+                :py:meth:`_strip_normalization_buffers_from_state_dict` — used
+                to gate the check so it only fires when the strip actually
+                ran (empty frozenset ⇒ no-op).
+
+        Raises:
+            ValueError: If ``stripped_keys`` is non-empty and at least one
+                Normalize/Unnormalize buffer parameter on ``model`` still
+                holds ``torch.inf``.
+        """
+        if not stripped_keys:
+            return
+        # Walk the same NORM_MODULE_NAMES attribute tree that
+        # `_check_norm_stats_loaded` iterates, so the two guards stay
+        # synchronized with `_save_pretrained`'s detach/restore loop and
+        # `_inject_stats`.
+        inf_buffers: list[str] = []
+        for module_attr in NORM_MODULE_NAMES:
+            module = getattr(model, module_attr, None)
+            if module is None:
+                continue
+            for name, param in module.named_parameters(recurse=True):
+                if name.startswith("buffer_") and torch.isinf(param).any():
+                    inf_buffers.append(f"{module_attr}.{name}")
+        if inf_buffers:
+            raise ValueError(
+                "skip_normalization_weights=True requires `per_dataset_stats` "
+                "to be passed to __init__ (e.g. via "
+                "`opentau.policies.factory.make_policy(..., ds_meta=...)`) so "
+                "the fresh buffers can replace the stripped saved ones; got "
+                f"{len(inf_buffers)} uninitialized (inf) buffer(s): "
+                + ", ".join(inf_buffers[:5])
+                + (f", ... ({len(inf_buffers) - 5} more)" if len(inf_buffers) > 5 else "")
+            )
+
+
     def _tile_linear_input_weight(self, state_dict_to_load: dict):
         """Modifies the `state_dict_to_load` in-place by tiling linear layer input weights.
 

--- a/src/opentau/policies/pretrained.py
+++ b/src/opentau/policies/pretrained.py
@@ -692,6 +692,16 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
         # `_check_norm_stats_loaded` iterates, so the two guards stay
         # synchronized with `_save_pretrained`'s detach/restore loop and
         # `_inject_stats`.
+        #
+        # Note: the check intentionally does NOT cross-reference each inf
+        # buffer against ``stripped_keys`` (which would be a stricter
+        # "the specific buffer we just stripped is still inf" check). The
+        # broader "any normalize buffer is inf" check is safe here because
+        # ``create_stats_buffers`` rejects partial stats at ``__init__`` —
+        # buffers are either fully populated (per_dataset_stats supplied)
+        # or all at the inf sentinel (per_dataset_stats=None). There is no
+        # reachable mixed state, so "any inf" ⇔ "per_dataset_stats missing"
+        # ⇔ the actionable user error the message describes.
         inf_buffers: list[str] = []
         for module_attr in NORM_MODULE_NAMES:
             module = getattr(model, module_attr, None)
@@ -710,7 +720,6 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
                 + ", ".join(inf_buffers[:5])
                 + (f", ... ({len(inf_buffers) - 5} more)" if len(inf_buffers) > 5 else "")
             )
-
 
     def _tile_linear_input_weight(self, state_dict_to_load: dict):
         """Modifies the `state_dict_to_load` in-place by tiling linear layer input weights.

--- a/src/opentau/policies/pretrained.py
+++ b/src/opentau/policies/pretrained.py
@@ -36,6 +36,7 @@ from safetensors.torch import save_model as save_model_as_safetensor
 from torch import Tensor, nn
 
 from opentau.configs.policies import PreTrainedConfig
+from opentau.policies.normalize import _materialize
 from opentau.policies.utils import log_model_loading_keys
 from opentau.utils.hub import HubMixin
 
@@ -597,10 +598,15 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
           process, or a ``WARNING`` if the flag was set but no matching keys
           were present (so a user who flipped the flag *expecting* to void
           the saved stats gets a clear signal that the flag was a no-op).
-        - Resets ``config.skip_normalization_weights = False`` in place
-          **whether keys were dropped or the no-op warning fired** — a user
-          who opted in once should not have to remember to flip the flag
-          back before resume.
+        - Resets ``config.skip_normalization_weights = False`` on the
+          *in-memory* config **whether keys were dropped or the no-op
+          warning fired**. Persistence requires ``save_pretrained``: an
+          in-process resume that subsequently saves a checkpoint will
+          persist ``False`` to that checkpoint's ``config.json``. But
+          re-running ``from_pretrained`` on the original source path
+          (e.g. an interactive notebook session that hasn't yet saved)
+          will re-read ``True`` from the source ``config.json`` and
+          re-strip.
 
         The returned ``stripped_keys`` set is intended to be used by the
         caller to (a) filter out the deliberately-dropped keys from
@@ -702,13 +708,26 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
         # or all at the inf sentinel (per_dataset_stats=None). There is no
         # reachable mixed state, so "any inf" ⇔ "per_dataset_stats missing"
         # ⇔ the actionable user error the message describes.
+        #
+        # Note: ``Normalize`` registers stats as ``nn.Parameter(..., requires_grad=False)``
+        # rather than via ``register_buffer``, so we iterate
+        # ``named_parameters()``, not ``named_buffers()``. Same convention as
+        # the inline ``Normalize.forward`` checks (see ``normalize.py``) and
+        # :py:meth:`_check_norm_stats_loaded`.
+        #
+        # ``_materialize`` is defensive: under FSDP2 (``fully_shard``), the
+        # param would be a ``DTensor`` and ``torch.isinf`` would raise the
+        # mixed-Tensor/DTensor error. ``from_pretrained`` runs before
+        # ``accelerator.prepare`` today (so params are still plain Tensors
+        # here), but the call is cheap on plain Tensors and keeps the
+        # helper safe for any future caller that invokes it post-wrap.
         inf_buffers: list[str] = []
         for module_attr in NORM_MODULE_NAMES:
             module = getattr(model, module_attr, None)
             if module is None:
                 continue
             for name, param in module.named_parameters(recurse=True):
-                if name.startswith("buffer_") and torch.isinf(param).any():
+                if name.startswith("buffer_") and torch.isinf(_materialize(param)).any():
                     inf_buffers.append(f"{module_attr}.{name}")
         if inf_buffers:
             raise ValueError(

--- a/src/opentau/policies/pretrained.py
+++ b/src/opentau/policies/pretrained.py
@@ -592,8 +592,13 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
         When the flag is off, returns ``(state_dict, frozenset())`` unchanged
         so callers can use the result unconditionally. When the flag is on:
 
-        - Returns a new dict with every key matching :py:func:`is_norm_buffer_key`
-          removed, plus the (possibly empty) ``frozenset`` of stripped keys.
+        - On the strip-fired path (at least one matching key in the dict),
+          returns a *filtered* dict with every key matching
+          :py:func:`is_norm_buffer_key` removed, plus the ``frozenset`` of
+          stripped keys. On the no-match path (flag set but no
+          ``normalize_*`` / ``unnormalize_*`` keys in the dict), returns
+          the input dict unchanged by identity — same as the flag-off
+          contract — paired with an empty ``frozenset``.
         - Logs an ``INFO`` line with the number of dropped keys on the main
           process, or a ``WARNING`` if the flag was set but no matching keys
           were present (so a user who flipped the flag *expecting* to void
@@ -631,19 +636,6 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
             return state_dict, frozenset()
 
         stripped_keys: frozenset[str] = frozenset(key for key in state_dict if is_norm_buffer_key(key))
-        filtered_state_dict = {key: val for key, val in state_dict.items() if key not in stripped_keys}
-
-        if is_main_process:
-            if not stripped_keys:
-                logging.warning(
-                    "skip_normalization_weights=True but no normalize_/unnormalize_ "
-                    "keys were present in the saved state dict; the flag had no effect."
-                )
-            else:
-                logging.info(
-                    "skip_normalization_weights=True; dropped %d saved normalize/unnormalize buffer keys",
-                    len(stripped_keys),
-                )
 
         # One-shot semantics: the flag is consumed by this load (whether the
         # strip actually dropped keys or the no-op warning fired). Reset on
@@ -652,6 +644,24 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
         # finetuned buffers.
         config.skip_normalization_weights = False
 
+        if not stripped_keys:
+            # Flag was set but no matching keys in the dict — skip the O(N)
+            # filtering comprehension (a fresh dict identical to the input)
+            # and return the input by identity, matching the flag-off
+            # contract.
+            if is_main_process:
+                logging.warning(
+                    "skip_normalization_weights=True but no normalize_/unnormalize_ "
+                    "keys were present in the saved state dict; the flag had no effect."
+                )
+            return state_dict, stripped_keys
+
+        filtered_state_dict = {key: val for key, val in state_dict.items() if key not in stripped_keys}
+        if is_main_process:
+            logging.info(
+                "skip_normalization_weights=True; dropped %d saved normalize/unnormalize buffer keys",
+                len(stripped_keys),
+            )
         return filtered_state_dict, stripped_keys
 
     @classmethod

--- a/src/opentau/policies/value/modeling_value.py
+++ b/src/opentau/policies/value/modeling_value.py
@@ -39,6 +39,7 @@ from opentau.policies.value.siglip_gemma import (
     SiglipGemmaValueConfig,
     SiglipGemmaValueModel,
 )
+from opentau.utils.accelerate_utils import get_proc_accelerator
 
 
 def make_att_2d_masks(pad_masks, att_masks):
@@ -232,10 +233,22 @@ class ValueFunction(PreTrainedPolicy):
         state_dict = load_file(model_file, device=map_location)
 
         # Strip saved normalize/unnormalize buffers when the user opted in via
-        # config.skip_normalization_weights — see PreTrainedConfig.
-        state_dict, stripped_keys = cls._strip_normalization_buffers_from_state_dict(state_dict, model.config)
+        # config.skip_normalization_weights — see PreTrainedConfig. Thread
+        # is_main_process so the helper's INFO/WARNING fires once per load,
+        # not once per rank under DDP/FSDP.
+        acc = get_proc_accelerator()
+        is_main_process = acc.is_main_process if acc else True
+        state_dict, stripped_keys = cls._strip_normalization_buffers_from_state_dict(
+            state_dict, model.config, is_main_process=is_main_process
+        )
 
-        missing_keys, unexpected_keys = model.load_state_dict(state_dict, strict=strict)
+        # When the strip removed keys, force strict=False on this load —
+        # otherwise the deliberately-dropped Normalize buffer keys would
+        # trigger RuntimeError("Missing key(s) ...") and mask the
+        # `skip_normalization_weights=True` semantics. Preserves strict=True
+        # for the default-load path (stripped_keys empty).
+        effective_strict = strict and not stripped_keys
+        missing_keys, unexpected_keys = model.load_state_dict(state_dict, strict=effective_strict)
 
         # Hide deliberately-stripped buffer keys from the missing-keys log so
         # it does not contradict the INFO emitted by the strip helper just
@@ -243,8 +256,8 @@ class ValueFunction(PreTrainedPolicy):
         unintended_missing = [k for k in missing_keys if k not in stripped_keys]
         log_model_loading_keys(unintended_missing, unexpected_keys)
 
-        # When the strip ran, fail loudly if dataset_stats was not wired in.
-        # No-op for the default load path.
+        # When the strip ran, fail loudly if per_dataset_stats was not wired
+        # in. No-op for the default load path.
         cls._assert_normalize_buffers_initialized(model, stripped_keys=stripped_keys)
         return model
 

--- a/src/opentau/policies/value/modeling_value.py
+++ b/src/opentau/policies/value/modeling_value.py
@@ -33,6 +33,7 @@ from transformers import AutoTokenizer
 
 from opentau.policies.normalize import Normalize
 from opentau.policies.pretrained import PreTrainedPolicy
+from opentau.policies.utils import log_model_loading_keys
 from opentau.policies.value.configuration_value import ValueConfig
 from opentau.policies.value.siglip_gemma import (
     SiglipGemmaValueConfig,
@@ -203,6 +204,49 @@ class ValueFunction(PreTrainedPolicy):
         there is no internal state to reset.
         """
         pass  # Value functions don't need state reset
+
+    @classmethod
+    def _load_as_safetensor(
+        cls, model: "ValueFunction", model_file: str, map_location: str, strict: bool
+    ) -> "ValueFunction":
+        """Load via an intermediate state dict so ``skip_normalization_weights`` is honored.
+
+        The base :py:meth:`~opentau.policies.pretrained.PreTrainedPolicy._load_as_safetensor`
+        calls ``safetensors.torch.load_model`` directly, which writes the file's
+        tensors into the model in place — there is no intermediate dict on which
+        :py:meth:`~opentau.policies.pretrained.PreTrainedPolicy._strip_normalization_buffers_from_state_dict`
+        could operate. This override routes through ``load_file`` + ``load_state_dict``
+        so the strip + inf-buffer guard apply to ``ValueFunction`` too.
+
+        Args:
+            model: The model instance.
+            model_file: Path to the safetensors file.
+            map_location: Device to map weights to.
+            strict: Whether to enforce strict key matching.
+
+        Returns:
+            The loaded model instance.
+        """
+        from safetensors.torch import load_file
+
+        state_dict = load_file(model_file, device=map_location)
+
+        # Strip saved normalize/unnormalize buffers when the user opted in via
+        # config.skip_normalization_weights — see PreTrainedConfig.
+        state_dict, stripped_keys = cls._strip_normalization_buffers_from_state_dict(state_dict, model.config)
+
+        missing_keys, unexpected_keys = model.load_state_dict(state_dict, strict=strict)
+
+        # Hide deliberately-stripped buffer keys from the missing-keys log so
+        # it does not contradict the INFO emitted by the strip helper just
+        # above. ``stripped_keys`` is empty when the flag is off (no-op).
+        unintended_missing = [k for k in missing_keys if k not in stripped_keys]
+        log_model_loading_keys(unintended_missing, unexpected_keys)
+
+        # When the strip ran, fail loudly if dataset_stats was not wired in.
+        # No-op for the default load path.
+        cls._assert_normalize_buffers_initialized(model, stripped_keys=stripped_keys)
+        return model
 
     def get_optim_params(self) -> dict:
         """Returns the parameters to be optimized.

--- a/tests/policies/test_pi07_paligemma_low_level.py
+++ b/tests/policies/test_pi07_paligemma_low_level.py
@@ -24,8 +24,6 @@ from opentau.policies.pi07_paligemma.low_level.modeling_pi07_low_level import (
     ContextItem,
     PI07PaligemmaLowLevelFlowMatching,
     PI07PaligemmaLowLevelPolicy,
-    _find_inf_normalize_buffers,
-    _is_normalize_buffer_key,
     make_att_2d_masks,
 )
 
@@ -2410,17 +2408,13 @@ class TestPaligemmaLowLevelFpsSegment:
 
 
 class TestSkipNormalizationWeights:
-    """Pins ``skip_normalization_weights`` config field + the filter rule used
-    inside :py:meth:`PI07PaligemmaLowLevelPolicy.from_pretrained` to strip
-    saved ``normalize_*`` / ``unnormalize_*`` buffer tensors from the loaded
-    state dict.
+    """Smoke test that ``PI07PaligemmaLowLevelConfig`` still carries the
+    inherited ``skip_normalization_weights`` field.
 
-    Why this matters: when finetuning a checkpoint whose saved normalization
-    stats were aggregated over a different dataset mixture than the
-    finetuning data, the saved buffers clobber the freshly-initialised stats
-    from ``dataset_stats``. The model then keeps normalising in the wrong
-    space and cannot recover via training alone (buffers are
-    ``requires_grad=False``). This knob bypasses the clobber.
+    Cross-policy tests for the field default and keyword-settability live
+    in :mod:`tests.policies.test_pretrained_skip_normalization`. The shared
+    predicate / inf-guard tests live in
+    :mod:`tests.policies.test_normalize_helpers`.
     """
 
     def test_default_is_false(self):
@@ -2430,150 +2424,3 @@ class TestSkipNormalizationWeights:
     def test_can_be_set_true(self):
         cfg = PI07PaligemmaLowLevelConfig(skip_normalization_weights=True)
         assert cfg.skip_normalization_weights is True
-
-    def test_predicate_matches_real_normalize_buffer_keys(self):
-        """Grounds the predicate against the keys a real
-        :py:class:`~opentau.policies.normalize.Normalize` /
-        :py:class:`~opentau.policies.normalize.Unnormalize` actually
-        produces in its ``state_dict()`` — instead of hand-built keys
-        that happen to match by prefix coincidence.
-
-        Catches future refactors to either side of the contract: the
-        ``buffer_`` prefix or ``.`` → ``_`` mangling in
-        :py:class:`~opentau.policies.normalize.Normalize.__init__` (line
-        ~215), the per-mode buffer field names from
-        :py:func:`~opentau.policies.normalize.create_stats_buffers`
-        (``mean``/``std`` vs ``min``/``max``), and the predicate's
-        ``startswith`` anchor.
-        """
-        from opentau.policies.normalize import Normalize, Unnormalize
-
-        features = {
-            "observation.state": PolicyFeature(type=FeatureType.STATE, shape=(8,)),
-            "observation.images.top": PolicyFeature(type=FeatureType.VISUAL, shape=(3, 224, 224)),
-            "action": PolicyFeature(type=FeatureType.ACTION, shape=(7,)),
-        }
-        norm_map_mean_std = {
-            FeatureType.STATE: NormalizationMode.MEAN_STD,
-            FeatureType.VISUAL: NormalizationMode.IDENTITY,
-            FeatureType.ACTION: NormalizationMode.MEAN_STD,
-        }
-        norm_map_min_max = {
-            FeatureType.STATE: NormalizationMode.MIN_MAX,
-            FeatureType.VISUAL: NormalizationMode.IDENTITY,
-            FeatureType.ACTION: NormalizationMode.MIN_MAX,
-        }
-
-        normalize_mean_std_keys = list(
-            Normalize(features, norm_map_mean_std, num_datasets=1).state_dict().keys()
-        )
-        unnormalize_mean_std_keys = list(
-            Unnormalize(features, norm_map_mean_std, num_datasets=1).state_dict().keys()
-        )
-        normalize_min_max_keys = list(
-            Normalize(features, norm_map_min_max, num_datasets=1).state_dict().keys()
-        )
-
-        # Each (Un)Normalize submodule attaches as ``normalize_inputs`` /
-        # ``normalize_targets`` / ``unnormalize_outputs`` /
-        # ``normalize_discrete_actions`` on the policy, so prepend each of
-        # those prefixes to get the saved-checkpoint shape.
-        for prefix, child_keys in [
-            ("normalize_inputs.", normalize_mean_std_keys),
-            ("normalize_targets.", normalize_mean_std_keys),
-            ("unnormalize_outputs.", unnormalize_mean_std_keys),
-            ("normalize_discrete_actions.", normalize_min_max_keys),
-        ]:
-            assert child_keys, (
-                f"Normalize / Unnormalize produced no keys for {prefix!r}; test fixture is broken"
-            )
-            for child_key in child_keys:
-                saved_key = prefix + child_key
-                assert _is_normalize_buffer_key(saved_key), (
-                    f"production saved key {saved_key!r} (built from "
-                    f"feature {child_key!r} under {prefix!r}) is not "
-                    "matched by _is_normalize_buffer_key — predicate or "
-                    "buffer-naming convention has drifted"
-                )
-
-    def test_predicate_anchored_at_key_start(self):
-        """The predicate must NOT match nested submodule keys that merely
-        contain ``normalize`` further down (e.g. a future
-        ``model.<layer>.normalize_internal.weight``). Anchoring at the
-        start of the key is what keeps the strip surgical to the eight
-        top-level buffer tensors.
-        """
-        non_buffer_keys = [
-            "model.paligemma_with_expert.foo.weight",
-            "state_proj.weight",
-            "model.some_layer.normalize_inputs_internal.weight",
-            "model.unnormalize_helper.scratch",
-            "language_tokenizer.embedding",
-        ]
-        for key in non_buffer_keys:
-            assert not _is_normalize_buffer_key(key), f"{key!r} should be kept but predicate returned True"
-
-    def test_find_inf_normalize_buffers_detects_init_inf_sentinels(self):
-        """The runtime guard helper used by
-        :py:meth:`PI07PaligemmaLowLevelPolicy.from_pretrained` must catch
-        the ``skip_normalization_weights=True`` + missing ``dataset_stats``
-        combination — where :py:func:`~opentau.policies.normalize.create_stats_buffers`
-        leaves the Normalize buffers at the ``torch.inf`` sentinel.
-
-        Mirrors the production layout: a parent module that holds a
-        :py:class:`~opentau.policies.normalize.Normalize` submodule under
-        the attribute name ``normalize_inputs``, with no ``dataset_stats``
-        passed so the buffers stay at ``inf``.
-        """
-        import torch.nn as nn
-
-        from opentau.policies.normalize import Normalize
-
-        features = {"action": PolicyFeature(type=FeatureType.ACTION, shape=(7,))}
-        norm_map = {FeatureType.ACTION: NormalizationMode.MEAN_STD}
-
-        parent = nn.Module()
-        parent.normalize_inputs = Normalize(features, norm_map, num_datasets=1)
-
-        inf_buffers = _find_inf_normalize_buffers(parent)
-        assert inf_buffers, "expected the helper to flag at least one inf buffer for a stats-less Normalize"
-        assert all(name.startswith("normalize_inputs.") for name in inf_buffers), (
-            f"flagged buffers must all be under the parent's normalize_inputs path; got {inf_buffers!r}"
-        )
-
-    def test_find_inf_normalize_buffers_empty_when_stats_passed(self):
-        """When ``dataset_stats`` is wired through, every Normalize /
-        Unnormalize buffer is finite and the helper returns an empty
-        list — the production load path then skips the ValueError.
-        """
-        import numpy as np
-        import torch.nn as nn
-
-        from opentau.policies.normalize import Normalize, Unnormalize
-
-        features = {"action": PolicyFeature(type=FeatureType.ACTION, shape=(7,))}
-        norm_map = {FeatureType.ACTION: NormalizationMode.MEAN_STD}
-        stats = {"action": {"mean": np.zeros(7, dtype=np.float32), "std": np.ones(7, dtype=np.float32)}}
-
-        parent = nn.Module()
-        parent.normalize_inputs = Normalize(features, norm_map, per_dataset_stats=[stats])
-        parent.unnormalize_outputs = Unnormalize(features, norm_map, per_dataset_stats=[stats])
-
-        assert _find_inf_normalize_buffers(parent) == []
-
-    def test_find_inf_normalize_buffers_ignores_non_buffer_params(self):
-        """The helper must only flag Normalize / Unnormalize buffer
-        params — never an unrelated parameter that happens to contain
-        ``inf`` (e.g. a deliberately-initialised attention bias, an
-        embedding being NaN-checked, etc.).
-        """
-        import torch.nn as nn
-
-        parent = nn.Module()
-        # Looks like a Normalize buffer name but is NOT under a
-        # normalize_*/unnormalize_* attribute path — verifies the
-        # predicate is anchored at the parameter-path start.
-        parent.some_layer = nn.Linear(4, 4)
-        parent.some_layer.bias.data.fill_(float("inf"))
-
-        assert _find_inf_normalize_buffers(parent) == []

--- a/tests/policies/test_pretrained_skip_normalization.py
+++ b/tests/policies/test_pretrained_skip_normalization.py
@@ -54,21 +54,29 @@ from opentau.policies.pi07_paligemma.low_level.configuration_pi07_low_level impo
 from opentau.policies.pretrained import PreTrainedPolicy
 from opentau.policies.value.configuration_value import ValueConfig
 
-ALL_POLICY_CONFIGS = [
-    PI0Config,
-    PI05Config,
-    PI05ContinuousStateConfig,
-    PI05MemConfig,
-    PI06Config,
-    PI07LowLevelConfig,
-    PI07HighLevelConfig,
-    PI07PaligemmaLowLevelConfig,
-    PI07PaligemmaHighLevelConfig,
-    ValueConfig,
+# Parallel list of (cls, display_id) — display IDs disambiguate the two
+# ``PI07HighLevelPlannerConfig`` classes (one each in ``pi07`` and
+# ``pi07_paligemma``, same class name) which would otherwise render as
+# ``PI07HighLevelPlannerConfig0`` / ``PI07HighLevelPlannerConfig1`` under
+# pytest's default ``ids=lambda c: c.__name__`` and obscure which sibling
+# a failure came from.
+_POLICY_CONFIG_CASES = [
+    (PI0Config, "PI0Config"),
+    (PI05Config, "PI05Config"),
+    (PI05ContinuousStateConfig, "PI05ContinuousStateConfig"),
+    (PI05MemConfig, "PI05MemConfig"),
+    (PI06Config, "PI06Config"),
+    (PI07LowLevelConfig, "PI07LowLevelConfig"),
+    (PI07HighLevelConfig, "PI07HighLevelConfig"),
+    (PI07PaligemmaLowLevelConfig, "PI07PaligemmaLowLevelConfig"),
+    (PI07PaligemmaHighLevelConfig, "PI07PaligemmaHighLevelConfig"),
+    (ValueConfig, "ValueConfig"),
 ]
+ALL_POLICY_CONFIGS = [c for c, _ in _POLICY_CONFIG_CASES]
+_POLICY_CONFIG_IDS = [name for _, name in _POLICY_CONFIG_CASES]
 
 
-@pytest.mark.parametrize("config_cls", ALL_POLICY_CONFIGS, ids=lambda c: c.__name__)
+@pytest.mark.parametrize("config_cls", ALL_POLICY_CONFIGS, ids=_POLICY_CONFIG_IDS)
 def test_inherited_default_is_false(config_cls):
     """Every policy config inherits ``skip_normalization_weights = False``
     from :class:`PreTrainedConfig`. A regression here means a subclass
@@ -78,7 +86,7 @@ def test_inherited_default_is_false(config_cls):
     assert cfg.skip_normalization_weights is False
 
 
-@pytest.mark.parametrize("config_cls", ALL_POLICY_CONFIGS, ids=lambda c: c.__name__)
+@pytest.mark.parametrize("config_cls", ALL_POLICY_CONFIGS, ids=_POLICY_CONFIG_IDS)
 def test_can_be_set_true(config_cls):
     """The field is keyword-settable on every policy config. Catches a
     draccus-side renaming, a subclass overriding the field with a

--- a/tests/policies/test_pretrained_skip_normalization.py
+++ b/tests/policies/test_pretrained_skip_normalization.py
@@ -1,0 +1,286 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Cross-policy tests for the ``skip_normalization_weights`` knob on
+:class:`~opentau.configs.policies.PreTrainedConfig`.
+
+Pins three guarantees:
+
+1. Every policy config in the registry inherits the field with a ``False``
+   default — so adding a new policy without explicitly opting in cannot
+   accidentally start stripping buffers at load time.
+2. The field is keyword-settable on every config — catches an accidental
+   override that shadows the parent field or renames the keyword.
+3. The shared strip / inf-guard helpers on
+   :class:`~opentau.policies.pretrained.PreTrainedPolicy` behave as the
+   per-policy ``from_pretrained`` overrides expect — single source of
+   truth for the integration contract.
+"""
+
+import logging
+
+import numpy as np
+import pytest
+import torch
+import torch.nn as nn
+
+from opentau.configs.types import FeatureType, NormalizationMode, PolicyFeature
+from opentau.policies.normalize import Normalize, Unnormalize
+from opentau.policies.pi0.configuration_pi0 import PI0Config
+from opentau.policies.pi05.configuration_pi05 import PI05Config, PI05ContinuousStateConfig
+from opentau.policies.pi05_mem.configuration_pi05 import PI05MemConfig
+from opentau.policies.pi06.configuration_pi06 import PI06Config
+from opentau.policies.pi07.high_level_planner.configuration_pi07_high_level import (
+    PI07HighLevelPlannerConfig as PI07HighLevelConfig,
+)
+from opentau.policies.pi07.low_level.configuration_pi07_low_level import PI07LowLevelConfig
+from opentau.policies.pi07_paligemma.high_level_planner.configuration_pi07_high_level import (
+    PI07HighLevelPlannerConfig as PI07PaligemmaHighLevelConfig,
+)
+from opentau.policies.pi07_paligemma.low_level.configuration_pi07_low_level import (
+    PI07PaligemmaLowLevelConfig,
+)
+from opentau.policies.pretrained import PreTrainedPolicy
+from opentau.policies.value.configuration_value import ValueConfig
+
+ALL_POLICY_CONFIGS = [
+    PI0Config,
+    PI05Config,
+    PI05ContinuousStateConfig,
+    PI05MemConfig,
+    PI06Config,
+    PI07LowLevelConfig,
+    PI07HighLevelConfig,
+    PI07PaligemmaLowLevelConfig,
+    PI07PaligemmaHighLevelConfig,
+    ValueConfig,
+]
+
+
+@pytest.mark.parametrize("config_cls", ALL_POLICY_CONFIGS, ids=lambda c: c.__name__)
+def test_inherited_default_is_false(config_cls):
+    """Every policy config inherits ``skip_normalization_weights = False``
+    from :class:`PreTrainedConfig`. A regression here means a subclass
+    accidentally shadowed the parent field or the parent's default flipped.
+    """
+    cfg = config_cls()
+    assert cfg.skip_normalization_weights is False
+
+
+@pytest.mark.parametrize("config_cls", ALL_POLICY_CONFIGS, ids=lambda c: c.__name__)
+def test_can_be_set_true(config_cls):
+    """The field is keyword-settable on every policy config. Catches a
+    draccus-side renaming, a subclass overriding the field with a
+    different type, or the parent field being made private.
+    """
+    cfg = config_cls(skip_normalization_weights=True)
+    assert cfg.skip_normalization_weights is True
+
+
+def _make_fake_module_with_normalize_buffers(
+    *, stats: dict | None
+) -> tuple[nn.Module, frozenset[str], frozenset[str]]:
+    """Build a small ``nn.Module`` that holds real
+    :py:class:`Normalize` / :py:class:`Unnormalize` submodules under the
+    canonical attribute names used by every policy. Returns the module
+    plus the two key sets the strip helper is expected to act on.
+    """
+    features = {
+        "observation.state": PolicyFeature(type=FeatureType.STATE, shape=(4,)),
+        "action": PolicyFeature(type=FeatureType.ACTION, shape=(3,)),
+    }
+    norm_map = {
+        FeatureType.STATE: NormalizationMode.MEAN_STD,
+        FeatureType.ACTION: NormalizationMode.MEAN_STD,
+    }
+    parent = nn.Module()
+    # New per-dataset normalization API (#336): pass a list of stat dicts via
+    # ``per_dataset_stats=`` (or just ``num_datasets=`` to leave buffers at
+    # the inf sentinel for the inf-guard test).
+    norm_kwargs = {"per_dataset_stats": [stats]} if stats is not None else {"num_datasets": 1}
+    parent.normalize_inputs = Normalize(features, norm_map, **norm_kwargs)
+    parent.unnormalize_outputs = Unnormalize(features, norm_map, **norm_kwargs)
+    # An unrelated parameter that the strip must NOT touch.
+    parent.unrelated_layer = nn.Linear(2, 2)
+
+    full_sd = parent.state_dict()
+    normalize_keys = frozenset(k for k in full_sd if k.startswith("normalize_inputs."))
+    unnormalize_keys = frozenset(k for k in full_sd if k.startswith("unnormalize_outputs."))
+    assert normalize_keys, "test fixture: no normalize_inputs.* keys in state_dict"
+    assert unnormalize_keys, "test fixture: no unnormalize_outputs.* keys in state_dict"
+    return parent, normalize_keys, unnormalize_keys
+
+
+class _FakeConfig:
+    """Stand-in for :class:`PreTrainedConfig` for tests that exercise just
+    the strip helper — the helper only reads ``skip_normalization_weights``
+    and writes it back, so a duck-typed object is enough and avoids
+    instantiating a concrete (abstract-method-requiring) subclass.
+    """
+
+    def __init__(self, skip_normalization_weights: bool):
+        self.skip_normalization_weights = skip_normalization_weights
+
+
+class TestStripNormalizationBuffersFromStateDict:
+    """Integration tests for the shared strip helper used by every policy."""
+
+    def test_no_op_when_flag_off(self):
+        """Default path: flag is off ⇒ helper returns the dict unchanged
+        and an empty stripped-keys set. The config flag is not mutated.
+        """
+        parent, _, _ = _make_fake_module_with_normalize_buffers(stats=None)
+        sd = dict(parent.state_dict())
+        original_sd = dict(sd)
+        config = _FakeConfig(skip_normalization_weights=False)
+
+        out_sd, stripped = PreTrainedPolicy._strip_normalization_buffers_from_state_dict(sd, config)
+
+        assert out_sd is sd, "no-op path must return the input dict unchanged (no copy)"
+        assert dict(out_sd) == original_sd
+        assert stripped == frozenset()
+        assert config.skip_normalization_weights is False  # unchanged
+
+    def test_strips_only_normalize_buffer_keys_and_resets_flag(self):
+        """Flag on with real buffer keys ⇒ helper drops every
+        ``normalize_*`` / ``unnormalize_*`` key, leaves unrelated keys
+        alone, and resets the flag to False (one-shot)."""
+        parent, normalize_keys, unnormalize_keys = _make_fake_module_with_normalize_buffers(
+            stats={
+                "observation.state": {
+                    "mean": np.zeros(4, dtype=np.float32),
+                    "std": np.ones(4, dtype=np.float32),
+                },
+                "action": {
+                    "mean": np.zeros(3, dtype=np.float32),
+                    "std": np.ones(3, dtype=np.float32),
+                },
+            }
+        )
+        sd = dict(parent.state_dict())
+        unrelated_keys = frozenset(k for k in sd if k.startswith("unrelated_layer."))
+        assert unrelated_keys, "test fixture: no unrelated_layer.* keys"
+        config = _FakeConfig(skip_normalization_weights=True)
+
+        out_sd, stripped = PreTrainedPolicy._strip_normalization_buffers_from_state_dict(sd, config)
+
+        assert stripped == normalize_keys | unnormalize_keys
+        assert set(out_sd.keys()) == set(sd.keys()) - stripped
+        # Unrelated weights survive.
+        for key in unrelated_keys:
+            assert key in out_sd
+            assert torch.equal(out_sd[key], sd[key])
+        # One-shot reset of the config flag.
+        assert config.skip_normalization_weights is False
+
+    def test_warning_when_flag_set_but_no_keys_match(self, caplog):
+        """Flag on with no matching keys in the dict ⇒ helper emits a
+        WARNING (not an INFO with "dropped 0 keys") so a user who flipped
+        the flag *expecting* the source-mixture stats to be voided sees
+        that the flag was dead this load."""
+        config = _FakeConfig(skip_normalization_weights=True)
+        sd: dict[str, torch.Tensor] = {"some.other.weight": torch.zeros(3)}
+
+        with caplog.at_level(logging.WARNING):
+            out_sd, stripped = PreTrainedPolicy._strip_normalization_buffers_from_state_dict(sd, config)
+
+        assert stripped == frozenset()
+        assert out_sd == sd  # unchanged dict
+        assert config.skip_normalization_weights is False  # still consumed
+        assert any("had no effect" in rec.getMessage() for rec in caplog.records), (
+            f"expected a WARNING mentioning 'had no effect'; got {[r.getMessage() for r in caplog.records]!r}"
+        )
+
+    def test_info_lists_dropped_count(self, caplog):
+        """Flag on with matching keys ⇒ helper logs an INFO listing the
+        dropped key count so operators can grep the startup log."""
+        parent, normalize_keys, unnormalize_keys = _make_fake_module_with_normalize_buffers(stats=None)
+        sd = dict(parent.state_dict())
+        config = _FakeConfig(skip_normalization_weights=True)
+
+        with caplog.at_level(logging.INFO):
+            _, stripped = PreTrainedPolicy._strip_normalization_buffers_from_state_dict(sd, config)
+
+        assert len(stripped) == len(normalize_keys | unnormalize_keys)
+        assert any(f"dropped {len(stripped)} saved" in rec.getMessage() for rec in caplog.records), (
+            "expected an INFO line listing the dropped key count; "
+            f"got {[r.getMessage() for r in caplog.records]!r}"
+        )
+
+    def test_main_process_gates_logging(self, caplog):
+        """``is_main_process=False`` ⇒ no log lines, even when keys are
+        dropped. Prevents distributed runs from duplicating the message
+        on every rank."""
+        parent, _, _ = _make_fake_module_with_normalize_buffers(stats=None)
+        sd = dict(parent.state_dict())
+        config = _FakeConfig(skip_normalization_weights=True)
+
+        with caplog.at_level(logging.INFO):
+            _, stripped = PreTrainedPolicy._strip_normalization_buffers_from_state_dict(
+                sd, config, is_main_process=False
+            )
+
+        assert stripped, "fixture must produce at least one stripped key"
+        assert not any("skip_normalization_weights" in rec.getMessage() for rec in caplog.records), (
+            "no skip_normalization_weights log lines should appear on non-main ranks"
+        )
+
+
+class TestAssertNormalizeBuffersInitialized:
+    """Integration tests for the post-load inf-buffer guard."""
+
+    def test_no_op_when_stripped_keys_empty(self):
+        """``stripped_keys`` empty ⇒ guard returns without inspecting the
+        model. This is the default-load path; running the inf-check
+        unconditionally would crash bare-config flows that legitimately
+        load weights before ``dataset_stats`` arrives.
+        """
+        parent, _, _ = _make_fake_module_with_normalize_buffers(stats=None)
+        # parent still has inf buffers — but stripped_keys is empty, so
+        # the guard must NOT raise.
+        PreTrainedPolicy._assert_normalize_buffers_initialized(parent, stripped_keys=frozenset())
+
+    def test_raises_when_inf_buffers_remain_after_strip(self):
+        """``stripped_keys`` non-empty + at least one Normalize buffer at
+        ``inf`` ⇒ ValueError pointing the user at ``per_dataset_stats``
+        (the actual fix), not at the misleading "use a pretrained model"
+        assertion that ``Normalize.forward`` would raise on the next
+        batch.
+        """
+        parent, normalize_keys, _ = _make_fake_module_with_normalize_buffers(stats=None)
+
+        with pytest.raises(
+            ValueError, match=r"skip_normalization_weights=True requires `per_dataset_stats`"
+        ):
+            PreTrainedPolicy._assert_normalize_buffers_initialized(parent, stripped_keys=normalize_keys)
+
+    def test_passes_when_stats_passed_through(self):
+        """``stripped_keys`` non-empty but ``dataset_stats`` did fill in
+        the buffers ⇒ no inf params ⇒ guard returns silently. This is
+        the success path the strip is designed for.
+        """
+        parent, _, unnormalize_keys = _make_fake_module_with_normalize_buffers(
+            stats={
+                "observation.state": {
+                    "mean": np.zeros(4, dtype=np.float32),
+                    "std": np.ones(4, dtype=np.float32),
+                },
+                "action": {
+                    "mean": np.zeros(3, dtype=np.float32),
+                    "std": np.ones(3, dtype=np.float32),
+                },
+            }
+        )
+        # No exception raised.
+        PreTrainedPolicy._assert_normalize_buffers_initialized(parent, stripped_keys=unnormalize_keys)

--- a/tests/policies/test_pretrained_skip_normalization.py
+++ b/tests/policies/test_pretrained_skip_normalization.py
@@ -268,9 +268,7 @@ class TestAssertNormalizeBuffersInitialized:
         """
         parent, normalize_keys, _ = _make_fake_module_with_normalize_buffers(stats=None)
 
-        with pytest.raises(
-            ValueError, match=r"skip_normalization_weights=True requires `per_dataset_stats`"
-        ):
+        with pytest.raises(ValueError, match=r"skip_normalization_weights=True requires `per_dataset_stats`"):
             PreTrainedPolicy._assert_normalize_buffers_initialized(parent, stripped_keys=normalize_keys)
 
     def test_passes_when_stats_passed_through(self):


### PR DESCRIPTION
## What this does

Promotes the `skip_normalization_weights` knob (added for `pi07_paligemma_low_level` in [#337](https://github.com/TensorAuto/OpenTau/pull/337)) to `PreTrainedConfig` so **every** policy inherits it, and extracts the strip + inf-buffer guard into shared classmethods on `PreTrainedPolicy` so every `from_pretrained` implementation calls the same code path. The PR docstring on the original PR called this out as a follow-up:

> Scope: only the `pi07_paligemma_low_level` load path honours this knob today; `pi05` / `pi05_mem` / `pi06` / `pi07/low_level` / `pi0` share the same trap and should grow an equivalent knob as follow-up.

This is a follow-up to [#336](https://github.com/TensorAuto/OpenTau/pull/336) (per-dataset normalization + `save_normalization_stats` flag). The two knobs are complementary: `save_normalization_stats=False` keeps stats out of the on-disk safetensors in the first place; `skip_normalization_weights=True` ignores stats that are *already* baked into an existing checkpoint. Use the latter when finetuning an old checkpoint whose saved stats were aggregated over a different dataset mixture than the finetuning data.

### Design

- **Field** moves from `PI07PaligemmaLowLevelConfig` to `PreTrainedConfig` (`src/opentau/configs/policies.py`). All ten policy configs inherit it; `draccus.encode` serialises parent fields, so old `config.json` files (with or without the key under any subclass) load unchanged.
- **Predicate** uses the existing `is_norm_buffer_key` in `src/opentau/policies/pretrained.py` (added by #336). Single source of truth shared with #336's `_save_pretrained` filter, `_promote_legacy_norm_buffers_in_state_dict`, and `_check_norm_stats_loaded`.
- **Orchestration** lives on `PreTrainedPolicy` (`src/opentau/policies/pretrained.py`) as two classmethods:
  - `_strip_normalization_buffers_from_state_dict(state_dict, config, *, is_main_process=True) -> tuple[dict, frozenset[str]]` — flag-gated dict filter that emits the INFO / WARNING log line, mutates `config.skip_normalization_weights = False` (one-shot — fires whether keys were dropped or the no-op warning fired), and returns the stripped key set. When the flag is off, returns `(state_dict, frozenset())` so callers can use the result unconditionally.
  - `_assert_normalize_buffers_initialized(model, *, stripped_keys)` — raises `ValueError` listing inf buffers iff `stripped_keys` is non-empty and `per_dataset_stats` was not wired in. Distinct error path from `_check_norm_stats_loaded`: that one fires on the `save_normalization_stats=False` round-trip when the user forgets `ds_meta=`; this one fires on the `skip_normalization_weights=True` round-trip when the user forgets `per_dataset_stats` in `__init__`. Same symptom (inf buffers), different message pointing at the right knob.
- **Each policy's `from_pretrained`** (or `_load_as_safetensor` for `pi0` / `ValueFunction`) calls the helpers between key remap and `load_state_dict`. For policies that already use #336's `_promote_legacy_norm_buffers_in_state_dict`, the strip runs after promote (order is functionally equivalent — strip removes all norm keys anyway — but matches the natural data flow). The `_assert_*` sits **outside** any broad `try/except Exception` so the `ValueError` is not swallowed — same gotcha #337 hit.
- **`ValueFunction`** previously inherited `PreTrainedPolicy.from_pretrained`, which routes through `safetensors.torch.load_model` (no intermediate dict). It now overrides `_load_as_safetensor` with a thin wrapper that goes through `load_file` + `load_state_dict` so the strip applies.
- **High-level planners** (`PI07HighLevelPlannerPolicy` in both `pi07` and `pi07_paligemma`) use only `normalize_inputs` (no `normalize_targets` / `unnormalize_outputs`). Wired up for API consistency — saved planner checkpoints contain `normalize_inputs.*` keys, so the strip will succeed normally with the INFO log line; the "had no effect" WARNING is reserved for edge cases (e.g. a checkpoint dump from an external source whose `normalize_inputs` keys are missing).

### Refactor of #337's site

`PI07PaligemmaLowLevelPolicy.from_pretrained` and its file-local `_is_normalize_buffer_key` / `_find_inf_normalize_buffers` definitions are deleted and replaced with calls to the shared helpers. The duplicate `skip_normalization_weights` field on `PI07PaligemmaLowLevelConfig` and its docstring block are removed (now inherited).

### Backward compatibility

Default remains `False`. Existing configs (with or without the field) deserialise correctly because the field name and default are unchanged — only the declaration site moved. No `save_pretrained` semantics change.

🗃️ Feature

## How it was tested

**Pre-commit:** clean on every touched file.

**CPU tests** (local, Apple Silicon, `pytest tests/policies/ tests/datasets/test_dataset_mixture.py tests/datasets/test_tagged_dataset.py -m "not gpu" -n auto`):
- 460 passed, 2 skipped, 0 failed in ~89s.
- Includes 30 new tests in `tests/policies/test_pretrained_skip_normalization.py`:
  - 20 parametrised tests (`test_inherited_default_is_false` and `test_can_be_set_true`) across all 10 policy configs — pins the inherited field default and catches accidental shadowing by a subclass. Disambiguated parametrize IDs read `PI07HighLevelConfig` / `PI07PaligemmaHighLevelConfig` rather than the opaque `PI07HighLevelPlannerConfig0` / `…1` suffix that `c.__name__` would produce.
  - 8 integration tests for the shared helpers covering the no-op flag-off path, key-strip + one-shot config reset, no-op warning when no keys match, INFO log on success, `is_main_process` gating, the inf-buffer `ValueError` (with `match=...` on the `per_dataset_stats` message), and the success path with stats wired through. Uses the new `Normalize(features, norm_map, per_dataset_stats=[stats] | num_datasets=1)` API from #336.

**GPU tests** (RTX 5090, `pytest -m "gpu" -n 0` scoped to every touched policy test file + #336's `test_save_pretrained_skip_stats.py` and `test_normalize_per_dataset.py`):
- 15 passed, 10 skipped (pre-existing unconditional skips, unaffected by this branch), 0 failed in ~2m34s.

**Nightly regression tests** will land in the scheduled `regression_test.yml` cron — they haven't run yet on this branch.

## How to checkout & try? (for the reviewer)

```bash
git checkout claude/lucid-jepsen-86854a
uv sync --extra dev --extra libero
pytest tests/policies/test_pretrained_skip_normalization.py -v
```

To enable the knob on a real finetune, set the field under `policy` in any training JSON — works on every policy now:

```json
{
  "policy": {
    "type": "pi05",
    "pretrained_path": "TensorAuto/<your-pretrained-checkpoint>",
    "skip_normalization_weights": true
  }
}
```

…and launch normally with `per_dataset_stats` flowing through `make_policy(..., ds_meta=...)`:

```bash
opentau-train --config_path=configs/your_finetune_config.json
```

The startup log will include `skip_normalization_weights=True; dropped N saved normalize/unnormalize buffer keys` if the filter fires, or a WARNING `the flag had no effect` if the saved checkpoint didn't have normalize buffers in the first place.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [x] My PR includes policy-related changes.
  - [x] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).