### PR TITLE
fix(scripts): inject dataset_index in inference smoke obs

### DIFF
--- a/src/opentau/utils/utils.py
+++ b/src/opentau/utils/utils.py
@@ -402,6 +402,11 @@ def create_dummy_observation(cfg, device, dtype=torch.bfloat16) -> dict:
         "prompt": ["Pick up yellow lego block and put it in the bin"],
         "img_is_pad": torch.zeros((1, cfg.num_cams), dtype=torch.bool, device=device),
         "action_is_pad": torch.zeros((1, cfg.action_chunk), dtype=torch.bool, device=device),
+        # Pin per-sample normalization to dataset row 0 so checkpoints trained
+        # with per-dataset stats on >1 datasets don't trip
+        # `_resolve_dataset_index`'s "missing selector" guard. A no-op for
+        # single-dataset policies (the fallback would resolve to the same).
+        "dataset_index": torch.zeros((1,), dtype=torch.long, device=device),
     }
 
 

--- a/tests/utils/test_utils_utils.py
+++ b/tests/utils/test_utils_utils.py
@@ -25,6 +25,7 @@ import torch
 from opentau.utils.hub import HubMixin
 from opentau.utils.utils import (
     capture_timestamp_utc,
+    create_dummy_observation,
     encode_accelerator_state_dict,
     format_big_number,
     get_channel_first_image_shape,
@@ -390,3 +391,24 @@ def test_another_invalid_shape_raises_value_error():
 def test_encode_accelerator_state_dict(obj, expected):
     output = encode_accelerator_state_dict(obj)
     assert output == expected, f"Expected {expected}, but got {output} for input"
+
+
+def test_create_dummy_observation_includes_dataset_index():
+    """Regression for #341: the smoke-test observation must carry a
+    `dataset_index` so multi-dataset checkpoints don't crash inside
+    `_resolve_dataset_index`.
+    """
+
+    @dataclass
+    class _Cfg:
+        resolution: tuple = (224, 224)
+        num_cams: int = 2
+        max_state_dim: int = 32
+        action_chunk: int = 10
+
+    obs = create_dummy_observation(_Cfg(), device=torch.device("cpu"), dtype=torch.float32)
+
+    assert "dataset_index" in obs
+    assert obs["dataset_index"].shape == (1,)
+    assert obs["dataset_index"].dtype == torch.long
+    assert torch.equal(obs["dataset_index"], torch.zeros(1, dtype=torch.long))


### PR DESCRIPTION
## What this does

Fixes #341. The nightly **Regression Tests** workflow's `Run Inference` step has been failing against the 2-dataset CI checkpoint with:

```
KeyError: 'Per-dataset normalization with 2 datasets requires either
`dataset_index` (LongTensor of shape (B,)) or `dataset_repo_id` (str or
list[str] of length B) in the batch.'
```

After #336 landed per-dataset Normalize/Unnormalize, multi-dataset checkpoints require the batch to carry either `dataset_index` or `dataset_repo_id`. The gRPC server and eval script already inject one; `create_dummy_observation` (used only by `src/opentau/scripts/inference.py` smoke test) did not.

This PR pins the smoke-path batch to dataset row 0:

- Single-dataset checkpoints: no behavior change — the `_resolve_dataset_index` fallback would have resolved to the same `zeros((1,))`.
- Multi-dataset checkpoints: the smoke test runs the first dataset's stats, which is what we want for a "just exercise the forward pass" benchmark.

Real deployment callers (`grpc/server.py`, `eval.py`) continue to read their own `dataset_repo_id` config field — those paths already worked, this PR doesn't touch them.

🐛 Bug

## How it was tested

- Added `test_create_dummy_observation_includes_dataset_index` in `tests/utils/test_utils_utils.py` to lock in the regression.
- Re-ran `tests/utils/test_utils_utils.py` and `tests/policies/test_normalize_per_dataset.py` locally — all pass.
- Cannot reproduce the CI `Run Inference` step end-to-end locally without a GPU and a trained checkpoint; the unit test exercises the only line that was wrong, and the failure mode (`_resolve_dataset_index` KeyError) is purely batch-content-driven so a fresh CPU forward through a 2-dataset policy would hit the same guard.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/utils/test_utils_utils.py::test_create_dummy_observation_includes_dataset_index
```

To re-verify the original failure scenario, the next nightly `Regression Tests` run on `main` (post-merge) should show the `Run Inference` step passing again. Alternatively, re-trigger via `workflow_dispatch` on `.github/workflows/regression_test.yml`.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.