### PR TITLE
chore(ci): make extract-claude-lessons fail gracefully

### DIFF
--- a/.github/workflows/extract-claude-lessons.yml
+++ b/.github/workflows/extract-claude-lessons.yml
@@ -44,11 +44,17 @@ jobs:
       )
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # Lessons extraction is best-effort: when claude-code-action exits non-zero
+    # (e.g. anthropic_api_key over its usage limit, transient API failure, OIDC
+    # hiccup), we don't want a red cross next to the just-merged PR. Mirror the
+    # pattern in claude-pr-review.yml (job- + step-level continue-on-error).
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
       - uses: anthropics/claude-code-action@v1
+        continue-on-error: true
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # Match the bot allowlist in the job-level `if:` above. Never `*` on


### PR DESCRIPTION
## What this does

Adds `continue-on-error: true` at both the job and step level of `.github/workflows/extract-claude-lessons.yml` so that when `anthropics/claude-code-action@v1` exits non-zero — most commonly because the `ANTHROPIC_API_KEY` has hit its usage limit, but also for transient API/OIDC failures — the workflow no longer surfaces as a red cross next to the merged PR.

The lessons-extraction job is best-effort (it tries to open a `chore(claude): learn from #N` PR if there's anything worth recording, and exits cleanly otherwise). It does not gate anything, so it should not pollute the post-merge CI signal when Claude is unavailable.

This mirrors the existing pattern in `.github/workflows/claude-pr-review.yml` (which already has the same job-level + step-level `continue-on-error` for the same reason). The implement-fixes workflow is deliberately left alone — that one is user-triggered (`@claude fix`), and a silent failure there would be worse than a red mark.

Label: 🐛 Bug (CI noise).

## How it was tested

- `uv tool run pre-commit run --files .github/workflows/extract-claude-lessons.yml` — all hooks pass (yaml check, zizmor, gitleaks, end-of-file, trailing-whitespace, typos).
- Diff inspected: only the two `continue-on-error: true` lines plus a short justifying comment were added. No other behavior changed; the existing `if:` trust gate and timeout are untouched.
- Runtime verification is not feasible in a PR context (it would require exhausting the real API key on a merged PR), but the YAML semantics of `continue-on-error` are well-defined by GitHub Actions and already exercised by `claude-pr-review.yml`.

## How to checkout & try? (for the reviewer)

```bash
git fetch origin claude/gracious-ritchie-JOW08
git checkout claude/gracious-ritchie-JOW08
git diff main -- .github/workflows/extract-claude-lessons.yml
```

After merge, the next time the lessons workflow runs against an exhausted API key, the workflow run page will still show the step as failed (so you can see why), but the PR check will be green.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.
