### PR TITLE
fix(policies): mask zero-pad action dims in flow-matching MSE

### DIFF
--- a/docs/source/concepts.rst
+++ b/docs/source/concepts.rst
@@ -124,16 +124,6 @@ dims — under per-dataset normalization (where padded-dim stats are
 ``mean=0, std=0``) that signal is a clean "predict 0 here" that contaminates
 samples in the same batch which do use those dims.
 
-The same per-dim mask is also applied to the sampled flow-matching noise
-*before* the action expert's input embedding (``action_in_proj``). This
-zeros out ``noise`` at padded dims, which in turn makes ``x_t =
-(1-t)*noise + t*actions`` and the target velocity ``u_t = noise - actions``
-both zero at padded dims — so the action expert never sees the noise that
-would otherwise leak into predictions at *real* dims via attention. The
-input-side mask is complementary to the loss-side mask: the loss-side mask
-ensures padded slots don't contribute to the gradient; the input-side mask
-ensures padded slots don't contaminate the embedding.
-
 This is distinct from ``action_is_pad``, which masks padded *timesteps*
 along the action chunk. The two masks are AND-ed together inside each
 policy's MSE block: a slot in ``(B, chunk_size, max_action_dim)`` contributes

--- a/docs/source/concepts.rst
+++ b/docs/source/concepts.rst
@@ -124,6 +124,16 @@ dims — under per-dataset normalization (where padded-dim stats are
 ``mean=0, std=0``) that signal is a clean "predict 0 here" that contaminates
 samples in the same batch which do use those dims.
 
+The same per-dim mask is also applied to the sampled flow-matching noise
+*before* the action expert's input embedding (``action_in_proj``). This
+zeros out ``noise`` at padded dims, which in turn makes ``x_t =
+(1-t)*noise + t*actions`` and the target velocity ``u_t = noise - actions``
+both zero at padded dims — so the action expert never sees the noise that
+would otherwise leak into predictions at *real* dims via attention. The
+input-side mask is complementary to the loss-side mask: the loss-side mask
+ensures padded slots don't contribute to the gradient; the input-side mask
+ensures padded slots don't contaminate the embedding.
+
 This is distinct from ``action_is_pad``, which masks padded *timesteps*
 along the action chunk. The two masks are AND-ed together inside each
 policy's MSE block: a slot in ``(B, chunk_size, max_action_dim)`` contributes

--- a/docs/source/concepts.rst
+++ b/docs/source/concepts.rst
@@ -65,7 +65,7 @@ Default format (``n_obs_history=None``):
 
         "img_is_pad": torch.BoolTensor,  # shape (num_cams,) with values 0 or 1, where 1 indicates that the camera image is a padded image.
         "action_is_pad": torch.BoolTensor,  # shape (action_chunk,) with values 0 or 1, where 1 indicates that the action is a padded action.
-        "action_dim": torch.LongTensor,  # scalar shape (); collates to (B,). Real (pre-pad) trailing dim of ``actions``. Used by per-policy flow-matching MSE to skip the zero-pad dim columns; see "Action-dim padding mask" below.
+        "real_action_dim": torch.LongTensor,  # scalar shape (); collates to (B,). Real (pre-pad) trailing dim of ``actions``. Used by per-policy flow-matching MSE to skip the zero-pad dim columns; see "Action-dim padding mask" below.
         "obs_history_is_pad": torch.BoolTensor,  # shape (1,) — always False when n_obs_history is None.
     }
 
@@ -84,7 +84,7 @@ With observation history (``n_obs_history=T``):
 
         "img_is_pad": torch.BoolTensor,  # shape (num_cams,) — camera slot availability.
         "action_is_pad": torch.BoolTensor,  # shape (action_chunk,)
-        "action_dim": torch.LongTensor,  # scalar shape (); collates to (B,). Real (pre-pad) trailing dim of ``actions``.
+        "real_action_dim": torch.LongTensor,  # scalar shape (); collates to (B,). Real (pre-pad) trailing dim of ``actions``.
         "obs_history_is_pad": torch.BoolTensor,  # shape (T,) — True for timesteps outside the episode boundary.
     }
 
@@ -115,33 +115,39 @@ Action-dim padding mask
 For heterogeneous co-training across datasets with different native action
 dimensionalities (e.g. a 7-DoF arm dataset and a 14-DoF bimanual dataset in
 one mixture), ``actions`` is zero-padded along the last axis to
-``max_action_dim`` to keep batches rectangular. The per-sample ``action_dim``
-scalar records the real (pre-pad) trailing dim; each policy's flow-matching
-MSE on the velocity field uses it to skip the zero-pad columns and only
-score the dims that the source dataset actually uses. Without it, the
-action expert would be supervised against zero targets on the padded tail
-dims — under per-dataset normalization (where padded-dim stats are
-``mean=0, std=0``) that signal is a clean "predict 0 here" that contaminates
-samples in the same batch which do use those dims.
+``max_action_dim`` to keep batches rectangular. The per-sample
+``real_action_dim`` scalar records the real (pre-pad) trailing dim; each
+policy's flow-matching MSE on the velocity field uses it to skip the
+zero-pad columns and only score the dims that the source dataset actually
+uses. Without it, the action expert would be supervised against zero
+targets on the padded tail dims — under per-dataset normalization (where
+padded-dim stats are ``mean=0, std=0``) that signal is a clean "predict 0
+here" that contaminates samples in the same batch which do use those dims.
+
+The name parallels (not collides with) the static ``original_action_dim``
+local variable in each policy's inference path
+(``sample_actions`` / ``select_action``), which is
+``self.config.action_feature.shape[0]`` — the deployed policy's
+homogeneous DoF, distinct from this per-sample dynamic key.
 
 This is distinct from ``action_is_pad``, which masks padded *timesteps*
 along the action chunk. The two masks are AND-ed together inside each
 policy's MSE block: a slot in ``(B, chunk_size, max_action_dim)`` contributes
 to the loss only when both its timestep is real (``~action_is_pad``) and
-its dim is real (column index ``< action_dim``). Policies with a
+its dim is real (column index ``< real_action_dim``). Policies with a
 real-time-inference frozen prefix (pi05, pi05_mem, pi06, pi07,
 pi07_paligemma) AND in a third condition, ``~prefix_mask`` — see
 ``flow_matching_masked_mse`` in :mod:`opentau.policies.pi06.modeling_pi06`
 for the full reduction. pi0 has no such frozen prefix and uses only the
 two conditions above.
 
-When ``action_dim`` is absent (single-dataset configs, externally constructed
-inference batches), all ``max_action_dim`` columns are treated as real and
-loss behavior is bit-identical to pre-fix. VQA-style items emit ``actions``
-already shaped ``(action_chunk, max_action_dim)`` and rely on the all-True
-``action_is_pad`` to drive the loss to zero — ``action_dim`` matches
-``max_action_dim`` for those items, and the all-True ``action_is_pad``
-still zeros the contribution.
+When ``real_action_dim`` is absent (single-dataset configs, externally
+constructed inference batches), all ``max_action_dim`` columns are treated
+as real and loss behavior is bit-identical to pre-fix. VQA-style items emit
+``actions`` already shaped ``(action_chunk, max_action_dim)`` and rely on
+the all-True ``action_is_pad`` to drive the loss to zero —
+``real_action_dim`` matches ``max_action_dim`` for those items, and the
+all-True ``action_is_pad`` still zeros the contribution.
 
 .. _standard-data-format-optional-keys:
 

--- a/docs/source/concepts.rst
+++ b/docs/source/concepts.rst
@@ -128,7 +128,12 @@ This is distinct from ``action_is_pad``, which masks padded *timesteps*
 along the action chunk. The two masks are AND-ed together inside each
 policy's MSE block: a slot in ``(B, chunk_size, max_action_dim)`` contributes
 to the loss only when both its timestep is real (``~action_is_pad``) and
-its dim is real (column index ``< action_dim``).
+its dim is real (column index ``< action_dim``). Policies with a
+real-time-inference frozen prefix (pi05, pi05_mem, pi06, pi07,
+pi07_paligemma) AND in a third condition, ``~prefix_mask`` — see
+``flow_matching_masked_mse`` in :mod:`opentau.policies.pi06.modeling_pi06`
+for the full reduction. pi0 has no such frozen prefix and uses only the
+two conditions above.
 
 When ``action_dim`` is absent (single-dataset configs, externally constructed
 inference batches), all ``max_action_dim`` columns are treated as real and

--- a/docs/source/concepts.rst
+++ b/docs/source/concepts.rst
@@ -65,6 +65,7 @@ Default format (``n_obs_history=None``):
 
         "img_is_pad": torch.BoolTensor,  # shape (num_cams,) with values 0 or 1, where 1 indicates that the camera image is a padded image.
         "action_is_pad": torch.BoolTensor,  # shape (action_chunk,) with values 0 or 1, where 1 indicates that the action is a padded action.
+        "action_dim": torch.LongTensor,  # scalar shape (); collates to (B,). Real (pre-pad) trailing dim of ``actions``. Used by per-policy flow-matching MSE to skip the zero-pad dim columns; see "Action-dim padding mask" below.
         "obs_history_is_pad": torch.BoolTensor,  # shape (1,) — always False when n_obs_history is None.
     }
 
@@ -83,6 +84,7 @@ With observation history (``n_obs_history=T``):
 
         "img_is_pad": torch.BoolTensor,  # shape (num_cams,) — camera slot availability.
         "action_is_pad": torch.BoolTensor,  # shape (action_chunk,)
+        "action_dim": torch.LongTensor,  # scalar shape (); collates to (B,). Real (pre-pad) trailing dim of ``actions``.
         "obs_history_is_pad": torch.BoolTensor,  # shape (T,) — True for timesteps outside the episode boundary.
     }
 
@@ -106,6 +108,35 @@ The following fields are set in ``DatasetMixtureConfig``:
 *   ``history_interval``: Step interval between historical observation steps. Defaults to ``1``. Only relevant when ``n_obs_history`` is set.
 
 Cameras should be labeled in order of importance (e.g. camera0 is the most important camera, camera1 is the second most important camera, etc.). The model dataset will select the most important cameras to use if num_cams is less than the number of cameras in the dataset.
+
+Action-dim padding mask
+~~~~~~~~~~~~~~~~~~~~~~~
+
+For heterogeneous co-training across datasets with different native action
+dimensionalities (e.g. a 7-DoF arm dataset and a 14-DoF bimanual dataset in
+one mixture), ``actions`` is zero-padded along the last axis to
+``max_action_dim`` to keep batches rectangular. The per-sample ``action_dim``
+scalar records the real (pre-pad) trailing dim; each policy's flow-matching
+MSE on the velocity field uses it to skip the zero-pad columns and only
+score the dims that the source dataset actually uses. Without it, the
+action expert would be supervised against zero targets on the padded tail
+dims — under per-dataset normalization (where padded-dim stats are
+``mean=0, std=0``) that signal is a clean "predict 0 here" that contaminates
+samples in the same batch which do use those dims.
+
+This is distinct from ``action_is_pad``, which masks padded *timesteps*
+along the action chunk. The two masks are AND-ed together inside each
+policy's MSE block: a slot in ``(B, chunk_size, max_action_dim)`` contributes
+to the loss only when both its timestep is real (``~action_is_pad``) and
+its dim is real (column index ``< action_dim``).
+
+When ``action_dim`` is absent (single-dataset configs, externally constructed
+inference batches), all ``max_action_dim`` columns are treated as real and
+loss behavior is bit-identical to pre-fix. VQA-style items emit ``actions``
+already shaped ``(action_chunk, max_action_dim)`` and rely on the all-True
+``action_is_pad`` to drive the loss to zero — ``action_dim`` matches
+``max_action_dim`` for those items, and the all-True ``action_is_pad``
+still zeros the contribution.
 
 .. _standard-data-format-optional-keys:
 

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -871,11 +871,14 @@ class BaseDataset(torch.utils.data.Dataset):
         # this yields `max_action_dim` — the existing all-True `action_is_pad`
         # still drives the loss to zero, so VQA behavior is unchanged.
         real_action_dim = int(standard_item["actions"].shape[-1])
-        if real_action_dim > self.max_action_dim:
+        if not 0 < real_action_dim <= self.max_action_dim:
             # Raise rather than assert so the check survives `python -O`.
+            # An empty trailing dim (`shape == (chunk, 0)`) would silently emit
+            # `action_dim=0` and contribute zero gradient at training time —
+            # treat it as a malformed dataset, same as exceeding the upper bound.
             raise ValueError(
-                f"real action dim {real_action_dim} exceeds max_action_dim="
-                f"{self.max_action_dim} (dataset={getattr(self, 'repo_id', '?')})"
+                f"real action dim {real_action_dim} is outside (0, "
+                f"{self.max_action_dim}] (dataset={getattr(self, 'repo_id', '?')})"
             )
         standard_item["action_dim"] = torch.tensor(real_action_dim, dtype=torch.long)
 

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -865,6 +865,18 @@ class BaseDataset(torch.utils.data.Dataset):
                 continue
             standard_item[new_key] = item[key]
 
+        # Record the real (pre-pad) action dimensionality so per-policy MSE on
+        # the velocity field can mask out the zero-pad tail dims. For VQA-style
+        # items where `actions` is already shaped `(chunk, max_action_dim)`,
+        # this yields `max_action_dim` — the existing all-True `action_is_pad`
+        # still drives the loss to zero, so VQA behavior is unchanged.
+        real_action_dim = int(standard_item["actions"].shape[-1])
+        assert real_action_dim <= self.max_action_dim, (
+            f"real action dim {real_action_dim} exceeds max_action_dim="
+            f"{self.max_action_dim} (dataset={getattr(self, 'repo_id', '?')})"
+        )
+        standard_item["action_dim"] = torch.tensor(real_action_dim, dtype=torch.long)
+
         # pad state and action vectors
         standard_item["state"] = self.pad_vector(standard_item["state"], self.max_state_dim)
         standard_item["actions"] = self.pad_vector(standard_item["actions"], self.max_action_dim)

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -871,10 +871,12 @@ class BaseDataset(torch.utils.data.Dataset):
         # this yields `max_action_dim` — the existing all-True `action_is_pad`
         # still drives the loss to zero, so VQA behavior is unchanged.
         real_action_dim = int(standard_item["actions"].shape[-1])
-        assert real_action_dim <= self.max_action_dim, (
-            f"real action dim {real_action_dim} exceeds max_action_dim="
-            f"{self.max_action_dim} (dataset={getattr(self, 'repo_id', '?')})"
-        )
+        if real_action_dim > self.max_action_dim:
+            # Raise rather than assert so the check survives `python -O`.
+            raise ValueError(
+                f"real action dim {real_action_dim} exceeds max_action_dim="
+                f"{self.max_action_dim} (dataset={getattr(self, 'repo_id', '?')})"
+            )
         standard_item["action_dim"] = torch.tensor(real_action_dim, dtype=torch.long)
 
         # pad state and action vectors

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -874,13 +874,13 @@ class BaseDataset(torch.utils.data.Dataset):
         if not 0 < real_action_dim <= self.max_action_dim:
             # Raise rather than assert so the check survives `python -O`.
             # An empty trailing dim (`shape == (chunk, 0)`) would silently emit
-            # `action_dim=0` and contribute zero gradient at training time —
+            # `real_action_dim=0` and contribute zero gradient at training time —
             # treat it as a malformed dataset, same as exceeding the upper bound.
             raise ValueError(
                 f"real action dim {real_action_dim} is outside (0, "
                 f"{self.max_action_dim}] (dataset={getattr(self, 'repo_id', '?')})"
             )
-        standard_item["action_dim"] = torch.tensor(real_action_dim, dtype=torch.long)
+        standard_item["real_action_dim"] = torch.tensor(real_action_dim, dtype=torch.long)
 
         # pad state and action vectors
         standard_item["state"] = self.pad_vector(standard_item["state"], self.max_state_dim)

--- a/src/opentau/policies/pi0/modeling_pi0.py
+++ b/src/opentau/policies/pi0/modeling_pi0.py
@@ -37,7 +37,7 @@ from opentau.policies.pi0.paligemma_with_expert import (
     PaliGemmaWithExpertModel,
 )
 from opentau.policies.pretrained import PreTrainedPolicy
-from opentau.policies.utils import log_model_loading_keys
+from opentau.policies.utils import log_model_loading_keys, make_action_dim_mask
 from opentau.utils.accelerate_utils import get_proc_accelerator
 from opentau.utils.utils import get_safe_dtype
 
@@ -490,9 +490,30 @@ class PI0Policy(PreTrainedPolicy):
 
         losses = self.model.forward(images, img_masks, lang_tokens, lang_masks, state, actions, noise, time)
 
+        # Crop to max_action_dim before masking so the shapes are well-defined when
+        # the model's velocity head emits extra trailing dims.
+        losses = losses[:, :, : self.config.max_action_dim]
+
+        # Per-timestep mask (B, chunk, 1) — True for real action steps.
         if actions_is_pad is not None:
-            in_episode_bound = ~actions_is_pad
-            losses = losses * in_episode_bound.unsqueeze(-1)
+            timestep_mask = rearrange(~actions_is_pad, "b c -> b c 1")
+        else:
+            timestep_mask = torch.ones(
+                (losses.shape[0], losses.shape[1], 1), dtype=torch.bool, device=losses.device
+            )
+
+        # Per-dim mask (B, 1, D) — True for real action dims; backwards compatible
+        # all-True fallback when `action_dim` is absent.
+        dim_mask = make_action_dim_mask(
+            batch.get("action_dim"),
+            self.config.max_action_dim,
+            batch_size=losses.shape[0],
+            device=losses.device,
+        )
+        dim_mask = rearrange(dim_mask, "b d -> b 1 d")
+
+        full_mask = timestep_mask & dim_mask  # (B, chunk, D)
+        losses = losses * full_mask
 
         if self.config.use_awr:
             # weight loss based on exponent of advantage. Also clamp at awr_max_weight.
@@ -503,11 +524,8 @@ class PI0Policy(PreTrainedPolicy):
                 ),
                 "b -> b 1 1",
             )
-        # Remove padding
-        losses = losses[:, :, : self.config.max_action_dim]
 
-        # For backward pass
-        loss = losses.mean()
+        loss = losses.sum() / (full_mask.sum() + 1e-8)
 
         return {"MSE": loss, "CE": torch.zeros_like(loss, requires_grad=True)}
 

--- a/src/opentau/policies/pi0/modeling_pi0.py
+++ b/src/opentau/policies/pi0/modeling_pi0.py
@@ -488,7 +488,17 @@ class PI0Policy(PreTrainedPolicy):
         actions = batch["actions"]
         actions_is_pad = batch.get("action_is_pad")
 
-        losses = self.model.forward(images, img_masks, lang_tokens, lang_masks, state, actions, noise, time)
+        losses = self.model.forward(
+            images,
+            img_masks,
+            lang_tokens,
+            lang_masks,
+            state,
+            actions,
+            noise,
+            time,
+            action_dim=batch.get("action_dim"),
+        )
 
         # Crop to max_action_dim before masking so the shapes are well-defined when
         # the model's velocity head emits extra trailing dims.
@@ -869,6 +879,7 @@ class PI0FlowMatching(nn.Module):
         actions: Tensor,
         noise: Tensor | None = None,
         time: Tensor | None = None,
+        action_dim: Tensor | None = None,
     ) -> Tensor:
         """Do a full training forward pass and compute the loss (batch_size x num_steps x num_motors).
 
@@ -881,6 +892,9 @@ class PI0FlowMatching(nn.Module):
             actions: Action tensor.
             noise: Optional noise tensor.
             time: Optional time tensor.
+            action_dim: Optional ``(B,)`` long tensor of real per-sample action
+                dims; when provided, noise is masked at padded dims so the
+                action expert's input embedding doesn't see contaminating noise.
 
         Returns:
             The computed loss tensor.
@@ -890,6 +904,18 @@ class PI0FlowMatching(nn.Module):
 
         if time is None:
             time = self.sample_time(actions.shape[0], actions.device)
+
+        # Zero noise at padded action dims so the action expert's input
+        # embedding never sees noise the model isn't supervised on. The
+        # outer caller (`PI0Policy.compute_loss`) applies the same dim mask
+        # to the returned MSE losses. All-True (no-op) when `action_dim is None`.
+        dim_mask = make_action_dim_mask(
+            action_dim,
+            self.config.max_action_dim,
+            batch_size=actions.shape[0],
+            device=actions.device,
+        )
+        noise = noise * rearrange(dim_mask, "b d -> b 1 d").to(noise.dtype)
 
         time_expanded = time[:, None, None]
         x_t = time_expanded * noise + (1 - time_expanded) * actions

--- a/src/opentau/policies/pi0/modeling_pi0.py
+++ b/src/opentau/policies/pi0/modeling_pi0.py
@@ -488,17 +488,7 @@ class PI0Policy(PreTrainedPolicy):
         actions = batch["actions"]
         actions_is_pad = batch.get("action_is_pad")
 
-        losses = self.model.forward(
-            images,
-            img_masks,
-            lang_tokens,
-            lang_masks,
-            state,
-            actions,
-            noise,
-            time,
-            action_dim=batch.get("action_dim"),
-        )
+        losses = self.model.forward(images, img_masks, lang_tokens, lang_masks, state, actions, noise, time)
 
         # Crop to max_action_dim before masking so the shapes are well-defined when
         # the model's velocity head emits extra trailing dims.
@@ -879,7 +869,6 @@ class PI0FlowMatching(nn.Module):
         actions: Tensor,
         noise: Tensor | None = None,
         time: Tensor | None = None,
-        action_dim: Tensor | None = None,
     ) -> Tensor:
         """Do a full training forward pass and compute the loss (batch_size x num_steps x num_motors).
 
@@ -892,9 +881,6 @@ class PI0FlowMatching(nn.Module):
             actions: Action tensor.
             noise: Optional noise tensor.
             time: Optional time tensor.
-            action_dim: Optional ``(B,)`` long tensor of real per-sample action
-                dims; when provided, noise is masked at padded dims so the
-                action expert's input embedding doesn't see contaminating noise.
 
         Returns:
             The computed loss tensor.
@@ -904,18 +890,6 @@ class PI0FlowMatching(nn.Module):
 
         if time is None:
             time = self.sample_time(actions.shape[0], actions.device)
-
-        # Zero noise at padded action dims so the action expert's input
-        # embedding never sees noise the model isn't supervised on. The
-        # outer caller (`PI0Policy.compute_loss`) applies the same dim mask
-        # to the returned MSE losses. All-True (no-op) when `action_dim is None`.
-        dim_mask = make_action_dim_mask(
-            action_dim,
-            self.config.max_action_dim,
-            batch_size=actions.shape[0],
-            device=actions.device,
-        )
-        noise = noise * rearrange(dim_mask, "b d -> b 1 d").to(noise.dtype)
 
         time_expanded = time[:, None, None]
         x_t = time_expanded * noise + (1 - time_expanded) * actions

--- a/src/opentau/policies/pi0/modeling_pi0.py
+++ b/src/opentau/policies/pi0/modeling_pi0.py
@@ -490,6 +490,16 @@ class PI0Policy(PreTrainedPolicy):
 
         losses = self.model.forward(images, img_masks, lang_tokens, lang_masks, state, actions, noise, time)
 
+        # NB: pi0 keeps the masked reduction inline rather than routing through
+        # `opentau.policies.utils.flow_matching_masked_mse` (which pi05 / pi05_mem /
+        # pi06 / pi07*/low_level share). Two reasons:
+        #   - no RTI-style frozen prefix (the shared helper's `prefix_mask` would
+        #     always default to None here, which is fine, but…)
+        #   - AWR weighting (`use_awr`) needs to apply between the masking and the
+        #     reduction, and the shared helper reduces internally — so pi0 would
+        #     need an extra `sample_weights` knob in the helper signature just for
+        #     this one call site. Keeping it inline preserves the shared helper's
+        #     minimal API.
         # Crop to max_action_dim before masking so the shapes are well-defined when
         # the model's velocity head emits extra trailing dims.
         losses = losses[:, :, : self.config.max_action_dim]

--- a/src/opentau/policies/pi0/modeling_pi0.py
+++ b/src/opentau/policies/pi0/modeling_pi0.py
@@ -503,9 +503,9 @@ class PI0Policy(PreTrainedPolicy):
             )
 
         # Per-dim mask (B, 1, D) — True for real action dims; backwards compatible
-        # all-True fallback when `action_dim` is absent.
+        # all-True fallback when `real_action_dim` is absent.
         dim_mask = make_action_dim_mask(
-            batch.get("action_dim"),
+            batch.get("real_action_dim"),
             self.config.max_action_dim,
             batch_size=losses.shape[0],
             device=losses.device,

--- a/src/opentau/policies/pi05/modeling_pi05.py
+++ b/src/opentau/policies/pi05/modeling_pi05.py
@@ -29,7 +29,7 @@ from pathlib import Path
 import numpy as np
 import torch
 import torch.nn.functional as F  # noqa: N812
-from einops import rearrange, repeat
+from einops import rearrange
 from torch import Tensor, nn
 from transformers import AutoProcessor, AutoTokenizer
 
@@ -44,6 +44,7 @@ from opentau.policies.pi05.paligemma_with_expert import (
     PaliGemmaWithExpertModel,
 )
 from opentau.policies.pretrained import PreTrainedPolicy, T
+from opentau.policies.utils import make_action_dim_mask
 from opentau.utils.accelerate_utils import get_proc_accelerator
 from opentau.utils.utils import get_safe_dtype
 
@@ -730,6 +731,7 @@ class PI05Policy(PreTrainedPolicy):
             discrete_actions,
             discrete_action_masks,
             state=state,
+            action_dim=batch.get("action_dim"),
         )
 
         mse_loss = losses["MSE"]
@@ -1312,6 +1314,7 @@ class PI05FlowMatching(nn.Module):
         discrete_actions: Tensor | None = None,
         discrete_action_masks: Tensor | None = None,
         state: Tensor | None = None,
+        action_dim: Tensor | None = None,
     ) -> dict[str, Tensor]:
         """Do a full training forward pass and compute the loss.
 
@@ -1446,14 +1449,21 @@ class PI05FlowMatching(nn.Module):
             )  # 0 for padded actions, 1 for non-padded actions
             postfix_mask = torch.logical_and(postfix_mask, in_episode_bound)
 
-        mse_loss = mse_loss * postfix_mask
-
-        # Remove padding
+        # Remove dim padding
         mse_loss = mse_loss[:, :, : self.config.max_action_dim]
 
-        # Do not include frozen actions and padded actions in the mean loss calculation
-        postfix_mask_expanded = repeat(postfix_mask, "b c 1 -> b c d", d=mse_loss.shape[-1])
-        mse_loss = mse_loss.sum() / (postfix_mask_expanded.sum() + 1e-8)
+        # Per-dim mask (B, 1, D) — True for real action dims; all-True fallback
+        # when `action_dim` is absent keeps single-dataset behavior unchanged.
+        dim_mask = make_action_dim_mask(
+            action_dim,
+            self.config.max_action_dim,
+            batch_size=mse_loss.shape[0],
+            device=mse_loss.device,
+        )
+        full_mask = postfix_mask & rearrange(dim_mask, "b d -> b 1 d")  # (B, chunk, D)
+
+        # Do not include frozen, timestep-padded, or dim-padded entries in the mean.
+        mse_loss = (mse_loss * full_mask).sum() / (full_mask.sum() + 1e-8)
 
         # compute cross entropy loss for discrete actions
         batch_size, seq_len = discrete_actions.shape

--- a/src/opentau/policies/pi05/modeling_pi05.py
+++ b/src/opentau/policies/pi05/modeling_pi05.py
@@ -731,7 +731,7 @@ class PI05Policy(PreTrainedPolicy):
             discrete_actions,
             discrete_action_masks,
             state=state,
-            action_dim=batch.get("action_dim"),
+            real_action_dim=batch.get("real_action_dim"),
         )
 
         mse_loss = losses["MSE"]
@@ -1314,7 +1314,7 @@ class PI05FlowMatching(nn.Module):
         discrete_actions: Tensor | None = None,
         discrete_action_masks: Tensor | None = None,
         state: Tensor | None = None,
-        action_dim: Tensor | None = None,
+        real_action_dim: Tensor | None = None,
     ) -> dict[str, Tensor]:
         """Do a full training forward pass and compute the loss.
 
@@ -1453,9 +1453,9 @@ class PI05FlowMatching(nn.Module):
         mse_loss = mse_loss[:, :, : self.config.max_action_dim]
 
         # Per-dim mask (B, 1, D) — True for real action dims; all-True fallback
-        # when `action_dim` is absent keeps single-dataset behavior unchanged.
+        # when `real_action_dim` is absent keeps single-dataset behavior unchanged.
         dim_mask = make_action_dim_mask(
-            action_dim,
+            real_action_dim,
             self.config.max_action_dim,
             batch_size=mse_loss.shape[0],
             device=mse_loss.device,

--- a/src/opentau/policies/pi05/modeling_pi05.py
+++ b/src/opentau/policies/pi05/modeling_pi05.py
@@ -1379,19 +1379,6 @@ class PI05FlowMatching(nn.Module):
         if time is None:
             time = self.sample_time(batch_size, actions.device)
 
-        # Build per-dim mask once and reuse it twice: (a) zero out noise at
-        # zero-padded action dims so the action expert's input embedding
-        # never sees noise the model isn't supervised on; (b) AND into the
-        # MSE reduction further down. All-True (no-op) when `action_dim is
-        # None` — preserves the backwards-compat contract.
-        dim_mask = make_action_dim_mask(
-            action_dim,
-            self.config.max_action_dim,
-            batch_size=batch_size,
-            device=actions.device,
-        )
-        noise = noise * rearrange(dim_mask, "b d -> b 1 d").to(noise.dtype)
-
         # handle real time inference delay
         delay = torch.randint(0, self.config.max_delay + 1, (batch_size,))
         prefix_mask = rearrange(torch.arange(self.config.chunk_size), "c -> 1 c") < rearrange(
@@ -1465,8 +1452,14 @@ class PI05FlowMatching(nn.Module):
         # Remove dim padding
         mse_loss = mse_loss[:, :, : self.config.max_action_dim]
 
-        # `dim_mask` was built once above (before noise masking) and is reused
-        # here as the per-dim (B, max_action_dim) bool component of the loss mask.
+        # Per-dim mask (B, 1, D) — True for real action dims; all-True fallback
+        # when `action_dim` is absent keeps single-dataset behavior unchanged.
+        dim_mask = make_action_dim_mask(
+            action_dim,
+            self.config.max_action_dim,
+            batch_size=mse_loss.shape[0],
+            device=mse_loss.device,
+        )
         full_mask = postfix_mask & rearrange(dim_mask, "b d -> b 1 d")  # (B, chunk, D)
 
         # Do not include frozen, timestep-padded, or dim-padded entries in the mean.

--- a/src/opentau/policies/pi05/modeling_pi05.py
+++ b/src/opentau/policies/pi05/modeling_pi05.py
@@ -44,7 +44,7 @@ from opentau.policies.pi05.paligemma_with_expert import (
     PaliGemmaWithExpertModel,
 )
 from opentau.policies.pretrained import PreTrainedPolicy, T
-from opentau.policies.utils import make_action_dim_mask
+from opentau.policies.utils import flow_matching_masked_mse
 from opentau.utils.accelerate_utils import get_proc_accelerator
 from opentau.utils.utils import get_safe_dtype
 
@@ -1435,35 +1435,17 @@ class PI05FlowMatching(nn.Module):
         v_t = self.action_out_proj(suffix_out)
         v_t = v_t.to(dtype=torch.float32)
 
-        mse_loss = F.mse_loss(u_t, v_t, reduction="none")
-
-        # mask out frozen actions and padded actions
-        postfix_mask = rearrange(
-            torch.logical_not(prefix_mask), "b c -> b c 1"
-        )  # 0 for frozen actions, 1 for non-frozen actions
-
-        if actions_is_pad is not None:
-            in_episode_bound = ~actions_is_pad
-            in_episode_bound = rearrange(
-                in_episode_bound, "b c -> b c 1"
-            )  # 0 for padded actions, 1 for non-padded actions
-            postfix_mask = torch.logical_and(postfix_mask, in_episode_bound)
-
-        # Remove dim padding
-        mse_loss = mse_loss[:, :, : self.config.max_action_dim]
-
-        # Per-dim mask (B, 1, D) — True for real action dims; all-True fallback
-        # when `real_action_dim` is absent keeps single-dataset behavior unchanged.
-        dim_mask = make_action_dim_mask(
-            real_action_dim,
-            self.config.max_action_dim,
-            batch_size=mse_loss.shape[0],
-            device=mse_loss.device,
+        # Shared masked-MSE reduction: AND-s frozen-prefix, timestep-pad, and
+        # dim-pad masks together and divides by the unmasked-slot count. See
+        # ``opentau.policies.utils.flow_matching_masked_mse`` for the full spec.
+        mse_loss = flow_matching_masked_mse(
+            u_t=u_t,
+            v_t=v_t,
+            max_action_dim=self.config.max_action_dim,
+            prefix_mask=prefix_mask,
+            actions_is_pad=actions_is_pad,
+            real_action_dim=real_action_dim,
         )
-        full_mask = postfix_mask & rearrange(dim_mask, "b d -> b 1 d")  # (B, chunk, D)
-
-        # Do not include frozen, timestep-padded, or dim-padded entries in the mean.
-        mse_loss = (mse_loss * full_mask).sum() / (full_mask.sum() + 1e-8)
 
         # compute cross entropy loss for discrete actions
         batch_size, seq_len = discrete_actions.shape

--- a/src/opentau/policies/pi05/modeling_pi05.py
+++ b/src/opentau/policies/pi05/modeling_pi05.py
@@ -1379,6 +1379,19 @@ class PI05FlowMatching(nn.Module):
         if time is None:
             time = self.sample_time(batch_size, actions.device)
 
+        # Build per-dim mask once and reuse it twice: (a) zero out noise at
+        # zero-padded action dims so the action expert's input embedding
+        # never sees noise the model isn't supervised on; (b) AND into the
+        # MSE reduction further down. All-True (no-op) when `action_dim is
+        # None` — preserves the backwards-compat contract.
+        dim_mask = make_action_dim_mask(
+            action_dim,
+            self.config.max_action_dim,
+            batch_size=batch_size,
+            device=actions.device,
+        )
+        noise = noise * rearrange(dim_mask, "b d -> b 1 d").to(noise.dtype)
+
         # handle real time inference delay
         delay = torch.randint(0, self.config.max_delay + 1, (batch_size,))
         prefix_mask = rearrange(torch.arange(self.config.chunk_size), "c -> 1 c") < rearrange(
@@ -1452,14 +1465,8 @@ class PI05FlowMatching(nn.Module):
         # Remove dim padding
         mse_loss = mse_loss[:, :, : self.config.max_action_dim]
 
-        # Per-dim mask (B, 1, D) — True for real action dims; all-True fallback
-        # when `action_dim` is absent keeps single-dataset behavior unchanged.
-        dim_mask = make_action_dim_mask(
-            action_dim,
-            self.config.max_action_dim,
-            batch_size=mse_loss.shape[0],
-            device=mse_loss.device,
-        )
+        # `dim_mask` was built once above (before noise masking) and is reused
+        # here as the per-dim (B, max_action_dim) bool component of the loss mask.
         full_mask = postfix_mask & rearrange(dim_mask, "b d -> b 1 d")  # (B, chunk, D)
 
         # Do not include frozen, timestep-padded, or dim-padded entries in the mean.

--- a/src/opentau/policies/pi05_mem/modeling_pi05.py
+++ b/src/opentau/policies/pi05_mem/modeling_pi05.py
@@ -41,7 +41,7 @@ from pathlib import Path
 import numpy as np
 import torch
 import torch.nn.functional as F  # noqa: N812
-from einops import rearrange, repeat
+from einops import rearrange
 from torch import Tensor, nn
 from transformers import AutoProcessor, AutoTokenizer
 
@@ -56,6 +56,7 @@ from opentau.policies.pi05.paligemma_with_expert import (
 from opentau.policies.pi05_mem.configuration_pi05 import PI05MemConfig
 from opentau.policies.pi07.video_encoder import SpaceTimeSiglipVideoEncoder
 from opentau.policies.pretrained import PreTrainedPolicy, T
+from opentau.policies.utils import make_action_dim_mask
 from opentau.utils.accelerate_utils import get_proc_accelerator
 from opentau.utils.utils import get_safe_dtype
 
@@ -694,6 +695,7 @@ class PI05MemPolicy(PreTrainedPolicy):
             discrete_actions,
             discrete_action_masks,
             obs_history_is_pad=obs_history_is_pad,
+            action_dim=batch.get("action_dim"),
         )
 
         mse_loss = losses["MSE"]
@@ -1079,6 +1081,7 @@ class PI05MemFlowMatching(nn.Module):
         discrete_actions: Tensor | None = None,
         discrete_action_masks: Tensor | None = None,
         obs_history_is_pad: Tensor | None = None,
+        action_dim: Tensor | None = None,
     ) -> dict[str, Tensor]:
         """Do a full training forward pass and compute the loss."""
         prefix_embs, prefix_pad_masks, prefix_att_masks = self.embed_prefix(
@@ -1171,12 +1174,19 @@ class PI05MemFlowMatching(nn.Module):
             in_episode_bound = rearrange(in_episode_bound, "b c -> b c 1")
             postfix_mask = torch.logical_and(postfix_mask, in_episode_bound)
 
-        mse_loss = mse_loss * postfix_mask
-
         mse_loss = mse_loss[:, :, : self.config.max_action_dim]
 
-        postfix_mask_expanded = repeat(postfix_mask, "b c 1 -> b c d", d=mse_loss.shape[-1])
-        mse_loss = mse_loss.sum() / (postfix_mask_expanded.sum() + 1e-8)
+        # Per-dim mask (B, 1, D) — True for real action dims; all-True fallback
+        # when `action_dim` is absent keeps single-dataset behavior unchanged.
+        dim_mask = make_action_dim_mask(
+            action_dim,
+            self.config.max_action_dim,
+            batch_size=mse_loss.shape[0],
+            device=mse_loss.device,
+        )
+        full_mask = postfix_mask & rearrange(dim_mask, "b d -> b 1 d")  # (B, chunk, D)
+
+        mse_loss = (mse_loss * full_mask).sum() / (full_mask.sum() + 1e-8)
 
         assert discrete_actions is not None
         assert discrete_action_masks is not None

--- a/src/opentau/policies/pi05_mem/modeling_pi05.py
+++ b/src/opentau/policies/pi05_mem/modeling_pi05.py
@@ -1117,6 +1117,16 @@ class PI05MemFlowMatching(nn.Module):
         if time is None:
             time = self.sample_time(batch_size, actions.device)
 
+        # Per-dim mask reused below to zero noise at padded dims (input-side)
+        # and to mask the velocity MSE (loss-side). See pi05 for the rationale.
+        dim_mask = make_action_dim_mask(
+            action_dim,
+            self.config.max_action_dim,
+            batch_size=batch_size,
+            device=actions.device,
+        )
+        noise = noise * rearrange(dim_mask, "b d -> b 1 d").to(noise.dtype)
+
         delay = torch.randint(0, self.config.max_delay + 1, (batch_size,))
         prefix_mask = rearrange(torch.arange(self.config.chunk_size), "c -> 1 c") < rearrange(
             delay, "b -> b 1"
@@ -1176,14 +1186,8 @@ class PI05MemFlowMatching(nn.Module):
 
         mse_loss = mse_loss[:, :, : self.config.max_action_dim]
 
-        # Per-dim mask (B, 1, D) — True for real action dims; all-True fallback
-        # when `action_dim` is absent keeps single-dataset behavior unchanged.
-        dim_mask = make_action_dim_mask(
-            action_dim,
-            self.config.max_action_dim,
-            batch_size=mse_loss.shape[0],
-            device=mse_loss.device,
-        )
+        # `dim_mask` was built once above (before noise masking) and is reused
+        # here as the per-dim (B, max_action_dim) bool component of the loss mask.
         full_mask = postfix_mask & rearrange(dim_mask, "b d -> b 1 d")  # (B, chunk, D)
 
         mse_loss = (mse_loss * full_mask).sum() / (full_mask.sum() + 1e-8)

--- a/src/opentau/policies/pi05_mem/modeling_pi05.py
+++ b/src/opentau/policies/pi05_mem/modeling_pi05.py
@@ -56,7 +56,7 @@ from opentau.policies.pi05.paligemma_with_expert import (
 from opentau.policies.pi05_mem.configuration_pi05 import PI05MemConfig
 from opentau.policies.pi07.video_encoder import SpaceTimeSiglipVideoEncoder
 from opentau.policies.pretrained import PreTrainedPolicy, T
-from opentau.policies.utils import make_action_dim_mask
+from opentau.policies.utils import flow_matching_masked_mse
 from opentau.utils.accelerate_utils import get_proc_accelerator
 from opentau.utils.utils import get_safe_dtype
 
@@ -1165,28 +1165,15 @@ class PI05MemFlowMatching(nn.Module):
         v_t = self.action_out_proj(suffix_out)
         v_t = v_t.to(dtype=torch.float32)
 
-        mse_loss = F.mse_loss(u_t, v_t, reduction="none")
-
-        postfix_mask = rearrange(torch.logical_not(prefix_mask), "b c -> b c 1")
-
-        if actions_is_pad is not None:
-            in_episode_bound = ~actions_is_pad
-            in_episode_bound = rearrange(in_episode_bound, "b c -> b c 1")
-            postfix_mask = torch.logical_and(postfix_mask, in_episode_bound)
-
-        mse_loss = mse_loss[:, :, : self.config.max_action_dim]
-
-        # Per-dim mask (B, 1, D) — True for real action dims; all-True fallback
-        # when `real_action_dim` is absent keeps single-dataset behavior unchanged.
-        dim_mask = make_action_dim_mask(
-            real_action_dim,
-            self.config.max_action_dim,
-            batch_size=mse_loss.shape[0],
-            device=mse_loss.device,
+        # Shared masked-MSE reduction; see pi05 for the rationale.
+        mse_loss = flow_matching_masked_mse(
+            u_t=u_t,
+            v_t=v_t,
+            max_action_dim=self.config.max_action_dim,
+            prefix_mask=prefix_mask,
+            actions_is_pad=actions_is_pad,
+            real_action_dim=real_action_dim,
         )
-        full_mask = postfix_mask & rearrange(dim_mask, "b d -> b 1 d")  # (B, chunk, D)
-
-        mse_loss = (mse_loss * full_mask).sum() / (full_mask.sum() + 1e-8)
 
         assert discrete_actions is not None
         assert discrete_action_masks is not None

--- a/src/opentau/policies/pi05_mem/modeling_pi05.py
+++ b/src/opentau/policies/pi05_mem/modeling_pi05.py
@@ -695,7 +695,7 @@ class PI05MemPolicy(PreTrainedPolicy):
             discrete_actions,
             discrete_action_masks,
             obs_history_is_pad=obs_history_is_pad,
-            action_dim=batch.get("action_dim"),
+            real_action_dim=batch.get("real_action_dim"),
         )
 
         mse_loss = losses["MSE"]
@@ -1081,7 +1081,7 @@ class PI05MemFlowMatching(nn.Module):
         discrete_actions: Tensor | None = None,
         discrete_action_masks: Tensor | None = None,
         obs_history_is_pad: Tensor | None = None,
-        action_dim: Tensor | None = None,
+        real_action_dim: Tensor | None = None,
     ) -> dict[str, Tensor]:
         """Do a full training forward pass and compute the loss."""
         prefix_embs, prefix_pad_masks, prefix_att_masks = self.embed_prefix(
@@ -1177,9 +1177,9 @@ class PI05MemFlowMatching(nn.Module):
         mse_loss = mse_loss[:, :, : self.config.max_action_dim]
 
         # Per-dim mask (B, 1, D) — True for real action dims; all-True fallback
-        # when `action_dim` is absent keeps single-dataset behavior unchanged.
+        # when `real_action_dim` is absent keeps single-dataset behavior unchanged.
         dim_mask = make_action_dim_mask(
-            action_dim,
+            real_action_dim,
             self.config.max_action_dim,
             batch_size=mse_loss.shape[0],
             device=mse_loss.device,

--- a/src/opentau/policies/pi05_mem/modeling_pi05.py
+++ b/src/opentau/policies/pi05_mem/modeling_pi05.py
@@ -1117,16 +1117,6 @@ class PI05MemFlowMatching(nn.Module):
         if time is None:
             time = self.sample_time(batch_size, actions.device)
 
-        # Per-dim mask reused below to zero noise at padded dims (input-side)
-        # and to mask the velocity MSE (loss-side). See pi05 for the rationale.
-        dim_mask = make_action_dim_mask(
-            action_dim,
-            self.config.max_action_dim,
-            batch_size=batch_size,
-            device=actions.device,
-        )
-        noise = noise * rearrange(dim_mask, "b d -> b 1 d").to(noise.dtype)
-
         delay = torch.randint(0, self.config.max_delay + 1, (batch_size,))
         prefix_mask = rearrange(torch.arange(self.config.chunk_size), "c -> 1 c") < rearrange(
             delay, "b -> b 1"
@@ -1186,8 +1176,14 @@ class PI05MemFlowMatching(nn.Module):
 
         mse_loss = mse_loss[:, :, : self.config.max_action_dim]
 
-        # `dim_mask` was built once above (before noise masking) and is reused
-        # here as the per-dim (B, max_action_dim) bool component of the loss mask.
+        # Per-dim mask (B, 1, D) — True for real action dims; all-True fallback
+        # when `action_dim` is absent keeps single-dataset behavior unchanged.
+        dim_mask = make_action_dim_mask(
+            action_dim,
+            self.config.max_action_dim,
+            batch_size=mse_loss.shape[0],
+            device=mse_loss.device,
+        )
         full_mask = postfix_mask & rearrange(dim_mask, "b d -> b 1 d")  # (B, chunk, D)
 
         mse_loss = (mse_loss * full_mask).sum() / (full_mask.sum() + 1e-8)

--- a/src/opentau/policies/pi06/modeling_pi06.py
+++ b/src/opentau/policies/pi06/modeling_pi06.py
@@ -36,7 +36,7 @@ from pathlib import Path
 import numpy as np
 import torch
 import torch.nn.functional as F  # noqa: N812
-from einops import rearrange, repeat
+from einops import rearrange
 from torch import Tensor, nn
 from transformers import AutoProcessor, AutoTokenizer
 
@@ -51,6 +51,7 @@ from opentau.policies.pi06.gemma3_with_expert import (
     Gemma3WithExpertModel,
 )
 from opentau.policies.pretrained import PreTrainedPolicy, T
+from opentau.policies.utils import make_action_dim_mask
 from opentau.utils.accelerate_utils import get_proc_accelerator
 from opentau.utils.utils import get_safe_dtype
 
@@ -194,14 +195,17 @@ def flow_matching_masked_mse(
     prefix_mask: Tensor,
     actions_is_pad: Tensor | None,
     max_action_dim: int,
+    action_dim: Tensor | None = None,
 ) -> Tensor:
     """Masked MSE for π0.6 flow matching.
 
     Zeros out (a) frozen-prefix steps from the real-time inference delay
-    (`prefix_mask=True` ⇒ frozen) and (b) fully-padded action samples — e.g.
+    (`prefix_mask=True` ⇒ frozen), (b) fully-padded action samples — e.g.
     VQA / web co-training items, where `VQADataset` sets `actions_is_pad`
     all-True so the action expert is not trained to regress to zero on items
-    that have no real actions.
+    that have no real actions — and (c) per-sample padded action dims, so
+    heterogeneous-DoF mixtures don't supervise the action expert against
+    zero-pad columns for samples whose source dataset has fewer dims.
 
     Args:
         u_t: Target velocity field, shape `(B, chunk_size, D)` (D ≥ max_action_dim).
@@ -212,16 +216,20 @@ def flow_matching_masked_mse(
             action chunk is padded (no real action target).
         max_action_dim: Number of leading action dims to score against;
             trailing dims are dropped before averaging.
+        action_dim: optional long `(B,)` — real (pre-pad) action dim per
+            sample. When ``None`` all ``max_action_dim`` columns are scored.
     """
     mse_loss = F.mse_loss(u_t, v_t, reduction="none")
     postfix_mask = rearrange(torch.logical_not(prefix_mask), "b c -> b c 1")
     if actions_is_pad is not None:
         in_episode_bound = rearrange(~actions_is_pad, "b c -> b c 1")
         postfix_mask = torch.logical_and(postfix_mask, in_episode_bound)
-    mse_loss = mse_loss * postfix_mask
     mse_loss = mse_loss[:, :, :max_action_dim]
-    postfix_mask_expanded = repeat(postfix_mask, "b c 1 -> b c d", d=mse_loss.shape[-1])
-    return mse_loss.sum() / (postfix_mask_expanded.sum() + 1e-8)
+    dim_mask = make_action_dim_mask(
+        action_dim, max_action_dim, batch_size=mse_loss.shape[0], device=mse_loss.device
+    )
+    full_mask = postfix_mask & rearrange(dim_mask, "b d -> b 1 d")
+    return (mse_loss * full_mask).sum() / (full_mask.sum() + 1e-8)
 
 
 def pad_discrete_tokens(tokens: list[list[int]], max_length: int) -> tuple[np.ndarray, np.ndarray]:
@@ -650,6 +658,7 @@ class PI06Policy(PreTrainedPolicy):
             time,
             discrete_actions,
             discrete_action_masks,
+            action_dim=batch.get("action_dim"),
         )
 
         mse_loss = losses["MSE"]
@@ -1011,6 +1020,7 @@ class PI06FlowMatching(nn.Module):
         time: Tensor | None = None,
         discrete_actions: Tensor | None = None,
         discrete_action_masks: Tensor | None = None,
+        action_dim: Tensor | None = None,
     ) -> dict[str, Tensor]:
         """Full training forward pass. Returns `{"MSE": ..., "CE": ...}`."""
         prefix_embs, prefix_pad_masks, prefix_att_masks = self.embed_prefix(
@@ -1100,6 +1110,7 @@ class PI06FlowMatching(nn.Module):
             prefix_mask=prefix_mask,
             actions_is_pad=actions_is_pad,
             max_action_dim=self.config.max_action_dim,
+            action_dim=action_dim,
         )
 
         # Discrete-action cross-entropy (FAST tokens) via the dedicated head.

--- a/src/opentau/policies/pi06/modeling_pi06.py
+++ b/src/opentau/policies/pi06/modeling_pi06.py
@@ -1057,20 +1057,6 @@ class PI06FlowMatching(nn.Module):
         if time is None:
             time = self.sample_time(batch_size, actions.device)
 
-        # Zero noise at zero-padded action dims so the action expert's input
-        # embedding never sees noise the model isn't supervised on. The MSE
-        # reduction below (via `flow_matching_masked_mse`) reapplies the same
-        # mask. All-True (no-op) when `action_dim is None`.
-        noise = noise * rearrange(
-            make_action_dim_mask(
-                action_dim,
-                self.config.max_action_dim,
-                batch_size=batch_size,
-                device=actions.device,
-            ),
-            "b d -> b 1 d",
-        ).to(noise.dtype)
-
         # Real-time inference delay: randomly freeze a prefix of the action chunk.
         delay = torch.randint(0, self.config.max_delay + 1, (batch_size,))
         prefix_mask = rearrange(torch.arange(self.config.chunk_size), "c -> 1 c") < rearrange(

--- a/src/opentau/policies/pi06/modeling_pi06.py
+++ b/src/opentau/policies/pi06/modeling_pi06.py
@@ -195,7 +195,7 @@ def flow_matching_masked_mse(
     prefix_mask: Tensor,
     actions_is_pad: Tensor | None,
     max_action_dim: int,
-    action_dim: Tensor | None = None,
+    real_action_dim: Tensor | None = None,
 ) -> Tensor:
     """Masked MSE for π0.6 flow matching.
 
@@ -216,7 +216,7 @@ def flow_matching_masked_mse(
             action chunk is padded (no real action target).
         max_action_dim: Number of leading action dims to score against;
             trailing dims are dropped before averaging.
-        action_dim: optional long `(B,)` — real (pre-pad) action dim per
+        real_action_dim: optional long `(B,)` — real (pre-pad) action dim per
             sample. When ``None`` all ``max_action_dim`` columns are scored.
     """
     mse_loss = F.mse_loss(u_t, v_t, reduction="none")
@@ -226,7 +226,7 @@ def flow_matching_masked_mse(
         postfix_mask = torch.logical_and(postfix_mask, in_episode_bound)
     mse_loss = mse_loss[:, :, :max_action_dim]
     dim_mask = make_action_dim_mask(
-        action_dim, max_action_dim, batch_size=mse_loss.shape[0], device=mse_loss.device
+        real_action_dim, max_action_dim, batch_size=mse_loss.shape[0], device=mse_loss.device
     )
     full_mask = postfix_mask & rearrange(dim_mask, "b d -> b 1 d")
     return (mse_loss * full_mask).sum() / (full_mask.sum() + 1e-8)
@@ -658,7 +658,7 @@ class PI06Policy(PreTrainedPolicy):
             time,
             discrete_actions,
             discrete_action_masks,
-            action_dim=batch.get("action_dim"),
+            real_action_dim=batch.get("real_action_dim"),
         )
 
         mse_loss = losses["MSE"]
@@ -1020,7 +1020,7 @@ class PI06FlowMatching(nn.Module):
         time: Tensor | None = None,
         discrete_actions: Tensor | None = None,
         discrete_action_masks: Tensor | None = None,
-        action_dim: Tensor | None = None,
+        real_action_dim: Tensor | None = None,
     ) -> dict[str, Tensor]:
         """Full training forward pass. Returns `{"MSE": ..., "CE": ...}`."""
         prefix_embs, prefix_pad_masks, prefix_att_masks = self.embed_prefix(
@@ -1110,7 +1110,7 @@ class PI06FlowMatching(nn.Module):
             prefix_mask=prefix_mask,
             actions_is_pad=actions_is_pad,
             max_action_dim=self.config.max_action_dim,
-            action_dim=action_dim,
+            real_action_dim=real_action_dim,
         )
 
         # Discrete-action cross-entropy (FAST tokens) via the dedicated head.

--- a/src/opentau/policies/pi06/modeling_pi06.py
+++ b/src/opentau/policies/pi06/modeling_pi06.py
@@ -1057,6 +1057,20 @@ class PI06FlowMatching(nn.Module):
         if time is None:
             time = self.sample_time(batch_size, actions.device)
 
+        # Zero noise at zero-padded action dims so the action expert's input
+        # embedding never sees noise the model isn't supervised on. The MSE
+        # reduction below (via `flow_matching_masked_mse`) reapplies the same
+        # mask. All-True (no-op) when `action_dim is None`.
+        noise = noise * rearrange(
+            make_action_dim_mask(
+                action_dim,
+                self.config.max_action_dim,
+                batch_size=batch_size,
+                device=actions.device,
+            ),
+            "b d -> b 1 d",
+        ).to(noise.dtype)
+
         # Real-time inference delay: randomly freeze a prefix of the action chunk.
         delay = torch.randint(0, self.config.max_delay + 1, (batch_size,))
         prefix_mask = rearrange(torch.arange(self.config.chunk_size), "c -> 1 c") < rearrange(

--- a/src/opentau/policies/pi06/modeling_pi06.py
+++ b/src/opentau/policies/pi06/modeling_pi06.py
@@ -51,7 +51,7 @@ from opentau.policies.pi06.gemma3_with_expert import (
     Gemma3WithExpertModel,
 )
 from opentau.policies.pretrained import PreTrainedPolicy, T
-from opentau.policies.utils import make_action_dim_mask
+from opentau.policies.utils import flow_matching_masked_mse
 from opentau.utils.accelerate_utils import get_proc_accelerator
 from opentau.utils.utils import get_safe_dtype
 
@@ -187,49 +187,6 @@ def resize_with_pad(img: Tensor, width: int, height: int, pad_value: int = -1) -
 
     padded_img = F.pad(resized_img, (pad_width, 0, pad_height, 0), value=pad_value)
     return padded_img
-
-
-def flow_matching_masked_mse(
-    u_t: Tensor,
-    v_t: Tensor,
-    prefix_mask: Tensor,
-    actions_is_pad: Tensor | None,
-    max_action_dim: int,
-    real_action_dim: Tensor | None = None,
-) -> Tensor:
-    """Masked MSE for π0.6 flow matching.
-
-    Zeros out (a) frozen-prefix steps from the real-time inference delay
-    (`prefix_mask=True` ⇒ frozen), (b) fully-padded action samples — e.g.
-    VQA / web co-training items, where `VQADataset` sets `actions_is_pad`
-    all-True so the action expert is not trained to regress to zero on items
-    that have no real actions — and (c) per-sample padded action dims, so
-    heterogeneous-DoF mixtures don't supervise the action expert against
-    zero-pad columns for samples whose source dataset has fewer dims.
-
-    Args:
-        u_t: Target velocity field, shape `(B, chunk_size, D)` (D ≥ max_action_dim).
-        v_t: Predicted velocity field, same shape as `u_t`.
-        prefix_mask: bool `(B, chunk_size)` — True where the step is frozen
-            (real-time-inference delay). Pass `torch.zeros(...)` to disable.
-        actions_is_pad: optional bool `(B, chunk_size)` — True where the
-            action chunk is padded (no real action target).
-        max_action_dim: Number of leading action dims to score against;
-            trailing dims are dropped before averaging.
-        real_action_dim: optional long `(B,)` — real (pre-pad) action dim per
-            sample. When ``None`` all ``max_action_dim`` columns are scored.
-    """
-    mse_loss = F.mse_loss(u_t, v_t, reduction="none")
-    postfix_mask = rearrange(torch.logical_not(prefix_mask), "b c -> b c 1")
-    if actions_is_pad is not None:
-        in_episode_bound = rearrange(~actions_is_pad, "b c -> b c 1")
-        postfix_mask = torch.logical_and(postfix_mask, in_episode_bound)
-    mse_loss = mse_loss[:, :, :max_action_dim]
-    dim_mask = make_action_dim_mask(
-        real_action_dim, max_action_dim, batch_size=mse_loss.shape[0], device=mse_loss.device
-    )
-    full_mask = postfix_mask & rearrange(dim_mask, "b d -> b 1 d")
-    return (mse_loss * full_mask).sum() / (full_mask.sum() + 1e-8)
 
 
 def pad_discrete_tokens(tokens: list[list[int]], max_length: int) -> tuple[np.ndarray, np.ndarray]:

--- a/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
@@ -45,7 +45,7 @@ from pathlib import Path
 import numpy as np
 import torch
 import torch.nn.functional as F  # noqa: N812
-from einops import rearrange, repeat
+from einops import rearrange
 from torch import Tensor, nn
 from transformers import AutoProcessor, AutoTokenizer
 
@@ -61,6 +61,7 @@ from opentau.policies.pi07.low_level.configuration_pi07_low_level import (
 )
 from opentau.policies.pi07.video_encoder import SpaceTimeSiglipVideoEncoder
 from opentau.policies.pretrained import PreTrainedPolicy, T
+from opentau.policies.utils import make_action_dim_mask
 from opentau.utils.accelerate_utils import get_proc_accelerator
 from opentau.utils.utils import get_safe_dtype
 
@@ -854,6 +855,7 @@ class PI07LowLevelPolicy(PreTrainedPolicy):
             metadata_masks=metadata_masks,
             response_tokens=response_tokens,
             response_masks=response_masks,
+            action_dim=batch.get("action_dim"),
         )
 
         mse_loss = losses["MSE"]
@@ -1784,6 +1786,7 @@ class PI07LowLevelFlowMatching(nn.Module):
         metadata_masks: Tensor | None = None,
         response_tokens: Tensor | None = None,
         response_masks: Tensor | None = None,
+        action_dim: Tensor | None = None,
     ) -> dict[str, Tensor]:
         """Training forward pass: embed all modalities and compute losses.
 
@@ -1921,12 +1924,19 @@ class PI07LowLevelFlowMatching(nn.Module):
             in_episode_bound = rearrange(in_episode_bound, "b c -> b c 1")
             postfix_mask = torch.logical_and(postfix_mask, in_episode_bound)
 
-        mse_loss = mse_loss * postfix_mask
-
         mse_loss = mse_loss[:, :, : self.config.max_action_dim]
 
-        postfix_mask_expanded = repeat(postfix_mask, "b c 1 -> b c d", d=mse_loss.shape[-1])
-        mse_loss = mse_loss.sum() / (postfix_mask_expanded.sum() + 1e-8)
+        # Per-dim mask (B, 1, D) — True for real action dims; all-True fallback
+        # when `action_dim` is absent keeps single-dataset behavior unchanged.
+        dim_mask = make_action_dim_mask(
+            action_dim,
+            self.config.max_action_dim,
+            batch_size=mse_loss.shape[0],
+            device=mse_loss.device,
+        )
+        full_mask = postfix_mask & rearrange(dim_mask, "b d -> b 1 d")  # (B, chunk, D)
+
+        mse_loss = (mse_loss * full_mask).sum() / (full_mask.sum() + 1e-8)
 
         assert discrete_actions is not None
         assert discrete_action_masks is not None

--- a/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
@@ -855,7 +855,7 @@ class PI07LowLevelPolicy(PreTrainedPolicy):
             metadata_masks=metadata_masks,
             response_tokens=response_tokens,
             response_masks=response_masks,
-            action_dim=batch.get("action_dim"),
+            real_action_dim=batch.get("real_action_dim"),
         )
 
         mse_loss = losses["MSE"]
@@ -1786,7 +1786,7 @@ class PI07LowLevelFlowMatching(nn.Module):
         metadata_masks: Tensor | None = None,
         response_tokens: Tensor | None = None,
         response_masks: Tensor | None = None,
-        action_dim: Tensor | None = None,
+        real_action_dim: Tensor | None = None,
     ) -> dict[str, Tensor]:
         """Training forward pass: embed all modalities and compute losses.
 
@@ -1927,9 +1927,9 @@ class PI07LowLevelFlowMatching(nn.Module):
         mse_loss = mse_loss[:, :, : self.config.max_action_dim]
 
         # Per-dim mask (B, 1, D) — True for real action dims; all-True fallback
-        # when `action_dim` is absent keeps single-dataset behavior unchanged.
+        # when `real_action_dim` is absent keeps single-dataset behavior unchanged.
         dim_mask = make_action_dim_mask(
-            action_dim,
+            real_action_dim,
             self.config.max_action_dim,
             batch_size=mse_loss.shape[0],
             device=mse_loss.device,

--- a/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
@@ -1866,6 +1866,16 @@ class PI07LowLevelFlowMatching(nn.Module):
         if time is None:
             time = self.sample_time(batch_size, actions.device)
 
+        # Per-dim mask reused below to zero noise at padded dims (input-side)
+        # and to mask the velocity MSE (loss-side). See pi05 for the rationale.
+        dim_mask = make_action_dim_mask(
+            action_dim,
+            self.config.max_action_dim,
+            batch_size=batch_size,
+            device=actions.device,
+        )
+        noise = noise * rearrange(dim_mask, "b d -> b 1 d").to(noise.dtype)
+
         delay = torch.randint(0, self.config.max_delay + 1, (batch_size,))
         prefix_mask = rearrange(torch.arange(self.config.chunk_size), "c -> 1 c") < rearrange(
             delay, "b -> b 1"
@@ -1926,14 +1936,8 @@ class PI07LowLevelFlowMatching(nn.Module):
 
         mse_loss = mse_loss[:, :, : self.config.max_action_dim]
 
-        # Per-dim mask (B, 1, D) — True for real action dims; all-True fallback
-        # when `action_dim` is absent keeps single-dataset behavior unchanged.
-        dim_mask = make_action_dim_mask(
-            action_dim,
-            self.config.max_action_dim,
-            batch_size=mse_loss.shape[0],
-            device=mse_loss.device,
-        )
+        # `dim_mask` was built once above (before noise masking) and is reused
+        # here as the per-dim (B, max_action_dim) bool component of the loss mask.
         full_mask = postfix_mask & rearrange(dim_mask, "b d -> b 1 d")  # (B, chunk, D)
 
         mse_loss = (mse_loss * full_mask).sum() / (full_mask.sum() + 1e-8)

--- a/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
@@ -61,7 +61,7 @@ from opentau.policies.pi07.low_level.configuration_pi07_low_level import (
 )
 from opentau.policies.pi07.video_encoder import SpaceTimeSiglipVideoEncoder
 from opentau.policies.pretrained import PreTrainedPolicy, T
-from opentau.policies.utils import make_action_dim_mask
+from opentau.policies.utils import flow_matching_masked_mse
 from opentau.utils.accelerate_utils import get_proc_accelerator
 from opentau.utils.utils import get_safe_dtype
 
@@ -1915,28 +1915,15 @@ class PI07LowLevelFlowMatching(nn.Module):
         v_t = self.action_out_proj(suffix_out)
         v_t = v_t.to(dtype=torch.float32)
 
-        mse_loss = F.mse_loss(u_t, v_t, reduction="none")
-
-        postfix_mask = rearrange(torch.logical_not(prefix_mask), "b c -> b c 1")
-
-        if actions_is_pad is not None:
-            in_episode_bound = ~actions_is_pad
-            in_episode_bound = rearrange(in_episode_bound, "b c -> b c 1")
-            postfix_mask = torch.logical_and(postfix_mask, in_episode_bound)
-
-        mse_loss = mse_loss[:, :, : self.config.max_action_dim]
-
-        # Per-dim mask (B, 1, D) — True for real action dims; all-True fallback
-        # when `real_action_dim` is absent keeps single-dataset behavior unchanged.
-        dim_mask = make_action_dim_mask(
-            real_action_dim,
-            self.config.max_action_dim,
-            batch_size=mse_loss.shape[0],
-            device=mse_loss.device,
+        # Shared masked-MSE reduction; see pi05 for the rationale.
+        mse_loss = flow_matching_masked_mse(
+            u_t=u_t,
+            v_t=v_t,
+            max_action_dim=self.config.max_action_dim,
+            prefix_mask=prefix_mask,
+            actions_is_pad=actions_is_pad,
+            real_action_dim=real_action_dim,
         )
-        full_mask = postfix_mask & rearrange(dim_mask, "b d -> b 1 d")  # (B, chunk, D)
-
-        mse_loss = (mse_loss * full_mask).sum() / (full_mask.sum() + 1e-8)
 
         assert discrete_actions is not None
         assert discrete_action_masks is not None

--- a/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
@@ -1866,16 +1866,6 @@ class PI07LowLevelFlowMatching(nn.Module):
         if time is None:
             time = self.sample_time(batch_size, actions.device)
 
-        # Per-dim mask reused below to zero noise at padded dims (input-side)
-        # and to mask the velocity MSE (loss-side). See pi05 for the rationale.
-        dim_mask = make_action_dim_mask(
-            action_dim,
-            self.config.max_action_dim,
-            batch_size=batch_size,
-            device=actions.device,
-        )
-        noise = noise * rearrange(dim_mask, "b d -> b 1 d").to(noise.dtype)
-
         delay = torch.randint(0, self.config.max_delay + 1, (batch_size,))
         prefix_mask = rearrange(torch.arange(self.config.chunk_size), "c -> 1 c") < rearrange(
             delay, "b -> b 1"
@@ -1936,8 +1926,14 @@ class PI07LowLevelFlowMatching(nn.Module):
 
         mse_loss = mse_loss[:, :, : self.config.max_action_dim]
 
-        # `dim_mask` was built once above (before noise masking) and is reused
-        # here as the per-dim (B, max_action_dim) bool component of the loss mask.
+        # Per-dim mask (B, 1, D) — True for real action dims; all-True fallback
+        # when `action_dim` is absent keeps single-dataset behavior unchanged.
+        dim_mask = make_action_dim_mask(
+            action_dim,
+            self.config.max_action_dim,
+            batch_size=mse_loss.shape[0],
+            device=mse_loss.device,
+        )
         full_mask = postfix_mask & rearrange(dim_mask, "b d -> b 1 d")  # (B, chunk, D)
 
         mse_loss = (mse_loss * full_mask).sum() / (full_mask.sum() + 1e-8)

--- a/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
@@ -1983,16 +1983,6 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
         if time is None:
             time = self.sample_time(batch_size, actions.device)
 
-        # Per-dim mask reused below to zero noise at padded dims (input-side)
-        # and to mask the velocity MSE (loss-side). See pi05 for the rationale.
-        dim_mask = make_action_dim_mask(
-            action_dim,
-            self.config.max_action_dim,
-            batch_size=batch_size,
-            device=actions.device,
-        )
-        noise = noise * rearrange(dim_mask, "b d -> b 1 d").to(noise.dtype)
-
         # handle real time inference delay
         delay = torch.randint(0, self.config.max_delay + 1, (batch_size,))
         prefix_mask = rearrange(torch.arange(self.config.chunk_size), "c -> 1 c") < rearrange(
@@ -2063,8 +2053,14 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
         # Remove dim padding
         mse_loss = mse_loss[:, :, : self.config.max_action_dim]
 
-        # `dim_mask` was built once above (before noise masking) and is reused
-        # here as the per-dim (B, max_action_dim) bool component of the loss mask.
+        # Per-dim mask (B, 1, D) — True for real action dims; all-True fallback
+        # when `action_dim` is absent keeps single-dataset behavior unchanged.
+        dim_mask = make_action_dim_mask(
+            action_dim,
+            self.config.max_action_dim,
+            batch_size=mse_loss.shape[0],
+            device=mse_loss.device,
+        )
         full_mask = postfix_mask & rearrange(dim_mask, "b d -> b 1 d")  # (B, chunk, D)
 
         # Do not include frozen, timestep-padded, or dim-padded entries in the mean.

--- a/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
@@ -48,7 +48,7 @@ from opentau.policies.pi07_paligemma.low_level.configuration_pi07_low_level impo
     PI07PaligemmaLowLevelConfig,
 )
 from opentau.policies.pretrained import PreTrainedPolicy, T
-from opentau.policies.utils import make_action_dim_mask
+from opentau.policies.utils import flow_matching_masked_mse
 from opentau.utils.accelerate_utils import get_proc_accelerator
 from opentau.utils.utils import get_safe_dtype
 
@@ -2036,35 +2036,15 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
         v_t = self.action_out_proj(suffix_out)
         v_t = v_t.to(dtype=torch.float32)
 
-        mse_loss = F.mse_loss(u_t, v_t, reduction="none")
-
-        # mask out frozen actions and padded actions
-        postfix_mask = rearrange(
-            torch.logical_not(prefix_mask), "b c -> b c 1"
-        )  # 0 for frozen actions, 1 for non-frozen actions
-
-        if actions_is_pad is not None:
-            in_episode_bound = ~actions_is_pad
-            in_episode_bound = rearrange(
-                in_episode_bound, "b c -> b c 1"
-            )  # 0 for padded actions, 1 for non-padded actions
-            postfix_mask = torch.logical_and(postfix_mask, in_episode_bound)
-
-        # Remove dim padding
-        mse_loss = mse_loss[:, :, : self.config.max_action_dim]
-
-        # Per-dim mask (B, 1, D) — True for real action dims; all-True fallback
-        # when `real_action_dim` is absent keeps single-dataset behavior unchanged.
-        dim_mask = make_action_dim_mask(
-            real_action_dim,
-            self.config.max_action_dim,
-            batch_size=mse_loss.shape[0],
-            device=mse_loss.device,
+        # Shared masked-MSE reduction; see pi05 for the rationale.
+        mse_loss = flow_matching_masked_mse(
+            u_t=u_t,
+            v_t=v_t,
+            max_action_dim=self.config.max_action_dim,
+            prefix_mask=prefix_mask,
+            actions_is_pad=actions_is_pad,
+            real_action_dim=real_action_dim,
         )
-        full_mask = postfix_mask & rearrange(dim_mask, "b d -> b 1 d")  # (B, chunk, D)
-
-        # Do not include frozen, timestep-padded, or dim-padded entries in the mean.
-        mse_loss = (mse_loss * full_mask).sum() / (full_mask.sum() + 1e-8)
 
         # compute cross entropy loss for discrete actions
         batch_size, seq_len = discrete_actions.shape

--- a/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
@@ -31,7 +31,7 @@ from typing import Literal
 import numpy as np
 import torch
 import torch.nn.functional as F  # noqa: N812
-from einops import rearrange, repeat
+from einops import rearrange
 from torch import Tensor, nn
 from transformers import AutoProcessor, AutoTokenizer
 
@@ -48,6 +48,7 @@ from opentau.policies.pi07_paligemma.low_level.configuration_pi07_low_level impo
     PI07PaligemmaLowLevelConfig,
 )
 from opentau.policies.pretrained import PreTrainedPolicy, T
+from opentau.policies.utils import make_action_dim_mask
 from opentau.utils.accelerate_utils import get_proc_accelerator
 from opentau.utils.utils import get_safe_dtype
 
@@ -1063,6 +1064,7 @@ class PI07PaligemmaLowLevelPolicy(PreTrainedPolicy):
             actions_is_pad=actions_is_pad,
             noise=noise,
             time=time,
+            action_dim=batch.get("action_dim"),
         )
 
         mse_loss = losses["MSE"]
@@ -1935,6 +1937,7 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
         actions_is_pad: Tensor | None = None,
         noise: Tensor | None = None,
         time: Tensor | None = None,
+        action_dim: Tensor | None = None,
     ) -> dict[str, Tensor]:
         """Do a full training forward pass and compute the loss.
 
@@ -2047,14 +2050,21 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
             )  # 0 for padded actions, 1 for non-padded actions
             postfix_mask = torch.logical_and(postfix_mask, in_episode_bound)
 
-        mse_loss = mse_loss * postfix_mask
-
-        # Remove padding
+        # Remove dim padding
         mse_loss = mse_loss[:, :, : self.config.max_action_dim]
 
-        # Do not include frozen actions and padded actions in the mean loss calculation
-        postfix_mask_expanded = repeat(postfix_mask, "b c 1 -> b c d", d=mse_loss.shape[-1])
-        mse_loss = mse_loss.sum() / (postfix_mask_expanded.sum() + 1e-8)
+        # Per-dim mask (B, 1, D) — True for real action dims; all-True fallback
+        # when `action_dim` is absent keeps single-dataset behavior unchanged.
+        dim_mask = make_action_dim_mask(
+            action_dim,
+            self.config.max_action_dim,
+            batch_size=mse_loss.shape[0],
+            device=mse_loss.device,
+        )
+        full_mask = postfix_mask & rearrange(dim_mask, "b d -> b 1 d")  # (B, chunk, D)
+
+        # Do not include frozen, timestep-padded, or dim-padded entries in the mean.
+        mse_loss = (mse_loss * full_mask).sum() / (full_mask.sum() + 1e-8)
 
         # compute cross entropy loss for discrete actions
         batch_size, seq_len = discrete_actions.shape

--- a/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
@@ -1983,6 +1983,16 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
         if time is None:
             time = self.sample_time(batch_size, actions.device)
 
+        # Per-dim mask reused below to zero noise at padded dims (input-side)
+        # and to mask the velocity MSE (loss-side). See pi05 for the rationale.
+        dim_mask = make_action_dim_mask(
+            action_dim,
+            self.config.max_action_dim,
+            batch_size=batch_size,
+            device=actions.device,
+        )
+        noise = noise * rearrange(dim_mask, "b d -> b 1 d").to(noise.dtype)
+
         # handle real time inference delay
         delay = torch.randint(0, self.config.max_delay + 1, (batch_size,))
         prefix_mask = rearrange(torch.arange(self.config.chunk_size), "c -> 1 c") < rearrange(
@@ -2053,14 +2063,8 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
         # Remove dim padding
         mse_loss = mse_loss[:, :, : self.config.max_action_dim]
 
-        # Per-dim mask (B, 1, D) — True for real action dims; all-True fallback
-        # when `action_dim` is absent keeps single-dataset behavior unchanged.
-        dim_mask = make_action_dim_mask(
-            action_dim,
-            self.config.max_action_dim,
-            batch_size=mse_loss.shape[0],
-            device=mse_loss.device,
-        )
+        # `dim_mask` was built once above (before noise masking) and is reused
+        # here as the per-dim (B, max_action_dim) bool component of the loss mask.
         full_mask = postfix_mask & rearrange(dim_mask, "b d -> b 1 d")  # (B, chunk, D)
 
         # Do not include frozen, timestep-padded, or dim-padded entries in the mean.

--- a/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
@@ -1064,7 +1064,7 @@ class PI07PaligemmaLowLevelPolicy(PreTrainedPolicy):
             actions_is_pad=actions_is_pad,
             noise=noise,
             time=time,
-            action_dim=batch.get("action_dim"),
+            real_action_dim=batch.get("real_action_dim"),
         )
 
         mse_loss = losses["MSE"]
@@ -1937,7 +1937,7 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
         actions_is_pad: Tensor | None = None,
         noise: Tensor | None = None,
         time: Tensor | None = None,
-        action_dim: Tensor | None = None,
+        real_action_dim: Tensor | None = None,
     ) -> dict[str, Tensor]:
         """Do a full training forward pass and compute the loss.
 
@@ -2054,9 +2054,9 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
         mse_loss = mse_loss[:, :, : self.config.max_action_dim]
 
         # Per-dim mask (B, 1, D) — True for real action dims; all-True fallback
-        # when `action_dim` is absent keeps single-dataset behavior unchanged.
+        # when `real_action_dim` is absent keeps single-dataset behavior unchanged.
         dim_mask = make_action_dim_mask(
-            action_dim,
+            real_action_dim,
             self.config.max_action_dim,
             batch_size=mse_loss.shape[0],
             device=mse_loss.device,

--- a/src/opentau/policies/utils.py
+++ b/src/opentau/policies/utils.py
@@ -110,7 +110,7 @@ def get_output_shape(module: nn.Module, input_shape: tuple) -> tuple:
 
 
 def make_action_dim_mask(
-    action_dim: Tensor | None,
+    real_action_dim: Tensor | None,
     max_action_dim: int,
     batch_size: int,
     device: torch.device,
@@ -124,32 +124,35 @@ def make_action_dim_mask(
     mask before reducing.
 
     Args:
-        action_dim: Optional ``(B,)`` long tensor of the real (pre-pad) action
-            dimensionality for each sample. When ``None``, the returned mask is
-            all-True so the dim-mask AND in the caller's reduction is a no-op
-            (pi0 additionally harmonized its `.mean()` to `sum / mask.sum()`
-            in this PR — see the PR body's "pi0 loss-magnitude shift" note;
-            the dim-mask itself is still a no-op when ``action_dim`` is None).
+        real_action_dim: Optional ``(B,)`` long tensor of the real (pre-pad)
+            action dimensionality for each sample (the batch key emitted by
+            ``LeRobotDataset._to_standard_data_format``). When ``None``, the
+            returned mask is all-True so the dim-mask AND in the caller's
+            reduction is a no-op (pi0 additionally harmonized its `.mean()`
+            to `sum / mask.sum()` in this PR — see the PR body's "pi0
+            loss-magnitude shift" note; the dim-mask itself is still a
+            no-op when ``real_action_dim`` is None).
         max_action_dim: The padded action dim (last-axis length of ``actions``).
         batch_size: Used to construct the all-True fallback shape; when
-            ``action_dim`` is provided, must match ``action_dim.shape[0]``.
+            ``real_action_dim`` is provided, must match
+            ``real_action_dim.shape[0]``.
         device: Output device.
 
     Returns:
         ``(batch_size, max_action_dim)`` bool tensor.
     """
-    if action_dim is None:
+    if real_action_dim is None:
         return torch.ones((batch_size, max_action_dim), dtype=torch.bool, device=device)
-    if action_dim.shape != (batch_size,):
-        # Catch caller drift (e.g. a sliced `action_dim` passed with the
+    if real_action_dim.shape != (batch_size,):
+        # Catch caller drift (e.g. a sliced `real_action_dim` passed with the
         # original `batch_size`) at the helper boundary — silent shape
         # mismatches propagate into broadcast errors deep in the loss reduction.
         raise ValueError(
-            f"action_dim.shape {tuple(action_dim.shape)} does not match "
+            f"real_action_dim.shape {tuple(real_action_dim.shape)} does not match "
             f"batch_size={batch_size}; expected ({batch_size},)"
         )
     arange = torch.arange(max_action_dim, device=device)
-    return rearrange(arange, "d -> 1 d") < rearrange(action_dim.to(device=device), "b -> b 1")
+    return rearrange(arange, "d -> 1 d") < rearrange(real_action_dim.to(device=device), "b -> b 1")
 
 
 def log_model_loading_keys(missing_keys: list[str], unexpected_keys: list[str]) -> None:

--- a/src/opentau/policies/utils.py
+++ b/src/opentau/policies/utils.py
@@ -26,6 +26,7 @@ import logging
 from collections import deque
 
 import torch
+import torch.nn.functional as F  # noqa: N812
 from einops import rearrange
 from torch import Tensor, nn
 
@@ -153,6 +154,63 @@ def make_action_dim_mask(
         )
     arange = torch.arange(max_action_dim, device=device)
     return rearrange(arange, "d -> 1 d") < rearrange(real_action_dim.to(device=device), "b -> b 1")
+
+
+def flow_matching_masked_mse(
+    u_t: Tensor,
+    v_t: Tensor,
+    *,
+    max_action_dim: int,
+    prefix_mask: Tensor | None = None,
+    actions_is_pad: Tensor | None = None,
+    real_action_dim: Tensor | None = None,
+) -> Tensor:
+    """Masked MSE for flow-matching velocity-field training.
+
+    Shared across pi05, pi05_mem, pi06, pi07 (low_level), and pi07_paligemma
+    (low_level). Builds a `(B, chunk_size, max_action_dim)` mask that AND-s
+    together up to three conditions and reduces ``F.mse_loss(u_t, v_t)``
+    over the unmasked slots:
+
+      1. **Frozen-prefix (RTI delay):** ``~prefix_mask`` — False where the
+         model isn't asked to predict (the action prefix is the actually
+         executed action from a previous inference, frozen as ground truth).
+         Pass ``None`` to disable (non-RTI policies); the helper builds an
+         all-False prefix mask internally so every step is supervised.
+      2. **Per-timestep chunk padding:** ``~actions_is_pad`` — False where
+         the action chunk extends past episode end. Pass ``None`` to skip.
+         Also covers VQA-style items (``actions_is_pad`` all-True ⇒ loss = 0).
+      3. **Per-sample real action dim:** built from ``real_action_dim`` via
+         :func:`make_action_dim_mask`. False on the zero-pad tail dims of
+         each sample. Pass ``None`` to score all ``max_action_dim`` columns.
+
+    Args:
+        u_t: Target velocity field, shape ``(B, chunk_size, D)`` (D ≥ max_action_dim).
+        v_t: Predicted velocity field, same shape as ``u_t``.
+        max_action_dim: Number of leading action dims to score against; trailing
+            dims are dropped before reduction. Keyword-only.
+        prefix_mask: Optional bool ``(B, chunk_size)`` — True where the step is
+            frozen (RTI delay). ``None`` ⇒ all-False (non-RTI behavior).
+        actions_is_pad: Optional bool ``(B, chunk_size)`` — True where the
+            action chunk is padded (no real action target). ``None`` ⇒ all-False.
+        real_action_dim: Optional long ``(B,)`` — real (pre-pad) action dim per
+            sample. ``None`` ⇒ all-True (every dim is real).
+
+    Returns:
+        Scalar tensor: masked mean of ``(u_t - v_t)**2`` over the unmasked slots.
+    """
+    mse_loss = F.mse_loss(u_t, v_t, reduction="none")
+    bsz, chunk_size = u_t.shape[:2]
+    if prefix_mask is None:
+        prefix_mask = torch.zeros((bsz, chunk_size), dtype=torch.bool, device=u_t.device)
+    postfix_mask = rearrange(torch.logical_not(prefix_mask), "b c -> b c 1")
+    if actions_is_pad is not None:
+        in_episode_bound = rearrange(~actions_is_pad, "b c -> b c 1")
+        postfix_mask = torch.logical_and(postfix_mask, in_episode_bound)
+    mse_loss = mse_loss[:, :, :max_action_dim]
+    dim_mask = make_action_dim_mask(real_action_dim, max_action_dim, batch_size=bsz, device=u_t.device)
+    full_mask = postfix_mask & rearrange(dim_mask, "b d -> b 1 d")
+    return (mse_loss * full_mask).sum() / (full_mask.sum() + 1e-8)
 
 
 def log_model_loading_keys(missing_keys: list[str], unexpected_keys: list[str]) -> None:

--- a/src/opentau/policies/utils.py
+++ b/src/opentau/policies/utils.py
@@ -126,9 +126,13 @@ def make_action_dim_mask(
     Args:
         action_dim: Optional ``(B,)`` long tensor of the real (pre-pad) action
             dimensionality for each sample. When ``None``, the returned mask is
-            all-True and the caller's reduction matches the pre-fix behavior.
+            all-True so the dim-mask AND in the caller's reduction is a no-op
+            (pi0 additionally harmonized its `.mean()` to `sum / mask.sum()`
+            in this PR — see the PR body's "pi0 loss-magnitude shift" note;
+            the dim-mask itself is still a no-op when ``action_dim`` is None).
         max_action_dim: The padded action dim (last-axis length of ``actions``).
-        batch_size: Used to construct the all-True fallback shape.
+        batch_size: Used to construct the all-True fallback shape; when
+            ``action_dim`` is provided, must match ``action_dim.shape[0]``.
         device: Output device.
 
     Returns:

--- a/src/opentau/policies/utils.py
+++ b/src/opentau/policies/utils.py
@@ -136,6 +136,14 @@ def make_action_dim_mask(
     """
     if action_dim is None:
         return torch.ones((batch_size, max_action_dim), dtype=torch.bool, device=device)
+    if action_dim.shape != (batch_size,):
+        # Catch caller drift (e.g. a sliced `action_dim` passed with the
+        # original `batch_size`) at the helper boundary — silent shape
+        # mismatches propagate into broadcast errors deep in the loss reduction.
+        raise ValueError(
+            f"action_dim.shape {tuple(action_dim.shape)} does not match "
+            f"batch_size={batch_size}; expected ({batch_size},)"
+        )
     arange = torch.arange(max_action_dim, device=device)
     return rearrange(arange, "d -> 1 d") < rearrange(action_dim.to(device=device), "b -> b 1")
 

--- a/src/opentau/policies/utils.py
+++ b/src/opentau/policies/utils.py
@@ -26,7 +26,8 @@ import logging
 from collections import deque
 
 import torch
-from torch import nn
+from einops import rearrange
+from torch import Tensor, nn
 
 
 def populate_queues(
@@ -106,6 +107,37 @@ def get_output_shape(module: nn.Module, input_shape: tuple) -> tuple:
     with torch.inference_mode():
         output = module(dummy_input)
     return tuple(output.shape)
+
+
+def make_action_dim_mask(
+    action_dim: Tensor | None,
+    max_action_dim: int,
+    batch_size: int,
+    device: torch.device,
+) -> Tensor:
+    """Per-sample bool mask over action dims; True for real dims, False for zero-pad.
+
+    Heterogeneous datasets are zero-padded to ``max_action_dim`` along the last
+    action axis to keep batches rectangular, but the flow-matching MSE on the
+    velocity field should only score real dims for each sample. This helper
+    builds the per-dim mask that callers AND into their existing per-timestep
+    mask before reducing.
+
+    Args:
+        action_dim: Optional ``(B,)`` long tensor of the real (pre-pad) action
+            dimensionality for each sample. When ``None``, the returned mask is
+            all-True and the caller's reduction matches the pre-fix behavior.
+        max_action_dim: The padded action dim (last-axis length of ``actions``).
+        batch_size: Used to construct the all-True fallback shape.
+        device: Output device.
+
+    Returns:
+        ``(batch_size, max_action_dim)`` bool tensor.
+    """
+    if action_dim is None:
+        return torch.ones((batch_size, max_action_dim), dtype=torch.bool, device=device)
+    arange = torch.arange(max_action_dim, device=device)
+    return rearrange(arange, "d -> 1 d") < rearrange(action_dim.to(device=device), "b -> b 1")
 
 
 def log_model_loading_keys(missing_keys: list[str], unexpected_keys: list[str]) -> None:

--- a/tests/datasets/test_action_dim.py
+++ b/tests/datasets/test_action_dim.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python
+
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""``action_dim`` emission from LeRobotDataset._to_standard_data_format.
+
+The dataset records the real (pre-pad) trailing dim of ``actions`` so
+per-policy MSE on the velocity field can skip the zero-pad columns
+under heterogeneous co-training.
+"""
+
+from dataclasses import dataclass
+
+import pytest
+import torch
+
+from opentau.configs.policies import PreTrainedConfig
+from opentau.datasets.factory import resolve_delta_timestamps
+from opentau.datasets.lerobot_dataset import LeRobotDataset
+from opentau.datasets.standard_data_format_mapping import DATA_FEATURES_NAME_MAPPING
+from tests.fixtures.constants import DUMMY_REPO_ID
+
+
+@dataclass
+class DummyPolicyConfig(PreTrainedConfig):
+    chunk_size: int = 50
+
+    @property
+    def observation_delta_indices(self):
+        return None
+
+    @property
+    def action_delta_indices(self):
+        return list(range(self.chunk_size))
+
+    @property
+    def reward_delta_indices(self):
+        return None
+
+    def get_optimizer_preset(self):
+        return None
+
+    def get_scheduler_preset(self):
+        return None
+
+    def validate_features(self):
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _fix_dummy_mapping():
+    original = DATA_FEATURES_NAME_MAPPING.get(DUMMY_REPO_ID, {}).copy()
+    DATA_FEATURES_NAME_MAPPING[DUMMY_REPO_ID] = {
+        "state": "state",
+        "actions": "action",
+        "prompt": "task",
+        "response": "response",
+    }
+    yield
+    DATA_FEATURES_NAME_MAPPING[DUMMY_REPO_ID] = original
+
+
+def _make_dataset(
+    lerobot_dataset_factory,
+    info_factory,
+    hf_dataset_factory,
+    tasks_factory,
+    episodes_factory,
+    stats_factory,
+    episodes_stats_factory,
+    tmp_path,
+    action_dim,
+    suffix,
+):
+    """Build a minimal LeRobotDataset whose underlying parquet matches a
+    custom ``action_dim``. We have to explicitly thread the same custom
+    features through both ``info_factory`` and ``hf_dataset_factory`` —
+    the default lerobot_dataset_factory hf_dataset path ignores info["features"].
+    """
+    motor_features = {
+        "action": {
+            "dtype": "float32",
+            "shape": (action_dim,),
+            "names": [f"a{i}" for i in range(action_dim)],
+        },
+        "state": {
+            "dtype": "float32",
+            "shape": (action_dim,),
+            "names": [f"s{i}" for i in range(action_dim)],
+        },
+    }
+    info = info_factory(
+        total_episodes=3,
+        total_frames=150,
+        total_tasks=1,
+        camera_features={},
+        motor_features=motor_features,
+    )
+    tasks = tasks_factory(total_tasks=1)
+    episode_dicts = episodes_factory(total_episodes=3, total_frames=150, tasks=tasks)
+    hf_dataset = hf_dataset_factory(
+        features=info["features"], tasks=tasks, episodes=episode_dicts, fps=info["fps"]
+    )
+    stats = stats_factory(features=info["features"])
+    episodes_stats = episodes_stats_factory(features=info["features"], total_episodes=3)
+    dataset = lerobot_dataset_factory(
+        root=tmp_path / f"action_dim_{action_dim}_{suffix}",
+        repo_id=DUMMY_REPO_ID,
+        total_episodes=3,
+        total_frames=150,
+        total_tasks=1,
+        info=info,
+        stats=stats,
+        episodes_stats=episodes_stats,
+        tasks=tasks,
+        episode_dicts=episode_dicts,
+        hf_dataset=hf_dataset,
+    )
+    dataset.cfg.policy = DummyPolicyConfig(chunk_size=dataset.cfg.action_chunk)
+    dt_info = resolve_delta_timestamps(dataset.cfg, dataset.cfg.dataset_mixture.datasets[0], dataset.meta)
+    dataset.delta_timestamps_params = LeRobotDataset.compute_delta_params(*dt_info)
+    return dataset
+
+
+def test_action_dim_reflects_pre_pad_shape(
+    lerobot_dataset_factory,
+    info_factory,
+    hf_dataset_factory,
+    tasks_factory,
+    episodes_factory,
+    stats_factory,
+    episodes_stats_factory,
+    tmp_path,
+):
+    """A dataset with a 4-DoF action emits ``action_dim==4`` per sample,
+    while the padded ``actions`` tensor is still ``max_action_dim`` wide."""
+    dataset = _make_dataset(
+        lerobot_dataset_factory,
+        info_factory,
+        hf_dataset_factory,
+        tasks_factory,
+        episodes_factory,
+        stats_factory,
+        episodes_stats_factory,
+        tmp_path,
+        action_dim=4,
+        suffix="single",
+    )
+    item = dataset[25]
+    assert "action_dim" in item, "dataset must emit action_dim alongside the padded actions tensor"
+    assert item["action_dim"].shape == (), f"action_dim must be scalar (got {item['action_dim'].shape})"
+    assert item["action_dim"].dtype == torch.long
+    assert int(item["action_dim"].item()) == 4
+    assert item["actions"].shape == (dataset.cfg.action_chunk, dataset.cfg.max_action_dim)
+
+
+def test_action_dim_default_dataloader_collation(
+    lerobot_dataset_factory,
+    info_factory,
+    hf_dataset_factory,
+    tasks_factory,
+    episodes_factory,
+    stats_factory,
+    episodes_stats_factory,
+    tmp_path,
+):
+    """Default PyTorch collate stacks the scalar ``action_dim`` into a (B,) long tensor."""
+    dataset = _make_dataset(
+        lerobot_dataset_factory,
+        info_factory,
+        hf_dataset_factory,
+        tasks_factory,
+        episodes_factory,
+        stats_factory,
+        episodes_stats_factory,
+        tmp_path,
+        action_dim=3,
+        suffix="collate",
+    )
+    loader = torch.utils.data.DataLoader(dataset, batch_size=4, shuffle=False, num_workers=0)
+    batch = next(iter(loader))
+    assert "action_dim" in batch
+    assert batch["action_dim"].shape == (4,)
+    assert batch["action_dim"].dtype == torch.long
+    assert (batch["action_dim"] == 3).all()
+
+
+def test_two_datasets_with_different_action_dims(
+    lerobot_dataset_factory,
+    info_factory,
+    hf_dataset_factory,
+    tasks_factory,
+    episodes_factory,
+    stats_factory,
+    episodes_stats_factory,
+    tmp_path,
+):
+    """Heterogeneous mixture: a 4-DoF and a 9-DoF dataset must each emit
+    the correct per-sample ``action_dim`` (4 and 9 respectively), independent
+    of the shared ``max_action_dim``."""
+    common = {
+        "lerobot_dataset_factory": lerobot_dataset_factory,
+        "info_factory": info_factory,
+        "hf_dataset_factory": hf_dataset_factory,
+        "tasks_factory": tasks_factory,
+        "episodes_factory": episodes_factory,
+        "stats_factory": stats_factory,
+        "episodes_stats_factory": episodes_stats_factory,
+        "tmp_path": tmp_path,
+    }
+    ds_a = _make_dataset(**common, action_dim=4, suffix="a")
+    ds_b = _make_dataset(**common, action_dim=9, suffix="b")
+    item_a = ds_a[10]
+    item_b = ds_b[10]
+    assert int(item_a["action_dim"].item()) == 4
+    assert int(item_b["action_dim"].item()) == 9
+    assert item_a["actions"].shape[-1] == ds_a.cfg.max_action_dim
+    assert item_b["actions"].shape[-1] == ds_b.cfg.max_action_dim
+    assert item_a["actions"].shape[-1] == item_b["actions"].shape[-1]

--- a/tests/datasets/test_action_dim.py
+++ b/tests/datasets/test_action_dim.py
@@ -254,3 +254,65 @@ def test_two_datasets_with_different_action_dims(
     assert item_a["actions"].shape[-1] == ds_a.cfg.max_action_dim
     assert item_b["actions"].shape[-1] == ds_b.cfg.max_action_dim
     assert item_a["actions"].shape[-1] == item_b["actions"].shape[-1]
+
+
+def test_cross_dataset_batch_routes_action_dim_into_loss(
+    lerobot_dataset_factory,
+    info_factory,
+    hf_dataset_factory,
+    tasks_factory,
+    episodes_factory,
+    stats_factory,
+    episodes_stats_factory,
+    tmp_path,
+):
+    """End-to-end heterogeneous-DoF scenario the fix targets: collate one
+    item from a 4-DoF dataset and one from a 9-DoF dataset into a single
+    batch, then verify (a) ``batch["action_dim"]`` is ``[4, 9]`` after
+    default collation and (b) feeding that into ``flow_matching_masked_mse``
+    produces the masked-mean we expect by hand (5-dim tail of item 0 and
+    23-dim tail of item 1 both excluded from the reduction).
+
+    The unit test ``test_flow_matching_masked_mse_excludes_padded_dims``
+    covers the loss math with a synthetic ``action_dim`` tensor; this test
+    closes the dataset → policy boundary by actually collating real
+    standardized items."""
+    from opentau.policies.pi06.modeling_pi06 import flow_matching_masked_mse
+
+    common = {
+        "lerobot_dataset_factory": lerobot_dataset_factory,
+        "info_factory": info_factory,
+        "hf_dataset_factory": hf_dataset_factory,
+        "tasks_factory": tasks_factory,
+        "episodes_factory": episodes_factory,
+        "stats_factory": stats_factory,
+        "episodes_stats_factory": episodes_stats_factory,
+        "tmp_path": tmp_path,
+    }
+    ds_a = _make_dataset(**common, action_dim=4, suffix="mixed_a")
+    ds_b = _make_dataset(**common, action_dim=9, suffix="mixed_b")
+    max_action_dim = ds_a.cfg.max_action_dim
+    chunk = ds_a.cfg.action_chunk
+
+    batch = torch.utils.data.default_collate([ds_a[0], ds_b[0]])
+    assert batch["action_dim"].tolist() == [4, 9]
+    assert batch["actions"].shape == (2, chunk, max_action_dim)
+
+    # Hand-crafted velocity tensors: u_t - v_t = 1 everywhere → per-element MSE = 1.
+    # No frozen prefix, no timestep padding — isolates the action_dim contribution.
+    u_t = torch.ones(2, chunk, max_action_dim)
+    v_t = torch.zeros(2, chunk, max_action_dim)
+    prefix_mask = torch.zeros(2, chunk, dtype=torch.bool)
+    actions_is_pad = torch.zeros(2, chunk, dtype=torch.bool)
+    loss = flow_matching_masked_mse(
+        u_t,
+        v_t,
+        prefix_mask,
+        actions_is_pad,
+        max_action_dim=max_action_dim,
+        action_dim=batch["action_dim"],
+    )
+    # Sample 0 contributes chunk * 4 slots; sample 1 contributes chunk * 9.
+    expected_denom = chunk * 4 + chunk * 9
+    expected = torch.tensor(expected_denom / (expected_denom + 1e-8))
+    torch.testing.assert_close(loss, expected)

--- a/tests/datasets/test_action_dim.py
+++ b/tests/datasets/test_action_dim.py
@@ -188,6 +188,40 @@ def test_action_dim_default_dataloader_collation(
     assert (batch["action_dim"] == 3).all()
 
 
+def test_dataset_raises_when_action_dim_exceeds_max(
+    lerobot_dataset_factory,
+    info_factory,
+    hf_dataset_factory,
+    tasks_factory,
+    episodes_factory,
+    stats_factory,
+    episodes_stats_factory,
+    tmp_path,
+):
+    """A dataset whose native action dim is *larger* than the policy's
+    ``max_action_dim`` must raise (not silently truncate). The check lives in
+    ``_to_standard_data_format`` and is a ``ValueError`` (not ``assert``) so
+    it survives ``python -O``."""
+    dataset = _make_dataset(
+        lerobot_dataset_factory,
+        info_factory,
+        hf_dataset_factory,
+        tasks_factory,
+        episodes_factory,
+        stats_factory,
+        episodes_stats_factory,
+        tmp_path,
+        action_dim=4,
+        suffix="oversized",
+    )
+    # Force max_action_dim *below* the dataset's real action dim.
+    dataset.max_action_dim = 2
+    # ``__getitem__`` wraps loader errors in a ``RuntimeError`` after retries,
+    # so match the inner ``ValueError`` text via substring.
+    with pytest.raises(RuntimeError, match="exceeds max_action_dim"):
+        _ = dataset[0]
+
+
 def test_two_datasets_with_different_action_dims(
     lerobot_dataset_factory,
     info_factory,

--- a/tests/datasets/test_action_dim.py
+++ b/tests/datasets/test_action_dim.py
@@ -72,7 +72,7 @@ def _make_dataset(
     stats_factory,
     episodes_stats_factory,
     tmp_path,
-    action_dim,
+    real_action_dim,
     suffix,
 ):
     """Build a minimal LeRobotDataset whose underlying parquet matches a
@@ -83,13 +83,13 @@ def _make_dataset(
     motor_features = {
         "action": {
             "dtype": "float32",
-            "shape": (action_dim,),
-            "names": [f"a{i}" for i in range(action_dim)],
+            "shape": (real_action_dim,),
+            "names": [f"a{i}" for i in range(real_action_dim)],
         },
         "state": {
             "dtype": "float32",
-            "shape": (action_dim,),
-            "names": [f"s{i}" for i in range(action_dim)],
+            "shape": (real_action_dim,),
+            "names": [f"s{i}" for i in range(real_action_dim)],
         },
     }
     info = info_factory(
@@ -107,7 +107,7 @@ def _make_dataset(
     stats = stats_factory(features=info["features"])
     episodes_stats = episodes_stats_factory(features=info["features"], total_episodes=3)
     dataset = lerobot_dataset_factory(
-        root=tmp_path / f"action_dim_{action_dim}_{suffix}",
+        root=tmp_path / f"action_dim_{real_action_dim}_{suffix}",
         repo_id=DUMMY_REPO_ID,
         total_episodes=3,
         total_frames=150,
@@ -146,14 +146,16 @@ def test_action_dim_reflects_pre_pad_shape(
         stats_factory,
         episodes_stats_factory,
         tmp_path,
-        action_dim=4,
+        real_action_dim=4,
         suffix="single",
     )
     item = dataset[25]
-    assert "action_dim" in item, "dataset must emit action_dim alongside the padded actions tensor"
-    assert item["action_dim"].shape == (), f"action_dim must be scalar (got {item['action_dim'].shape})"
-    assert item["action_dim"].dtype == torch.long
-    assert int(item["action_dim"].item()) == 4
+    assert "real_action_dim" in item, "dataset must emit action_dim alongside the padded actions tensor"
+    assert item["real_action_dim"].shape == (), (
+        f"real_action_dim must be scalar (got {item['real_action_dim'].shape})"
+    )
+    assert item["real_action_dim"].dtype == torch.long
+    assert int(item["real_action_dim"].item()) == 4
     assert item["actions"].shape == (dataset.cfg.action_chunk, dataset.cfg.max_action_dim)
 
 
@@ -177,15 +179,15 @@ def test_action_dim_default_dataloader_collation(
         stats_factory,
         episodes_stats_factory,
         tmp_path,
-        action_dim=3,
+        real_action_dim=3,
         suffix="collate",
     )
     loader = torch.utils.data.DataLoader(dataset, batch_size=4, shuffle=False, num_workers=0)
     batch = next(iter(loader))
-    assert "action_dim" in batch
-    assert batch["action_dim"].shape == (4,)
-    assert batch["action_dim"].dtype == torch.long
-    assert (batch["action_dim"] == 3).all()
+    assert "real_action_dim" in batch
+    assert batch["real_action_dim"].shape == (4,)
+    assert batch["real_action_dim"].dtype == torch.long
+    assert (batch["real_action_dim"] == 3).all()
 
 
 def test_dataset_raises_when_action_dim_exceeds_max(
@@ -211,7 +213,7 @@ def test_dataset_raises_when_action_dim_exceeds_max(
         stats_factory,
         episodes_stats_factory,
         tmp_path,
-        action_dim=4,
+        real_action_dim=4,
         suffix="oversized",
     )
     # Force max_action_dim *below* the dataset's real action dim.
@@ -245,12 +247,12 @@ def test_two_datasets_with_different_action_dims(
         "episodes_stats_factory": episodes_stats_factory,
         "tmp_path": tmp_path,
     }
-    ds_a = _make_dataset(**common, action_dim=4, suffix="a")
-    ds_b = _make_dataset(**common, action_dim=9, suffix="b")
+    ds_a = _make_dataset(**common, real_action_dim=4, suffix="a")
+    ds_b = _make_dataset(**common, real_action_dim=9, suffix="b")
     item_a = ds_a[10]
     item_b = ds_b[10]
-    assert int(item_a["action_dim"].item()) == 4
-    assert int(item_b["action_dim"].item()) == 9
+    assert int(item_a["real_action_dim"].item()) == 4
+    assert int(item_b["real_action_dim"].item()) == 9
     assert item_a["actions"].shape[-1] == ds_a.cfg.max_action_dim
     assert item_b["actions"].shape[-1] == ds_b.cfg.max_action_dim
     assert item_a["actions"].shape[-1] == item_b["actions"].shape[-1]
@@ -268,7 +270,7 @@ def test_cross_dataset_batch_routes_action_dim_into_loss(
 ):
     """End-to-end heterogeneous-DoF scenario the fix targets: collate one
     item from a 4-DoF dataset and one from a 9-DoF dataset into a single
-    batch, then verify (a) ``batch["action_dim"]`` is ``[4, 9]`` after
+    batch, then verify (a) ``batch["real_action_dim"]`` is ``[4, 9]`` after
     default collation and (b) feeding that into ``flow_matching_masked_mse``
     produces the masked-mean we expect by hand (5-dim tail of item 0 and
     23-dim tail of item 1 both excluded from the reduction).
@@ -289,13 +291,13 @@ def test_cross_dataset_batch_routes_action_dim_into_loss(
         "episodes_stats_factory": episodes_stats_factory,
         "tmp_path": tmp_path,
     }
-    ds_a = _make_dataset(**common, action_dim=4, suffix="mixed_a")
-    ds_b = _make_dataset(**common, action_dim=9, suffix="mixed_b")
+    ds_a = _make_dataset(**common, real_action_dim=4, suffix="mixed_a")
+    ds_b = _make_dataset(**common, real_action_dim=9, suffix="mixed_b")
     max_action_dim = ds_a.cfg.max_action_dim
     chunk = ds_a.cfg.action_chunk
 
     batch = torch.utils.data.default_collate([ds_a[0], ds_b[0]])
-    assert batch["action_dim"].tolist() == [4, 9]
+    assert batch["real_action_dim"].tolist() == [4, 9]
     assert batch["actions"].shape == (2, chunk, max_action_dim)
 
     # Hand-crafted velocity tensors: u_t - v_t = 1 everywhere → per-element MSE = 1.
@@ -310,7 +312,7 @@ def test_cross_dataset_batch_routes_action_dim_into_loss(
         prefix_mask,
         actions_is_pad,
         max_action_dim=max_action_dim,
-        action_dim=batch["action_dim"],
+        real_action_dim=batch["real_action_dim"],
     )
     # Sample 0 contributes chunk * 4 slots; sample 1 contributes chunk * 9.
     expected_denom = chunk * 4 + chunk * 9

--- a/tests/datasets/test_action_dim.py
+++ b/tests/datasets/test_action_dim.py
@@ -279,7 +279,7 @@ def test_cross_dataset_batch_routes_action_dim_into_loss(
     covers the loss math with a synthetic ``action_dim`` tensor; this test
     closes the dataset → policy boundary by actually collating real
     standardized items."""
-    from opentau.policies.pi06.modeling_pi06 import flow_matching_masked_mse
+    from opentau.policies.utils import flow_matching_masked_mse
 
     common = {
         "lerobot_dataset_factory": lerobot_dataset_factory,
@@ -309,9 +309,9 @@ def test_cross_dataset_batch_routes_action_dim_into_loss(
     loss = flow_matching_masked_mse(
         u_t,
         v_t,
-        prefix_mask,
-        actions_is_pad,
         max_action_dim=max_action_dim,
+        prefix_mask=prefix_mask,
+        actions_is_pad=actions_is_pad,
         real_action_dim=batch["real_action_dim"],
     )
     # Sample 0 contributes chunk * 4 slots; sample 1 contributes chunk * 9.

--- a/tests/datasets/test_action_dim.py
+++ b/tests/datasets/test_action_dim.py
@@ -218,7 +218,7 @@ def test_dataset_raises_when_action_dim_exceeds_max(
     dataset.max_action_dim = 2
     # ``__getitem__`` wraps loader errors in a ``RuntimeError`` after retries,
     # so match the inner ``ValueError`` text via substring.
-    with pytest.raises(RuntimeError, match="exceeds max_action_dim"):
+    with pytest.raises(RuntimeError, match="is outside"):
         _ = dataset[0]
 
 

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -422,6 +422,7 @@ def check_standard_data_format(item, delta_timestamps_params, dataset, train_pip
         ("response", None),
         ("img_is_pad", (train_pipeline_config.num_cams,)),
         ("action_is_pad", (train_pipeline_config.action_chunk,)),
+        ("action_dim", ()),
         ("obs_history_is_pad", obs_pad_shape),
     ]
     for i in range(train_pipeline_config.num_cams):
@@ -444,6 +445,10 @@ def check_standard_data_format(item, delta_timestamps_params, dataset, train_pip
         elif key in ("img_is_pad", "action_is_pad", "obs_history_is_pad"):
             assert item[key].shape == shape, f"{key}"
             assert isinstance(item[key], torch.BoolTensor), f"{key}"
+        elif key == "action_dim":
+            assert item[key].shape == shape, f"{key}"
+            assert item[key].dtype == torch.long, f"{key}"
+            assert 0 < int(item[key].item()) <= train_pipeline_config.max_action_dim, f"{key}"
 
     # test delta_timestamps — per-feature keys
     dt_mean = delta_timestamps_params[0]

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -422,7 +422,7 @@ def check_standard_data_format(item, delta_timestamps_params, dataset, train_pip
         ("response", None),
         ("img_is_pad", (train_pipeline_config.num_cams,)),
         ("action_is_pad", (train_pipeline_config.action_chunk,)),
-        ("action_dim", ()),
+        ("real_action_dim", ()),
         ("obs_history_is_pad", obs_pad_shape),
     ]
     for i in range(train_pipeline_config.num_cams):
@@ -445,7 +445,7 @@ def check_standard_data_format(item, delta_timestamps_params, dataset, train_pip
         elif key in ("img_is_pad", "action_is_pad", "obs_history_is_pad"):
             assert item[key].shape == shape, f"{key}"
             assert isinstance(item[key], torch.BoolTensor), f"{key}"
-        elif key == "action_dim":
+        elif key == "real_action_dim":
             assert item[key].shape == shape, f"{key}"
             assert item[key].dtype == torch.long, f"{key}"
             assert 0 < int(item[key].item()) <= train_pipeline_config.max_action_dim, f"{key}"

--- a/tests/policies/test_action_dim_mask.py
+++ b/tests/policies/test_action_dim_mask.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python
+
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Per-dim action mask for heterogeneous-DoF flow-matching MSE.
+
+The padded tail dims of ``actions`` must not contribute to the velocity
+loss when datasets in a mixture have different native action dims. These
+tests exercise the helper and the per-policy MSE reduction directly,
+with hand-crafted ``u_t`` / ``v_t`` tensors so the loss is predictable.
+"""
+
+import pytest
+import torch
+import torch.nn.functional as F  # noqa: N812
+from einops import rearrange
+
+from opentau.policies.pi06.modeling_pi06 import flow_matching_masked_mse
+from opentau.policies.utils import make_action_dim_mask
+
+
+def _reference_dense_mse(u_t: torch.Tensor, v_t: torch.Tensor, action_is_pad: torch.Tensor) -> torch.Tensor:
+    """Pre-fix MSE: sum-of-squares masked only by timestep, divided by the
+    count of unmasked ``(b, c, d)`` slots (the historical sum/denom pattern)."""
+    mse = F.mse_loss(u_t, v_t, reduction="none")
+    timestep_mask = rearrange(~action_is_pad, "b c -> b c 1")
+    full = timestep_mask.expand(-1, -1, mse.shape[-1])
+    return (mse * full).sum() / (full.sum() + 1e-8)
+
+
+def test_helper_shape_and_values():
+    action_dim = torch.tensor([7, 14], dtype=torch.long)
+    mask = make_action_dim_mask(action_dim, max_action_dim=32, batch_size=2, device=torch.device("cpu"))
+    assert mask.shape == (2, 32)
+    assert mask.dtype == torch.bool
+    # row 0: first 7 columns True, rest False
+    assert mask[0, :7].all() and not mask[0, 7:].any()
+    # row 1: first 14 columns True, rest False
+    assert mask[1, :14].all() and not mask[1, 14:].any()
+
+
+def test_helper_none_returns_all_true():
+    mask = make_action_dim_mask(None, max_action_dim=32, batch_size=4, device=torch.device("cpu"))
+    assert mask.shape == (4, 32)
+    assert mask.all()
+
+
+def test_helper_device_placement_when_action_dim_on_cpu():
+    """The helper must move ``action_dim`` to the requested device."""
+    action_dim = torch.tensor([3, 5], dtype=torch.long, device="cpu")
+    mask = make_action_dim_mask(action_dim, max_action_dim=8, batch_size=2, device=torch.device("cpu"))
+    assert mask.device.type == "cpu"
+
+
+def test_flow_matching_masked_mse_excludes_padded_dims():
+    """A sample's loss must only count its first ``action_dim`` columns."""
+    torch.manual_seed(0)
+    bsz, chunk, dim = 2, 4, 8
+    u_t = torch.randn(bsz, chunk, dim)
+    v_t = torch.randn(bsz, chunk, dim)
+    prefix_mask = torch.zeros(bsz, chunk, dtype=torch.bool)
+    actions_is_pad = torch.zeros(bsz, chunk, dtype=torch.bool)
+    action_dim = torch.tensor([3, 5], dtype=torch.long)
+
+    loss = flow_matching_masked_mse(
+        u_t, v_t, prefix_mask, actions_is_pad, max_action_dim=dim, action_dim=action_dim
+    )
+
+    # Manually compute the expected loss over the unmasked slots only.
+    per_elem = (u_t - v_t).pow(2)
+    expected_num = per_elem[0, :, :3].sum() + per_elem[1, :, :5].sum()
+    expected_denom = chunk * 3 + chunk * 5
+    expected = expected_num / (expected_denom + 1e-8)
+    torch.testing.assert_close(loss, expected)
+
+
+def test_flow_matching_masked_mse_none_action_dim_matches_old_behavior():
+    """``action_dim=None`` must reproduce the pre-fix sum/denom result."""
+    torch.manual_seed(42)
+    bsz, chunk, dim = 3, 5, 6
+    u_t = torch.randn(bsz, chunk, dim)
+    v_t = torch.randn(bsz, chunk, dim)
+    prefix_mask = torch.zeros(bsz, chunk, dtype=torch.bool)
+    actions_is_pad = torch.zeros(bsz, chunk, dtype=torch.bool)
+
+    new = flow_matching_masked_mse(u_t, v_t, prefix_mask, actions_is_pad, max_action_dim=dim, action_dim=None)
+    old = _reference_dense_mse(u_t, v_t, actions_is_pad)
+    torch.testing.assert_close(new, old)
+
+
+def test_flow_matching_masked_mse_action_dim_at_max_matches_old_behavior():
+    """When every sample's ``action_dim == max_action_dim`` the dim mask is
+    a no-op and the loss must equal the pre-fix computation bit-exactly."""
+    torch.manual_seed(7)
+    bsz, chunk, dim = 4, 6, 10
+    u_t = torch.randn(bsz, chunk, dim)
+    v_t = torch.randn(bsz, chunk, dim)
+    prefix_mask = torch.zeros(bsz, chunk, dtype=torch.bool)
+    actions_is_pad = torch.zeros(bsz, chunk, dtype=torch.bool)
+    action_dim = torch.full((bsz,), dim, dtype=torch.long)
+
+    new = flow_matching_masked_mse(
+        u_t, v_t, prefix_mask, actions_is_pad, max_action_dim=dim, action_dim=action_dim
+    )
+    old = _reference_dense_mse(u_t, v_t, actions_is_pad)
+    torch.testing.assert_close(new, old)
+
+
+def test_flow_matching_masked_mse_combines_with_timestep_pad():
+    """A slot must be excluded if its timestep OR its dim is padded."""
+    bsz, chunk, dim = 2, 4, 6
+    # u_t - v_t = 1 everywhere → per-element MSE = 1.
+    u_t = torch.ones(bsz, chunk, dim)
+    v_t = torch.zeros(bsz, chunk, dim)
+    prefix_mask = torch.zeros(bsz, chunk, dtype=torch.bool)
+    # Pad the last two timesteps of sample 0.
+    actions_is_pad = torch.zeros(bsz, chunk, dtype=torch.bool)
+    actions_is_pad[0, -2:] = True
+    # action_dim = [4, 2]
+    action_dim = torch.tensor([4, 2], dtype=torch.long)
+
+    loss = flow_matching_masked_mse(
+        u_t, v_t, prefix_mask, actions_is_pad, max_action_dim=dim, action_dim=action_dim
+    )
+
+    # Sample 0: 2 real timesteps * 4 real dims = 8 unmasked slots, each contributing 1.
+    # Sample 1: 4 real timesteps * 2 real dims = 8 unmasked slots, each contributing 1.
+    expected_num = 8 + 8
+    expected_denom = 8 + 8
+    expected = torch.tensor(expected_num / (expected_denom + 1e-8))
+    torch.testing.assert_close(loss, expected)
+
+
+def test_action_dim_zero_yields_zero_loss():
+    """A sample with ``action_dim=0`` (e.g. VQA-style item with no real action)
+    contributes nothing to the loss, and behaves as if fully masked."""
+    bsz, chunk, dim = 2, 3, 4
+    u_t = torch.ones(bsz, chunk, dim)
+    v_t = torch.zeros(bsz, chunk, dim)
+    prefix_mask = torch.zeros(bsz, chunk, dtype=torch.bool)
+    actions_is_pad = torch.zeros(bsz, chunk, dtype=torch.bool)
+    action_dim = torch.tensor([0, 0], dtype=torch.long)
+
+    loss = flow_matching_masked_mse(
+        u_t, v_t, prefix_mask, actions_is_pad, max_action_dim=dim, action_dim=action_dim
+    )
+    # Numerator and denominator both 0 → loss = 0 / (0 + eps) ≈ 0.
+    assert loss.item() == pytest.approx(0.0, abs=1e-6)
+
+
+def test_action_dim_assertion_when_exceeds_max():
+    """``make_action_dim_mask`` clamps via the strict-less comparison, so
+    requesting ``action_dim > max_action_dim`` simply yields an all-True
+    mask (same as ``None``). The hard assertion lives in the dataset
+    standardization path; here we just confirm the helper is total."""
+    action_dim = torch.tensor([99], dtype=torch.long)
+    mask = make_action_dim_mask(action_dim, max_action_dim=4, batch_size=1, device=torch.device("cpu"))
+    assert mask.shape == (1, 4)
+    assert mask.all()

--- a/tests/policies/test_action_dim_mask.py
+++ b/tests/policies/test_action_dim_mask.py
@@ -134,6 +134,55 @@ def test_flow_matching_masked_mse_combines_with_timestep_pad():
     torch.testing.assert_close(loss, expected)
 
 
+def test_input_side_noise_masking_zeros_padded_dims():
+    """Each policy multiplies the per-dim mask into ``noise`` before forming
+    ``x_t = (1-t)*noise + t*actions``. Because zero-padded actions are also
+    zero at padded dims (post-normalization, ``(0-mean)/(std+eps)=0`` when
+    the unused-dim stats are ``(mean=0, std=0)``), the resulting ``x_t`` and
+    ``u_t = noise - actions`` are both zero at padded dims — so the action
+    expert's input embedding never sees the noise that would otherwise leak
+    into predictions at real dims via attention. This test exercises the
+    pattern policies use to apply that mask."""
+    bsz, chunk, dim = 2, 4, 8
+    actions = torch.zeros(bsz, chunk, dim)
+    # Real dims have non-zero values; padded dims are 0 (matches the
+    # post-normalization invariant for unused dims).
+    actions[0, :, :3] = torch.randn(chunk, 3)
+    actions[1, :, :5] = torch.randn(chunk, 5)
+    noise = torch.randn(bsz, chunk, dim)
+    action_dim = torch.tensor([3, 5], dtype=torch.long)
+
+    dim_mask = make_action_dim_mask(action_dim, dim, batch_size=bsz, device=torch.device("cpu"))
+    noise_masked = noise * rearrange(dim_mask, "b d -> b 1 d").to(noise.dtype)
+
+    # Build x_t (flow-matching noisy input) and u_t (target velocity) with a
+    # mid-trajectory time. After masking noise, both must be zero at padded
+    # dims regardless of `t`.
+    t = 0.4
+    x_t = t * noise_masked + (1 - t) * actions
+    u_t = noise_masked - actions
+
+    # Sample 0: dims 3..7 padded; sample 1: dims 5..7 padded.
+    assert (x_t[0, :, 3:] == 0).all()
+    assert (u_t[0, :, 3:] == 0).all()
+    assert (x_t[1, :, 5:] == 0).all()
+    assert (u_t[1, :, 5:] == 0).all()
+    # Real dims unchanged compared with the un-masked computation.
+    torch.testing.assert_close(x_t[0, :, :3], t * noise[0, :, :3] + (1 - t) * actions[0, :, :3])
+    torch.testing.assert_close(x_t[1, :, :5], t * noise[1, :, :5] + (1 - t) * actions[1, :, :5])
+
+
+def test_input_side_noise_masking_noop_when_action_dim_none():
+    """When `action_dim is None` the mask is all-True so noise is unchanged
+    — the input-side fix degrades to a no-op for single-dataset configs and
+    pre-#336 callers, preserving bit-identical behavior at the input embedding."""
+    bsz, chunk, dim = 2, 4, 8
+    noise = torch.randn(bsz, chunk, dim)
+    dim_mask = make_action_dim_mask(None, dim, batch_size=bsz, device=torch.device("cpu"))
+    noise_masked = noise * rearrange(dim_mask, "b d -> b 1 d").to(noise.dtype)
+    torch.testing.assert_close(noise_masked, noise)
+
+
 def test_action_dim_zero_yields_zero_loss():
     """A sample with ``action_dim=0`` (e.g. VQA-style item with no real action)
     contributes nothing to the loss, and behaves as if fully masked."""

--- a/tests/policies/test_action_dim_mask.py
+++ b/tests/policies/test_action_dim_mask.py
@@ -151,11 +151,12 @@ def test_action_dim_zero_yields_zero_loss():
     assert loss.item() == pytest.approx(0.0, abs=1e-6)
 
 
-def test_action_dim_assertion_when_exceeds_max():
+def test_helper_is_total_when_action_dim_exceeds_max():
     """``make_action_dim_mask`` clamps via the strict-less comparison, so
     requesting ``action_dim > max_action_dim`` simply yields an all-True
-    mask (same as ``None``). The hard assertion lives in the dataset
-    standardization path; here we just confirm the helper is total."""
+    mask (same as ``None``). The hard boundary check lives in the dataset
+    standardization path (see ``tests/datasets/test_action_dim.py``); here
+    we just confirm the helper is total and doesn't raise."""
     action_dim = torch.tensor([99], dtype=torch.long)
     mask = make_action_dim_mask(action_dim, max_action_dim=4, batch_size=1, device=torch.device("cpu"))
     assert mask.shape == (1, 4)

--- a/tests/policies/test_action_dim_mask.py
+++ b/tests/policies/test_action_dim_mask.py
@@ -18,8 +18,7 @@ import torch
 import torch.nn.functional as F  # noqa: N812
 from einops import rearrange
 
-from opentau.policies.pi06.modeling_pi06 import flow_matching_masked_mse
-from opentau.policies.utils import make_action_dim_mask
+from opentau.policies.utils import flow_matching_masked_mse, make_action_dim_mask
 
 
 def _reference_dense_mse(u_t: torch.Tensor, v_t: torch.Tensor, action_is_pad: torch.Tensor) -> torch.Tensor:
@@ -66,7 +65,12 @@ def test_flow_matching_masked_mse_excludes_padded_dims():
     real_action_dim = torch.tensor([3, 5], dtype=torch.long)
 
     loss = flow_matching_masked_mse(
-        u_t, v_t, prefix_mask, actions_is_pad, max_action_dim=dim, real_action_dim=real_action_dim
+        u_t,
+        v_t,
+        max_action_dim=dim,
+        prefix_mask=prefix_mask,
+        actions_is_pad=actions_is_pad,
+        real_action_dim=real_action_dim,
     )
 
     # Manually compute the expected loss over the unmasked slots only.
@@ -87,7 +91,12 @@ def test_flow_matching_masked_mse_none_action_dim_matches_old_behavior():
     actions_is_pad = torch.zeros(bsz, chunk, dtype=torch.bool)
 
     new = flow_matching_masked_mse(
-        u_t, v_t, prefix_mask, actions_is_pad, max_action_dim=dim, real_action_dim=None
+        u_t,
+        v_t,
+        max_action_dim=dim,
+        prefix_mask=prefix_mask,
+        actions_is_pad=actions_is_pad,
+        real_action_dim=None,
     )
     old = _reference_dense_mse(u_t, v_t, actions_is_pad)
     torch.testing.assert_close(new, old)
@@ -105,7 +114,12 @@ def test_flow_matching_masked_mse_action_dim_at_max_matches_old_behavior():
     real_action_dim = torch.full((bsz,), dim, dtype=torch.long)
 
     new = flow_matching_masked_mse(
-        u_t, v_t, prefix_mask, actions_is_pad, max_action_dim=dim, real_action_dim=real_action_dim
+        u_t,
+        v_t,
+        max_action_dim=dim,
+        prefix_mask=prefix_mask,
+        actions_is_pad=actions_is_pad,
+        real_action_dim=real_action_dim,
     )
     old = _reference_dense_mse(u_t, v_t, actions_is_pad)
     torch.testing.assert_close(new, old)
@@ -125,7 +139,12 @@ def test_flow_matching_masked_mse_combines_with_timestep_pad():
     real_action_dim = torch.tensor([4, 2], dtype=torch.long)
 
     loss = flow_matching_masked_mse(
-        u_t, v_t, prefix_mask, actions_is_pad, max_action_dim=dim, real_action_dim=real_action_dim
+        u_t,
+        v_t,
+        max_action_dim=dim,
+        prefix_mask=prefix_mask,
+        actions_is_pad=actions_is_pad,
+        real_action_dim=real_action_dim,
     )
 
     # Sample 0: 2 real timesteps * 4 real dims = 8 unmasked slots, each contributing 1.
@@ -147,7 +166,12 @@ def test_action_dim_zero_yields_zero_loss():
     real_action_dim = torch.tensor([0, 0], dtype=torch.long)
 
     loss = flow_matching_masked_mse(
-        u_t, v_t, prefix_mask, actions_is_pad, max_action_dim=dim, real_action_dim=real_action_dim
+        u_t,
+        v_t,
+        max_action_dim=dim,
+        prefix_mask=prefix_mask,
+        actions_is_pad=actions_is_pad,
+        real_action_dim=real_action_dim,
     )
     # Numerator and denominator both 0 → loss = 0 / (0 + eps) ≈ 0.
     assert loss.item() == pytest.approx(0.0, abs=1e-6)
@@ -159,6 +183,55 @@ def test_helper_raises_on_action_dim_batch_size_mismatch():
     real_action_dim = torch.tensor([3, 5, 7], dtype=torch.long)
     with pytest.raises(ValueError, match="does not match batch_size"):
         make_action_dim_mask(real_action_dim, max_action_dim=8, batch_size=2, device=torch.device("cpu"))
+
+
+def test_flow_matching_masked_mse_prefix_mask_default_none():
+    """``prefix_mask=None`` (item 7 from the review): non-RTI policies (e.g. pi0)
+    don't have a frozen-prefix concept, so the helper must accept ``None`` and
+    build an all-False prefix mask internally. Equivalent to passing an
+    explicit all-zeros tensor; supervises every step."""
+    torch.manual_seed(3)
+    bsz, chunk, dim = 2, 4, 6
+    u_t = torch.randn(bsz, chunk, dim)
+    v_t = torch.randn(bsz, chunk, dim)
+    actions_is_pad = torch.zeros(bsz, chunk, dtype=torch.bool)
+    real_action_dim = torch.tensor([3, 5], dtype=torch.long)
+
+    loss_default = flow_matching_masked_mse(
+        u_t,
+        v_t,
+        max_action_dim=dim,
+        actions_is_pad=actions_is_pad,
+        real_action_dim=real_action_dim,
+    )
+    loss_explicit = flow_matching_masked_mse(
+        u_t,
+        v_t,
+        max_action_dim=dim,
+        prefix_mask=torch.zeros(bsz, chunk, dtype=torch.bool),
+        actions_is_pad=actions_is_pad,
+        real_action_dim=real_action_dim,
+    )
+    torch.testing.assert_close(loss_default, loss_explicit)
+
+
+def test_flow_matching_masked_mse_actions_is_pad_default_none():
+    """``actions_is_pad=None`` (also part of the cleaner API): every timestep
+    is treated as real. Equivalent to passing an explicit all-False tensor."""
+    torch.manual_seed(11)
+    bsz, chunk, dim = 2, 3, 4
+    u_t = torch.randn(bsz, chunk, dim)
+    v_t = torch.randn(bsz, chunk, dim)
+
+    loss_default = flow_matching_masked_mse(u_t, v_t, max_action_dim=dim)
+    loss_explicit = flow_matching_masked_mse(
+        u_t,
+        v_t,
+        max_action_dim=dim,
+        prefix_mask=torch.zeros(bsz, chunk, dtype=torch.bool),
+        actions_is_pad=torch.zeros(bsz, chunk, dtype=torch.bool),
+    )
+    torch.testing.assert_close(loss_default, loss_explicit)
 
 
 def test_helper_is_total_when_action_dim_exceeds_max():

--- a/tests/policies/test_action_dim_mask.py
+++ b/tests/policies/test_action_dim_mask.py
@@ -151,6 +151,14 @@ def test_action_dim_zero_yields_zero_loss():
     assert loss.item() == pytest.approx(0.0, abs=1e-6)
 
 
+def test_helper_raises_on_action_dim_batch_size_mismatch():
+    """A caller that passes `batch_size` inconsistent with `action_dim.shape[0]`
+    gets a clear error from the helper, not a silent downstream broadcast bug."""
+    action_dim = torch.tensor([3, 5, 7], dtype=torch.long)
+    with pytest.raises(ValueError, match="does not match batch_size"):
+        make_action_dim_mask(action_dim, max_action_dim=8, batch_size=2, device=torch.device("cpu"))
+
+
 def test_helper_is_total_when_action_dim_exceeds_max():
     """``make_action_dim_mask`` clamps via the strict-less comparison, so
     requesting ``action_dim > max_action_dim`` simply yields an all-True

--- a/tests/policies/test_action_dim_mask.py
+++ b/tests/policies/test_action_dim_mask.py
@@ -32,8 +32,8 @@ def _reference_dense_mse(u_t: torch.Tensor, v_t: torch.Tensor, action_is_pad: to
 
 
 def test_helper_shape_and_values():
-    action_dim = torch.tensor([7, 14], dtype=torch.long)
-    mask = make_action_dim_mask(action_dim, max_action_dim=32, batch_size=2, device=torch.device("cpu"))
+    real_action_dim = torch.tensor([7, 14], dtype=torch.long)
+    mask = make_action_dim_mask(real_action_dim, max_action_dim=32, batch_size=2, device=torch.device("cpu"))
     assert mask.shape == (2, 32)
     assert mask.dtype == torch.bool
     # row 0: first 7 columns True, rest False
@@ -49,24 +49,24 @@ def test_helper_none_returns_all_true():
 
 
 def test_helper_device_placement_when_action_dim_on_cpu():
-    """The helper must move ``action_dim`` to the requested device."""
-    action_dim = torch.tensor([3, 5], dtype=torch.long, device="cpu")
-    mask = make_action_dim_mask(action_dim, max_action_dim=8, batch_size=2, device=torch.device("cpu"))
+    """The helper must move ``real_action_dim`` to the requested device."""
+    real_action_dim = torch.tensor([3, 5], dtype=torch.long, device="cpu")
+    mask = make_action_dim_mask(real_action_dim, max_action_dim=8, batch_size=2, device=torch.device("cpu"))
     assert mask.device.type == "cpu"
 
 
 def test_flow_matching_masked_mse_excludes_padded_dims():
-    """A sample's loss must only count its first ``action_dim`` columns."""
+    """A sample's loss must only count its first ``real_action_dim`` columns."""
     torch.manual_seed(0)
     bsz, chunk, dim = 2, 4, 8
     u_t = torch.randn(bsz, chunk, dim)
     v_t = torch.randn(bsz, chunk, dim)
     prefix_mask = torch.zeros(bsz, chunk, dtype=torch.bool)
     actions_is_pad = torch.zeros(bsz, chunk, dtype=torch.bool)
-    action_dim = torch.tensor([3, 5], dtype=torch.long)
+    real_action_dim = torch.tensor([3, 5], dtype=torch.long)
 
     loss = flow_matching_masked_mse(
-        u_t, v_t, prefix_mask, actions_is_pad, max_action_dim=dim, action_dim=action_dim
+        u_t, v_t, prefix_mask, actions_is_pad, max_action_dim=dim, real_action_dim=real_action_dim
     )
 
     # Manually compute the expected loss over the unmasked slots only.
@@ -78,7 +78,7 @@ def test_flow_matching_masked_mse_excludes_padded_dims():
 
 
 def test_flow_matching_masked_mse_none_action_dim_matches_old_behavior():
-    """``action_dim=None`` must reproduce the pre-fix sum/denom result."""
+    """``real_action_dim=None`` must reproduce the pre-fix sum/denom result."""
     torch.manual_seed(42)
     bsz, chunk, dim = 3, 5, 6
     u_t = torch.randn(bsz, chunk, dim)
@@ -86,7 +86,9 @@ def test_flow_matching_masked_mse_none_action_dim_matches_old_behavior():
     prefix_mask = torch.zeros(bsz, chunk, dtype=torch.bool)
     actions_is_pad = torch.zeros(bsz, chunk, dtype=torch.bool)
 
-    new = flow_matching_masked_mse(u_t, v_t, prefix_mask, actions_is_pad, max_action_dim=dim, action_dim=None)
+    new = flow_matching_masked_mse(
+        u_t, v_t, prefix_mask, actions_is_pad, max_action_dim=dim, real_action_dim=None
+    )
     old = _reference_dense_mse(u_t, v_t, actions_is_pad)
     torch.testing.assert_close(new, old)
 
@@ -100,10 +102,10 @@ def test_flow_matching_masked_mse_action_dim_at_max_matches_old_behavior():
     v_t = torch.randn(bsz, chunk, dim)
     prefix_mask = torch.zeros(bsz, chunk, dtype=torch.bool)
     actions_is_pad = torch.zeros(bsz, chunk, dtype=torch.bool)
-    action_dim = torch.full((bsz,), dim, dtype=torch.long)
+    real_action_dim = torch.full((bsz,), dim, dtype=torch.long)
 
     new = flow_matching_masked_mse(
-        u_t, v_t, prefix_mask, actions_is_pad, max_action_dim=dim, action_dim=action_dim
+        u_t, v_t, prefix_mask, actions_is_pad, max_action_dim=dim, real_action_dim=real_action_dim
     )
     old = _reference_dense_mse(u_t, v_t, actions_is_pad)
     torch.testing.assert_close(new, old)
@@ -119,11 +121,11 @@ def test_flow_matching_masked_mse_combines_with_timestep_pad():
     # Pad the last two timesteps of sample 0.
     actions_is_pad = torch.zeros(bsz, chunk, dtype=torch.bool)
     actions_is_pad[0, -2:] = True
-    # action_dim = [4, 2]
-    action_dim = torch.tensor([4, 2], dtype=torch.long)
+    # real_action_dim = [4, 2]
+    real_action_dim = torch.tensor([4, 2], dtype=torch.long)
 
     loss = flow_matching_masked_mse(
-        u_t, v_t, prefix_mask, actions_is_pad, max_action_dim=dim, action_dim=action_dim
+        u_t, v_t, prefix_mask, actions_is_pad, max_action_dim=dim, real_action_dim=real_action_dim
     )
 
     # Sample 0: 2 real timesteps * 4 real dims = 8 unmasked slots, each contributing 1.
@@ -135,37 +137,37 @@ def test_flow_matching_masked_mse_combines_with_timestep_pad():
 
 
 def test_action_dim_zero_yields_zero_loss():
-    """A sample with ``action_dim=0`` (e.g. VQA-style item with no real action)
+    """A sample with ``real_action_dim=0`` (e.g. VQA-style item with no real action)
     contributes nothing to the loss, and behaves as if fully masked."""
     bsz, chunk, dim = 2, 3, 4
     u_t = torch.ones(bsz, chunk, dim)
     v_t = torch.zeros(bsz, chunk, dim)
     prefix_mask = torch.zeros(bsz, chunk, dtype=torch.bool)
     actions_is_pad = torch.zeros(bsz, chunk, dtype=torch.bool)
-    action_dim = torch.tensor([0, 0], dtype=torch.long)
+    real_action_dim = torch.tensor([0, 0], dtype=torch.long)
 
     loss = flow_matching_masked_mse(
-        u_t, v_t, prefix_mask, actions_is_pad, max_action_dim=dim, action_dim=action_dim
+        u_t, v_t, prefix_mask, actions_is_pad, max_action_dim=dim, real_action_dim=real_action_dim
     )
     # Numerator and denominator both 0 → loss = 0 / (0 + eps) ≈ 0.
     assert loss.item() == pytest.approx(0.0, abs=1e-6)
 
 
 def test_helper_raises_on_action_dim_batch_size_mismatch():
-    """A caller that passes `batch_size` inconsistent with `action_dim.shape[0]`
+    """A caller that passes `batch_size` inconsistent with `real_action_dim.shape[0]`
     gets a clear error from the helper, not a silent downstream broadcast bug."""
-    action_dim = torch.tensor([3, 5, 7], dtype=torch.long)
+    real_action_dim = torch.tensor([3, 5, 7], dtype=torch.long)
     with pytest.raises(ValueError, match="does not match batch_size"):
-        make_action_dim_mask(action_dim, max_action_dim=8, batch_size=2, device=torch.device("cpu"))
+        make_action_dim_mask(real_action_dim, max_action_dim=8, batch_size=2, device=torch.device("cpu"))
 
 
 def test_helper_is_total_when_action_dim_exceeds_max():
     """``make_action_dim_mask`` clamps via the strict-less comparison, so
-    requesting ``action_dim > max_action_dim`` simply yields an all-True
+    requesting ``real_action_dim > max_action_dim`` simply yields an all-True
     mask (same as ``None``). The hard boundary check lives in the dataset
     standardization path (see ``tests/datasets/test_action_dim.py``); here
     we just confirm the helper is total and doesn't raise."""
-    action_dim = torch.tensor([99], dtype=torch.long)
-    mask = make_action_dim_mask(action_dim, max_action_dim=4, batch_size=1, device=torch.device("cpu"))
+    real_action_dim = torch.tensor([99], dtype=torch.long)
+    mask = make_action_dim_mask(real_action_dim, max_action_dim=4, batch_size=1, device=torch.device("cpu"))
     assert mask.shape == (1, 4)
     assert mask.all()

--- a/tests/policies/test_action_dim_mask.py
+++ b/tests/policies/test_action_dim_mask.py
@@ -134,55 +134,6 @@ def test_flow_matching_masked_mse_combines_with_timestep_pad():
     torch.testing.assert_close(loss, expected)
 
 
-def test_input_side_noise_masking_zeros_padded_dims():
-    """Each policy multiplies the per-dim mask into ``noise`` before forming
-    ``x_t = (1-t)*noise + t*actions``. Because zero-padded actions are also
-    zero at padded dims (post-normalization, ``(0-mean)/(std+eps)=0`` when
-    the unused-dim stats are ``(mean=0, std=0)``), the resulting ``x_t`` and
-    ``u_t = noise - actions`` are both zero at padded dims — so the action
-    expert's input embedding never sees the noise that would otherwise leak
-    into predictions at real dims via attention. This test exercises the
-    pattern policies use to apply that mask."""
-    bsz, chunk, dim = 2, 4, 8
-    actions = torch.zeros(bsz, chunk, dim)
-    # Real dims have non-zero values; padded dims are 0 (matches the
-    # post-normalization invariant for unused dims).
-    actions[0, :, :3] = torch.randn(chunk, 3)
-    actions[1, :, :5] = torch.randn(chunk, 5)
-    noise = torch.randn(bsz, chunk, dim)
-    action_dim = torch.tensor([3, 5], dtype=torch.long)
-
-    dim_mask = make_action_dim_mask(action_dim, dim, batch_size=bsz, device=torch.device("cpu"))
-    noise_masked = noise * rearrange(dim_mask, "b d -> b 1 d").to(noise.dtype)
-
-    # Build x_t (flow-matching noisy input) and u_t (target velocity) with a
-    # mid-trajectory time. After masking noise, both must be zero at padded
-    # dims regardless of `t`.
-    t = 0.4
-    x_t = t * noise_masked + (1 - t) * actions
-    u_t = noise_masked - actions
-
-    # Sample 0: dims 3..7 padded; sample 1: dims 5..7 padded.
-    assert (x_t[0, :, 3:] == 0).all()
-    assert (u_t[0, :, 3:] == 0).all()
-    assert (x_t[1, :, 5:] == 0).all()
-    assert (u_t[1, :, 5:] == 0).all()
-    # Real dims unchanged compared with the un-masked computation.
-    torch.testing.assert_close(x_t[0, :, :3], t * noise[0, :, :3] + (1 - t) * actions[0, :, :3])
-    torch.testing.assert_close(x_t[1, :, :5], t * noise[1, :, :5] + (1 - t) * actions[1, :, :5])
-
-
-def test_input_side_noise_masking_noop_when_action_dim_none():
-    """When `action_dim is None` the mask is all-True so noise is unchanged
-    — the input-side fix degrades to a no-op for single-dataset configs and
-    pre-#336 callers, preserving bit-identical behavior at the input embedding."""
-    bsz, chunk, dim = 2, 4, 8
-    noise = torch.randn(bsz, chunk, dim)
-    dim_mask = make_action_dim_mask(None, dim, batch_size=bsz, device=torch.device("cpu"))
-    noise_masked = noise * rearrange(dim_mask, "b d -> b 1 d").to(noise.dtype)
-    torch.testing.assert_close(noise_masked, noise)
-
-
 def test_action_dim_zero_yields_zero_loss():
     """A sample with ``action_dim=0`` (e.g. VQA-style item with no real action)
     contributes nothing to the loss, and behaves as if fully masked."""


### PR DESCRIPTION
## What this does

For heterogeneous-DoF co-training, `actions` is zero-padded along the last axis to `max_action_dim` to keep batches rectangular. The existing per-timestep mask `action_is_pad` broadcasts across every dim column, so the flow-matching MSE on the velocity field was scoring the padded tail dims against zero — supervising the action expert on dimensions a given sample's source dataset doesn't use.

This gets strictly worse under per-dataset normalization (#336): for a 7-DoF dataset, dims 7..31 get `mean=0, std=0` stats, so the normalized target is exactly `(0 - 0) / (0 + 1e-6) ≈ 0`. That's a clean "predict 0 here" signal that contaminates samples in the same batch which actually use those dims.

The fix exposes the real (pre-pad) action dim per sample so each policy's MSE can skip the padded columns:

- **Dataset** (`src/opentau/datasets/lerobot_dataset.py`): `_to_standard_data_format` now emits `action_dim` — a scalar `torch.long` (shape `()`) captured before `pad_vector` is applied. Default PyTorch collation stacks it into a `(B,)` tensor. A `ValueError` (not `assert`, so it survives `python -O`) fires if a dataset declares more dims than the policy config allows.
- **Helper** (`src/opentau/policies/utils.py`): new `make_action_dim_mask` builds `(B, max_action_dim)` bool from `action_dim`. Returns all-True when `action_dim is None`, so behavior is bit-identical to today for callers that don't supply it.
- **Per-policy MSE** (all six flow-matching call sites): AND the per-dim mask into the existing `postfix_mask` along the dim axis before reducing. Files touched:
  - `src/opentau/policies/pi0/modeling_pi0.py` (see "**pi0 loss-magnitude shift**" below)
  - `src/opentau/policies/pi05/modeling_pi05.py`
  - `src/opentau/policies/pi05_mem/modeling_pi05.py`
  - `src/opentau/policies/pi06/modeling_pi06.py` (extended `flow_matching_masked_mse` signature with optional `action_dim`)
  - `src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py`
  - `src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py`
- **Docs** (`docs/source/concepts.rst`): documents `action_dim` in both Standard Data Format code blocks and adds an "Action-dim padding mask" subsection explaining the relationship with `action_is_pad` and the backwards-compatibility contract.

Discrete-action CE loss and inference paths (`select_action` / `sample_actions`) are unchanged — they already truncate via `config.action_feature.shape[0]` and have their own per-token masking. Padding itself is unchanged; only the MSE reduction now skips the zero-pad columns.

### pi0 loss-magnitude shift (heads-up for anyone tracking pi0 training-loss curves)

pi0 was the one policy that previously reduced its flow-matching MSE with `losses.mean()` rather than `sum / mask.sum()`. The old code zeroed out timestep-padded slots in the numerator but still counted them in the denominator, so the per-element mean was biased downward in proportion to how much episode-boundary `action_is_pad` was present.

This PR switches pi0 to the same `sum / mask.sum()` pattern the other five policies already use. The gradient direction is unchanged; only the reported MSE scale shifts upward by roughly `total_slots / unmasked_slots`. Equivalent to today when `action_is_pad` is all-False; deviates when episode-boundary padding exists. The new reduction is more semantically correct (a true mean over real targets) and brings pi0 in line with the rest of the policies, but pre-merge / post-merge pi0 MSE values aren't directly comparable.

### Deliberate scope: inline per-policy MSE blocks, not a shared helper

The five policies outside pi06 still have inlined 3-4 line MSE blocks rather than going through a shared helper. This was a deliberate planning trade-off (minimal diff over consolidation) per CLAUDE.md's "don't refactor beyond what the task requires." Each block follows the exact same pattern (`postfix_mask & rearrange(dim_mask, "b d -> b 1 d")` → multiply → sum/mask.sum()), and the bit-identical equivalence tests on `flow_matching_masked_mse` (pi06's helper) catch the most likely class of regression. A future consolidation pass — likely when pi06's helper is generalized to handle discrete-action signatures too — could fold all six into one place.

## How it was tested

- **9 unit tests** in `tests/policies/test_action_dim_mask.py` exercise `make_action_dim_mask` and the per-policy MSE reduction directly with hand-crafted `u_t` / `v_t` tensors. Two of them explicitly assert bit-identical equivalence with the pre-fix sum/denom computation when `action_dim` is `None` or equals `max_action_dim` — the no-op backwards-compatibility guarantee.
- **4 integration tests** in `tests/datasets/test_action_dim.py` build minimal `LeRobotDataset` instances at 4-DoF and 9-DoF and verify: (a) `__getitem__` emits the right per-sample `action_dim`, (b) default PyTorch collation stacks it to a `(B,)` long tensor, (c) a heterogeneous 2-dataset mix produces the right values per row, (d) declaring more dims than `max_action_dim` raises `ValueError`.
- `tests/datasets/test_datasets.py::check_standard_data_format` extended to require `action_dim` on every standardized item.
- `pre-commit run --all-files` clean.
- `pytest -m "not gpu" -n auto` clean (1370 passed locally; 3 pre-existing LIBERO failures unrelated to this change).
- `pytest -m "gpu" -n 0` on an internal GPU box: **19 passed, 10 skipped, 0 failed** in 2:43.

## How to checkout & try? (for the reviewer)

```bash
git fetch && git checkout claude/nervous-galileo-1d23a0
pytest -sx tests/policies/test_action_dim_mask.py
pytest -sx tests/datasets/test_action_dim.py
```

To confirm the no-op default is bit-identical for single-dataset configs:
```bash
pytest -sx tests/policies/test_action_dim_mask.py::test_flow_matching_masked_mse_none_action_dim_matches_old_behavior
pytest -sx tests/policies/test_action_dim_mask.py::test_flow_matching_masked_mse_action_dim_at_max_matches_old_behavior
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [x] My PR includes policy-related changes.
  - [x] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.