### PR TITLE
feat(policies): per-(robot_type, control_mode) normalization heads

### DIFF
--- a/src/opentau/configs/default.py
+++ b/src/opentau/configs/default.py
@@ -510,15 +510,24 @@ class EvalConfig:
 
     recording_root: str | None = None
 
-    # Which training-time dataset's normalization stats to use when calling
-    # `policy.select_action` on eval observations. ``None`` (default) falls
-    # through to the policy's `_resolve_dataset_index` single-dataset fallback
-    # (works for any policy trained on exactly one dataset). Set this to one
-    # of the strings in `policy.config.dataset_names` when running eval
-    # against a multi-dataset checkpoint, otherwise the inference call will
-    # raise a `KeyError`. Plumbed into each `select_action` call by
+    # Which training-time norm head to use when calling `policy.select_action`
+    # on eval observations. Either:
+    #   - set both `robot_type` and `control_mode` to address the head by
+    #     `(robot_type, control_mode)` (preferred for multi-head checkpoints
+    #     trained against the new per-`(robot_type, control_mode)`
+    #     aggregation),
+    #   - or set `dataset_repo_id` to a training-time dataset name (the
+    #     policy maps it to the norm head via its persisted
+    #     `dataset_to_norm_index`; back-compat path that also works on
+    #     legacy per-dataset checkpoints).
+    # When all three are ``None`` (default), single-head policies fall back
+    # to the `_resolve_dataset_index` zero-default; multi-head ones raise.
+    # The robot_type / control_mode pair takes precedence over
+    # `dataset_repo_id` when both are set. Plumbed by
     # `scripts/eval.py::rollout`.
     dataset_repo_id: str | None = None
+    robot_type: str | None = None
+    control_mode: str | None = None
 
     def __post_init__(self):
         """Validate evaluation configuration."""

--- a/src/opentau/configs/deployment.py
+++ b/src/opentau/configs/deployment.py
@@ -50,13 +50,19 @@ class ServerConfig:
     max_workers: int = 4
     max_send_message_length_mb: int = 100
     max_receive_message_length_mb: int = 100
-    # Which training-time dataset's normalization stats to use for inference
-    # requests. ``None`` (default) falls through to the policy's
-    # `_resolve_dataset_index` single-dataset fallback (works for any
-    # checkpoint trained on exactly one dataset). Set this to one of the
-    # strings in `policy.config.dataset_names` when serving a multi-dataset
-    # checkpoint, otherwise the inference call will raise `KeyError`.
+    # Which training-time norm head to use for inference requests. Either:
+    #   - set both `robot_type` and `control_mode` to address the head by
+    #     `(robot_type, control_mode)` (preferred for multi-head checkpoints),
+    #   - or set `dataset_repo_id` to a training-time dataset name (the
+    #     policy maps it via its persisted `dataset_to_norm_index`;
+    #     back-compat path that also works on legacy per-dataset checkpoints).
+    # When all three are ``None`` (default), single-head policies fall back
+    # to the `_resolve_dataset_index` zero-default; multi-head ones raise.
+    # The robot_type / control_mode pair takes precedence over
+    # `dataset_repo_id` when both are set.
     dataset_repo_id: str | None = None
+    robot_type: str | None = None
+    control_mode: str | None = None
 
     def __post_init__(self):
         """Validate server configuration parameters."""

--- a/src/opentau/configs/policies.py
+++ b/src/opentau/configs/policies.py
@@ -315,12 +315,24 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):
     # repopulated; otherwise the inf-init assertion fires at first forward.
     save_normalization_stats: bool = True
 
-    # Ordered list of dataset names this policy was trained on. Used by the per-sample
-    # Normalize/Unnormalize indexing path to map an inference-time
-    # `batch["dataset_repo_id"]` (str) into the leading dim of the stacked stats
-    # buffers. `None` only for policies constructed outside the standard
-    # `make_policy(ds_meta=...)` path (e.g. legacy single-stats fallbacks).
+    # Ordered list of norm-head identifiers this policy was trained on — one
+    # per row of the stacked Normalize/Unnormalize buffers. With
+    # `dataset_to_norm_index` set (new checkpoints), each entry is a norm key
+    # ("<robot_type>::<control_mode>" or a fallback dataset name). Legacy
+    # checkpoints (`dataset_to_norm_index is None`) carry one entry per
+    # training dataset and the entries are dataset names; the per-dataset and
+    # per-norm-head axes are then the same. `None` only for policies
+    # constructed outside the standard `make_policy(ds_meta=...)` path (e.g.
+    # legacy single-stats fallbacks).
     dataset_names: list[str] | None = None
+
+    # `{training_dataset_name: norm_head_row}` map persisted at training
+    # time. Lets inference resolve a `batch["dataset_repo_id"]` (a
+    # training-time dataset name) to the right row when datasets share a
+    # `(robot_type, control_mode)` head. `None` on legacy checkpoints; the
+    # policy then falls back to treating `dataset_names` as a 1:1
+    # per-dataset list (identity mapping) for inference-time lookup.
+    dataset_to_norm_index: dict[str, int] | None = None
 
     # Deprecated: latency fields are no longer used. Kept for backward-compatible
     # loading of old JSON configs. Must remain 0.0; non-zero values will raise.

--- a/src/opentau/datasets/dataset_mixture.py
+++ b/src/opentau/datasets/dataset_mixture.py
@@ -81,7 +81,7 @@ from opentau.datasets.standard_data_format_mapping import DATA_FEATURES_NAME_MAP
 
 
 class _TaggedDataset(Dataset):
-    """Wraps a ``BaseDataset`` so every sample carries its mixture-level identity.
+    """Wraps a ``BaseDataset`` so every sample carries its norm-head identity.
 
     The wrapped sample dict gains two keys:
 
@@ -89,12 +89,20 @@ class _TaggedDataset(Dataset):
         (matches an entry in ``DatasetMixtureMetadata.dataset_names``).
         Default PyTorch collate batches a per-sample ``str`` into a
         ``list[str]`` of length B.
-      - ``"dataset_index"``: ``torch.long`` scalar — the position of this
-        dataset in ``DatasetMixtureMetadata.dataset_names``. Default collate
-        stacks into a ``(B,)`` long tensor.
+      - ``"dataset_index"``: ``torch.long`` scalar — the policy's
+        **norm-head row** for this dataset (i.e.
+        ``DatasetMixtureMetadata.dataset_to_norm_index[dataset_repo_id]``).
+        Default collate stacks into a ``(B,)`` long tensor. Note: the field
+        name is retained for back-compat, but the value indexes the
+        norm-head axis, not the per-dataset enumerate axis — two datasets
+        sharing a ``(robot_type, control_mode)`` get the same value here.
 
     Policies read either key via ``PreTrainedPolicy._resolve_dataset_index``
     and route per-sample into the stacked Normalize/Unnormalize buffers.
+    The training path always uses ``dataset_index`` (immune to the
+    optional-key dropout that ``robot_type`` / ``control_mode`` undergo);
+    inference can additionally supply ``dataset_repo_id`` or
+    ``(robot_type, control_mode)``.
 
     The wrapper exposes the underlying dataset's ``.meta`` so callers of
     ``WeightedDatasetMixture`` (e.g. metadata validation, per-dataset val
@@ -147,6 +155,46 @@ def pad_vector(vector: np.ndarray, new_dim: int) -> np.ndarray:
     return new_vector
 
 
+# Values that mean "no usable label" when resolving the
+# (robot_type, control_mode) norm key:
+#   - None: field absent from info.json.
+#   - "" / whitespace-only: explicit clear via `DatasetConfig.{robot_type,control_mode}=""`.
+#   - "unknown": the `LeRobotDatasetMetadata.control_mode` default for
+#     missing `info.json` field — not an explicit user-supplied tag.
+_NORM_KEY_MISSING_CONTROL_MODES: frozenset[str] = frozenset({"unknown"})
+
+
+def compute_norm_key(
+    robot_type: str | None, control_mode: str | None, fallback_name: str
+) -> tuple[str, bool]:
+    """Compute the normalization-head key for a dataset.
+
+    Datasets that share the same `(robot_type, control_mode)` are
+    expected to share normalization stats because they share the units,
+    axis count, and physical ranges of the proprio / action vectors.
+    When either tag is missing, fall back to keying by the dataset's own
+    name so the dataset still gets a head — it just won't share one with
+    anything else.
+
+    Args:
+        robot_type: From `meta.info["robot_type"]` (after overrides).
+        control_mode: From `meta.info["control_mode"]` (after overrides).
+        fallback_name: The dataset's deduplicated mixture-level name,
+            used as the head key when fallback fires.
+
+    Returns:
+        A `(norm_key, fallback_fired)` pair. `norm_key` is
+        `"<robot_type>::<control_mode>"` on the happy path and
+        `fallback_name` otherwise; `fallback_fired` is True iff the
+        fallback path was taken.
+    """
+    rt = (robot_type or "").strip()
+    cm = (control_mode or "").strip()
+    if not rt or not cm or cm in _NORM_KEY_MISSING_CONTROL_MODES:
+        return fallback_name, True
+    return f"{rt}::{cm}", False
+
+
 def _apply_data_feature_name_mapping_overrides(
     worker_id: int, mapping_overrides: dict[str, dict[str, str]]
 ) -> None:
@@ -160,23 +208,43 @@ def _apply_data_feature_name_mapping_overrides(
 
 
 class DatasetMixtureMetadata:
-    """Per-dataset metadata for a mixture (no cross-dataset stat aggregation).
+    """Per-(robot_type, control_mode) normalization metadata for a mixture.
 
     Each underlying dataset's stats are normalised into the standard data
     format (feature renaming, state/action padding to ``cfg.max_state_dim`` /
-    ``cfg.max_action_dim``, missing-camera zero placeholders) and kept
-    *separate* on ``self.per_dataset_stats``. The policy's Normalize /
-    Unnormalize layers stack these along a new leading dim and use a
-    per-sample ``dataset_index`` to select the right row.
+    ``cfg.max_action_dim``, missing-camera zero placeholders). Datasets
+    sharing the same ``(robot_type, control_mode)`` are then grouped into a
+    single **norm head** whose stats are sample-count-pooled via
+    :func:`~opentau.datasets.compute_stats.aggregate_stats`. The policy's
+    ``Normalize`` / ``Unnormalize`` layers stack one row per norm head and
+    use a per-sample index (chosen via ``dataset_to_norm_index``) to select
+    the right row.
+
+    Datasets whose ``(robot_type, control_mode)`` pair is missing — empty,
+    ``None``, whitespace, or the ``"unknown"`` sentinel — fall back to
+    keying by the dataset's own deduplicated mixture name, giving them a
+    private head. See :func:`compute_norm_key`.
 
     Attributes:
-        per_dataset_stats: ``list[dict[str, dict[str, np.ndarray]]]`` ordered
-            to match ``dataset_names``. ``per_dataset_stats[i]`` is the
-            standardised stats dict for dataset ``dataset_names[i]``.
+        per_dataset_stats: One entry per underlying dataset, parallel to
+            ``dataset_names``. Used by ``aggregated_action_stats()`` and
+            kept for diagnostic / back-compat consumers.
         dataset_names: Ordered deduplicated mixture-level names (matches
             ``WeightedDatasetMixture._make_dataset_names`` output).
-        dataset_name_to_index: ``{name: i}`` reverse lookup for O(1)
-            inference-time resolution.
+        dataset_name_to_index: ``{name: i}`` reverse lookup over
+            ``dataset_names`` (per-dataset axis, NOT the norm-head axis).
+        per_norm_key_stats: One entry per unique norm head, parallel to
+            ``norm_keys``. This is what the policy's stacked
+            Normalize / Unnormalize buffers consume.
+        norm_keys: Ordered deduplicated norm-head identifiers
+            (``"<robot_type>::<control_mode>"`` or fallback dataset name).
+        norm_key_to_index: ``{norm_key: row}`` reverse lookup over
+            ``norm_keys`` — the norm-head axis on the policy.
+        dataset_to_norm_index: ``{dataset_name: norm_head_row}`` —
+            the per-sample mapping consumed by ``_TaggedDataset`` at
+            training time and by the policy at inference.
+        norm_key_to_dataset_names: ``{norm_key: [dataset_name, ...]}`` —
+            operator diagnostic showing which datasets share each head.
     """
 
     def __init__(
@@ -189,12 +257,27 @@ class DatasetMixtureMetadata:
         self.cfg = cfg
         self._dataset_weights = list(dataset_weights)
 
+        # Snapshot raw state / action dims BEFORE `_to_standard_data_format`
+        # pads the standardized stats. Used to surface incompatible-dim
+        # configurations (two datasets sharing a (robot_type, control_mode)
+        # but with mismatched proprio / action widths). Done up front because
+        # the standardize loop below clobbers `metadata.stats`.
+        raw_dims: list[tuple[int, int]] = []
+        for m in metadatas:
+            name_map = DATA_FEATURES_NAME_MAPPING[m.repo_id]
+            raw_dims.append(
+                (
+                    int(m.stats[name_map["state"]]["mean"].shape[-1]),
+                    int(m.stats[name_map["actions"]]["mean"].shape[-1]),
+                )
+            )
+
         # convert each metadata stats to the standard data format
         for metadata in metadatas:
             metadata.stats = self._to_standard_data_format(metadata.repo_id, metadata.stats)
 
-        # Per-dataset stats (no cross-dataset aggregation). Policies stack
-        # these along a leading axis and index per-sample.
+        # Per-dataset stats kept for diagnostic / back-compat consumers
+        # (e.g. `aggregated_action_stats` for the BPE codec).
         self.per_dataset_stats: list[dict[str, dict[str, np.ndarray]]] = [m.stats for m in metadatas]
 
         # Names default to repo_id when WeightedDatasetMixture didn't supply
@@ -214,6 +297,137 @@ class DatasetMixtureMetadata:
             )
         self.dataset_names: list[str] = list(dataset_names)
         self.dataset_name_to_index: dict[str, int] = {n: i for i, n in enumerate(self.dataset_names)}
+
+        # Compute per-dataset norm keys and group into norm heads.
+        (
+            self.norm_keys,
+            self.per_norm_key_stats,
+            self.norm_key_to_index,
+            self.dataset_to_norm_index,
+            self.norm_key_to_dataset_names,
+        ) = self._build_norm_heads(metadatas, raw_dims)
+
+    def _build_norm_heads(
+        self,
+        metadatas: List[DatasetMetadata],
+        raw_dims: list[tuple[int, int]],
+    ) -> tuple[
+        list[str],
+        list[dict[str, dict[str, np.ndarray]]],
+        dict[str, int],
+        dict[str, int],
+        dict[str, list[str]],
+    ]:
+        """Aggregate per-dataset stats into per-(robot_type, control_mode) heads.
+
+        See the class docstring for the full contract on the returned
+        structures.
+        """
+        per_dataset_norm_keys: list[str] = []
+        fallback_dataset_names: list[str] = []
+        for ds_name, meta in zip(self.dataset_names, metadatas, strict=True):
+            info = getattr(meta, "info", {}) or {}
+            key, fallback_fired = compute_norm_key(info.get("robot_type"), info.get("control_mode"), ds_name)
+            per_dataset_norm_keys.append(key)
+            if fallback_fired:
+                fallback_dataset_names.append(ds_name)
+
+        # Insertion-order-preserving dedup; one head per unique key.
+        norm_keys: list[str] = list(dict.fromkeys(per_dataset_norm_keys))
+        norm_key_to_index: dict[str, int] = {k: i for i, k in enumerate(norm_keys)}
+        dataset_to_norm_index: dict[str, int] = {
+            ds_name: norm_key_to_index[k]
+            for ds_name, k in zip(self.dataset_names, per_dataset_norm_keys, strict=True)
+        }
+        norm_key_to_dataset_names: dict[str, list[str]] = {k: [] for k in norm_keys}
+        for ds_name, k in zip(self.dataset_names, per_dataset_norm_keys, strict=True):
+            norm_key_to_dataset_names[k].append(ds_name)
+
+        # Dimensional incompatibility check: two datasets sharing a
+        # non-fallback (robot_type, control_mode) pair MUST have the same
+        # raw state and action widths. Fallback-keyed groups are singletons
+        # by construction (each fallback dataset is its own norm key) so
+        # they cannot trip this check.
+        for k in norm_keys:
+            member_indices = [i for i, dnk in enumerate(per_dataset_norm_keys) if dnk == k]
+            if len(member_indices) <= 1:
+                continue
+            # Fallback rows are singletons (a fallback key == the unique
+            # dataset name), so a key with >1 member is necessarily a real
+            # (robot_type, control_mode) pair.
+            unique_dims = {raw_dims[i] for i in member_indices}
+            if len(unique_dims) > 1:
+                offenders = [
+                    f"{self.dataset_names[i]} (state_dim={raw_dims[i][0]}, action_dim={raw_dims[i][1]})"
+                    for i in member_indices
+                ]
+                raise ValueError(
+                    f"Datasets sharing norm key {k!r} have incompatible raw "
+                    "(pre-padding) state/action dims, so their normalization "
+                    "stats cannot be pooled. Override `DatasetConfig.robot_type` "
+                    "or `DatasetConfig.control_mode` to split them into "
+                    f"distinct heads. Offenders: {offenders}"
+                )
+
+        # Per-norm-head stats. Singletons reuse the dataset's standardized
+        # stats verbatim; multi-member groups go through
+        # `aggregate_stats` weighted by each contributor's `info["total_frames"]`
+        # (true sample-count pooling — passing `weights=` replaces the
+        # internal `count` field, so we use total_frames rather than the
+        # mixture sampling weights, which would conflate distributional
+        # pooling with training-time prevalence).
+        per_norm_key_stats: list[dict[str, dict[str, np.ndarray]]] = []
+        for k in norm_keys:
+            member_indices = [i for i, dnk in enumerate(per_dataset_norm_keys) if dnk == k]
+            if len(member_indices) == 1:
+                per_norm_key_stats.append(self.per_dataset_stats[member_indices[0]])
+                continue
+            member_stats = [self.per_dataset_stats[i] for i in member_indices]
+            member_weights = [
+                float(getattr(metadatas[i], "info", {}).get("total_frames", 1) or 1) for i in member_indices
+            ]
+            per_norm_key_stats.append(aggregate_stats(member_stats, weights=member_weights))
+
+        # One aggregated warning for fallback datasets, capped at 10 names
+        # so a 30-dataset mixture without tags doesn't spam the log.
+        if fallback_dataset_names:
+            shown = fallback_dataset_names[:10]
+            suffix = (
+                f", ... and {len(fallback_dataset_names) - 10} more"
+                if len(fallback_dataset_names) > 10
+                else ""
+            )
+            logging.warning(
+                "DatasetMixtureMetadata: %d dataset(s) lack a usable "
+                "(robot_type, control_mode) pair; falling back to "
+                "dataset-name keying for their normalization heads. "
+                "Set DatasetConfig.robot_type / control_mode (or fix "
+                "info.json) to enable cross-dataset stat sharing. "
+                "Fallback datasets: %s%s",
+                len(fallback_dataset_names),
+                shown,
+                suffix,
+            )
+
+        # Operator diagnostic: log {norm_key: [dataset_repo_ids]} so the
+        # train log shows exactly which datasets share each head.
+        summary_lines = [
+            f"Norm-head aggregation: {len(norm_keys)} heads over {len(self.dataset_names)} datasets."
+        ]
+        for k in sorted(norm_keys):
+            ds_list = norm_key_to_dataset_names[k]
+            shown_ds = ds_list[:10]
+            ds_suffix = f", ... and {len(ds_list) - 10} more" if len(ds_list) > 10 else ""
+            summary_lines.append(f"  - {k}: {shown_ds}{ds_suffix}")
+        logging.info("\n".join(summary_lines))
+
+        return (
+            norm_keys,
+            per_norm_key_stats,
+            norm_key_to_index,
+            dataset_to_norm_index,
+            norm_key_to_dataset_names,
+        )
 
     def aggregated_action_stats(self) -> dict[str, np.ndarray]:
         """Single mixture-wide action stats (mean/std/min/max/count).
@@ -497,14 +711,25 @@ class WeightedDatasetMixture:
         if not all(hasattr(ds, "meta") and ds.meta is not None for ds in datasets):
             raise ValueError("All datasets must have a 'meta' attribute with valid metadata.")
 
+        # Build the norm-head mapping FIRST so `_TaggedDataset` can tag each
+        # sample with its norm-head row, not the per-dataset enumerate index.
+        # `DatasetMixtureMetadata` clobbers `metadata.stats` via
+        # `_to_standard_data_format`; this must run before any downstream
+        # consumer that reads the raw per-feature stats.
+        self.meta = DatasetMixtureMetadata(
+            cfg,
+            [ds.meta for ds in datasets],
+            dataset_weights,
+            dataset_names=self.dataset_names,
+        )
+
         # Wrap every underlying dataset so __getitem__ injects
-        # `dataset_repo_id: str` and `dataset_index: torch.long`. The policy's
-        # Normalize/Unnormalize uses these to gather per-sample stats.
-        # `_TaggedDataset` preserves `.meta` so `get_per_dataset_dataloaders`
-        # and other consumers keep working.
+        # `dataset_repo_id: str` and `dataset_index: torch.long`. The
+        # `dataset_index` value is the norm-head row index (datasets sharing
+        # a `(robot_type, control_mode)` get the same value).
         self.datasets = [
-            _TaggedDataset(ds, name, idx)
-            for idx, (ds, name) in enumerate(zip(datasets, self.dataset_names, strict=True))
+            _TaggedDataset(ds, name, self.meta.dataset_to_norm_index[name])
+            for ds, name in zip(datasets, self.dataset_names, strict=True)
         ]
 
         logging.info("Initializing WeightedDatasetMixture...")
@@ -522,13 +747,6 @@ class WeightedDatasetMixture:
                 f"must match concatenated_dataset length ({len(self.concatenated_dataset)})."
             )
         logging.info("-" * 30)
-
-        self.meta = DatasetMixtureMetadata(
-            cfg,
-            [ds.meta for ds in datasets],
-            dataset_weights,
-            dataset_names=self.dataset_names,
-        )
 
     @staticmethod
     def _make_dataset_names(cfg: TrainPipelineConfig, datasets: List[BaseDataset]) -> List[str]:

--- a/src/opentau/datasets/dataset_mixture.py
+++ b/src/opentau/datasets/dataset_mixture.py
@@ -155,13 +155,17 @@ def pad_vector(vector: np.ndarray, new_dim: int) -> np.ndarray:
     return new_vector
 
 
-# Values that mean "no usable label" when resolving the
-# (robot_type, control_mode) norm key:
+# Case-insensitive sentinels that mean "no usable label" when resolving
+# the (robot_type, control_mode) norm key:
 #   - None: field absent from info.json.
 #   - "" / whitespace-only: explicit clear via `DatasetConfig.{robot_type,control_mode}=""`.
-#   - "unknown": the `LeRobotDatasetMetadata.control_mode` default for
-#     missing `info.json` field — not an explicit user-supplied tag.
-_NORM_KEY_MISSING_CONTROL_MODES: frozenset[str] = frozenset({"unknown"})
+#   - "unknown" (any casing): the `LeRobotDatasetMetadata.control_mode`
+#     default for missing `info.json["control_mode"]`, and a common stand-in
+#     for missing `info.json["robot_type"]` — not an explicit user-supplied tag.
+# Both fields share the same sentinel set so a dataset labeled
+# `robot_type="unknown"` doesn't silently anchor a `"unknown::<mode>"` head
+# that pools across unrelated embodiments.
+_NORM_KEY_MISSING_VALUES: frozenset[str] = frozenset({"unknown"})
 
 
 def compute_norm_key(
@@ -176,6 +180,12 @@ def compute_norm_key(
     name so the dataset still gets a head — it just won't share one with
     anything else.
 
+    A value is treated as missing when it is `None`, empty after
+    `strip()`, or matches `"unknown"` case-insensitively (the sentinel
+    that `LeRobotDatasetMetadata.control_mode` returns when
+    `info.json["control_mode"]` is absent — and the typical stand-in for
+    missing `robot_type`).
+
     Args:
         robot_type: From `meta.info["robot_type"]` (after overrides).
         control_mode: From `meta.info["control_mode"]` (after overrides).
@@ -184,13 +194,15 @@ def compute_norm_key(
 
     Returns:
         A `(norm_key, fallback_fired)` pair. `norm_key` is
-        `"<robot_type>::<control_mode>"` on the happy path and
-        `fallback_name` otherwise; `fallback_fired` is True iff the
-        fallback path was taken.
+        `"<robot_type>::<control_mode>"` (preserving the original casing
+        of each tag) on the happy path and `fallback_name` otherwise;
+        `fallback_fired` is True iff the fallback path was taken.
     """
     rt = (robot_type or "").strip()
     cm = (control_mode or "").strip()
-    if not rt or not cm or cm in _NORM_KEY_MISSING_CONTROL_MODES:
+    if not rt or not cm:
+        return fallback_name, True
+    if rt.casefold() in _NORM_KEY_MISSING_VALUES or cm.casefold() in _NORM_KEY_MISSING_VALUES:
         return fallback_name, True
     return f"{rt}::{cm}", False
 

--- a/src/opentau/policies/factory.py
+++ b/src/opentau/policies/factory.py
@@ -215,44 +215,67 @@ def make_policy(
     policy_cls = get_policy_class(cfg.type)
 
     kwargs = {}
-    per_dataset_stats: list[dict[str, dict[str, np.ndarray]]] | None = None
-    dataset_names: list[str] | None = None
+    # Per-NORM-HEAD stats; one entry per row of the policy's stacked
+    # Normalize/Unnormalize buffer. Built from the mixture's pooled
+    # `(robot_type, control_mode)` aggregation when available, else from a
+    # single dataset, else from caller-supplied opaque stats.
+    per_norm_key_stats: list[dict[str, dict[str, np.ndarray]]] | None = None
+    norm_keys: list[str] | None = None
+    dataset_to_norm_index: dict[str, int] | None = None
 
     if ds_meta is not None:
         features = dataset_to_policy_features(ds_meta.features)
-        # `DatasetMixtureMetadata` exposes per-dataset stats + names; a bare
-        # `LeRobotDatasetMetadata` (single-dataset path, e.g. some scripts /
-        # tests) exposes only `.stats` — wrap it into a singleton list so the
-        # policy ctor sees a uniform shape.
-        if hasattr(ds_meta, "per_dataset_stats") and hasattr(ds_meta, "dataset_names"):
-            per_dataset_stats = list(ds_meta.per_dataset_stats)
-            dataset_names = list(ds_meta.dataset_names)
+        # `DatasetMixtureMetadata` (new attrs) provides per-norm-head stats
+        # already pooled across datasets sharing a (robot_type, control_mode).
+        # A bare `LeRobotDatasetMetadata` exposes only `.stats`; treat it as
+        # a singleton head, deriving the key from its info.
+        if hasattr(ds_meta, "per_norm_key_stats") and hasattr(ds_meta, "norm_keys"):
+            per_norm_key_stats = list(ds_meta.per_norm_key_stats)
+            norm_keys = list(ds_meta.norm_keys)
+            dataset_to_norm_index = dict(ds_meta.dataset_to_norm_index)
         else:
-            per_dataset_stats = [ds_meta.stats]
-            dataset_names = [getattr(ds_meta, "repo_id", "default")]
+            # Inline import keeps `make_policy` from pulling
+            # `dataset_mixture` (and transitively LeRobot) at module load.
+            from opentau.datasets.dataset_mixture import compute_norm_key
+
+            repo_id = getattr(ds_meta, "repo_id", "default")
+            info = getattr(ds_meta, "info", {}) or {}
+            norm_key, _ = compute_norm_key(info.get("robot_type"), info.get("control_mode"), repo_id)
+            per_norm_key_stats = [ds_meta.stats]
+            norm_keys = [norm_key]
+            dataset_to_norm_index = {repo_id: 0}
 
     if not features_already_set:
         cfg.output_features = {key: ft for key, ft in features.items() if ft.type is FeatureType.ACTION}
         cfg.input_features = {key: ft for key, ft in features.items() if key not in cfg.output_features}
 
     if stats is not None:
-        # External per-dataset stats override. Accept either a single
-        # dict-of-features (wrapped into a singleton list) or an already-
-        # listed `per_dataset_stats`.
+        # External opaque stats override. Accept either a single
+        # dict-of-features (wrapped into a singleton list) or an
+        # already-listed per-norm-head sequence. We leave `dataset_to_norm_index`
+        # as None here — the caller passed stats without identity context,
+        # so we can't synthesize a dataset_repo_id -> row mapping; inference
+        # must use `dataset_index` or `dataset_names` directly.
         if isinstance(stats, dict):
-            per_dataset_stats = [stats]
-            dataset_names = dataset_names or ["external"]
+            per_norm_key_stats = [stats]
+            norm_keys = norm_keys or ["external"]
         else:
-            per_dataset_stats = list(stats)
-            dataset_names = dataset_names or [f"external_{i}" for i in range(len(per_dataset_stats))]
+            per_norm_key_stats = list(stats)
+            norm_keys = norm_keys or [f"external_{i}" for i in range(len(per_norm_key_stats))]
 
-    if per_dataset_stats is not None:
-        kwargs["per_dataset_stats"] = per_dataset_stats
-        kwargs["dataset_names"] = dataset_names
-        # Persist the ordered name list into the policy config so it survives
-        # save -> load. Inference-time `batch["dataset_repo_id"]` strings are
-        # resolved against this list.
-        cfg.dataset_names = list(dataset_names)
+    if per_norm_key_stats is not None:
+        # The Normalize / Unnormalize kwargs are named `per_dataset_stats` /
+        # `dataset_names` for back-compat — the values are now per-norm-head.
+        kwargs["per_dataset_stats"] = per_norm_key_stats
+        kwargs["dataset_names"] = norm_keys
+        # Persist into the policy config so the checkpoint round-trip
+        # preserves identity:
+        #   - `dataset_names` = the norm-head identifiers (one per buffer row)
+        #   - `dataset_to_norm_index` = training dataset name -> row, so
+        #     inference can resolve a `dataset_repo_id` even when multiple
+        #     datasets share a head.
+        cfg.dataset_names = list(norm_keys)
+        cfg.dataset_to_norm_index = dict(dataset_to_norm_index) if dataset_to_norm_index is not None else None
 
     if execution_target is not None:
         kwargs["execution_target"] = execution_target
@@ -274,8 +297,8 @@ def make_policy(
     # buffers loaded back as +inf — repopulate from the caller's stats if we
     # have them, otherwise raise a clear error rather than letting the first
     # forward fail mid-step.
-    if cfg.pretrained_path and per_dataset_stats is not None:
-        policy._inject_stats(per_dataset_stats, dataset_names=dataset_names)
+    if cfg.pretrained_path and per_norm_key_stats is not None:
+        policy._inject_stats(per_norm_key_stats, dataset_names=norm_keys)
     elif cfg.pretrained_path:
         policy._check_norm_stats_loaded()
 

--- a/src/opentau/policies/pretrained.py
+++ b/src/opentau/policies/pretrained.py
@@ -117,16 +117,29 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
                 f"`model = {self.__class__.__name__}.from_pretrained(PRETRAINED_MODEL_NAME)`"
             )
         self.config = config
-        # Build the name -> index lookup used by `_resolve_dataset_index` to
-        # map inference-time `batch["dataset_repo_id"]` (str) to the leading
-        # axis of the stacked Normalize buffers. Stays None for legacy
-        # checkpoints whose config.json predates the per-dataset rewrite —
-        # those callers must pass `batch["dataset_index"]` directly.
+        # Build the two lookups used by `_resolve_dataset_index`:
+        #   * `_norm_key_to_index`: norm-key string -> row in the stacked
+        #     Normalize/Unnormalize buffer. Always parallel to
+        #     `config.dataset_names` (which on new checkpoints is the list
+        #     of norm-key identifiers — see PreTrainedConfig docstring).
+        #   * `_dataset_to_norm_index`: training-time dataset name ->
+        #     norm-head row. Prefers `config.dataset_to_norm_index` when
+        #     set; falls back to the identity mapping over
+        #     `config.dataset_names` on legacy checkpoints (where the
+        #     per-dataset and per-norm-head axes coincided 1:1).
+        # Both stay None when the config carries no dataset_names at all
+        # (legacy single-row policies built outside `make_policy`).
         names = getattr(config, "dataset_names", None)
         if names is None:
-            self._dataset_name_to_index: dict[str, int] | None = None
+            self._norm_key_to_index: dict[str, int] | None = None
+            self._dataset_to_norm_index: dict[str, int] | None = None
         else:
-            self._dataset_name_to_index = {name: i for i, name in enumerate(names)}
+            self._norm_key_to_index = {name: i for i, name in enumerate(names)}
+            persisted = getattr(config, "dataset_to_norm_index", None)
+            if persisted:
+                self._dataset_to_norm_index = dict(persisted)
+            else:
+                self._dataset_to_norm_index = {n: i for i, n in enumerate(names)}
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
@@ -287,7 +300,9 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
     # `_infer_batch_size_and_device` walks the batch — otherwise the helper
     # could return CPU based on a `dataset_index` that the caller hand-built
     # on CPU even when every actual observation tensor is on GPU.
-    _NON_DATA_BATCH_KEYS: frozenset[str] = frozenset({"dataset_index", "dataset_repo_id"})
+    _NON_DATA_BATCH_KEYS: frozenset[str] = frozenset(
+        {"dataset_index", "dataset_repo_id", "robot_type", "control_mode"}
+    )
 
     def _model_device(self) -> torch.device:
         """Return the policy's compute device, falling back to CPU on a no-param policy."""
@@ -344,29 +359,50 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
         return 0, self._model_device()
 
     def _resolve_dataset_index(self, batch: dict[str, Tensor]) -> Tensor:
-        """Resolve per-sample dataset indices from a training or inference batch.
+        """Resolve per-sample norm-head row indices from a training or inference batch.
 
-        Training path: the dataloader's ``_TaggedDataset`` wrapper attaches
-        ``batch["dataset_index"]`` as a ``(B,)`` ``LongTensor`` already.
+        Dispatch order (first match wins):
 
-        Inference path: the caller passes ``batch["dataset_repo_id"]`` as
-        either a single ``str`` (broadcast to the full batch) or a
-        ``list[str]`` of length B. We map each name through the policy's
-        training-time ``dataset_names`` list (stored on ``self.config``) to
-        the corresponding integer index.
+        1. **Training path.** ``batch["dataset_index"]`` is a ``(B,)``
+           ``LongTensor`` injected by ``_TaggedDataset`` and is the
+           norm-head row for each sample. Used directly — bypasses the
+           string-lookup branches below. This is the ONLY route used at
+           training time because ``robot_type`` / ``control_mode`` are
+           subject to per-sample optional-key dropout
+           (``metadata_drop_each_prob`` / ``metadata_drop_all_prob`` in
+           ``LeRobotDataset._emit_optional_keys``); deriving the norm head
+           from those keys would silently route random samples to wrong
+           heads.
 
-        Single-dataset fallback: when the batch lacks BOTH keys AND the
-        policy was constructed with ``num_datasets <= 1`` (or legacy
-        ``dataset_names is None``), default to zeros so callers don't have
-        to inject ``dataset_index`` for the one-row buffer. Multi-dataset
-        policies always require the caller to be explicit; otherwise mixing
-        samples from different datasets without identification is silently
-        wrong.
+        2. **Inference by repo id.** ``batch["dataset_repo_id"]`` (a
+           single ``str`` or ``list[str]`` of length B) is mapped through
+           ``self._dataset_to_norm_index`` (training-time dataset name →
+           norm-head row). Works on legacy checkpoints too because the
+           policy synthesizes the identity mapping when the persisted
+           ``dataset_to_norm_index`` is ``None``.
+
+        3. **Inference by (robot_type, control_mode).** Both
+           ``batch["robot_type"]`` and ``batch["control_mode"]`` are
+           ``list[str]`` of length B (or single strings). Each sample's
+           norm key is computed via :func:`~opentau.datasets.dataset_mixture.compute_norm_key`
+           with an empty fallback name (so a missing pair raises rather
+           than silently picking the wrong row) and looked up in
+           ``self._norm_key_to_index``.
+
+        4. **Single-row fallback.** When the batch lacks all of the above
+           AND the buffer has at most one row, default to zeros. Lets
+           single-dataset callers skip explicit tagging; multi-row
+           policies always require explicit identification — anything
+           else would silently route samples to the wrong head.
 
         Raises:
-            KeyError: neither ``dataset_index`` nor ``dataset_repo_id`` was
-                provided AND the policy has more than one dataset.
-            ValueError: a name was provided that isn't in ``dataset_names``.
+            KeyError: the batch is unidentifiable and the buffer has more
+                than one row.
+            ValueError: an identifier was supplied that doesn't match any
+                row on the policy.
+            RuntimeError: ``dataset_repo_id`` or ``(robot_type, control_mode)``
+                supplied but the policy has no name maps (legacy
+                pre-multi-dataset checkpoint).
         """
         if "dataset_index" in batch:
             idx = batch["dataset_index"]
@@ -382,42 +418,82 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
             # live.
             return idx.to(dtype=torch.long, device=self._model_device())
 
-        if "dataset_repo_id" not in batch:
-            # Source of truth is the buffer's leading dim, NOT
-            # `len(self._dataset_name_to_index)`. A caller can construct a
-            # policy directly (`PI05Policy(config, per_dataset_stats=[s1, s2])`
-            # without setting `config.dataset_names`) — the name map stays
-            # None, but the buffer has 2 rows, so falling through to
-            # "default to zeros" would silently normalize every sample
-            # against `s1` and ignore `s2`. Reading the buffer is unambiguous.
-            num_datasets = self._stacked_num_datasets()
-            if num_datasets <= 1:
-                batch_size, device = self._infer_batch_size_and_device(batch)
-                return torch.zeros(batch_size or 1, dtype=torch.long, device=device)
-            raise KeyError(
-                f"Per-dataset normalization with {num_datasets} datasets "
-                "requires either `dataset_index` (LongTensor of shape (B,)) "
-                "or `dataset_repo_id` (str or list[str] of length B) in the "
-                "batch."
-            )
+        if "dataset_repo_id" in batch:
+            if self._dataset_to_norm_index is None:
+                raise RuntimeError(
+                    "Policy was loaded without `dataset_names`; cannot resolve "
+                    "`dataset_repo_id` strings. Either pass `batch['dataset_index']` "
+                    "directly or rebuild the policy via `make_policy(cfg, ds_meta=...)`."
+                )
+            raw = batch["dataset_repo_id"]
+            batch_size, device = self._infer_batch_size_and_device(batch)
+            names = [raw] * (batch_size or 1) if isinstance(raw, str) else list(raw)
+            try:
+                indices = [self._dataset_to_norm_index[n] for n in names]
+            except KeyError as e:
+                raise ValueError(
+                    f"dataset_repo_id {e.args[0]!r} not in this policy's "
+                    f"training set {list(self._dataset_to_norm_index)}"
+                ) from None
+            return torch.tensor(indices, dtype=torch.long, device=device)
 
-        if self._dataset_name_to_index is None:
-            raise RuntimeError(
-                "Policy was loaded without `dataset_names`; cannot resolve "
-                "`dataset_repo_id` strings. Either pass `batch['dataset_index']` "
-                "directly or rebuild the policy via `make_policy(cfg, ds_meta=...)`."
-            )
-        raw = batch["dataset_repo_id"]
-        batch_size, device = self._infer_batch_size_and_device(batch)
-        names = [raw] * (batch_size or 1) if isinstance(raw, str) else list(raw)
-        try:
-            indices = [self._dataset_name_to_index[n] for n in names]
-        except KeyError as e:
-            raise ValueError(
-                f"dataset_repo_id {e.args[0]!r} not in this policy's training "
-                f"set {list(self._dataset_name_to_index)}"
-            ) from None
-        return torch.tensor(indices, dtype=torch.long, device=device)
+        if "robot_type" in batch and "control_mode" in batch:
+            if self._norm_key_to_index is None:
+                raise RuntimeError(
+                    "Policy was loaded without `dataset_names`; cannot resolve "
+                    "`(robot_type, control_mode)` to a norm head. Pass "
+                    "`batch['dataset_index']` directly or rebuild the policy via "
+                    "`make_policy(cfg, ds_meta=...)`."
+                )
+            from opentau.datasets.dataset_mixture import compute_norm_key
+
+            batch_size, device = self._infer_batch_size_and_device(batch)
+            rts = batch["robot_type"]
+            cms = batch["control_mode"]
+            rts_list = [rts] * (batch_size or 1) if isinstance(rts, str) else list(rts)
+            cms_list = [cms] * (batch_size or 1) if isinstance(cms, str) else list(cms)
+            if len(rts_list) != len(cms_list):
+                raise ValueError(
+                    f"`robot_type` ({len(rts_list)}) and `control_mode` "
+                    f"({len(cms_list)}) must have the same length."
+                )
+            # Empty fallback name means "no usable dataset identity" — any
+            # sample whose pair was dropped or unset reaches the lookup with
+            # a fallback key of "", which won't match any policy row and
+            # raises below. That's intentional: silently routing such a
+            # sample would pick an arbitrary head.
+            keys_with_fallback = [
+                compute_norm_key(rt, cm, "") for rt, cm in zip(rts_list, cms_list, strict=True)
+            ]
+            try:
+                indices = [self._norm_key_to_index[key] for key, _ in keys_with_fallback]
+            except KeyError as e:
+                raise ValueError(
+                    f"norm key {e.args[0]!r} (derived from `(robot_type, "
+                    "control_mode)`) not in this policy's training set "
+                    f"{list(self._norm_key_to_index)}"
+                ) from None
+            return torch.tensor(indices, dtype=torch.long, device=device)
+
+        # Source of truth for "single-row fallback OK" is the buffer's
+        # leading dim, NOT `len(self._dataset_to_norm_index)`. A caller can
+        # construct a policy directly (`PI05Policy(config,
+        # per_dataset_stats=[s1, s2])` without setting `config.dataset_names`)
+        # — the maps stay None, but the buffer has 2 rows, so falling
+        # through to "default to zeros" would silently normalize every
+        # sample against `s1` and ignore `s2`. Reading the buffer is
+        # unambiguous.
+        num_datasets = self._stacked_num_datasets()
+        if num_datasets <= 1:
+            batch_size, device = self._infer_batch_size_and_device(batch)
+            return torch.zeros(batch_size or 1, dtype=torch.long, device=device)
+        raise KeyError(
+            f"Per-norm-head normalization with {num_datasets} heads "
+            "requires one of: `dataset_index` (LongTensor of shape (B,)), "
+            "`dataset_repo_id` (str or list[str] of length B), or "
+            "both `robot_type` and `control_mode` (str or list[str] of length B) "
+            "in the batch."
+        )
 
     def _inject_stats(
         self,
@@ -498,7 +574,14 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
 
         if dataset_names is not None:
             self.config.dataset_names = list(dataset_names)
-            self._dataset_name_to_index = {name: i for i, name in enumerate(dataset_names)}
+            self._norm_key_to_index = {name: i for i, name in enumerate(dataset_names)}
+            # `_inject_stats` is called with the new per-norm-row identifiers
+            # (norm_keys), not the original training dataset names. We can't
+            # reconstruct `_dataset_to_norm_index` from these alone — leave it
+            # as set in `__init__` from the persisted `config.dataset_to_norm_index`
+            # if any, else the identity fallback. Callers that want to refresh
+            # the dataset->norm-row map should update `config.dataset_to_norm_index`
+            # before reinstantiating the policy.
 
     def _check_norm_stats_loaded(self) -> None:
         """Raise a clear error if any Normalize/Unnormalize buffer is still ∞.

--- a/src/opentau/policies/pretrained.py
+++ b/src/opentau/policies/pretrained.py
@@ -374,20 +374,23 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
            from those keys would silently route random samples to wrong
            heads.
 
-        2. **Inference by repo id.** ``batch["dataset_repo_id"]`` (a
-           single ``str`` or ``list[str]`` of length B) is mapped through
-           ``self._dataset_to_norm_index`` (training-time dataset name →
-           norm-head row). Works on legacy checkpoints too because the
-           policy synthesizes the identity mapping when the persisted
-           ``dataset_to_norm_index`` is ``None``.
-
-        3. **Inference by (robot_type, control_mode).** Both
+        2. **Inference by (robot_type, control_mode).** Both
            ``batch["robot_type"]`` and ``batch["control_mode"]`` are
            ``list[str]`` of length B (or single strings). Each sample's
            norm key is computed via :func:`~opentau.datasets.dataset_mixture.compute_norm_key`
            with an empty fallback name (so a missing pair raises rather
            than silently picking the wrong row) and looked up in
-           ``self._norm_key_to_index``.
+           ``self._norm_key_to_index``. Checked before ``dataset_repo_id``
+           so the "precedence when both are present" invariant documented
+           on ``EvalConfig`` / ``ServerConfig`` holds even for callers
+           that bypass the eval / gRPC scripts.
+
+        3. **Inference by repo id.** ``batch["dataset_repo_id"]`` (a
+           single ``str`` or ``list[str]`` of length B) is mapped through
+           ``self._dataset_to_norm_index`` (training-time dataset name →
+           norm-head row). Works on legacy checkpoints too because the
+           policy synthesizes the identity mapping when the persisted
+           ``dataset_to_norm_index`` is ``None``.
 
         4. **Single-row fallback.** When the batch lacks all of the above
            AND the buffer has at most one row, default to zeros. Lets
@@ -417,25 +420,6 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
             # is unambiguous and matches where Normalize's buffers actually
             # live.
             return idx.to(dtype=torch.long, device=self._model_device())
-
-        if "dataset_repo_id" in batch:
-            if self._dataset_to_norm_index is None:
-                raise RuntimeError(
-                    "Policy was loaded without `dataset_names`; cannot resolve "
-                    "`dataset_repo_id` strings. Either pass `batch['dataset_index']` "
-                    "directly or rebuild the policy via `make_policy(cfg, ds_meta=...)`."
-                )
-            raw = batch["dataset_repo_id"]
-            batch_size, device = self._infer_batch_size_and_device(batch)
-            names = [raw] * (batch_size or 1) if isinstance(raw, str) else list(raw)
-            try:
-                indices = [self._dataset_to_norm_index[n] for n in names]
-            except KeyError as e:
-                raise ValueError(
-                    f"dataset_repo_id {e.args[0]!r} not in this policy's "
-                    f"training set {list(self._dataset_to_norm_index)}"
-                ) from None
-            return torch.tensor(indices, dtype=torch.long, device=device)
 
         if "robot_type" in batch and "control_mode" in batch:
             if self._norm_key_to_index is None:
@@ -472,6 +456,25 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
                     f"norm key {e.args[0]!r} (derived from `(robot_type, "
                     "control_mode)`) not in this policy's training set "
                     f"{list(self._norm_key_to_index)}"
+                ) from None
+            return torch.tensor(indices, dtype=torch.long, device=device)
+
+        if "dataset_repo_id" in batch:
+            if self._dataset_to_norm_index is None:
+                raise RuntimeError(
+                    "Policy was loaded without `dataset_names`; cannot resolve "
+                    "`dataset_repo_id` strings. Either pass `batch['dataset_index']` "
+                    "directly or rebuild the policy via `make_policy(cfg, ds_meta=...)`."
+                )
+            raw = batch["dataset_repo_id"]
+            batch_size, device = self._infer_batch_size_and_device(batch)
+            names = [raw] * (batch_size or 1) if isinstance(raw, str) else list(raw)
+            try:
+                indices = [self._dataset_to_norm_index[n] for n in names]
+            except KeyError as e:
+                raise ValueError(
+                    f"dataset_repo_id {e.args[0]!r} not in this policy's "
+                    f"training set {list(self._dataset_to_norm_index)}"
                 ) from None
             return torch.tensor(indices, dtype=torch.long, device=device)
 

--- a/src/opentau/policies/value/modeling_value.py
+++ b/src/opentau/policies/value/modeling_value.py
@@ -189,10 +189,19 @@ class ValueFunction(PreTrainedPolicy):
             )
             self.config.dataset_names = kept
             self._norm_key_to_index = {name: i for i, name in enumerate(kept)}
-            # Restrict the dataset->norm-row map to the surviving keys; if
-            # the persisted config didn't carry one, fall back to identity.
+            # Truncating to a single row means the surviving row is row 0
+            # (we kept `dataset_names[:1]`), so the surviving dataset->row
+            # entries are exactly those that pointed at 0. Filter the
+            # persisted map down to those.
             persisted = getattr(self.config, "dataset_to_norm_index", None) or {}
-            self._dataset_to_norm_index = {k: v for k, v in persisted.items() if v == 0} or {kept[0]: 0}
+            surviving = {k: v for k, v in persisted.items() if v == 0}
+            # Two distinct cases reach the fallback `{kept[0]: 0}`:
+            #   - persisted map was empty (legacy config without the
+            #     field, or freshly built value policy);
+            #   - persisted map had entries but none pointed at row 0
+            #     (would be a malformed config — defensive).
+            # Both want the identity mapping for the kept name.
+            self._dataset_to_norm_index = surviving or {kept[0]: 0}
         num_datasets = 1
         self.normalize_inputs = Normalize(
             config.input_features,

--- a/src/opentau/policies/value/modeling_value.py
+++ b/src/opentau/policies/value/modeling_value.py
@@ -167,15 +167,17 @@ class ValueFunction(PreTrainedPolicy):
             per_dataset_stats = per_dataset_stats[:1]
             if dataset_names is not None:
                 dataset_names = dataset_names[:1]
-        # `super().__init__(config)` already populated `self._dataset_name_to_index`
-        # from `config.dataset_names`. The value policy is single-dataset by
-        # construction, so any multi-dataset config the caller carried in
-        # would leave a 3-entry name map pointing at a 1-row buffer — an
-        # inference call with `dataset_repo_id='<second>'` would index out
-        # of range. Rebuild the name map to match the truncated stats.
+        # `super().__init__(config)` already populated `self._norm_key_to_index`
+        # and `self._dataset_to_norm_index` from `config.dataset_names` /
+        # `config.dataset_to_norm_index`. The value policy is single-dataset
+        # by design, so any multi-dataset config the caller carried in would
+        # leave maps pointing at a 1-row buffer — an inference call with
+        # `dataset_repo_id='<second>'` would index out of range. Rebuild
+        # both maps to match the truncated stats.
         if dataset_names is not None:
             self.config.dataset_names = list(dataset_names)
-            self._dataset_name_to_index = {name: i for i, name in enumerate(dataset_names)}
+            self._norm_key_to_index = {name: i for i, name in enumerate(dataset_names)}
+            self._dataset_to_norm_index = dict(self._norm_key_to_index)
         elif getattr(self.config, "dataset_names", None) and len(self.config.dataset_names) > 1:
             kept = self.config.dataset_names[:1]
             logging.warning(
@@ -186,7 +188,11 @@ class ValueFunction(PreTrainedPolicy):
                 kept,
             )
             self.config.dataset_names = kept
-            self._dataset_name_to_index = {name: i for i, name in enumerate(kept)}
+            self._norm_key_to_index = {name: i for i, name in enumerate(kept)}
+            # Restrict the dataset->norm-row map to the surviving keys; if
+            # the persisted config didn't carry one, fall back to identity.
+            persisted = getattr(self.config, "dataset_to_norm_index", None) or {}
+            self._dataset_to_norm_index = {k: v for k, v in persisted.items() if v == 0} or {kept[0]: 0}
         num_datasets = 1
         self.normalize_inputs = Normalize(
             config.input_features,

--- a/src/opentau/scripts/eval.py
+++ b/src/opentau/scripts/eval.py
@@ -164,13 +164,19 @@ def rollout(
         if return_observations:
             all_observations.append(deepcopy(observation))
 
-        # Tag the observation with which training-time dataset's stats to
-        # use for per-sample Normalize/Unnormalize. `EvalConfig.dataset_repo_id`
-        # is `None` by default, in which case the policy's
-        # `_resolve_dataset_index` single-dataset fallback handles things —
-        # required only for multi-dataset checkpoints.
+        # Tag the observation with the training-time norm head to use for
+        # per-sample Normalize/Unnormalize. Prefer the
+        # `(robot_type, control_mode)` pair when both are configured (new
+        # per-`(robot_type, control_mode)` aggregation route); else use
+        # `dataset_repo_id`. When all are `None` (default), the policy's
+        # `_resolve_dataset_index` single-head fallback handles things.
+        eval_robot_type = getattr(cfg.eval, "robot_type", None)
+        eval_control_mode = getattr(cfg.eval, "control_mode", None)
         eval_dataset_repo_id = getattr(cfg.eval, "dataset_repo_id", None)
-        if eval_dataset_repo_id is not None:
+        if eval_robot_type is not None and eval_control_mode is not None:
+            observation["robot_type"] = eval_robot_type
+            observation["control_mode"] = eval_control_mode
+        elif eval_dataset_repo_id is not None:
             observation["dataset_repo_id"] = eval_dataset_repo_id
 
         with torch.inference_mode():

--- a/src/opentau/scripts/grpc/server.py
+++ b/src/opentau/scripts/grpc/server.py
@@ -94,11 +94,17 @@ class RobotPolicyServicer(robot_inference_pb2_grpc.RobotPolicyServiceServicer):
             "prompt": ["Pick up yellow lego block and put it in the bin"],
             "img_is_pad": torch.zeros((1, 1), dtype=torch.bool, device=self.device),
         }
-        # Mirror `_prepare_observation`'s dataset tagging for the warmup call —
-        # otherwise a multi-dataset checkpoint trips `_resolve_dataset_index`
-        # at compile time rather than at the first real request.
+        # Mirror `_prepare_observation`'s norm-head tagging for the warmup
+        # call — otherwise a multi-head checkpoint trips
+        # `_resolve_dataset_index` at compile time rather than at the first
+        # real request. Prefer (robot_type, control_mode) when both are set.
+        warmup_robot_type = getattr(self.cfg.server, "robot_type", None)
+        warmup_control_mode = getattr(self.cfg.server, "control_mode", None)
         warmup_dataset_repo_id = getattr(self.cfg.server, "dataset_repo_id", None)
-        if warmup_dataset_repo_id is not None:
+        if warmup_robot_type is not None and warmup_control_mode is not None:
+            observation["robot_type"] = warmup_robot_type
+            observation["control_mode"] = warmup_control_mode
+        elif warmup_dataset_repo_id is not None:
             observation["dataset_repo_id"] = warmup_dataset_repo_id
         action_prefix = torch.zeros(
             (1, self.cfg.action_chunk, self.cfg.max_action_dim), dtype=self.dtype, device=self.device
@@ -195,13 +201,20 @@ class RobotPolicyServicer(robot_inference_pb2_grpc.RobotPolicyServiceServicer):
         # Process prompt
         batch["prompt"] = [request.prompt] if request.prompt else [""]
 
-        # Tag the batch with which training-time dataset's stats to use for
-        # per-sample Normalize/Unnormalize. When `server.dataset_repo_id` is
-        # `None` (default), the policy's `_resolve_dataset_index` single-
-        # dataset fallback handles things — only needed for multi-dataset
-        # checkpoints.
+        # Tag the batch with the training-time norm head to use for
+        # per-sample Normalize/Unnormalize. Prefer the
+        # `(robot_type, control_mode)` pair when both are configured (the
+        # new per-`(robot_type, control_mode)` aggregation route); else use
+        # `dataset_repo_id` (back-compat, also resolves on legacy
+        # per-dataset checkpoints). When all are `None`, the policy's
+        # `_resolve_dataset_index` single-head fallback handles things.
+        server_robot_type = getattr(self.cfg.server, "robot_type", None)
+        server_control_mode = getattr(self.cfg.server, "control_mode", None)
         server_dataset_repo_id = getattr(self.cfg.server, "dataset_repo_id", None)
-        if server_dataset_repo_id is not None:
+        if server_robot_type is not None and server_control_mode is not None:
+            batch["robot_type"] = server_robot_type
+            batch["control_mode"] = server_control_mode
+        elif server_dataset_repo_id is not None:
             batch["dataset_repo_id"] = server_dataset_repo_id
         if request.prefix_action:
             prefix_action = torch.tensor(

--- a/tests/datasets/test_norm_key_aggregation.py
+++ b/tests/datasets/test_norm_key_aggregation.py
@@ -71,6 +71,23 @@ class TestComputeNormKey:
         assert key == "franka_arm::joint"
         assert fallback is False
 
+    def test_robot_type_unknown_falls_back(self):
+        # Symmetric with control_mode: `robot_type="unknown"` is the
+        # common stand-in for missing info.json["robot_type"] and must
+        # not silently anchor an "unknown::<mode>" shared head.
+        key, fallback = compute_norm_key("unknown", "joint", "foo/bar")
+        assert key == "foo/bar"
+        assert fallback is True
+
+    def test_unknown_is_case_insensitive(self):
+        for variant in ("Unknown", "UNKNOWN", "uNkNoWn"):
+            key, fallback = compute_norm_key("franka", variant, "foo/bar")
+            assert key == "foo/bar"
+            assert fallback is True
+            key, fallback = compute_norm_key(variant, "joint", "foo/bar")
+            assert key == "foo/bar"
+            assert fallback is True
+
 
 # -- DatasetMixtureMetadata fixtures ---------------------------------------
 
@@ -270,6 +287,75 @@ class TestDatasetMixtureMetadataNormAggregation:
         # min/max are the global element-wise min/max.
         np.testing.assert_allclose(head["state"]["min"][0], m1_val - 5.0, atol=1e-6)
         np.testing.assert_allclose(head["state"]["max"][0], m2_val + 5.0, atol=1e-6)
+
+    def test_pooled_stats_closed_form_three_datasets(self):
+        """3-dataset pooling with mismatched per-dataset counts. Catches
+        any off-by-one in the weights-wiring path that 2-dataset cases
+        would not expose (e.g. dropping a dataset's contribution silently).
+        """
+        _patch_name_mapping(["repo/a", "repo/b", "repo/c"])
+        cfg = _make_cfg(max_state_dim=4, max_action_dim=4)
+        # Mismatched counts on purpose so the weighted pool is sensitive
+        # to each contributor's weight; means / stds are also distinct.
+        params = [
+            {"n": 100, "mean": 0.0, "std": 0.25},
+            {"n": 250, "mean": 4.0, "std": 0.5},
+            {"n": 650, "mean": -1.0, "std": 1.5},
+        ]
+
+        def stats_for(mean: float, std: float, n: int) -> dict:
+            return {
+                "state": {
+                    "mean": np.full((4,), mean, dtype=np.float32),
+                    "std": np.full((4,), std, dtype=np.float32),
+                    "min": np.full((4,), mean - 5.0, dtype=np.float32),
+                    "max": np.full((4,), mean + 5.0, dtype=np.float32),
+                    "count": np.array([n], dtype=np.int64),
+                },
+                "actions": {
+                    "mean": np.full((4,), mean, dtype=np.float32),
+                    "std": np.full((4,), std, dtype=np.float32),
+                    "min": np.full((4,), mean - 5.0, dtype=np.float32),
+                    "max": np.full((4,), mean + 5.0, dtype=np.float32),
+                    "count": np.array([n], dtype=np.int64),
+                },
+                "camera0": {
+                    "mean": np.full((3, 1, 1), mean * 0.01, dtype=np.float32),
+                    "std": np.full((3, 1, 1), std, dtype=np.float32),
+                    "min": np.zeros((3, 1, 1), dtype=np.float32),
+                    "max": np.ones((3, 1, 1), dtype=np.float32),
+                    "count": np.array([n], dtype=np.int64),
+                },
+            }
+
+        metadatas = [
+            _make_metadata(
+                f"repo/{name}",
+                info={
+                    "robot_type": "franka",
+                    "control_mode": "joint",
+                    "total_frames": p["n"],
+                },
+                stats=stats_for(p["mean"], p["std"], p["n"]),
+            )
+            for name, p in zip("abc", params, strict=True)
+        ]
+        meta = DatasetMixtureMetadata(
+            cfg,
+            metadatas,
+            dataset_weights=[1 / 3, 1 / 3, 1 / 3],
+            dataset_names=["repo/a", "repo/b", "repo/c"],
+        )
+        assert meta.norm_keys == ["franka::joint"]
+        head = meta.per_norm_key_stats[0]
+
+        n_total = sum(p["n"] for p in params)
+        expected_mean = sum(p["n"] * p["mean"] for p in params) / n_total
+        expected_var = (
+            sum(p["n"] * (p["std"] ** 2 + (p["mean"] - expected_mean) ** 2) for p in params) / n_total
+        )
+        np.testing.assert_allclose(head["state"]["mean"][0], expected_mean, atol=1e-5)
+        np.testing.assert_allclose(head["state"]["std"][0], np.sqrt(expected_var), atol=1e-5)
 
     def test_norm_head_summary_logged(self, caplog):
         _patch_name_mapping(["repo/a", "repo/b", "repo/c"])

--- a/tests/datasets/test_norm_key_aggregation.py
+++ b/tests/datasets/test_norm_key_aggregation.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python
+
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Tests for per-(robot_type, control_mode) normalization-head aggregation.
+
+Covers:
+  - `compute_norm_key` rules (happy path, fallback triggers).
+  - `DatasetMixtureMetadata` grouping by `(robot_type, control_mode)` and
+    pooling stats via `aggregate_stats`.
+  - Closed-form pooled-mean / pooled-variance correctness for groups
+    sharing a head.
+  - Dimensional-incompatibility hard-failure.
+  - Logging: single aggregated fallback warning + the per-head INFO summary.
+"""
+
+import logging
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from opentau.datasets.dataset_mixture import DatasetMixtureMetadata, compute_norm_key
+from opentau.datasets.standard_data_format_mapping import DATA_FEATURES_NAME_MAPPING
+
+
+class TestComputeNormKey:
+    """`compute_norm_key`: rules for joining or falling back."""
+
+    def test_both_present(self):
+        key, fallback = compute_norm_key("franka_arm", "joint_position", "foo/bar")
+        assert key == "franka_arm::joint_position"
+        assert fallback is False
+
+    def test_robot_type_empty_falls_back(self):
+        key, fallback = compute_norm_key("", "joint_position", "foo/bar")
+        assert key == "foo/bar"
+        assert fallback is True
+
+    def test_robot_type_none_falls_back(self):
+        key, fallback = compute_norm_key(None, "joint_position", "foo/bar")
+        assert key == "foo/bar"
+        assert fallback is True
+
+    def test_control_mode_empty_falls_back(self):
+        key, fallback = compute_norm_key("franka_arm", "", "foo/bar")
+        assert key == "foo/bar"
+        assert fallback is True
+
+    def test_control_mode_unknown_falls_back(self):
+        # "unknown" is the LeRobotDatasetMetadata sentinel for missing
+        # info.json["control_mode"]; treat it as missing.
+        key, fallback = compute_norm_key("franka_arm", "unknown", "foo/bar")
+        assert key == "foo/bar"
+        assert fallback is True
+
+    def test_whitespace_only_falls_back(self):
+        key, fallback = compute_norm_key("   ", "joint", "foo/bar")
+        assert key == "foo/bar"
+        assert fallback is True
+        key, fallback = compute_norm_key("franka", "\t  ", "foo/bar")
+        assert key == "foo/bar"
+        assert fallback is True
+
+    def test_explicit_tags_strip_whitespace(self):
+        # Trim surrounding whitespace but keep the inner content.
+        key, fallback = compute_norm_key("  franka_arm ", "  joint ", "foo/bar")
+        assert key == "franka_arm::joint"
+        assert fallback is False
+
+
+# -- DatasetMixtureMetadata fixtures ---------------------------------------
+
+
+def _make_stats(state_dim: int, action_dim: int, *, value: float, count: int) -> dict:
+    """Build a stats dict matching the standardized layout that
+    `DatasetMixtureMetadata` consumes (state, actions, single camera).
+    """
+    return {
+        "state": {
+            "mean": np.full((state_dim,), float(value), dtype=np.float32),
+            "std": np.full((state_dim,), float(value) * 0.1 + 0.5, dtype=np.float32),
+            "min": np.full((state_dim,), float(value) - 1.0, dtype=np.float32),
+            "max": np.full((state_dim,), float(value) + 1.0, dtype=np.float32),
+            "count": np.array([count], dtype=np.int64),
+        },
+        "actions": {
+            "mean": np.full((action_dim,), float(value) * 2.0, dtype=np.float32),
+            "std": np.full((action_dim,), float(value) * 0.1 + 0.5, dtype=np.float32),
+            "min": np.full((action_dim,), float(value) - 1.0, dtype=np.float32),
+            "max": np.full((action_dim,), float(value) + 1.0, dtype=np.float32),
+            "count": np.array([count], dtype=np.int64),
+        },
+        "camera0": {
+            "mean": np.full((3, 1, 1), float(value) * 0.01, dtype=np.float32),
+            "std": np.full((3, 1, 1), 0.5, dtype=np.float32),
+            "min": np.zeros((3, 1, 1), dtype=np.float32),
+            "max": np.ones((3, 1, 1), dtype=np.float32),
+            "count": np.array([count], dtype=np.int64),
+        },
+    }
+
+
+def _make_metadata(repo_id: str, info: dict, stats: dict) -> SimpleNamespace:
+    """Minimal stand-in for ``LeRobotDatasetMetadata`` — only the attributes
+    `DatasetMixtureMetadata.__init__` reads.
+    """
+    return SimpleNamespace(repo_id=repo_id, info=info, stats=stats)
+
+
+def _make_cfg(num_cams: int = 1, max_state_dim: int = 32, max_action_dim: int = 32) -> SimpleNamespace:
+    """`TrainPipelineConfig` stand-in. Only the attributes that
+    `_to_standard_data_format` reads need to be present.
+    """
+    return SimpleNamespace(
+        num_cams=num_cams,
+        max_state_dim=max_state_dim,
+        max_action_dim=max_action_dim,
+        resolution=(224, 224),
+    )
+
+
+def _patch_name_mapping(repo_ids: list[str]):
+    """Register an identity (state/actions/camera0) name map for each repo."""
+    for repo_id in repo_ids:
+        DATA_FEATURES_NAME_MAPPING[repo_id] = {
+            "state": "state",
+            "actions": "actions",
+            "camera0": "camera0",
+        }
+
+
+class TestDatasetMixtureMetadataNormAggregation:
+    """`DatasetMixtureMetadata`: per-(robot_type, control_mode) grouping."""
+
+    def test_two_datasets_same_robot_and_mode_share_head(self):
+        _patch_name_mapping(["repo/a", "repo/b"])
+        cfg = _make_cfg()
+        m1 = _make_metadata(
+            "repo/a",
+            info={"robot_type": "franka", "control_mode": "joint", "total_frames": 100},
+            stats=_make_stats(6, 7, value=1.0, count=100),
+        )
+        m2 = _make_metadata(
+            "repo/b",
+            info={"robot_type": "franka", "control_mode": "joint", "total_frames": 200},
+            stats=_make_stats(6, 7, value=3.0, count=200),
+        )
+        meta = DatasetMixtureMetadata(
+            cfg, [m1, m2], dataset_weights=[0.5, 0.5], dataset_names=["repo/a", "repo/b"]
+        )
+        assert meta.norm_keys == ["franka::joint"]
+        assert len(meta.per_norm_key_stats) == 1
+        assert meta.dataset_to_norm_index == {"repo/a": 0, "repo/b": 0}
+        assert meta.norm_key_to_dataset_names == {"franka::joint": ["repo/a", "repo/b"]}
+        assert len(meta.per_dataset_stats) == 2  # per-dataset list still around
+        assert meta.dataset_names == ["repo/a", "repo/b"]
+
+    def test_same_robot_different_control_mode_distinct_rows(self):
+        _patch_name_mapping(["repo/a", "repo/b"])
+        cfg = _make_cfg()
+        m1 = _make_metadata(
+            "repo/a",
+            info={"robot_type": "franka", "control_mode": "joint", "total_frames": 100},
+            stats=_make_stats(6, 7, value=1.0, count=100),
+        )
+        m2 = _make_metadata(
+            "repo/b",
+            info={"robot_type": "franka", "control_mode": "ee", "total_frames": 100},
+            stats=_make_stats(6, 7, value=2.0, count=100),
+        )
+        meta = DatasetMixtureMetadata(
+            cfg, [m1, m2], dataset_weights=[0.5, 0.5], dataset_names=["repo/a", "repo/b"]
+        )
+        assert set(meta.norm_keys) == {"franka::joint", "franka::ee"}
+        assert meta.dataset_to_norm_index["repo/a"] != meta.dataset_to_norm_index["repo/b"]
+        assert len(meta.per_norm_key_stats) == 2
+
+    def test_missing_robot_type_falls_back_with_single_warning(self, caplog):
+        _patch_name_mapping(["repo/a", "repo/b"])
+        cfg = _make_cfg()
+        m1 = _make_metadata(
+            "repo/a",
+            info={"robot_type": "franka", "control_mode": "joint", "total_frames": 100},
+            stats=_make_stats(6, 7, value=1.0, count=100),
+        )
+        m2 = _make_metadata(
+            "repo/b",
+            info={"robot_type": None, "control_mode": "joint", "total_frames": 100},
+            stats=_make_stats(6, 7, value=2.0, count=100),
+        )
+        with caplog.at_level(logging.WARNING):
+            meta = DatasetMixtureMetadata(
+                cfg, [m1, m2], dataset_weights=[0.5, 0.5], dataset_names=["repo/a", "repo/b"]
+            )
+        # repo/b falls back to its own name as the norm key.
+        assert meta.dataset_to_norm_index == {"repo/a": 0, "repo/b": 1}
+        assert meta.norm_keys[1] == "repo/b"
+        # Exactly one warning for the whole mixture, mentioning the
+        # fallback dataset.
+        fallback_warnings = [
+            r for r in caplog.records if r.levelno == logging.WARNING and "fallback" in r.getMessage().lower()
+        ]
+        assert len(fallback_warnings) == 1
+        assert "repo/b" in fallback_warnings[0].getMessage()
+
+    def test_pooled_stats_closed_form(self):
+        """Pooled mean/variance per the Chan-style weighted formula."""
+        _patch_name_mapping(["repo/a", "repo/b"])
+        cfg = _make_cfg(max_state_dim=4, max_action_dim=4)
+        n1, n2 = 100, 300
+        m1_val, m2_val = 1.0, 5.0
+        s1_val, s2_val = 0.5, 0.8
+
+        # Build raw 4-dim stats with explicit, scalar-broadcast mean/std/count.
+        def stats_for(mean: float, std: float, n: int) -> dict:
+            return {
+                "state": {
+                    "mean": np.full((4,), mean, dtype=np.float32),
+                    "std": np.full((4,), std, dtype=np.float32),
+                    "min": np.full((4,), mean - 5.0, dtype=np.float32),
+                    "max": np.full((4,), mean + 5.0, dtype=np.float32),
+                    "count": np.array([n], dtype=np.int64),
+                },
+                "actions": {
+                    "mean": np.full((4,), mean * 2.0, dtype=np.float32),
+                    "std": np.full((4,), std, dtype=np.float32),
+                    "min": np.full((4,), mean - 5.0, dtype=np.float32),
+                    "max": np.full((4,), mean + 5.0, dtype=np.float32),
+                    "count": np.array([n], dtype=np.int64),
+                },
+                "camera0": {
+                    "mean": np.full((3, 1, 1), mean * 0.01, dtype=np.float32),
+                    "std": np.full((3, 1, 1), std, dtype=np.float32),
+                    "min": np.zeros((3, 1, 1), dtype=np.float32),
+                    "max": np.ones((3, 1, 1), dtype=np.float32),
+                    "count": np.array([n], dtype=np.int64),
+                },
+            }
+
+        m1 = _make_metadata(
+            "repo/a",
+            info={"robot_type": "franka", "control_mode": "joint", "total_frames": n1},
+            stats=stats_for(m1_val, s1_val, n1),
+        )
+        m2 = _make_metadata(
+            "repo/b",
+            info={"robot_type": "franka", "control_mode": "joint", "total_frames": n2},
+            stats=stats_for(m2_val, s2_val, n2),
+        )
+        meta = DatasetMixtureMetadata(
+            cfg, [m1, m2], dataset_weights=[0.5, 0.5], dataset_names=["repo/a", "repo/b"]
+        )
+        head = meta.per_norm_key_stats[0]
+        # Pooled mean and variance match the Chan-style closed form when
+        # weights are sample counts (the aggregator's contract when
+        # weights= is passed). Implementation passes `total_frames` as
+        # weights, so use the same numerator/denominator pair here.
+        n_total = n1 + n2
+        expected_mean = (n1 * m1_val + n2 * m2_val) / n_total
+        expected_var = (
+            n1 * (s1_val**2 + (m1_val - expected_mean) ** 2)
+            + n2 * (s2_val**2 + (m2_val - expected_mean) ** 2)
+        ) / n_total
+        np.testing.assert_allclose(head["state"]["mean"][0], expected_mean, atol=1e-6)
+        np.testing.assert_allclose(head["state"]["std"][0], np.sqrt(expected_var), atol=1e-6)
+        # min/max are the global element-wise min/max.
+        np.testing.assert_allclose(head["state"]["min"][0], m1_val - 5.0, atol=1e-6)
+        np.testing.assert_allclose(head["state"]["max"][0], m2_val + 5.0, atol=1e-6)
+
+    def test_norm_head_summary_logged(self, caplog):
+        _patch_name_mapping(["repo/a", "repo/b", "repo/c"])
+        cfg = _make_cfg()
+        m1 = _make_metadata(
+            "repo/a",
+            info={"robot_type": "franka", "control_mode": "joint", "total_frames": 100},
+            stats=_make_stats(6, 7, value=1.0, count=100),
+        )
+        m2 = _make_metadata(
+            "repo/b",
+            info={"robot_type": "franka", "control_mode": "joint", "total_frames": 100},
+            stats=_make_stats(6, 7, value=2.0, count=100),
+        )
+        m3 = _make_metadata(
+            "repo/c",
+            info={"robot_type": "ur5", "control_mode": "ee", "total_frames": 100},
+            stats=_make_stats(6, 7, value=3.0, count=100),
+        )
+        with caplog.at_level(logging.INFO):
+            DatasetMixtureMetadata(
+                cfg,
+                [m1, m2, m3],
+                dataset_weights=[0.3, 0.3, 0.4],
+                dataset_names=["repo/a", "repo/b", "repo/c"],
+            )
+        summaries = [r.getMessage() for r in caplog.records if "Norm-head aggregation" in r.getMessage()]
+        assert len(summaries) == 1
+        summary = summaries[0]
+        assert "2 heads over 3 datasets" in summary
+        assert "franka::joint" in summary
+        assert "ur5::ee" in summary
+        assert "repo/a" in summary and "repo/b" in summary and "repo/c" in summary
+
+    def test_dim_mismatch_in_shared_head_raises(self):
+        _patch_name_mapping(["repo/a", "repo/b"])
+        cfg = _make_cfg()
+        # Both datasets carry the same (robot, control) tag but raw state
+        # dims differ. This is the failure mode the user wants surfaced.
+        m1 = _make_metadata(
+            "repo/a",
+            info={"robot_type": "franka", "control_mode": "joint", "total_frames": 100},
+            stats=_make_stats(state_dim=6, action_dim=7, value=1.0, count=100),
+        )
+        m2 = _make_metadata(
+            "repo/b",
+            info={"robot_type": "franka", "control_mode": "joint", "total_frames": 100},
+            stats=_make_stats(state_dim=8, action_dim=7, value=2.0, count=100),
+        )
+        with pytest.raises(ValueError, match="incompatible raw"):
+            DatasetMixtureMetadata(
+                cfg, [m1, m2], dataset_weights=[0.5, 0.5], dataset_names=["repo/a", "repo/b"]
+            )
+
+    def test_dim_mismatch_in_fallback_is_allowed(self):
+        """A fallback-keyed dataset is by construction a singleton head, so
+        a dim mismatch with any other dataset cannot trigger the check."""
+        _patch_name_mapping(["repo/a", "repo/b"])
+        cfg = _make_cfg()
+        m1 = _make_metadata(
+            "repo/a",
+            info={"robot_type": "franka", "control_mode": "joint", "total_frames": 100},
+            stats=_make_stats(state_dim=6, action_dim=7, value=1.0, count=100),
+        )
+        m2 = _make_metadata(
+            "repo/b",
+            info={"robot_type": None, "control_mode": "joint", "total_frames": 100},
+            stats=_make_stats(state_dim=8, action_dim=7, value=2.0, count=100),
+        )
+        # Must not raise.
+        meta = DatasetMixtureMetadata(
+            cfg, [m1, m2], dataset_weights=[0.5, 0.5], dataset_names=["repo/a", "repo/b"]
+        )
+        assert meta.dataset_to_norm_index["repo/a"] != meta.dataset_to_norm_index["repo/b"]
+
+
+class TestTaggedDatasetIndexIsNormHead:
+    """The `_TaggedDataset` index emitted into samples is the norm-head row
+    (computed via `dataset_to_norm_index`), not the per-dataset enumerate
+    position. Verifies the rewiring done in `WeightedDatasetMixture`.
+    """
+
+    def test_shared_norm_key_yields_same_index(self):
+        _patch_name_mapping(["repo/a", "repo/b"])
+        cfg = _make_cfg()
+        m1 = _make_metadata(
+            "repo/a",
+            info={"robot_type": "franka", "control_mode": "joint", "total_frames": 50},
+            stats=_make_stats(6, 7, value=1.0, count=50),
+        )
+        m2 = _make_metadata(
+            "repo/b",
+            info={"robot_type": "franka", "control_mode": "joint", "total_frames": 50},
+            stats=_make_stats(6, 7, value=2.0, count=50),
+        )
+        meta = DatasetMixtureMetadata(
+            cfg, [m1, m2], dataset_weights=[0.5, 0.5], dataset_names=["repo/a", "repo/b"]
+        )
+        assert meta.dataset_to_norm_index["repo/a"] == meta.dataset_to_norm_index["repo/b"] == 0

--- a/tests/policies/test_normalize_per_dataset.py
+++ b/tests/policies/test_normalize_per_dataset.py
@@ -167,3 +167,172 @@ def test_per_dataset_stats_length_mismatch_raises():
     per_dataset_stats = _build_per_dataset_stats(2)
     with pytest.raises(ValueError, match="must have the same length"):
         Normalize(features, norm_map, per_dataset_stats=per_dataset_stats, dataset_names=["only-one"])
+
+
+# -- _resolve_dataset_index dispatch ---------------------------------------
+
+
+class _TinyConfig:
+    """Stand-in for `PreTrainedConfig` exposing only what
+    `PreTrainedPolicy.__init__` reads. Real configs are dataclasses; this
+    avoids pulling a concrete subclass (and its policy class wiring) into
+    a normalize-only test."""
+
+    def __init__(self, dataset_names, dataset_to_norm_index=None):
+        self.dataset_names = dataset_names
+        self.dataset_to_norm_index = dataset_to_norm_index
+
+
+def _make_policy_with_normalize(dataset_names, dataset_to_norm_index, *, num_rows):
+    """Build a minimal `nn.Module` carrying the policy's name maps plus
+    one `Normalize` so `_resolve_dataset_index` has a buffer to sniff
+    (`_stacked_num_datasets`).
+    """
+    from opentau.configs.policies import PreTrainedConfig
+    from opentau.policies.pretrained import PreTrainedPolicy
+
+    class _DummyConfig(PreTrainedConfig):
+        @property
+        def observation_delta_indices(self):
+            return None
+
+        @property
+        def action_delta_indices(self):
+            return None
+
+        @property
+        def reward_delta_indices(self):
+            return None
+
+        def get_optimizer_preset(self):
+            raise NotImplementedError
+
+        def get_scheduler_preset(self):
+            return None
+
+        def validate_features(self):
+            return None
+
+    class _DummyPolicy(PreTrainedPolicy):
+        config_class = _DummyConfig
+        name = "dummy-test-policy"
+
+        def __init__(self, config):
+            super().__init__(config)
+            features = {
+                "observation.state": PolicyFeature(type=FeatureType.STATE, shape=(2,)),
+            }
+            norm_map = {"STATE": NormalizationMode.MEAN_STD}
+            stats = [
+                {
+                    "observation.state": {
+                        "mean": torch.full((2,), float(i)),
+                        "std": torch.ones(2),
+                    }
+                }
+                for i in range(num_rows)
+            ]
+            self.normalize_inputs = Normalize(
+                features, norm_map, per_dataset_stats=stats, dataset_names=dataset_names
+            )
+
+        def get_optim_params(self):
+            return {}
+
+        def reset(self):
+            pass
+
+        def forward(self, batch):
+            raise NotImplementedError
+
+        def select_action(self, batch):
+            raise NotImplementedError
+
+    cfg = _DummyConfig()
+    cfg.dataset_names = list(dataset_names)
+    cfg.dataset_to_norm_index = dict(dataset_to_norm_index) if dataset_to_norm_index is not None else None
+    return _DummyPolicy(cfg)
+
+
+class TestResolveDatasetIndex:
+    """`_resolve_dataset_index`: training, repo-id, and (robot,control) routes."""
+
+    def test_dataset_index_passthrough(self):
+        policy = _make_policy_with_normalize(
+            ["franka::joint", "ur5::ee"],
+            {"franka_repo": 0, "ur5_repo": 1},
+            num_rows=2,
+        )
+        idx = policy._resolve_dataset_index({"dataset_index": torch.tensor([0, 1], dtype=torch.long)})
+        assert torch.equal(idx.cpu(), torch.tensor([0, 1], dtype=torch.long))
+
+    def test_dataset_repo_id_maps_via_dataset_to_norm_index(self):
+        policy = _make_policy_with_normalize(
+            ["franka::joint", "ur5::ee"],
+            # Two dataset names route to the same head; another to a
+            # different head — exercises the new mapping faithfully.
+            {"franka_repo_a": 0, "franka_repo_b": 0, "ur5_repo": 1},
+            num_rows=2,
+        )
+        idx = policy._resolve_dataset_index(
+            {
+                "dataset_repo_id": ["franka_repo_a", "franka_repo_b", "ur5_repo"],
+                "observation.state": torch.zeros(3, 2),
+            }
+        )
+        assert torch.equal(idx.cpu(), torch.tensor([0, 0, 1], dtype=torch.long))
+
+    def test_robot_type_control_mode_route(self):
+        policy = _make_policy_with_normalize(
+            ["franka::joint", "ur5::ee"],
+            {"franka_repo": 0, "ur5_repo": 1},
+            num_rows=2,
+        )
+        idx = policy._resolve_dataset_index(
+            {
+                "robot_type": ["franka", "ur5"],
+                "control_mode": ["joint", "ee"],
+                "observation.state": torch.zeros(2, 2),
+            }
+        )
+        assert torch.equal(idx.cpu(), torch.tensor([0, 1], dtype=torch.long))
+
+    def test_robot_type_control_mode_unknown_raises(self):
+        policy = _make_policy_with_normalize(
+            ["franka::joint", "ur5::ee"],
+            {"franka_repo": 0, "ur5_repo": 1},
+            num_rows=2,
+        )
+        # "unknown" triggers fallback to "", which is not in
+        # `_norm_key_to_index` — raises rather than silently routing.
+        with pytest.raises(ValueError, match="not in this policy's training"):
+            policy._resolve_dataset_index(
+                {
+                    "robot_type": ["franka"],
+                    "control_mode": ["unknown"],
+                    "observation.state": torch.zeros(1, 2),
+                }
+            )
+
+    def test_legacy_config_without_dataset_to_norm_index(self):
+        """Old checkpoint: only `dataset_names` is persisted. The policy
+        synthesizes the identity mapping so dataset_repo_id lookups still
+        resolve."""
+        policy = _make_policy_with_normalize(
+            ["repo/foo", "repo/bar"],
+            dataset_to_norm_index=None,  # legacy
+            num_rows=2,
+        )
+        idx = policy._resolve_dataset_index(
+            {"dataset_repo_id": ["repo/bar", "repo/foo"], "observation.state": torch.zeros(2, 2)}
+        )
+        assert torch.equal(idx.cpu(), torch.tensor([1, 0], dtype=torch.long))
+
+    def test_multirow_unidentified_batch_raises(self):
+        policy = _make_policy_with_normalize(
+            ["franka::joint", "ur5::ee"],
+            {"franka_repo": 0, "ur5_repo": 1},
+            num_rows=2,
+        )
+        with pytest.raises(KeyError, match="requires one of"):
+            policy._resolve_dataset_index({"observation.state": torch.zeros(1, 2)})

--- a/tests/policies/test_normalize_per_dataset.py
+++ b/tests/policies/test_normalize_per_dataset.py
@@ -328,6 +328,28 @@ class TestResolveDatasetIndex:
         )
         assert torch.equal(idx.cpu(), torch.tensor([1, 0], dtype=torch.long))
 
+    def test_robot_type_control_mode_takes_precedence_over_dataset_repo_id(self):
+        """When both inference keys are supplied (e.g. by a caller that
+        bypasses the eval / gRPC scripts and hands-builds a batch),
+        `(robot_type, control_mode)` wins — matches the precedence
+        documented on `EvalConfig` / `ServerConfig`."""
+        policy = _make_policy_with_normalize(
+            ["franka::joint", "ur5::ee"],
+            # Crafted so the two routes resolve to different rows: the
+            # repo_id would say row 0, the (robot, control) pair says row 1.
+            {"franka_repo": 0, "ur5_repo": 1},
+            num_rows=2,
+        )
+        idx = policy._resolve_dataset_index(
+            {
+                "dataset_repo_id": ["franka_repo"],
+                "robot_type": ["ur5"],
+                "control_mode": ["ee"],
+                "observation.state": torch.zeros(1, 2),
+            }
+        )
+        assert torch.equal(idx.cpu(), torch.tensor([1], dtype=torch.long))
+
     def test_multirow_unidentified_batch_raises(self):
         policy = _make_policy_with_normalize(
             ["franka::joint", "ur5::ee"],


### PR DESCRIPTION
## What this does

Switches Normalize / Unnormalize from one stat head per training dataset
to one stat head per unique `(robot_type, control_mode)`. Datasets sharing
both tags share a single head whose stats are sample-count-pooled via
`opentau.datasets.compute_stats.aggregate_stats`. Datasets missing either
tag (None / `""` / whitespace / `"unknown"` case-insensitive on either
field) fall back to per-dataset heads with a single aggregated warning.
Closes #346.

Key invariants preserved:

- `Normalize` / `Unnormalize` semantics unchanged — they remain agnostic
  to what each of their `D` rows means.
- The training path keeps using `batch["dataset_index"]` injected by
  `_TaggedDataset` (the value now indexes the norm-head axis, but the
  wire-level field stays). `robot_type` / `control_mode` from
  `_emit_optional_keys` are subject to dropout and would silently route
  random samples to wrong heads, so they are explicitly NOT consulted at
  training time.
- Backward compatibility: old checkpoints that lack
  `config.dataset_to_norm_index` are loaded as legacy (each
  `dataset_names` entry is its own row, identity mapping).

New behaviour:

- `DatasetMixtureMetadata` exposes `per_norm_key_stats`, `norm_keys`,
  `norm_key_to_index`, `dataset_to_norm_index`, `norm_key_to_dataset_names`.
- Hard fail at mixture construction when two datasets sharing a
  non-fallback norm key have incompatible raw state / action widths
  (the dimensions the buffer would have to pool across).
- An `INFO` summary `Norm-head aggregation: K heads over N datasets` is
  logged, listing each head and its member dataset repo ids — operators
  can audit head assignments from the train log without a sidecar file.
- The `dataset_to_norm_index` map is persisted in `config.json` via the
  existing draccus round-trip; no new files in the checkpoint layout.
- Eval and gRPC accept new optional `robot_type` / `control_mode` config
  fields and inject them into the inference batch. The
  `(robot_type, control_mode)` pair takes precedence over
  `dataset_repo_id` when both are set, and `_resolve_dataset_index`
  enforces the same precedence at the policy layer so callers that
  hand-build a batch see the same behaviour.

## How it was tested

- Added `tests/datasets/test_norm_key_aggregation.py` covering:
  `compute_norm_key` rules (incl. case-insensitive `"Unknown"`, the
  `robot_type == "unknown"` fallback), head sharing, distinct-control-mode
  separation, the fallback warning, the closed-form pooled mean /
  variance correctness for both 2- and 3-dataset pooling with mismatched
  counts, the per-head INFO summary, and the dim-mismatch hard fail.
- Added `TestResolveDatasetIndex` to `tests/policies/test_normalize_per_dataset.py`
  covering all dispatch routes (`dataset_index`, `dataset_repo_id`,
  `(robot_type, control_mode)`, both inference keys present
  simultaneously, the legacy-config path, and the multi-row
  unidentified-batch error).
- Full CPU sweep across `tests/policies/`, `tests/datasets/`,
  `tests/configs/`, `tests/scripts/` (591 passed, 6 skipped — the
  PaliGemma / Gemma3 tests that hit gated HF repos in this sandbox are
  environment-side failures unrelated to this PR).
- GPU tests (`pytest -m "gpu"`) and the model-parallelism regression run
  were dispatched against this branch and both passed.

## How to checkout & try? (for the reviewer)

```bash
git fetch && git checkout claude/robot-control-mode-normalization-2hwwP

# Aggregation + dispatch tests
pytest -sx tests/datasets/test_norm_key_aggregation.py tests/policies/test_normalize_per_dataset.py

# Broader CPU sweep
pytest -m "not gpu" -n auto tests/policies tests/datasets tests/configs tests/scripts
```

Sample train log under the new code (two repos with the same
`(franka_arm, joint_position)` plus one repo of `(ur5, ee)`):

```
INFO  Norm-head aggregation: 2 heads over 3 datasets.
  - franka_arm::joint_position: ['lab/franka_kitchen#0', 'lab/franka_kitchen#1']
  - ur5::ee: ['lab/ur5_cobot']
```

A mixture with two datasets sharing `(franka_arm, joint_position)` but
mismatched raw state widths raises at construction time:

```
ValueError: Datasets sharing norm key 'franka_arm::joint_position' have
incompatible raw (pre-padding) state/action dims, so their normalization
stats cannot be pooled. Override `DatasetConfig.robot_type` or
`DatasetConfig.control_mode` to split them into distinct heads.
Offenders: ['lab/a (state_dim=6, action_dim=7)', 'lab/b (state_dim=8, action_dim=7)']
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [x] My PR includes policy-related changes.
  - [x] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.
