### PR TITLE
perf(pi07_paligemma): skip subgoal image tower when all-padded

### DIFF
--- a/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
@@ -43,6 +43,7 @@ from opentau.policies.pi05.paligemma_with_expert import (
     PaliGemmaWithExpertConfig,
     PaliGemmaWithExpertModel,
 )
+from opentau.policies.pi07.low_level.modeling_pi07_low_level import _global_or_branch_decisions
 from opentau.policies.pi07.video_encoder import SpaceTimeSiglipVideoEncoder
 from opentau.policies.pi07_paligemma.low_level.configuration_pi07_low_level import (
     PI07PaligemmaLowLevelConfig,
@@ -1752,12 +1753,20 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
           all-True per-rank), never per-sample data that can diverge
           across ranks — otherwise DDP with
           ``find_unused_parameters=False`` will deadlock.
+        - ``image``: subgoal image through PaliGemma's image tower. Same
+          skip-and-emit-zeros efficiency win as ``video``, but the
+          ``pad_mask`` here *is* per-sample data (``subgoal_is_pad`` can
+          diverge across ranks), so the run/skip decision is OR-reduced
+          across ranks via :func:`_global_or_branch_decisions` to keep the
+          DDP invariant. The skip is bypassed (tower runs unconditionally)
+          under ``torch.compile`` / ONNX export.
         - ``action``: noisy-action projection (suffix only).
 
         The pad mask is broadcast/expanded so the returned mask matches
         the embedded sequence length: per-sample ``(B,)`` is allowed for
-        ``video`` and is expanded to ``(B, num_video_tokens)``; all other
-        types pass through ``(B, L)`` unchanged.
+        ``video`` (expanded to ``(B, num_video_tokens)``) and ``image``
+        (expanded to ``(B, num_image_tokens)``); all other types pass
+        through ``(B, L)`` unchanged.
         """
         t = item.item_type
         if t == "text":
@@ -1776,16 +1785,50 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
         if t == "image":
             # Subgoal images: 4-D (B, C, H, W) in [-1, 1] through the VLM's
             # image tower (byte-identical to embed_video at T=1 on the shared
-            # tower). Run unconditionally so all ranks stay in lockstep — no
-            # data-dependent skip; the per-sample mask zeros padded slots
-            # downstream.
+            # tower). When no sample on ANY rank needs this subgoal, the image
+            # tower is skipped and zeros are emitted instead — a strict
+            # efficiency win (the per-sample mask zeros the slot regardless),
+            # e.g. at inference or whenever every rank's subgoal_is_pad is True.
+            #
+            # The skip is data-dependent: unlike the config-determined video
+            # mask, per-sample subgoal_is_pad can differ across ranks, so each
+            # rank's local ``.any()`` may diverge. Running the tower on some
+            # ranks but not others would desync DDP / FSDP collective counts and
+            # hang at NCCL (CLAUDE.md hard rule 5), so the run/skip decision is
+            # OR-reduced across ranks first via ``_global_or_branch_decisions``
+            # — presence is structurally True here (the image item is in the
+            # prefix on every rank by config), so only the ``.any()`` is
+            # reduced. Under torch.compile / ONNX export the all-reduce and the
+            # Python branch can't be traced (and export must bake in the tower
+            # so the exported graph can encode real subgoals), so run
+            # unconditionally.
             image = item.data
             per_sample_mask = item.pad_mask
             if per_sample_mask.ndim != 1:
                 raise ValueError(
                     f"image pad_mask must be (B,) per-sample; got shape {tuple(per_sample_mask.shape)}."
                 )
-            emb = self.paligemma_with_expert.embed_image(image).to(dtype=_preferred_dtype())
+            dtype = _preferred_dtype()
+            if torch.compiler.is_compiling() or torch.onnx.is_in_onnx_export():
+                run_image_tower = True
+            else:
+                (run_image_tower,) = _global_or_branch_decisions(
+                    presence_locals=(True,),
+                    any_locals=(bool(per_sample_mask.any()),),
+                    field_names=("subgoal_image",),
+                    device=image.device,
+                )
+            if run_image_tower:
+                emb = self.paligemma_with_expert.embed_image(image).to(dtype=dtype)
+            else:
+                pg_text_cfg = self.paligemma_with_expert.config.paligemma_config.text_config
+                emb = torch.zeros(
+                    image.shape[0],
+                    pg_text_cfg.num_image_tokens,
+                    pg_text_cfg.hidden_size,
+                    device=image.device,
+                    dtype=dtype,
+                )
             expanded = per_sample_mask[:, None].expand(emb.shape[0], emb.shape[1])
             return emb, expanded
         if t == "video":

--- a/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
@@ -1732,7 +1732,51 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
         """
         return self.video_encoder(video, obs_history_is_pad=obs_history_is_pad)
 
-    def _embed_item(self, item: ContextItem) -> tuple[Tensor, Tensor]:
+    def _global_run_image_tower(self, items: list[ContextItem]) -> bool:
+        """Decide once, across all ranks, whether the subgoal image tower runs.
+
+        :meth:`embed_prefix` calls this exactly once per forward — before the
+        per-item loop and on *every* rank, even one whose prefix happens to
+        contain no ``image`` item — then threads the result into each
+        :meth:`_embed_item` via ``run_image_tower``. Hoisting the collective
+        out of the per-item branch (mirroring pi07's ``embed_prefix``) is what
+        keeps DDP / FSDP collective counts aligned: a real
+        ``subgoal_present_local`` flows through
+        :func:`_global_or_branch_decisions`, so its presence-divergence check
+        actually fires (raising loudly) if a future heterogeneous mixture ever
+        gives ranks a different number of subgoal-image items — instead of the
+        all-reduce count silently desyncing and hanging at NCCL (CLAUDE.md hard
+        rule 5). Putting the all-reduce *inside* the ``image`` branch would
+        reintroduce exactly that anti-pattern.
+
+        The OR runs over all cameras (matching pi07's single ``has_subgoal``):
+        if any subgoal on any rank is real, every camera's tower runs, and the
+        per-camera pad masks still zero unused slots downstream. Bypassed
+        (returns ``True``) under ``torch.compile`` / ONNX export, where the
+        collective and Python branch can't be traced and the exported graph
+        must always include the tower.
+
+        Args:
+            items: The ordered prefix ``ContextItem``s passed to
+                :meth:`embed_prefix`.
+
+        Returns:
+            Whether this rank should run the image tower this step.
+        """
+        if torch.compiler.is_compiling() or torch.onnx.is_in_onnx_export():
+            return True
+        image_items = [it for it in items if it.item_type == "image"]
+        subgoal_present_local = bool(image_items)
+        subgoal_any_local = any(bool(it.pad_mask.any()) for it in image_items)
+        (run_image_tower,) = _global_or_branch_decisions(
+            presence_locals=(subgoal_present_local,),
+            any_locals=(subgoal_any_local,),
+            field_names=("subgoal_image",),
+            device=items[0].data.device,
+        )
+        return run_image_tower
+
+    def _embed_item(self, item: ContextItem, *, run_image_tower: bool | None = None) -> tuple[Tensor, Tensor]:
         """Embed a single ``ContextItem`` and return ``(emb, expanded_pad_mask)``.
 
         Dispatches on ``item.item_type``:
@@ -1756,10 +1800,12 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
         - ``image``: subgoal image through PaliGemma's image tower. Same
           skip-and-emit-zeros efficiency win as ``video``, but the
           ``pad_mask`` here *is* per-sample data (``subgoal_is_pad`` can
-          diverge across ranks), so the run/skip decision is OR-reduced
-          across ranks via :func:`_global_or_branch_decisions` to keep the
-          DDP invariant. The skip is bypassed (tower runs unconditionally)
-          under ``torch.compile`` / ONNX export.
+          diverge across ranks). The cross-rank run/skip decision is computed
+          once per forward by :meth:`_global_run_image_tower` and threaded in
+          via ``run_image_tower`` — the collective is kept out of this
+          per-item branch (see that method). When called directly with
+          ``run_image_tower=None`` (single-process unit tests) it falls back
+          to a rank-local decision that fires no collective.
         - ``action``: noisy-action projection (suffix only).
 
         The pad mask is broadcast/expanded so the returned mask matches
@@ -1785,23 +1831,17 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
         if t == "image":
             # Subgoal images: 4-D (B, C, H, W) in [-1, 1] through the VLM's
             # image tower (byte-identical to embed_video at T=1 on the shared
-            # tower). When no sample on ANY rank needs this subgoal, the image
-            # tower is skipped and zeros are emitted instead — a strict
-            # efficiency win (the per-sample mask zeros the slot regardless),
-            # e.g. at inference or whenever every rank's subgoal_is_pad is True.
+            # tower). When no sample needs this subgoal the tower is skipped and
+            # zeros are emitted — a strict, mask-equivalent efficiency win (the
+            # per-sample mask zeros the slot regardless), e.g. at inference or
+            # whenever subgoal_is_pad is all-True.
             #
-            # The skip is data-dependent: unlike the config-determined video
-            # mask, per-sample subgoal_is_pad can differ across ranks, so each
-            # rank's local ``.any()`` may diverge. Running the tower on some
-            # ranks but not others would desync DDP / FSDP collective counts and
-            # hang at NCCL (CLAUDE.md hard rule 5), so the run/skip decision is
-            # OR-reduced across ranks first via ``_global_or_branch_decisions``
-            # — presence is structurally True here (the image item is in the
-            # prefix on every rank by config), so only the ``.any()`` is
-            # reduced. Under torch.compile / ONNX export the all-reduce and the
-            # Python branch can't be traced (and export must bake in the tower
-            # so the exported graph can encode real subgoals), so run
-            # unconditionally.
+            # ``run_image_tower`` is the cross-rank decision computed once per
+            # forward in ``_global_run_image_tower`` and passed down by
+            # ``embed_prefix``; the collective lives there, not here, so it
+            # can't hide behind this per-item branch (CLAUDE.md hard rule 5).
+            # A direct call (single-process unit tests) leaves it None and we
+            # fall back to a purely-local decision that fires no collective.
             image = item.data
             per_sample_mask = item.pad_mask
             if per_sample_mask.ndim != 1:
@@ -1809,14 +1849,11 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
                     f"image pad_mask must be (B,) per-sample; got shape {tuple(per_sample_mask.shape)}."
                 )
             dtype = _preferred_dtype()
-            if torch.compiler.is_compiling() or torch.onnx.is_in_onnx_export():
-                run_image_tower = True
-            else:
-                (run_image_tower,) = _global_or_branch_decisions(
-                    presence_locals=(True,),
-                    any_locals=(bool(per_sample_mask.any()),),
-                    field_names=("subgoal_image",),
-                    device=image.device,
+            if run_image_tower is None:
+                run_image_tower = (
+                    torch.compiler.is_compiling()
+                    or torch.onnx.is_in_onnx_export()
+                    or bool(per_sample_mask.any())
                 )
             if run_image_tower:
                 emb = self.paligemma_with_expert.embed_image(image).to(dtype=dtype)
@@ -1893,10 +1930,16 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
         pad_masks: list[Tensor] = []
         att_masks_flat: list[int] = []
 
+        # Cross-rank subgoal-image run/skip decision, computed once here (every
+        # rank, before the loop) and threaded into each item — see
+        # _global_run_image_tower for why the collective must not live inside
+        # the per-item ``image`` branch.
+        run_image_tower = self._global_run_image_tower(items)
+
         cross_att_running = 0
         cross_att_locked = False
         for item in items:
-            emb, mask = self._embed_item(item)
+            emb, mask = self._embed_item(item, run_image_tower=run_image_tower)
             length = emb.shape[1]
             embs.append(emb)
             pad_masks.append(mask)

--- a/tests/policies/test_pi07_paligemma_low_level.py
+++ b/tests/policies/test_pi07_paligemma_low_level.py
@@ -701,7 +701,9 @@ class TestPI07PaligemmaLowLevelStateEmbedding:
         h = hidden_size
         model = object.__new__(PI07PaligemmaLowLevelFlowMatching)
 
-        _text_cfg = type("_TextConfig", (), {"hidden_size": h})()
+        # num_image_tokens mirrors embed_image's 4-token output below, so the
+        # image-tower skip path (zeros of that width) matches the run path.
+        _text_cfg = type("_TextConfig", (), {"hidden_size": h, "num_image_tokens": 4})()
         _pg_cfg = type("_PaliGemmaConfig", (), {"text_config": _text_cfg})()
         _stub_cfg = type("_StubConfig", (), {"paligemma_config": _pg_cfg})()
 
@@ -1253,7 +1255,9 @@ class TestPI07PaligemmaLowLevelResponseEmbedding:
         h = hidden_size
         model = object.__new__(PI07PaligemmaLowLevelFlowMatching)
 
-        _text_cfg = type("_TextConfig", (), {"hidden_size": h})()
+        # num_image_tokens mirrors embed_image's 4-token output below, so the
+        # image-tower skip path (zeros of that width) matches the run path.
+        _text_cfg = type("_TextConfig", (), {"hidden_size": h, "num_image_tokens": 4})()
         _pg_cfg = type("_PaliGemmaConfig", (), {"text_config": _text_cfg})()
         _stub_cfg = type("_StubConfig", (), {"paligemma_config": _pg_cfg})()
 
@@ -1774,6 +1778,67 @@ class TestPI07PaligemmaLowLevelMetadataEmbedding:
         assert torch.equal(pm_a, pm_b)
 
 
+def _find_free_port() -> int:
+    """Pick an ephemeral localhost port for a gloo rendezvous."""
+    import socket
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _ddp_image_skip_worker(rank: int, world_size: int, port: int, scenario: str) -> None:
+    """Subprocess body for ``test_ddp_lockstep_image_tower_skip``.
+
+    Each rank drives ``_embed_item`` on an ``image`` item with a rank-specific
+    pad mask and asserts the run/skip decision matches the *global* OR — not the
+    rank-local ``.any()``. Must be module-level so the macOS ``spawn`` start
+    method can pickle it. Asserts raise in-process; ``mp.spawn(join=True)``
+    re-raises them in the parent test.
+    """
+    import os
+
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    torch.distributed.init_process_group(backend="gloo", rank=rank, world_size=world_size)
+    try:
+        bsz, h = 2, 8
+        model = TestPI07PaligemmaLowLevelResponseEmbedding._make_mock_model(hidden_size=h)
+
+        called = {"hit": False}
+
+        def _recording_embed_image(image):
+            called["hit"] = True
+            return torch.zeros(image.shape[0], 4, h, dtype=torch.bfloat16)
+
+        model.paligemma_with_expert.embed_image = _recording_embed_image
+
+        if scenario == "divergent":
+            # rank 0 has no real subgoal, rank 1 does → global OR is True, so
+            # BOTH ranks must run the tower (rank 0 despite its all-False local
+            # mask). This is the lockstep guarantee the OR-reduce provides.
+            local_mask = torch.zeros(bsz, dtype=torch.bool) if rank == 0 else torch.tensor([False, True])
+            expect_called = True
+        else:  # "all_padded": no rank has a real subgoal → both skip.
+            local_mask = torch.zeros(bsz, dtype=torch.bool)
+            expect_called = False
+
+        item = ContextItem(
+            data=torch.full((bsz, 3, 224, 224), 0.3),
+            item_type="image",
+            pad_mask=local_mask,
+            attention="continue",
+        )
+        emb, _ = model._embed_item(item)
+
+        assert emb.shape == (bsz, 4, h), (rank, scenario, tuple(emb.shape))
+        assert called["hit"] == expect_called, (
+            f"rank {rank} / {scenario}: embed_image called={called['hit']}, expected {expect_called}"
+        )
+    finally:
+        torch.distributed.destroy_process_group()
+
+
 class TestPI07PaligemmaLowLevelSubgoalEmbedding:
     """CPU-only tests for subgoal block pad masks in ``embed_prefix``.
 
@@ -2180,13 +2245,98 @@ class TestPI07PaligemmaLowLevelSubgoalEmbedding:
 
         # Main history video → one embed_video call (T=n_obs_steps); subgoal
         # images → embed_image, one call per subgoal camera, each a 4-D
-        # (B, C, H, W) tensor. embed_image runs unconditionally (no per-sample
-        # skip), so the padded sample is still embedded then masked downstream.
+        # (B, C, H, W) tensor. Sample 1 has a real subgoal, so the cross-rank
+        # OR of the mask is True (here single-process, so just the local
+        # ``.any()``) and the image tower runs for every camera; the padded
+        # sample 0 is still embedded then masked downstream.
         assert len(video_calls) == 1
         assert video_calls[0][0] == (bsz, n_obs_steps, 3, 8, 8)
         assert len(image_calls) == len(sg_images)
         for shape in image_calls:
             assert shape == (bsz, 3, 224, 224), shape
+
+    # ------------------------------------------------------------------ #
+    # Image-tower skip: when no sample needs the subgoal (all-padded), the
+    # PaliGemma image tower is bypassed and zeros are emitted. Single-process
+    # (no process group), so the OR-reduce returns the local ``.any()``.
+    # ------------------------------------------------------------------ #
+    def test_all_padded_subgoal_skips_image_tower(self):
+        """All-padded subgoal mask → ``embed_image`` is not called and the image
+        block is zeros of width ``num_image_tokens``."""
+        bsz, h = 3, 8
+        model = TestPI07PaligemmaLowLevelResponseEmbedding._make_mock_model(hidden_size=h)
+        n_img_tokens = model.paligemma_with_expert.config.paligemma_config.text_config.num_image_tokens
+
+        calls: list[tuple[int, ...]] = []
+
+        def _exploding_embed_image(image):
+            calls.append(tuple(image.shape))
+            raise AssertionError("embed_image must be skipped when the subgoal is all-padded")
+
+        model.paligemma_with_expert.embed_image = _exploding_embed_image
+
+        item = ContextItem(
+            data=torch.full((bsz, 3, 224, 224), 0.5),
+            item_type="image",
+            pad_mask=torch.zeros(bsz, dtype=torch.bool),
+            attention="continue",
+        )
+        emb, expanded_mask = model._embed_item(item)
+
+        assert calls == [], "image tower should not run for an all-padded subgoal"
+        assert emb.shape == (bsz, n_img_tokens, h)
+        assert emb.dtype == torch.bfloat16
+        assert not emb.any(), "skipped image embedding must be all zeros"
+        assert expanded_mask.shape == (bsz, n_img_tokens)
+        assert not expanded_mask.any(), "all-padded mask stays all-False after expansion"
+
+    def test_some_real_subgoal_runs_image_tower(self):
+        """A mask with any real sample runs ``embed_image`` (no skip)."""
+        bsz, h = 3, 8
+        model = TestPI07PaligemmaLowLevelResponseEmbedding._make_mock_model(hidden_size=h)
+
+        calls: list[tuple[int, ...]] = []
+
+        def _capturing_embed_image(image):
+            calls.append(tuple(image.shape))
+            return torch.full((image.shape[0], 4, h), 7.0, dtype=torch.bfloat16)
+
+        model.paligemma_with_expert.embed_image = _capturing_embed_image
+
+        item = ContextItem(
+            data=torch.full((bsz, 3, 224, 224), 0.5),
+            item_type="image",
+            pad_mask=torch.tensor([False, True, False]),
+            attention="continue",
+        )
+        emb, expanded_mask = model._embed_item(item)
+
+        assert calls == [(bsz, 3, 224, 224)], "image tower should run when any sample is real"
+        assert emb.shape == (bsz, 4, h)
+        assert emb.eq(7.0).all(), "running path must return the real embed_image output, not zeros"
+        # Per-sample mask expands across the 4 image tokens.
+        assert expanded_mask.shape == (bsz, 4)
+        assert expanded_mask[1].all() and not expanded_mask[0].any() and not expanded_mask[2].any()
+
+    # ------------------------------------------------------------------ #
+    # DDP lockstep: the run/skip decision must follow the *global* OR of the
+    # subgoal mask, not each rank's local ``.any()`` — otherwise ranks fire a
+    # different number of vision-encoder collectives and hang at NCCL. Verified
+    # here over a 2-rank gloo group on CPU (no GPU needed).
+    # ------------------------------------------------------------------ #
+    @pytest.mark.slow
+    def test_ddp_lockstep_image_tower_skip(self):
+        """With divergent per-rank masks (rank 0 all-padded, rank 1 real) both
+        ranks must run the image tower; with all ranks padded both must skip."""
+        import torch.multiprocessing as mp
+
+        if not torch.distributed.is_available():
+            pytest.skip("torch.distributed is not available")
+
+        # Divergent local masks → global OR True → both ranks RUN.
+        mp.spawn(_ddp_image_skip_worker, args=(2, _find_free_port(), "divergent"), nprocs=2, join=True)
+        # Every rank all-padded → global OR False → both ranks SKIP.
+        mp.spawn(_ddp_image_skip_worker, args=(2, _find_free_port(), "all_padded"), nprocs=2, join=True)
 
 
 class TestPI07PaligemmaLowLevelExecutionHorizon:

--- a/tests/policies/test_pi07_paligemma_low_level.py
+++ b/tests/policies/test_pi07_paligemma_low_level.py
@@ -1790,11 +1790,12 @@ def _find_free_port() -> int:
 def _ddp_image_skip_worker(rank: int, world_size: int, port: int, scenario: str) -> None:
     """Subprocess body for ``test_ddp_lockstep_image_tower_skip``.
 
-    Each rank drives ``_embed_item`` on an ``image`` item with a rank-specific
-    pad mask and asserts the run/skip decision matches the *global* OR — not the
-    rank-local ``.any()``. Must be module-level so the macOS ``spawn`` start
-    method can pickle it. Asserts raise in-process; ``mp.spawn(join=True)``
-    re-raises them in the parent test.
+    Each rank calls ``_global_run_image_tower`` — the single, hoisted collective
+    — on a rank-specific prefix and asserts the decision follows the *global* OR
+    (not the rank-local ``.any()``), and that a cross-rank presence mismatch
+    raises rather than silently desyncing. Must be module-level so the macOS
+    ``spawn`` start method can pickle it. Asserts raise in-process;
+    ``mp.spawn(join=True)`` re-raises them in the parent test.
     """
     import os
 
@@ -1805,36 +1806,49 @@ def _ddp_image_skip_worker(rank: int, world_size: int, port: int, scenario: str)
         bsz, h = 2, 8
         model = TestPI07PaligemmaLowLevelResponseEmbedding._make_mock_model(hidden_size=h)
 
-        called = {"hit": False}
+        def _image_item(mask: torch.Tensor) -> ContextItem:
+            return ContextItem(
+                data=torch.full((bsz, 3, 224, 224), 0.3),
+                item_type="image",
+                pad_mask=mask,
+                attention="continue",
+            )
 
-        def _recording_embed_image(image):
-            called["hit"] = True
-            return torch.zeros(image.shape[0], 4, h, dtype=torch.bfloat16)
-
-        model.paligemma_with_expert.embed_image = _recording_embed_image
-
-        if scenario == "divergent":
-            # rank 0 has no real subgoal, rank 1 does → global OR is True, so
-            # BOTH ranks must run the tower (rank 0 despite its all-False local
-            # mask). This is the lockstep guarantee the OR-reduce provides.
-            local_mask = torch.zeros(bsz, dtype=torch.bool) if rank == 0 else torch.tensor([False, True])
-            expect_called = True
-        else:  # "all_padded": no rank has a real subgoal → both skip.
-            local_mask = torch.zeros(bsz, dtype=torch.bool)
-            expect_called = False
-
-        item = ContextItem(
-            data=torch.full((bsz, 3, 224, 224), 0.3),
-            item_type="image",
-            pad_mask=local_mask,
+        # A non-image filler so every rank's prefix is non-empty (as in production,
+        # where video/text/state items always precede the subgoal block).
+        text_item = ContextItem(
+            data=torch.zeros(bsz, 3, dtype=torch.long),
+            item_type="text",
+            pad_mask=torch.ones(bsz, 3, dtype=torch.bool),
             attention="continue",
         )
-        emb, _ = model._embed_item(item)
 
-        assert emb.shape == (bsz, 4, h), (rank, scenario, tuple(emb.shape))
-        assert called["hit"] == expect_called, (
-            f"rank {rank} / {scenario}: embed_image called={called['hit']}, expected {expect_called}"
-        )
+        if scenario == "divergent":
+            # rank 0 has no real subgoal, rank 1 does → global OR True, so BOTH
+            # ranks must run (rank 0 despite its all-False local mask). This is
+            # the lockstep guarantee the hoisted OR-reduce provides.
+            mask = torch.zeros(bsz, dtype=torch.bool) if rank == 0 else torch.tensor([False, True])
+            assert model._global_run_image_tower([text_item, _image_item(mask)]), (
+                f"rank {rank}/divergent: expected global RUN despite local mask {mask.tolist()}"
+            )
+        elif scenario == "all_padded":
+            # No rank has a real subgoal → global OR False → both skip.
+            items = [text_item, _image_item(torch.zeros(bsz, dtype=torch.bool))]
+            assert not model._global_run_image_tower(items), f"rank {rank}/all_padded: expected SKIP"
+        elif scenario == "presence_divergence":
+            # rank 0's prefix has an image item, rank 1's has none. The helper's
+            # presence-divergence check must fire (loud RuntimeError) rather than
+            # let the per-rank collective count silently desync — the exact
+            # failure the hoist restores protection against (CLAUDE.md rule 5).
+            items = [text_item, _image_item(torch.tensor([False, True]))] if rank == 0 else [text_item]
+            try:
+                model._global_run_image_tower(items)
+            except RuntimeError:
+                pass
+            else:
+                raise AssertionError(f"rank {rank}/presence_divergence: expected RuntimeError, got none")
+        else:
+            raise ValueError(f"unknown scenario {scenario!r}")
     finally:
         torch.distributed.destroy_process_group()
 
@@ -2256,9 +2270,10 @@ class TestPI07PaligemmaLowLevelSubgoalEmbedding:
             assert shape == (bsz, 3, 224, 224), shape
 
     # ------------------------------------------------------------------ #
-    # Image-tower skip: when no sample needs the subgoal (all-padded), the
-    # PaliGemma image tower is bypassed and zeros are emitted. Single-process
-    # (no process group), so the OR-reduce returns the local ``.any()``.
+    # Image-tower skip via _embed_item's local fallback: called directly with
+    # run_image_tower=None (no process group), the image branch decides from
+    # the rank-local ``.any()`` and fires no collective. The hoisted cross-rank
+    # decision is covered by the _global_run_image_tower / lockstep tests below.
     # ------------------------------------------------------------------ #
     def test_all_padded_subgoal_skips_image_tower(self):
         """All-padded subgoal mask → ``embed_image`` is not called and the image
@@ -2318,25 +2333,90 @@ class TestPI07PaligemmaLowLevelSubgoalEmbedding:
         assert expanded_mask.shape == (bsz, 4)
         assert expanded_mask[1].all() and not expanded_mask[0].any() and not expanded_mask[2].any()
 
+    def test_run_image_tower_override_wins_over_local_mask(self):
+        """The decision passed from ``embed_prefix`` overrides the local mask:
+        ``run_image_tower=False`` skips even a real sample; ``True`` runs even an
+        all-padded one. This is the contract that lets the cross-rank decision
+        actually control the per-item branch."""
+        bsz, h = 3, 8
+        model = TestPI07PaligemmaLowLevelResponseEmbedding._make_mock_model(hidden_size=h)
+        n_img_tokens = model.paligemma_with_expert.config.paligemma_config.text_config.num_image_tokens
+        calls: list[tuple[int, ...]] = []
+
+        def _capturing_embed_image(image):
+            calls.append(tuple(image.shape))
+            return torch.full((image.shape[0], 4, h), 1.0, dtype=torch.bfloat16)
+
+        model.paligemma_with_expert.embed_image = _capturing_embed_image
+
+        # Real sample but forced skip → zeros, no call.
+        real = ContextItem(
+            data=torch.full((bsz, 3, 224, 224), 0.5),
+            item_type="image",
+            pad_mask=torch.tensor([False, True, False]),
+            attention="continue",
+        )
+        emb_skip, _ = model._embed_item(real, run_image_tower=False)
+        assert calls == [], "run_image_tower=False must skip even a real sample"
+        assert emb_skip.shape == (bsz, n_img_tokens, h) and not emb_skip.any()
+
+        # All-padded but forced run → real output, one call.
+        padded = ContextItem(
+            data=torch.full((bsz, 3, 224, 224), 0.5),
+            item_type="image",
+            pad_mask=torch.zeros(bsz, dtype=torch.bool),
+            attention="continue",
+        )
+        emb_run, _ = model._embed_item(padded, run_image_tower=True)
+        assert calls == [(bsz, 3, 224, 224)], "run_image_tower=True must run even an all-padded sample"
+        assert emb_run.shape == (bsz, 4, h)
+
+    def test_global_run_image_tower_local_decision(self):
+        """Single-process (no process group): ``_global_run_image_tower`` returns
+        the local OR over image items — True if any camera mask is real, False
+        for all-padded, and False when the prefix has no image item at all."""
+        bsz, h = 2, 8
+        model = TestPI07PaligemmaLowLevelResponseEmbedding._make_mock_model(hidden_size=h)
+
+        def _img(mask):
+            return ContextItem(
+                data=torch.zeros(bsz, 3, 224, 224), item_type="image", pad_mask=mask, attention="continue"
+            )
+
+        text = ContextItem(
+            data=torch.zeros(bsz, 3, dtype=torch.long),
+            item_type="text",
+            pad_mask=torch.ones(bsz, 3, dtype=torch.bool),
+            attention="continue",
+        )
+        # Two cameras, one with a real sample → run.
+        assert model._global_run_image_tower(
+            [text, _img(torch.zeros(bsz, dtype=torch.bool)), _img(torch.tensor([False, True]))]
+        )
+        # All cameras all-padded → skip.
+        assert not model._global_run_image_tower([text, _img(torch.zeros(bsz, dtype=torch.bool))])
+        # No image item at all → skip (and no crash deriving the device).
+        assert not model._global_run_image_tower([text])
+
     # ------------------------------------------------------------------ #
-    # DDP lockstep: the run/skip decision must follow the *global* OR of the
-    # subgoal mask, not each rank's local ``.any()`` — otherwise ranks fire a
-    # different number of vision-encoder collectives and hang at NCCL. Verified
-    # here over a 2-rank gloo group on CPU (no GPU needed).
+    # DDP lockstep: the hoisted ``_global_run_image_tower`` collective must make
+    # the run/skip decision follow the *global* OR (not each rank's local
+    # ``.any()``), and must detect cross-rank presence divergence loudly —
+    # otherwise ranks fire a different number of collectives and hang at NCCL.
+    # Verified over a 2-rank gloo group on CPU (no GPU needed).
     # ------------------------------------------------------------------ #
     @pytest.mark.slow
     def test_ddp_lockstep_image_tower_skip(self):
-        """With divergent per-rank masks (rank 0 all-padded, rank 1 real) both
-        ranks must run the image tower; with all ranks padded both must skip."""
+        """Divergent per-rank masks → both ranks RUN (global OR); all-padded →
+        both SKIP; one rank missing the image item → loud RuntimeError, not a
+        silent collective-count desync."""
         import torch.multiprocessing as mp
 
         if not torch.distributed.is_available():
             pytest.skip("torch.distributed is not available")
 
-        # Divergent local masks → global OR True → both ranks RUN.
-        mp.spawn(_ddp_image_skip_worker, args=(2, _find_free_port(), "divergent"), nprocs=2, join=True)
-        # Every rank all-padded → global OR False → both ranks SKIP.
-        mp.spawn(_ddp_image_skip_worker, args=(2, _find_free_port(), "all_padded"), nprocs=2, join=True)
+        for scenario in ("divergent", "all_padded", "presence_divergence"):
+            mp.spawn(_ddp_image_skip_worker, args=(2, _find_free_port(), scenario), nprocs=2, join=True)
 
 
 class TestPI07PaligemmaLowLevelExecutionHorizon:


### PR DESCRIPTION
## What this does

In `PI07PaligemmaLowLevelFlowMatching._embed_item`, the `image` (subgoal) branch previously ran `paligemma_with_expert.embed_image` **unconditionally** — the comment cited DDP lockstep as the reason (a data-dependent skip would desync per-rank collective counts and hang at NCCL).

This runs the full PaliGemma image tower even when no sample needs a subgoal (inference, or any training step where every rank's `subgoal_is_pad` is `True`), since the per-sample mask zeros those slots downstream anyway.

This PR makes the skip safe instead of avoiding it:

- The per-sample subgoal mask's `.any()` is **OR-reduced across ranks** via the existing `_global_or_branch_decisions` helper (the same pattern `pi07` uses), so every rank takes the *same* run/skip decision and collective counts stay aligned.
- When the global OR is `False`, the image tower is skipped and zeros of shape `(B, num_image_tokens, hidden_size)` are emitted instead. This is mask-equivalent: those tokens carry an all-`False` pad mask, so real tokens can never attend to them and the model output is unchanged — only wasted compute is removed.
- Under `torch.compile` / ONNX export the all-reduce and Python branch can't be traced, so the tower runs unconditionally there (the exported graph must always include it).

⚡️ Performance optimization. Behavior is provably output-equivalent; only redundant vision-encoder work is dropped.

## How it was tested

- `pre-commit run` on the changed files: all hooks pass (ruff lint + format, etc.).
- **CPU** (`pytest -m "not gpu"`): 269 tests pass across the affected files (`test_pi07_paligemma_low_level.py`, `test_pi07_low_level.py`, `test_pi07_cpu.py`, `test_pi07_attention_layout.py`, plus the high-level-planner / video-encoder CPU files). New coverage:
  - `test_all_padded_subgoal_skips_image_tower` / `test_some_real_subgoal_runs_image_tower` — assert the skip emits correctly-shaped zeros without calling `embed_image`, and that any real sample still runs the tower.
  - `test_ddp_lockstep_image_tower_skip` — a 2-rank **gloo** CPU test: with divergent per-rank masks (rank 0 all-padded, rank 1 real) **both** ranks run the tower; with all ranks padded both skip. This is the direct regression guard for the NCCL-divergence concern.
- **GPU** (`pytest -m "gpu" -n 0 tests/policies/test_pi07_paligemma_low_level.py`) on a single GPU: the runnable GPU test passes. The one GPU test that exercises subgoals end-to-end (`test_complete_pi07_low_level_pipeline`) stays hard-skipped for memory, so I separately verified on-GPU that a real PaliGemma `embed_image` emits exactly `text_config.num_image_tokens` (256) tokens — confirming the skip-path zeros `(B, 256, hidden)` are shape-identical to the run path on a real model.
- The nightly regression suite (`regression_test.yml`, g6.12xlarge cron) was not run locally and will run on schedule.

## How to checkout & try? (for the reviewer)

```bash
# Skip-path units + the 2-rank gloo lockstep test (CPU)
pytest -sx tests/policies/test_pi07_paligemma_low_level.py -k "image_tower or lockstep"
```
```bash
# Targeted GPU subset for the policy file
pytest -m "gpu" -n 0 tests/policies/test_pi07_paligemma_low_level.py
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [x] My PR includes policy-related changes.
  - [x] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).