### PR TITLE
feat(scripts): inference-speed benchmark + fix pi07_paligemma registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,6 @@ cython_debug/
 # Cursor configuration
 .cursorignore
 .cursorindexingignore
+
+# Inference benchmark run artifacts (per-host JSONs, dmon traces, diagnostic dumps)
+benchmark_results/

--- a/configs/benchmarks/pi05.json
+++ b/configs/benchmarks/pi05.json
@@ -1,0 +1,87 @@
+{
+    "dataset_mixture": {
+        "datasets": [{"repo_id": "TensorAuto/libero"}],
+        "weights": [1.0],
+        "action_freq": null,
+        "image_resample_strategy": "nearest",
+        "vector_resample_strategy": "nearest"
+    },
+    "policy": {
+        "type": "pi05",
+        "pretrained_path": null,
+        "n_obs_steps": 1,
+        "normalization_mapping": {
+            "VISUAL": "IDENTITY",
+            "STATE": "MEAN_STD",
+            "ACTION": "MEAN_STD"
+        },
+        "input_features": {
+            "state": {"type": "STATE", "shape": [32]},
+            "camera0": {"type": "VISUAL", "shape": [3, 224, 224]},
+            "camera1": {"type": "VISUAL", "shape": [3, 224, 224]},
+            "camera2": {"type": "VISUAL", "shape": [3, 224, 224]}
+        },
+        "output_features": {
+            "actions": {"type": "ACTION", "shape": [32]}
+        },
+        "chunk_size": 10,
+        "n_action_steps": 10,
+        "max_state_dim": 32,
+        "max_action_dim": 32,
+        "proj_width": 1024,
+        "dropout": 0.0,
+        "num_steps": 10,
+        "resize_imgs_with_padding": [224, 224],
+        "attention_implementation": "sdpa",
+        "freeze_vision_encoder": true,
+        "train_expert_only": false,
+        "prompt_max_length": 64,
+        "discrete_action_max_length": 32
+    },
+    "resume": false,
+    "seed": 1000,
+    "resolution": [224, 224],
+    "num_cams": 3,
+    "max_state_dim": 32,
+    "max_action_dim": 32,
+    "action_chunk": 10,
+    "num_workers": 0,
+    "batch_size": 1,
+    "dataloader_batch_size": 1,
+    "gradient_accumulation_steps": 1,
+    "steps": 0,
+    "log_freq": 1,
+    "save_checkpoint": false,
+    "save_freq": 0,
+    "use_policy_training_preset": false,
+    "trace_nans": false,
+    "optimizer": {
+        "type": "adamw",
+        "lr": 2.5e-05,
+        "weight_decay": 1e-10,
+        "grad_clip_norm": 10.0,
+        "betas": [0.9, 0.95],
+        "eps": 1e-08
+    },
+    "scheduler": {
+        "type": "cosine_decay_with_warmup",
+        "num_warmup_steps": 1,
+        "num_decay_steps": 1,
+        "peak_lr": 2.5e-05,
+        "decay_lr": 2.5e-06
+    },
+    "wandb": {
+        "enable": false,
+        "entity": null,
+        "project": null,
+        "run_id": null,
+        "name": null,
+        "notes": "benchmark",
+        "tags": [],
+        "group": null,
+        "job_type": null,
+        "mode": null,
+        "allow_resume": false,
+        "disable_artifact": true
+    }
+}

--- a/configs/benchmarks/pi05.json
+++ b/configs/benchmarks/pi05.json
@@ -12,8 +12,8 @@
         "n_obs_steps": 1,
         "normalization_mapping": {
             "VISUAL": "IDENTITY",
-            "STATE": "MEAN_STD",
-            "ACTION": "MEAN_STD"
+            "STATE": "IDENTITY",
+            "ACTION": "IDENTITY"
         },
         "input_features": {
             "state": {"type": "STATE", "shape": [32]},

--- a/configs/benchmarks/pi05_mem.json
+++ b/configs/benchmarks/pi05_mem.json
@@ -1,0 +1,90 @@
+{
+    "dataset_mixture": {
+        "datasets": [{"repo_id": "TensorAuto/libero"}],
+        "weights": [1.0],
+        "action_freq": null,
+        "n_obs_history": 6,
+        "image_resample_strategy": "nearest",
+        "vector_resample_strategy": "nearest"
+    },
+    "policy": {
+        "type": "pi05_mem",
+        "pretrained_path": null,
+        "n_obs_steps": 6,
+        "history_interval": 1,
+        "normalization_mapping": {
+            "VISUAL": "IDENTITY",
+            "STATE": "MEAN_STD",
+            "ACTION": "MEAN_STD"
+        },
+        "input_features": {
+            "state": {"type": "STATE", "shape": [32]},
+            "camera0": {"type": "VISUAL", "shape": [3, 224, 224]},
+            "camera1": {"type": "VISUAL", "shape": [3, 224, 224]},
+            "camera2": {"type": "VISUAL", "shape": [3, 224, 224]}
+        },
+        "output_features": {
+            "actions": {"type": "ACTION", "shape": [32]}
+        },
+        "chunk_size": 10,
+        "n_action_steps": 10,
+        "max_state_dim": 32,
+        "max_action_dim": 32,
+        "proj_width": 1024,
+        "dropout": 0.0,
+        "num_steps": 10,
+        "resize_imgs_with_padding": [224, 224],
+        "attention_implementation": "sdpa",
+        "freeze_vision_encoder": true,
+        "train_expert_only": false,
+        "prompt_max_length": 64,
+        "discrete_action_max_length": 32,
+        "spacetime_layer_stride": 4
+    },
+    "resume": false,
+    "seed": 1000,
+    "resolution": [224, 224],
+    "num_cams": 3,
+    "max_state_dim": 32,
+    "max_action_dim": 32,
+    "action_chunk": 10,
+    "num_workers": 0,
+    "batch_size": 1,
+    "dataloader_batch_size": 1,
+    "gradient_accumulation_steps": 1,
+    "steps": 0,
+    "log_freq": 1,
+    "save_checkpoint": false,
+    "save_freq": 0,
+    "use_policy_training_preset": false,
+    "trace_nans": false,
+    "optimizer": {
+        "type": "adamw",
+        "lr": 2.5e-05,
+        "weight_decay": 1e-10,
+        "grad_clip_norm": 10.0,
+        "betas": [0.9, 0.95],
+        "eps": 1e-08
+    },
+    "scheduler": {
+        "type": "cosine_decay_with_warmup",
+        "num_warmup_steps": 1,
+        "num_decay_steps": 1,
+        "peak_lr": 2.5e-05,
+        "decay_lr": 2.5e-06
+    },
+    "wandb": {
+        "enable": false,
+        "entity": null,
+        "project": null,
+        "run_id": null,
+        "name": null,
+        "notes": "benchmark",
+        "tags": [],
+        "group": null,
+        "job_type": null,
+        "mode": null,
+        "allow_resume": false,
+        "disable_artifact": true
+    }
+}

--- a/configs/benchmarks/pi05_mem.json
+++ b/configs/benchmarks/pi05_mem.json
@@ -14,8 +14,8 @@
         "history_interval": 1,
         "normalization_mapping": {
             "VISUAL": "IDENTITY",
-            "STATE": "MEAN_STD",
-            "ACTION": "MEAN_STD"
+            "STATE": "IDENTITY",
+            "ACTION": "IDENTITY"
         },
         "input_features": {
             "state": {"type": "STATE", "shape": [32]},

--- a/configs/benchmarks/pi07_high_level.json
+++ b/configs/benchmarks/pi07_high_level.json
@@ -13,7 +13,7 @@
         "n_obs_steps": 1,
         "normalization_mapping": {
             "VISUAL": "IDENTITY",
-            "STATE": "MEAN_STD"
+            "STATE": "IDENTITY"
         },
         "input_features": {
             "state": {"type": "STATE", "shape": [32]},

--- a/configs/benchmarks/pi07_high_level.json
+++ b/configs/benchmarks/pi07_high_level.json
@@ -1,0 +1,85 @@
+{
+    "dataset_mixture": {
+        "datasets": [{"repo_id": "TensorAuto/libero"}],
+        "weights": [1.0],
+        "action_freq": null,
+        "emit_fps": true,
+        "image_resample_strategy": "nearest",
+        "vector_resample_strategy": "nearest"
+    },
+    "policy": {
+        "type": "pi07_high_level",
+        "pretrained_path": null,
+        "n_obs_steps": 1,
+        "normalization_mapping": {
+            "VISUAL": "IDENTITY",
+            "STATE": "MEAN_STD"
+        },
+        "input_features": {
+            "state": {"type": "STATE", "shape": [32]},
+            "camera0": {"type": "VISUAL", "shape": [3, 448, 448]},
+            "camera1": {"type": "VISUAL", "shape": [3, 448, 448]},
+            "camera2": {"type": "VISUAL", "shape": [3, 448, 448]}
+        },
+        "output_features": {
+            "actions": {"type": "ACTION", "shape": [32]}
+        },
+        "max_state_dim": 32,
+        "resize_imgs_with_padding": [448, 448],
+        "attention_implementation": "sdpa",
+        "gradient_checkpointing": false,
+        "freeze_vision_encoder": true,
+        "prompt_max_length": 64,
+        "memory_max_length": 50,
+        "response_max_length": 50,
+        "metadata_max_length": 52,
+        "subtask_indicator_max_length": 4,
+        "memory_indicator_max_length": 4
+    },
+    "resume": false,
+    "seed": 1000,
+    "resolution": [448, 448],
+    "num_cams": 3,
+    "max_state_dim": 32,
+    "max_action_dim": 32,
+    "action_chunk": 10,
+    "num_workers": 0,
+    "batch_size": 1,
+    "dataloader_batch_size": 1,
+    "gradient_accumulation_steps": 1,
+    "steps": 0,
+    "log_freq": 1,
+    "save_checkpoint": false,
+    "save_freq": 0,
+    "use_policy_training_preset": false,
+    "trace_nans": false,
+    "optimizer": {
+        "type": "adamw",
+        "lr": 2.5e-05,
+        "weight_decay": 1e-10,
+        "grad_clip_norm": 10.0,
+        "betas": [0.9, 0.95],
+        "eps": 1e-08
+    },
+    "scheduler": {
+        "type": "cosine_decay_with_warmup",
+        "num_warmup_steps": 1,
+        "num_decay_steps": 1,
+        "peak_lr": 2.5e-05,
+        "decay_lr": 2.5e-06
+    },
+    "wandb": {
+        "enable": false,
+        "entity": null,
+        "project": null,
+        "run_id": null,
+        "name": null,
+        "notes": "benchmark",
+        "tags": [],
+        "group": null,
+        "job_type": null,
+        "mode": null,
+        "allow_resume": false,
+        "disable_artifact": true
+    }
+}

--- a/configs/benchmarks/pi07_low_level.json
+++ b/configs/benchmarks/pi07_low_level.json
@@ -1,0 +1,93 @@
+{
+    "dataset_mixture": {
+        "datasets": [{"repo_id": "TensorAuto/libero"}],
+        "weights": [1.0],
+        "action_freq": null,
+        "emit_fps": true,
+        "n_obs_history": 6,
+        "image_resample_strategy": "nearest",
+        "vector_resample_strategy": "nearest"
+    },
+    "policy": {
+        "type": "pi07_low_level",
+        "pretrained_path": null,
+        "n_obs_steps": 6,
+        "history_interval": 1,
+        "normalization_mapping": {
+            "VISUAL": "IDENTITY",
+            "STATE": "MIN_MAX",
+            "ACTION": "MEAN_STD"
+        },
+        "input_features": {
+            "state": {"type": "STATE", "shape": [32]},
+            "camera0": {"type": "VISUAL", "shape": [3, 448, 448]},
+            "camera1": {"type": "VISUAL", "shape": [3, 448, 448]},
+            "camera2": {"type": "VISUAL", "shape": [3, 448, 448]}
+        },
+        "output_features": {
+            "actions": {"type": "ACTION", "shape": [32]}
+        },
+        "chunk_size": 10,
+        "n_action_steps": 10,
+        "max_state_dim": 32,
+        "max_action_dim": 32,
+        "proj_width": 1280,
+        "num_steps": 5,
+        "resize_imgs_with_padding": [448, 448],
+        "attention_implementation": "sdpa",
+        "gradient_checkpointing": false,
+        "freeze_vision_encoder": true,
+        "train_expert_only": false,
+        "prompt_max_length": 64,
+        "discrete_action_max_length": 32,
+        "metadata_max_length": 52,
+        "response_max_length": 52,
+        "spacetime_layer_stride": 4
+    },
+    "resume": false,
+    "seed": 1000,
+    "resolution": [448, 448],
+    "num_cams": 3,
+    "max_state_dim": 32,
+    "max_action_dim": 32,
+    "action_chunk": 10,
+    "num_workers": 0,
+    "batch_size": 1,
+    "dataloader_batch_size": 1,
+    "gradient_accumulation_steps": 1,
+    "steps": 0,
+    "log_freq": 1,
+    "save_checkpoint": false,
+    "save_freq": 0,
+    "use_policy_training_preset": false,
+    "trace_nans": false,
+    "optimizer": {
+        "type": "adamw",
+        "lr": 2.5e-05,
+        "weight_decay": 1e-10,
+        "grad_clip_norm": 10.0,
+        "betas": [0.9, 0.95],
+        "eps": 1e-08
+    },
+    "scheduler": {
+        "type": "cosine_decay_with_warmup",
+        "num_warmup_steps": 1,
+        "num_decay_steps": 1,
+        "peak_lr": 2.5e-05,
+        "decay_lr": 2.5e-06
+    },
+    "wandb": {
+        "enable": false,
+        "entity": null,
+        "project": null,
+        "run_id": null,
+        "name": null,
+        "notes": "benchmark",
+        "tags": [],
+        "group": null,
+        "job_type": null,
+        "mode": null,
+        "allow_resume": false,
+        "disable_artifact": true
+    }
+}

--- a/configs/benchmarks/pi07_low_level.json
+++ b/configs/benchmarks/pi07_low_level.json
@@ -15,8 +15,8 @@
         "history_interval": 1,
         "normalization_mapping": {
             "VISUAL": "IDENTITY",
-            "STATE": "MIN_MAX",
-            "ACTION": "MEAN_STD"
+            "STATE": "IDENTITY",
+            "ACTION": "IDENTITY"
         },
         "input_features": {
             "state": {"type": "STATE", "shape": [32]},

--- a/configs/benchmarks/pi07_paligemma_high_level.json
+++ b/configs/benchmarks/pi07_paligemma_high_level.json
@@ -13,7 +13,7 @@
         "n_obs_steps": 1,
         "normalization_mapping": {
             "VISUAL": "IDENTITY",
-            "STATE": "MEAN_STD"
+            "STATE": "IDENTITY"
         },
         "input_features": {
             "state": {"type": "STATE", "shape": [32]},

--- a/configs/benchmarks/pi07_paligemma_high_level.json
+++ b/configs/benchmarks/pi07_paligemma_high_level.json
@@ -1,0 +1,84 @@
+{
+    "dataset_mixture": {
+        "datasets": [{"repo_id": "TensorAuto/libero"}],
+        "weights": [1.0],
+        "action_freq": null,
+        "emit_fps": true,
+        "image_resample_strategy": "nearest",
+        "vector_resample_strategy": "nearest"
+    },
+    "policy": {
+        "type": "pi07_paligemma_high_level_planner",
+        "pretrained_path": null,
+        "n_obs_steps": 1,
+        "normalization_mapping": {
+            "VISUAL": "IDENTITY",
+            "STATE": "MEAN_STD"
+        },
+        "input_features": {
+            "state": {"type": "STATE", "shape": [32]},
+            "camera0": {"type": "VISUAL", "shape": [3, 224, 224]},
+            "camera1": {"type": "VISUAL", "shape": [3, 224, 224]},
+            "camera2": {"type": "VISUAL", "shape": [3, 224, 224]}
+        },
+        "output_features": {
+            "actions": {"type": "ACTION", "shape": [32]}
+        },
+        "max_state_dim": 32,
+        "resize_imgs_with_padding": [224, 224],
+        "attention_implementation": "sdpa",
+        "freeze_vision_encoder": true,
+        "prompt_max_length": 64,
+        "memory_max_length": 50,
+        "response_max_length": 50,
+        "metadata_max_length": 52,
+        "subtask_indicator_max_length": 4,
+        "memory_indicator_max_length": 4
+    },
+    "resume": false,
+    "seed": 1000,
+    "resolution": [224, 224],
+    "num_cams": 3,
+    "max_state_dim": 32,
+    "max_action_dim": 32,
+    "action_chunk": 10,
+    "num_workers": 0,
+    "batch_size": 1,
+    "dataloader_batch_size": 1,
+    "gradient_accumulation_steps": 1,
+    "steps": 0,
+    "log_freq": 1,
+    "save_checkpoint": false,
+    "save_freq": 0,
+    "use_policy_training_preset": false,
+    "trace_nans": false,
+    "optimizer": {
+        "type": "adamw",
+        "lr": 2.5e-05,
+        "weight_decay": 1e-10,
+        "grad_clip_norm": 10.0,
+        "betas": [0.9, 0.95],
+        "eps": 1e-08
+    },
+    "scheduler": {
+        "type": "cosine_decay_with_warmup",
+        "num_warmup_steps": 1,
+        "num_decay_steps": 1,
+        "peak_lr": 2.5e-05,
+        "decay_lr": 2.5e-06
+    },
+    "wandb": {
+        "enable": false,
+        "entity": null,
+        "project": null,
+        "run_id": null,
+        "name": null,
+        "notes": "benchmark",
+        "tags": [],
+        "group": null,
+        "job_type": null,
+        "mode": null,
+        "allow_resume": false,
+        "disable_artifact": true
+    }
+}

--- a/configs/benchmarks/pi07_paligemma_low_level.json
+++ b/configs/benchmarks/pi07_paligemma_low_level.json
@@ -15,8 +15,8 @@
         "history_interval": 1,
         "normalization_mapping": {
             "VISUAL": "IDENTITY",
-            "STATE": "MIN_MAX",
-            "ACTION": "MEAN_STD"
+            "STATE": "IDENTITY",
+            "ACTION": "IDENTITY"
         },
         "input_features": {
             "state": {"type": "STATE", "shape": [32]},

--- a/configs/benchmarks/pi07_paligemma_low_level.json
+++ b/configs/benchmarks/pi07_paligemma_low_level.json
@@ -1,0 +1,92 @@
+{
+    "dataset_mixture": {
+        "datasets": [{"repo_id": "TensorAuto/libero"}],
+        "weights": [1.0],
+        "action_freq": null,
+        "emit_fps": true,
+        "n_obs_history": 6,
+        "image_resample_strategy": "nearest",
+        "vector_resample_strategy": "nearest"
+    },
+    "policy": {
+        "type": "pi07_paligemma_low_level",
+        "pretrained_path": null,
+        "n_obs_steps": 6,
+        "history_interval": 1,
+        "normalization_mapping": {
+            "VISUAL": "IDENTITY",
+            "STATE": "MIN_MAX",
+            "ACTION": "MEAN_STD"
+        },
+        "input_features": {
+            "state": {"type": "STATE", "shape": [32]},
+            "camera0": {"type": "VISUAL", "shape": [3, 224, 224]},
+            "camera1": {"type": "VISUAL", "shape": [3, 224, 224]},
+            "camera2": {"type": "VISUAL", "shape": [3, 224, 224]}
+        },
+        "output_features": {
+            "actions": {"type": "ACTION", "shape": [32]}
+        },
+        "chunk_size": 10,
+        "n_action_steps": 10,
+        "max_state_dim": 32,
+        "max_action_dim": 32,
+        "proj_width": 1024,
+        "num_steps": 10,
+        "resize_imgs_with_padding": [224, 224],
+        "attention_implementation": "sdpa",
+        "freeze_vision_encoder": true,
+        "train_expert_only": false,
+        "prompt_max_length": 64,
+        "discrete_action_max_length": 32,
+        "metadata_max_length": 52,
+        "response_max_length": 52,
+        "spacetime_layer_stride": 4
+    },
+    "resume": false,
+    "seed": 1000,
+    "resolution": [224, 224],
+    "num_cams": 3,
+    "max_state_dim": 32,
+    "max_action_dim": 32,
+    "action_chunk": 10,
+    "num_workers": 0,
+    "batch_size": 1,
+    "dataloader_batch_size": 1,
+    "gradient_accumulation_steps": 1,
+    "steps": 0,
+    "log_freq": 1,
+    "save_checkpoint": false,
+    "save_freq": 0,
+    "use_policy_training_preset": false,
+    "trace_nans": false,
+    "optimizer": {
+        "type": "adamw",
+        "lr": 2.5e-05,
+        "weight_decay": 1e-10,
+        "grad_clip_norm": 10.0,
+        "betas": [0.9, 0.95],
+        "eps": 1e-08
+    },
+    "scheduler": {
+        "type": "cosine_decay_with_warmup",
+        "num_warmup_steps": 1,
+        "num_decay_steps": 1,
+        "peak_lr": 2.5e-05,
+        "decay_lr": 2.5e-06
+    },
+    "wandb": {
+        "enable": false,
+        "entity": null,
+        "project": null,
+        "run_id": null,
+        "name": null,
+        "notes": "benchmark",
+        "tags": [],
+        "group": null,
+        "job_type": null,
+        "mode": null,
+        "allow_resume": false,
+        "disable_artifact": true
+    }
+}

--- a/src/opentau/policies/__init__.py
+++ b/src/opentau/policies/__init__.py
@@ -29,4 +29,18 @@ from .pi07.high_level_planner.configuration_pi07_high_level import (
 from .pi07.low_level.configuration_pi07_low_level import (
     PI07LowLevelConfig as PI07LowLevelConfig,
 )
+
+# Side-effect imports: the two ``pi07_paligemma`` config modules each carry an
+# ``@PreTrainedConfig.register_subclass(...)`` decorator that draccus relies on
+# to resolve ``--policy.type=pi07_paligemma_low_level`` /
+# ``pi07_paligemma_high_level_planner``. The high-level config class shares the
+# name ``PI07HighLevelPlannerConfig`` with its pi07 counterpart, so we cannot
+# re-export it from this package without shadowing the latter; importers reach
+# the class directly via its full module path or through ``get_policy_class``.
+from .pi07_paligemma.high_level_planner import (
+    configuration_pi07_high_level as _pi07_paligemma_high_level_config,  # noqa: F401
+)
+from .pi07_paligemma.low_level import (
+    configuration_pi07_low_level as _pi07_paligemma_low_level_config,  # noqa: F401
+)
 from .value.configuration_value import ValueConfig as ValueConfig

--- a/src/opentau/scripts/benchmark_inference.py
+++ b/src/opentau/scripts/benchmark_inference.py
@@ -1,0 +1,295 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Inference-speed benchmark.
+
+A dedicated harness for measuring per-call inference latency of a policy under
+deployment-like conditions: random-init (no checkpoint download), bf16, single
+batch, three cameras, ~50-token prompt. Distinct from
+``opentau.scripts.inference``, which is a quick smoke runner with N=10 and no
+CUDA sync.
+
+Configured via the same ``TrainPipelineConfig`` JSON used elsewhere. Runtime
+flags ride on env vars (so we don't have to break the ``@parser.wrap``
+signature):
+
+  BENCH_NO_COMPILE=1          # skip torch.compile entirely
+  BENCH_COMPILE_MODE=...      # default "max-autotune"
+  BENCH_N_WARMUP=5            # post-compile warmup calls
+  BENCH_N_TIMED=50            # timed calls after warmup
+  BENCH_OUTPUT_DIR=...        # default benchmark_results/
+
+The script writes a single JSON to ``${BENCH_OUTPUT_DIR}/<host>_<policy>_<ts>.json``
+with the config snapshot, host/GPU/driver/torch versions, per-warmup wall-clock
+series, all timed samples, and a summary (mean/std/p50/p95/min/max).
+"""
+
+import datetime as dt
+import json
+import logging
+import os
+import socket
+import statistics
+import subprocess
+import time
+from dataclasses import asdict
+from pathlib import Path
+from pprint import pformat
+
+import torch
+
+from opentau.configs import parser
+from opentau.configs.train import TrainPipelineConfig
+from opentau.policies.factory import make_policy
+from opentau.policies.normalize import NormalizationMode
+from opentau.utils.random_utils import set_seed
+from opentau.utils.utils import (
+    auto_torch_device,
+    create_dummy_observation,
+    init_logging,
+)
+
+# ~50-token prompt under SentencePiece tokenizers used by PaliGemma / Gemma 3.
+# We additionally pin policy.prompt_max_length=64 in the configs so the
+# attended sequence is bounded at 64 regardless of tokenizer-specific drift.
+BENCHMARK_PROMPT = (
+    "Pick up the small yellow lego block from the table and carefully "
+    "place it inside the gray bin on the left side now please."
+)
+
+HIGH_LEVEL_POLICY_TYPES = frozenset({"pi07_high_level", "pi07_paligemma_high_level_planner"})
+
+
+def _is_high_level(policy_type: str) -> bool:
+    return policy_type in HIGH_LEVEL_POLICY_TYPES
+
+
+def _force_identity_normalization(cfg_policy) -> None:
+    """Random-init policies have no stats; switch all norm modes to IDENTITY
+    so the inf-init buffers in `Normalize` are never read.
+    """
+    for k in list(cfg_policy.normalization_mapping.keys()):
+        cfg_policy.normalization_mapping[k] = NormalizationMode.IDENTITY
+
+
+def _build_observation(cfg: TrainPipelineConfig, device, dtype) -> dict:
+    obs = create_dummy_observation(cfg, device, dtype=dtype)
+    # Override prompt with a ~50-token sentence (the create_dummy_observation
+    # default is ~11 tokens — too short to exercise the requested workload).
+    obs["prompt"] = [BENCHMARK_PROMPT]
+
+    # Video-stack policies (pi05_mem, pi07_low_level, pi07_paligemma_low_level
+    # when n_obs_steps > 1) consume a 5D (B, T, C, H, W) camera tensor instead
+    # of 4D. They also expect an `obs_history_is_pad` mask shaped (B, T). The
+    # base create_dummy_observation builds 4D, so promote the cameras here.
+    n_obs = getattr(cfg.policy, "n_obs_steps", 1) or 1
+    if n_obs > 1:
+        h, w = cfg.resolution
+        for cam_key in [k for k in list(obs.keys()) if k.startswith("camera")]:
+            obs[cam_key] = torch.zeros((1, n_obs, 3, h, w), dtype=dtype, device=device)
+        obs["state"] = torch.zeros((1, n_obs, cfg.max_state_dim), dtype=dtype, device=device)
+        obs["obs_history_is_pad"] = torch.zeros((1, n_obs), dtype=torch.bool, device=device)
+
+    if _is_high_level(cfg.policy.type):
+        # High-level planner reads batch["past_memory"] as list[str]; default
+        # to an empty memory token (tokenizer pads to memory_max_length=50).
+        obs["past_memory"] = [""]
+        # prepare_metadata reads speed/quality/mistake + *_is_pad and an
+        # optional fps. Setting every _is_pad=True drops the values from the
+        # metadata string entirely (just "Metadata: " padded to
+        # metadata_max_length). Cleanest no-op for a speed benchmark.
+        b = 1
+        zero_long = torch.zeros(b, dtype=torch.long, device=device)
+        all_pad = torch.ones(b, dtype=torch.bool, device=device)
+        obs["speed"] = zero_long
+        obs["quality"] = zero_long
+        obs["mistake"] = zero_long
+        obs["speed_is_pad"] = all_pad
+        obs["quality_is_pad"] = all_pad
+        obs["mistake_is_pad"] = all_pad
+        obs["fps"] = zero_long
+        obs["fps_is_pad"] = all_pad
+    return obs
+
+
+def _verify_compile(compiled_fn) -> None:
+    """Raise if torch.compile silently returned the original callable.
+
+    The historical ``attempt_torch_compile`` helper swallows exceptions and
+    returns ``fn`` — we want the opposite, a loud failure.
+    """
+    if not hasattr(compiled_fn, "_torchdynamo_orig_callable"):
+        raise RuntimeError(
+            "torch.compile did not produce a Dynamo-wrapped callable. "
+            f"Got {type(compiled_fn).__name__} without _torchdynamo_orig_callable. "
+            "Either torch.compile is unavailable, or it silently bailed."
+        )
+
+
+def _sync(device) -> None:
+    if device.type == "cuda":
+        torch.cuda.synchronize()
+
+
+def _summarize(samples_ms: list[float]) -> dict:
+    sorted_samples = sorted(samples_ms)
+    n = len(sorted_samples)
+
+    def pct(p: float) -> float:
+        # Lower bound index for the p-th percentile.
+        idx = max(0, min(n - 1, int(round((p / 100.0) * (n - 1)))))
+        return sorted_samples[idx]
+
+    return {
+        "n": n,
+        "mean_ms": statistics.fmean(samples_ms),
+        "std_ms": statistics.stdev(samples_ms) if n > 1 else 0.0,
+        "min_ms": sorted_samples[0],
+        "p50_ms": pct(50),
+        "p95_ms": pct(95),
+        "p99_ms": pct(99),
+        "max_ms": sorted_samples[-1],
+    }
+
+
+def _nvidia_driver_version() -> str | None:
+    try:
+        out = subprocess.run(  # nosec B607 - nvidia-smi is intentionally resolved via PATH
+            ["nvidia-smi", "--query-gpu=driver_version", "--format=csv,noheader"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        return out.stdout.strip().splitlines()[0]
+    except (FileNotFoundError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        return None
+
+
+@parser.wrap()
+def benchmark_main(cfg: TrainPipelineConfig):
+    init_logging()
+    logging.info(pformat(asdict(cfg)))
+
+    no_compile = os.environ.get("BENCH_NO_COMPILE", "0") == "1"
+    compile_mode = os.environ.get("BENCH_COMPILE_MODE", "max-autotune")
+    n_warmup = int(os.environ.get("BENCH_N_WARMUP", "5"))
+    n_timed = int(os.environ.get("BENCH_N_TIMED", "50"))
+    out_dir = Path(os.environ.get("BENCH_OUTPUT_DIR", "benchmark_results"))
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    device = torch.device(auto_torch_device())
+    if cfg.seed is not None:
+        set_seed(cfg.seed)
+    torch.backends.cudnn.benchmark = True
+    torch.set_float32_matmul_precision("high")
+
+    is_hl = _is_high_level(cfg.policy.type)
+    logging.info(
+        f"Policy type={cfg.policy.type} (high_level={is_hl}), no_compile={no_compile}, "
+        f"compile_mode={compile_mode}, n_warmup={n_warmup}, n_timed={n_timed}"
+    )
+
+    # Random init path: bypass stats requirement.
+    if cfg.policy.pretrained_path is None:
+        _force_identity_normalization(cfg.policy)
+        logging.info("pretrained_path is null: forced normalization_mapping -> IDENTITY")
+
+    logging.info("Building policy via make_policy (features pre-set in config).")
+    policy = make_policy(cfg.policy)
+    policy.to(device=device, dtype=torch.bfloat16)
+    policy.eval()
+    policy.reset()
+
+    # Compile + verify.
+    compile_status = "no-compile"
+    if not no_compile:
+        torch._dynamo.reset()
+        compiled = torch.compile(policy.model.sample_actions, mode=compile_mode, fullgraph=False)
+        _verify_compile(compiled)
+        policy.model.sample_actions = compiled
+        compile_status = f"compiled:{compile_mode}"
+        logging.info(f"torch.compile attached: mode={compile_mode}")
+
+    observation = _build_observation(cfg, device, dtype=torch.bfloat16)
+    logging.info(f"Observation keys: {sorted(observation.keys())}")
+
+    # Warmup. Time each call so we can verify compile actually fired (call 1
+    # should dominate by ~5-100x).
+    warmup_ms: list[float] = []
+    with torch.inference_mode():
+        for i in range(n_warmup):
+            _sync(device)
+            t0 = time.perf_counter()
+            _ = policy.sample_actions(observation)
+            _sync(device)
+            t1 = time.perf_counter()
+            warmup_ms.append((t1 - t0) * 1000.0)
+            logging.info(f"  warmup {i + 1}/{n_warmup}: {warmup_ms[-1]:.2f} ms")
+
+    if not no_compile and n_warmup >= 5:
+        ratio = warmup_ms[0] / max(warmup_ms[-1], 1e-6)
+        if ratio < 5.0:
+            raise RuntimeError(
+                f"Warmup call 1 / call {n_warmup} ratio is {ratio:.2f}x — expected >= 5x if "
+                f"torch.compile fired. Either compile silently bailed, or the cache is being "
+                f"reused (try torch._dynamo.reset() / clearing TORCHINDUCTOR_CACHE_DIR)."
+            )
+
+    # Timed loop.
+    times_ms: list[float] = []
+    with torch.inference_mode():
+        _sync(device)
+        for _ in range(n_timed):
+            _sync(device)
+            t0 = time.perf_counter()
+            _ = policy.sample_actions(observation)
+            _sync(device)
+            t1 = time.perf_counter()
+            times_ms.append((t1 - t0) * 1000.0)
+
+    summary = _summarize(times_ms)
+    logging.info(
+        f"Inference (ms): mean={summary['mean_ms']:.2f} std={summary['std_ms']:.2f} "
+        f"p50={summary['p50_ms']:.2f} p95={summary['p95_ms']:.2f} "
+        f"min={summary['min_ms']:.2f} max={summary['max_ms']:.2f}"
+    )
+
+    record = {
+        "timestamp": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "host": socket.gethostname(),
+        "gpu_name": torch.cuda.get_device_name(0) if device.type == "cuda" else None,
+        "gpu_capability": list(torch.cuda.get_device_capability(0)) if device.type == "cuda" else None,
+        "driver_version": _nvidia_driver_version(),
+        "torch_version": torch.__version__,
+        "cuda_version": torch.version.cuda,
+        "cudnn_version": torch.backends.cudnn.version(),
+        "policy_type": cfg.policy.type,
+        "compile_status": compile_status,
+        "n_warmup": n_warmup,
+        "n_timed": n_timed,
+        "warmup_ms": warmup_ms,
+        "samples_ms": times_ms,
+        "summary": summary,
+        "config": asdict(cfg),
+    }
+
+    out_path = (
+        out_dir / f"{record['host']}_{cfg.policy.type}_{dt.datetime.now().strftime('%Y%m%d-%H%M%S')}.json"
+    )
+    out_path.write_text(json.dumps(record, indent=2, default=str))
+    logging.info(f"Wrote {out_path}")
+
+
+if __name__ == "__main__":
+    benchmark_main()

--- a/src/opentau/scripts/benchmark_inference.py
+++ b/src/opentau/scripts/benchmark_inference.py
@@ -211,13 +211,21 @@ def benchmark_main(cfg: TrainPipelineConfig):
     policy.eval()
     policy.reset()
 
-    # Compile + verify.
+    # Compile + verify. We rebind ``policy.model.sample_actions`` on the
+    # instance so the outer ``policy.sample_actions`` wrapper (which calls
+    # ``self.model.sample_actions(...)`` at attribute-access time) picks up the
+    # compiled callable; the assert below catches any code path that might
+    # still hold a pre-compile bound reference.
     compile_status = "no-compile"
     if not no_compile:
         torch._dynamo.reset()
         compiled = torch.compile(policy.model.sample_actions, mode=compile_mode, fullgraph=False)
         _verify_compile(compiled)
         policy.model.sample_actions = compiled
+        assert policy.model.sample_actions is compiled, (
+            "rebinding model.sample_actions did not stick — outer policy.sample_actions "
+            "would call the eager version, which would silently invalidate the benchmark."
+        )
         compile_status = f"compiled:{compile_mode}"
         logging.info(f"torch.compile attached: mode={compile_mode}")
 
@@ -261,7 +269,7 @@ def benchmark_main(cfg: TrainPipelineConfig):
     summary = _summarize(times_ms)
     logging.info(
         f"Inference (ms): mean={summary['mean_ms']:.2f} std={summary['std_ms']:.2f} "
-        f"p50={summary['p50_ms']:.2f} p95={summary['p95_ms']:.2f} "
+        f"p50={summary['p50_ms']:.2f} p95={summary['p95_ms']:.2f} p99={summary['p99_ms']:.2f} "
         f"min={summary['min_ms']:.2f} max={summary['max_ms']:.2f}"
     )
 

--- a/src/opentau/scripts/diagnose_host.sh
+++ b/src/opentau/scripts/diagnose_host.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Capture a one-shot host snapshot before an inference benchmark run.
+#
+# Read alongside the benchmark JSON to interpret cross-host numbers — e.g. if
+# the faster GPU box isn't ~2x the slower one, is the GPU itself slow
+# (driver/clocks), the path to it (PCIe negotiated below x16), or the CPU side
+# (governor, idle competing processes)?
+#
+# Usage:
+#   src/opentau/scripts/diagnose_host.sh [out_dir]
+#
+# Default out_dir is ./benchmark_results. Writes to <out_dir>/<host>_diagnose.txt.
+
+set -u
+
+OUT_DIR="${1:-benchmark_results}"
+mkdir -p "$OUT_DIR"
+
+HOST="$(hostname)"
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+OUT="${OUT_DIR}/${HOST}_diagnose.txt"
+
+section() {
+    printf '\n========== %s ==========\n' "$1" >> "$OUT"
+}
+
+run() {
+    # Tolerate missing tools / non-zero exits without nuking the whole report.
+    printf '\n$ %s\n' "$*" >> "$OUT"
+    eval "$@" >> "$OUT" 2>&1 || printf '(command failed or unavailable)\n' >> "$OUT"
+}
+
+: > "$OUT"
+printf 'host=%s\ntimestamp=%s\nuname=%s\n' "$HOST" "$TS" "$(uname -a)" >> "$OUT"
+
+section "GPU snapshot (nvidia-smi)"
+run "nvidia-smi --query-gpu=name,driver_version,memory.total,pstate,power.draw,power.limit,clocks.gr,clocks.mem,utilization.gpu,utilization.memory,pcie.link.gen.current,pcie.link.width.current --format=csv"
+
+section "GPU detail: persistence, power, clocks"
+run "nvidia-smi -q -d CLOCK,POWER,PERFORMANCE | grep -E 'Persistence|Power Limit|Default Power|Graphics|Memory Clock' | head -40"
+
+section "Currently running GPU processes"
+run "nvidia-smi --query-compute-apps=pid,name,used_memory --format=csv"
+
+section "CPU"
+run "lscpu | grep -E 'Model name|CPU\\(s\\)|CPU MHz|CPU max MHz|NUMA|Architecture'"
+
+section "CPU frequency governor (cpu0)"
+run "cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor"
+
+section "Memory"
+run "free -h"
+run "sudo -n dmidecode -t memory | grep -E 'Speed:|Type:' | head -20"
+
+section "PCIe link (NVIDIA)"
+run "lspci -vvv -s \"\$(lspci | grep -i nvidia | awk '{print \$1}' | head -1)\" | grep -E 'LnkCap|LnkSta'"
+
+section "Storage"
+run "lsblk -d -o name,rota,size,model 2>/dev/null | grep -v loop"
+
+section "PyTorch / CUDA / cuDNN"
+# Prefer a known venv if BENCH_PYTHON is set; otherwise fall back to python3.
+PYBIN="${BENCH_PYTHON:-python3}"
+run "$PYBIN -c \"import torch; print('torch', torch.__version__); print('cuda', torch.version.cuda); print('cap', torch.cuda.get_device_capability(0) if torch.cuda.is_available() else None); print('cudnn', torch.backends.cudnn.version())\""
+
+section "Top processes by CPU"
+run "ps -eo pid,%cpu,%mem,cmd --sort=-%cpu | head -10"
+
+printf '\n# Report written to %s\n' "$OUT"


### PR DESCRIPTION
## What this does

Two commits, bundled for shipping together because the bugfix is what unblocks the benchmark from running on those two policies:

1. `fix(policies)` — register `pi07_paligemma_low_level` and `pi07_paligemma_high_level_planner` with draccus. Their `@PreTrainedConfig.register_subclass(...)` decorators live on the config modules but those modules were never imported anywhere on the package's import path, so the decorators silently never fired and both policy types were unloadable via `--policy.type=...`. Side-effect imports added in `src/opentau/policies/__init__.py`; the high-level class is not re-exported because its name collides with the pi07 (non-paligemma) variant (callers reach it via the full module path or `get_policy_class`).
2. `feat(scripts)` — a dedicated inference-speed benchmark harness covering pi05, pi05_mem, both pi07 low-level variants, and both pi07 high-level planners.

The harness (`src/opentau/scripts/benchmark_inference.py`) is distinct from the existing `inference.py` smoke (which runs N=10, has no `torch.cuda.synchronize()`, and silently falls back to eager if `torch.compile` fails). It runs N=50 timed iterations with CUDA sync around each call, reports mean / std / p50 / p95 / min / max, and dumps a per-run JSON. `torch.compile` is failed-loud — the script asserts the returned callable carries `_torchdynamo_orig_callable`, runs five warmups, and asserts `warmup[0] / warmup[-1] >= 5x` to confirm the compile actually fired. CLI flags ride on `BENCH_*` env vars so the script slots under `@parser.wrap` without touching the draccus signature.

`configs/benchmarks/*.json` (six configs) are tuned to 3 cameras, `prompt_max_length=64`, `pretrained_path=null` (random-init — no checkpoint download / auth needed, parameter counts and shapes are what matter for latency), `attention_implementation="sdpa"`, and the per-policy `num_steps` / `n_obs_steps` / image-size defaults documented in each policy config class.

`src/opentau/scripts/diagnose_host.sh` captures the host snapshot we read alongside the timing JSONs (driver, persistence, PCIe gen/width, CPU governor, RAM speed, current GPU processes). `benchmark_results/` is added to `.gitignore` — per-run artifacts, not source.

## How it was tested

Ran all six configs end-to-end on two single-GPU dev boxes (RTX 5090 / RTX 3090). For each policy:
- Random-init forward smoke with `BENCH_NO_COMPILE=1` first to verify the obs builder hits the right tensor shapes (the video-stack policies need `(B, T, C, H, W)` cameras + `(B, T, D)` state; the AR planners need `past_memory` + `speed/quality/mistake/fps` metadata fields with all `*_is_pad=True`).
- Then with `torch.compile(mode="max-autotune")`. All six compile cleanly: warmup-1 latency ranged 14s–127s, steady-state 52–915 ms; the warmup ratio guard fires comfortably (≥175x on every policy).
- Steady-state per-iter std was ≤0.79 ms across all six, except one outlier in `pi07_low_level` (max=2331 ms in 50 samples — Inductor autotune fire) which a re-run did not reproduce.
- `TORCH_LOGS=recompiles` shows 4 recompiles of `_embed_item` during warmup (one per item_type in the prefix layout) and **zero recompiles in the timed loop**.
- Sanity-checked that compile isn't constant-folding zero-valued inputs by re-randomizing camera + state every iter: p50 = 111.63 ms (random) vs 111.51 ms (zeros). Identical to within sub-millisecond — kernels are running real compute, not memoizing results.

Targeted paligemma GPU tests (`pytest -m gpu -n 0`) on a 5090:

```
tests/policies/test_pi07_paligemma_high_level_planner.py s        # skipped: "run on local machine" marker
tests/policies/test_pi07_paligemma_low_level.py s.                # 1 skip (24 GB VRAM gate, unrelated), 1 PASS
1 passed, 2 skipped, 52 deselected in 18.92s
```

The one test that exercises the policy class end-to-end on GPU passes. Both skips are pre-existing markers unrelated to this PR — one is a developer-local guard, the other is a VRAM gate (the test was authored to skip on ≤24 GB cards regardless of which card is present). The registration fix itself is also verified via the direct `get_policy_class` lookup smoke:

```
$ python -c "from opentau.policies.factory import get_policy_class; \
              print(get_policy_class('pi07_paligemma_high_level_planner')); \
              print(get_policy_class('pi07_paligemma_low_level'))"
OK pi07_paligemma_high_level_planner -> PI07HighLevelPlannerPolicy
OK pi07_paligemma_low_level          -> PI07PaligemmaLowLevelPolicy
```

On `main` both lookups raise — that's the bug the first commit fixes.

No unit tests added — this is a script + configs, no library API surface to test. The `__init__.py` change is registration-only (it adds two side-effect imports; it does not alter any policy modeling code).

## How to checkout & try? (for the reviewer)

```bash
git checkout claude/focused-dubinsky-3b9965

# Host snapshot (run first, read the report at benchmark_results/<host>_diagnose.txt)
./src/opentau/scripts/diagnose_host.sh

# Single benchmark, full N=50 with compile + verify (replace pi05 with any of the 6 configs)
BENCH_N_WARMUP=5 BENCH_N_TIMED=50 \
    CUDA_VISIBLE_DEVICES=0 OMP_NUM_THREADS=4 MKL_NUM_THREADS=4 \
    python -m opentau.scripts.benchmark_inference \
    --config_path=configs/benchmarks/pi05.json

# Skip compile (faster iteration during debug)
BENCH_NO_COMPILE=1 BENCH_N_WARMUP=2 BENCH_N_TIMED=5 \
    python -m opentau.scripts.benchmark_inference \
    --config_path=configs/benchmarks/pi05.json
```

The bugfix can be poked at independently:

```bash
python -c "from opentau.policies.factory import get_policy_class; print(get_policy_class('pi07_paligemma_low_level'))"
python -c "from opentau.policies.factory import get_policy_class; print(get_policy_class('pi07_paligemma_high_level_planner'))"
```

Both now succeed; on `main` they raise because the decorators were never wired up.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [x] My PR includes policy-related changes.
  - [x] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.