### PR TITLE
fix(scripts): commit wandb step after all per-step logging

### DIFF
--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -186,6 +186,36 @@ def _observe_optional(
     setattr(tracker, key, value)
 
 
+def _commit_wandb_step(accelerator: accelerate.Accelerator, step: int) -> None:
+    """Seal + flush the pending wandb row for ``step`` immediately.
+
+    OpenTau logs every metric with an explicit ``step=``, so wandb keeps row N
+    open as the "pending" row (letting the many per-step ``accelerator.log(...)``
+    calls accumulate into it) and only seals + uploads it when it next sees a
+    ``log(step > N)`` -- i.e. when step N+1 first logs. That makes the newest
+    point (especially a just-finished eval and its videos) lag one logging
+    interval on the dashboard, and risks losing the last pending row on an
+    ungraceful kill.
+
+    Calling this once, after every training / validation / eval log for
+    ``step``, forces the seal now. ``accelerator.log(values, step, log_kwargs)``
+    forwards ``log_kwargs["wandb"]`` straight to ``wandb.run.log`` (other
+    trackers only see kwargs keyed to their own name), so ``commit=True`` is
+    tracker-safe; an empty ``values`` dict flushes the accumulated row without
+    adding keys.
+
+    Must be the LAST wandb write for ``step``: wandb requires monotonically
+    increasing steps and warns-and-drops any ``log(step=N)`` issued after N is
+    sealed.
+
+    Args:
+        accelerator: The active accelerate ``Accelerator`` (caller must already
+            be on the main process, where the trackers live).
+        step: The training step whose pending wandb row should be sealed.
+    """
+    accelerator.log({}, step=step, log_kwargs={"wandb": {"commit": True}})
+
+
 def _mixture_weighted_aggregate(
     per_dataset_trackers: dict[str, MetricsTracker],
     name_to_weight: dict[str, float],
@@ -918,6 +948,15 @@ def train(cfg: TrainPipelineConfig):
                             s["post_resv"],
                             s["post_alloc"] - s["pre_alloc"],
                         )
+
+        # Seal this step's wandb row as soon as all of its logging (training /
+        # validation / eval scalars + eval videos) is done, instead of waiting
+        # for the next logging step to auto-commit it. Guarded on the same
+        # conditions that gate the logging blocks above, so we only commit on
+        # steps that actually logged, and only on main where the trackers live.
+        # See issue #353.
+        if accelerator.is_main_process and (is_log_step or is_val_step or (is_eval_step and eval_envs)):
+            _commit_wandb_step(accelerator, step)
 
     if cfg.eval_freq > 0 and eval_envs:
         close_envs(eval_envs)

--- a/tests/scripts/test_train.py
+++ b/tests/scripts/test_train.py
@@ -29,6 +29,7 @@ import accelerate
 import pytest
 
 from opentau.scripts.train import (
+    _commit_wandb_step,
     _find_unused_params_from_env,
     _mixture_weighted_aggregate,
     _sync_deepspeed_gradient_accumulation_steps,
@@ -258,6 +259,26 @@ class TestMixtureWeightedAggregate:
         assert agg["loss"] == pytest.approx(0.25 * 1.0 + 0.75 * 5.0)
         assert agg["mse_loss"] == pytest.approx(0.25 * 2.0 + 0.75 * 6.0)
         assert agg["ce_loss"] == pytest.approx(0.25 * 3.0 + 0.75 * 7.0)
+
+
+class TestCommitWandbStep:
+    """``_commit_wandb_step`` issues exactly one empty, commit-tagged log."""
+
+    def test_emits_empty_commit_log_at_step(self):
+        # The fix relies on three properties of the emitted call: an empty
+        # ``values`` dict (flush the accumulated row, add no keys), the explicit
+        # ``step`` (seal that row, not some other), and ``commit=True`` routed
+        # only under the ``"wandb"`` key (tracker-safe; other trackers never see
+        # it). Assert the exact call shape to pin all three.
+        calls = []
+
+        def _log(values, step=None, log_kwargs=None):
+            calls.append((values, step, log_kwargs))
+
+        accelerator = SimpleNamespace(log=_log)
+        _commit_wandb_step(accelerator, 1234)
+
+        assert calls == [({}, 1234, {"wandb": {"commit": True}})]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What this does
Fixes #353.

On the wandb dashboard a step's metrics — especially eval scalars and `Eval Videos/*` panels — only appear once the **next** logging step fires. With `eval_freq=1000` and ~20 min between training logs, a just-finished eval doesn't show up in the workspace until the next training step logs ~20 min later.

**Root cause:** `scripts/train.py` logs every metric with an explicit `step=` (so the many per-step `accelerator.log({single_key: val}, step=step)` calls all accumulate into one row). With an explicit step and no `commit` kwarg, wandb keeps row N open as the "pending" row and only seals + uploads it when it next sees a `log(step > N)`, on `wandb.finish()`, or a periodic flush. Hence the one-interval display lag, plus the risk of losing the last pending row on an ungraceful kill (recoverable with `wandb sync`, but easy to miss).

**Fix:** add `_commit_wandb_step()` and call it once at the bottom of the step loop, *after* the training / validation / eval logging blocks, gated on the same per-step flags (`is_log_step or is_val_step or (is_eval_step and eval_envs)`) so it only fires on steps that actually logged, and only on the main process where the trackers live. It threads `commit=True` to wandb via `log_kwargs={"wandb": {"commit": True}}` — `accelerator.log` forwards those kwargs straight to `wandb.run.log` and only to the wandb tracker, so it's tracker-safe — with an empty `values` dict, which flushes the accumulated row without adding keys. Keeping it the last `log(step=N)` for the step means no "step must be monotonically increasing" warnings and the x-axis stays aligned across all metric families. `accelerator.end_training()` still does the final `wandb.finish()` flush after the loop; the per-step commit additionally makes each logged step durable mid-run.

## How it was tested
- Added `TestCommitWandbStep::test_emits_empty_commit_log_at_step` in `tests/scripts/test_train.py`, asserting the helper emits exactly one `log({}, step=N, log_kwargs={"wandb": {"commit": True}})` call.
- Ran `pre-commit run --all-files` (clean) and `pytest -m "not gpu" tests/scripts/test_train.py` (18 passed) locally.
- Behavior verified against the installed `wandb==0.27.0` / `accelerate==1.12.0` source: `accelerator.log({}, step=N, log_kwargs={"wandb": {"commit": True}})` → `wandb.run.log({}, step=N, commit=True)` → `publish_partial_history(..., flush=True)`, which seals row N immediately. End-to-end placement in the full training loop is exercised by `regression_test.yml` (GPU nightly); not run on this CPU-only machine.

## How to checkout & try? (for the reviewer)
```bash
pytest -sx tests/scripts/test_train.py::TestCommitWandbStep
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).