### PR TITLE
fix(scripts): compact LIBERO eval logging, drop verbose video_paths

### DIFF
--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -879,9 +879,7 @@ def train(cfg: TrainPipelineConfig):
                 # compact per-group + overall summary (drop verbose video_paths)
                 def _fmt(m: dict) -> str:
                     return (
-                        f"success={m.get('pc_success', float('nan')):.1f}% "
-                        f"∑rwrd={m.get('avg_sum_reward', float('nan')):.3f} "
-                        f"n={m.get('n_episodes', 0)}"
+                        f"success={m['pc_success']:.1f}% ∑rwrd={m['avg_sum_reward']:.3f} n={m['n_episodes']}"
                     )
 
                 for group, v in eval_info["per_group"].items():

--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -876,9 +876,17 @@ def train(cfg: TrainPipelineConfig):
                 # overall metrics (suite-agnostic)
                 aggregated = eval_info["overall"]
 
-                # optional: per-suite logging
-                for suite, suite_info in eval_info.items():
-                    logging.info("Suite %s aggregated: %s", suite, suite_info)
+                # compact per-group + overall summary (drop verbose video_paths)
+                def _fmt(m: dict) -> str:
+                    return (
+                        f"success={m.get('pc_success', float('nan')):.1f}% "
+                        f"∑rwrd={m.get('avg_sum_reward', float('nan')):.3f} "
+                        f"n={m.get('n_episodes', 0)}"
+                    )
+
+                for group, v in eval_info["per_group"].items():
+                    logging.info("eval[%s]: %s", group, _fmt(v))
+                logging.info("eval[overall]: %s", _fmt(aggregated))
 
                 # meters/tracker
                 eval_metrics = {


### PR DESCRIPTION
## What this does

LIBERO eval logging in `scripts/train.py` dumped the `per_task`, `per_group`,
and `overall` sections of `eval_info` verbatim on every eval. Each section
carried the full per-episode `video_paths` list, so a single eval flooded the
console with hundreds of lines of repeated paths.

This replaces that loop with a compact one-line-per-group summary plus an
overall line:

```
eval[libero_10]: success=0.0% ∑rwrd=0.000 n=64
eval[overall]: success=0.0% ∑rwrd=0.000 n=64
```

Nothing is lost: the complete `eval_info` (including all video paths) is still
written to `eval_info.json` in the per-step videos dir, exactly as before.

## How it was tested

- `ruff check` / `ruff format --check` pass; full pre-commit suite passes.
- Logging-only change: the new `_fmt` helper reads the same `pc_success`,
  `avg_sum_reward`, and `n_episodes` keys already produced by
  `consolidate_eval_info`, and the wandb/tracker logging below it is untouched.

## How to checkout & try? (for the reviewer)

Run any config with a LIBERO eval enabled and observe the per-group + overall
summary lines in place of the previous multi-hundred-line dumps:

```bash
opentau-train --config_path=configs/examples/pi05_training_config.json
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.