### PR TITLE
feat: dataset provenance fields + pi07_paligemma outlier warning

### DIFF
--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -2207,9 +2207,11 @@ class LeRobotDataset(BaseDataset):
             # BaseDataset._emit_optional_keys can apply dropout uniformly.
             ep_start = int(self.episode_data_index["from"][self.epi2idx[ep_idx]].item())
             frame_in_ep = idx - ep_start
-            # Stash the within-episode frame index so `_to_standard_data_format`
-            # can emit it as provenance (the raw item carries `episode_index`
-            # already, but not the within-episode `frame_index`).
+            # Stash the within-episode frame offset (idx - ep_start) under
+            # `frame_index` so `_to_standard_data_format` can emit it as
+            # provenance. The raw hf row also carries a `frame_index` column;
+            # we deliberately use the recomputed offset, which stays correct
+            # even if that column is malformed.
             item["frame_index"] = frame_in_ep
             if "memory" in item:
                 item["memory_raw"] = str(item["memory"])

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -908,6 +908,21 @@ class BaseDataset(torch.utils.data.Dataset):
             if isinstance(value, torch.Tensor) and value.dtype.is_floating_point:
                 standard_item[key] = value.to(dtype=torch.bfloat16)
 
+        # Provenance fields (part of the standard data format). `source` is the
+        # dataset's identity (repo_id for LeRobotDataset, the dataset key for
+        # VQA), so a sample's origin survives into the training batch — useful
+        # for debugging which dataset/frame produced an outlier. `episode_index`
+        # / `frame_index` are plain ints (default-collate to a (B,) int64
+        # tensor); VQA / missing values emit the sentinel -1 so a heterogeneous
+        # LeRobot+VQA batch stays schema-aligned under default collation.
+        standard_item["source"] = self._get_feature_mapping_key()
+        ep = item.get("episode_index")
+        standard_item["episode_index"] = (
+            int(ep.item() if torch.is_tensor(ep) else ep) if ep is not None else -1
+        )
+        fr = item.get("frame_index")
+        standard_item["frame_index"] = int(fr.item() if torch.is_tensor(fr) else fr) if fr is not None else -1
+
         return standard_item
 
     def _emit_optional_keys(self, item: dict, standard_item: dict) -> None:
@@ -2192,6 +2207,10 @@ class LeRobotDataset(BaseDataset):
             # BaseDataset._emit_optional_keys can apply dropout uniformly.
             ep_start = int(self.episode_data_index["from"][self.epi2idx[ep_idx]].item())
             frame_in_ep = idx - ep_start
+            # Stash the within-episode frame index so `_to_standard_data_format`
+            # can emit it as provenance (the raw item carries `episode_index`
+            # already, but not the within-episode `frame_index`).
+            item["frame_index"] = frame_in_ep
             if "memory" in item:
                 item["memory_raw"] = str(item["memory"])
             if "mistake" in item:

--- a/src/opentau/policies/pi07_paligemma/low_level/configuration_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/configuration_pi07_low_level.py
@@ -168,6 +168,15 @@ class PI07PaligemmaLowLevelConfig(PreTrainedConfig):
     scheduler_decay_steps: int = 30_000
     scheduler_decay_lr: float = 2.5e-6
 
+    # Debug aid: during the training forward, emit a logging.warning when any
+    # individual NORMALIZED state/action feature dim (after taking abs) exceeds
+    # this value — a symptom of bad normalization stats (e.g. near-zero std on a
+    # constant dim) or corrupt data. The warning names the offending
+    # source/episode/frame when those batch fields are present, to point at the
+    # dataset/frame to inspect. Set to 0.0 (or negative) to disable entirely and
+    # skip the per-step device sync.
+    warn_outlier_threshold: float = 10.0
+
     @property
     def obs_buffer_size(self) -> int:
         """Total raw frames the state history buffer must keep.

--- a/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
@@ -290,16 +290,29 @@ def pad_discrete_tokens(tokens: list[list[int]], max_length: int) -> tuple[np.nd
     return np.array(discrete_action_tokens), np.array(discrete_action_masks)
 
 
+# Process-local set of ``(source, key, dim)`` outlier offenders already warned
+# about, so ``_warn_state_action_outliers`` fires at most once per offender per
+# run instead of every training step. Under DDP each rank keeps its own set and
+# logs its own first occurrence (no cross-rank coordination — keeps the helper
+# rule-5 safe). Tests clear this between cases.
+_WARNED_OUTLIER_KEYS: set[tuple[object, str, int]] = set()
+
+
 def _warn_state_action_outliers(batch: dict[str, Tensor], threshold: float | None) -> None:
     """Warn when a normalized state/action feature dim exceeds ``threshold``.
 
     A normalized value far from unit scale almost always means bad
     normalization stats (e.g. near-zero std on a constant dim) or corrupt
-    data. This logs one concise ``logging.warning`` per offending tensor,
-    naming the offending ``source`` / ``episode_index`` / ``frame_index`` when
-    those provenance fields are present in the batch (they are emitted by the
-    dataset's standard data format), so a poorly-normalized dim can be traced
-    back to the dataset/frame to inspect.
+    data. This logs a concise ``logging.warning`` naming the offending
+    ``source`` / ``episode_index`` / ``frame_index`` when those provenance
+    fields are present in the batch (they are emitted by the dataset's standard
+    data format), so a poorly-normalized dim can be traced back to the
+    dataset/frame to inspect.
+
+    To avoid drowning the log when a dim is persistently out of range, each
+    ``(source, key, dim)`` offender is warned about at most once per process
+    (tracked in ``_WARNED_OUTLIER_KEYS``); a fresh offender later in the run
+    still gets its own line.
 
     Pure and log-only: it reads ``batch`` without mutating it and MUST NOT gate
     any model call on its result. Keeping it log-only keeps the ``forward``
@@ -336,24 +349,46 @@ def _warn_state_action_outliers(batch: dict[str, Tensor], threshold: float | Non
     src = batch.get("source")
     ep = batch.get("episode_index")
     fr = batch.get("frame_index")
+
+    def _per_sample(value: object, i: int) -> object:
+        if isinstance(value, list):
+            return value[i]
+        if torch.is_tensor(value):
+            return int(value[i])
+        return value
+
     for key, (per_dim_max, viol) in per_key.items():
-        n = int(viol.any(dim=-1).sum().item())
-        if n == 0:
+        # (sample, dim) coordinates of every violating entry this step.
+        coords = torch.nonzero(viol, as_tuple=False).tolist()
+        if not coords:
             continue
-        worst = int(per_dim_max.amax(dim=-1).argmax().item())
-        worst_dims = torch.nonzero(viol[worst], as_tuple=False).flatten().tolist()
+        # Index on CPU once so the per-offender lookups below don't each sync.
+        pdm = per_dim_max.detach().cpu()
+        # Keep only offenders not yet warned about, deduped per (source, key, dim).
+        fresh = []
+        for s_i, d in coords:
+            tup = (_per_sample(src, s_i), key, d)
+            if tup not in _WARNED_OUTLIER_KEYS:
+                _WARNED_OUTLIER_KEYS.add(tup)
+                fresh.append((s_i, d))
+        if not fresh:
+            continue
+        # Report the worst (largest |value|) among the newly-seen offenders.
+        worst_s, worst_d = max(fresh, key=lambda sd: pdm[sd[0], sd[1]].item())
+        fresh_dims = sorted({d for _, d in fresh})
         logging.warning(
-            "Outlier normalized %s: %d/%d samples exceed |%.1f|; worst sample "
-            "dims=%s max=%.2f (source=%s episode=%s frame=%s)",
+            "Outlier normalized %s: %d new (source,dim) offender(s) exceed |%.1f|; "
+            "new dims=%s; worst dim=%d max=%.2f (source=%s episode=%s frame=%s). "
+            "Repeat warnings for these (source,dim) pairs are suppressed.",
             key,
-            n,
-            viol.shape[0],
+            len(fresh),
             threshold,
-            worst_dims,
-            float(per_dim_max[worst].max().item()),
-            src[worst] if isinstance(src, list) else src,
-            int(ep[worst]) if torch.is_tensor(ep) else ep,
-            int(fr[worst]) if torch.is_tensor(fr) else fr,
+            fresh_dims,
+            worst_d,
+            float(pdm[worst_s, worst_d]),
+            _per_sample(src, worst_s),
+            _per_sample(ep, worst_s),
+            _per_sample(fr, worst_s),
         )
 
 

--- a/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
@@ -31,7 +31,7 @@ from typing import Literal
 import numpy as np
 import torch
 import torch.nn.functional as F  # noqa: N812
-from einops import rearrange
+from einops import rearrange, reduce
 from torch import Tensor, nn
 from transformers import AutoProcessor, AutoTokenizer
 
@@ -288,6 +288,73 @@ def pad_discrete_tokens(tokens: list[list[int]], max_length: int) -> tuple[np.nd
             )
             discrete_action_tokens.append(np.pad(token, (0, max_length - len(token)), constant_values=0))
     return np.array(discrete_action_tokens), np.array(discrete_action_masks)
+
+
+def _warn_state_action_outliers(batch: dict[str, Tensor], threshold: float | None) -> None:
+    """Warn when a normalized state/action feature dim exceeds ``threshold``.
+
+    A normalized value far from unit scale almost always means bad
+    normalization stats (e.g. near-zero std on a constant dim) or corrupt
+    data. This logs one concise ``logging.warning`` per offending tensor,
+    naming the offending ``source`` / ``episode_index`` / ``frame_index`` when
+    those provenance fields are present in the batch (they are emitted by the
+    dataset's standard data format), so a poorly-normalized dim can be traced
+    back to the dataset/frame to inspect.
+
+    Pure and log-only: it reads ``batch`` without mutating it and MUST NOT gate
+    any model call on its result. Keeping it log-only keeps the ``forward``
+    graph — and therefore the collective counts under FSDP / ZeRO — identical
+    across ranks regardless of what any rank's local data contains (CLAUDE.md
+    rule 5).
+
+    Args:
+        batch: Training batch *after* input/target normalization. Reads
+            ``state`` ``(B, [T,] D)`` and ``actions`` ``(B, chunk, D)``; the
+            zero-padded tail dims never trigger.
+        threshold: Absolute-value ceiling. ``None`` or ``<= 0`` disables the
+            check entirely (early return, no device sync).
+    """
+    if threshold is None or threshold <= 0:
+        return
+    per_key: dict[str, tuple[Tensor, Tensor]] = {}
+    for key in ("state", "actions"):
+        t = batch.get(key)
+        if t is None:
+            continue
+        # (B, [T|chunk,] D) -> (B, D): max |value| per feature dim. The
+        # ``b ... d`` pattern absorbs the optional middle axis (2-D state, 3-D
+        # state history, 3-D action chunk) in a single expression.
+        per_dim_max = reduce(t.detach().abs().float(), "b ... d -> b d", "max")
+        per_key[key] = (per_dim_max, per_dim_max > threshold)
+    if not per_key:
+        return
+    # One device->host sync covering both tensors; skip the rest on the common
+    # (no-outlier) path.
+    if not bool(torch.cat([viol.flatten() for _, viol in per_key.values()]).any()):
+        return
+
+    src = batch.get("source")
+    ep = batch.get("episode_index")
+    fr = batch.get("frame_index")
+    for key, (per_dim_max, viol) in per_key.items():
+        n = int(viol.any(dim=-1).sum().item())
+        if n == 0:
+            continue
+        worst = int(per_dim_max.amax(dim=-1).argmax().item())
+        worst_dims = torch.nonzero(viol[worst], as_tuple=False).flatten().tolist()
+        logging.warning(
+            "Outlier normalized %s: %d/%d samples exceed |%.1f|; worst sample "
+            "dims=%s max=%.2f (source=%s episode=%s frame=%s)",
+            key,
+            n,
+            viol.shape[0],
+            threshold,
+            worst_dims,
+            float(per_dim_max[worst].max().item()),
+            src[worst] if isinstance(src, list) else src,
+            int(ep[worst]) if torch.is_tensor(ep) else ep,
+            int(fr[worst]) if torch.is_tensor(fr) else fr,
+        )
 
 
 class PI07PaligemmaLowLevelPolicy(PreTrainedPolicy):
@@ -1044,6 +1111,11 @@ class PI07PaligemmaLowLevelPolicy(PreTrainedPolicy):
         batch = self.normalize_inputs(batch, dataset_index)
         batch["discrete_actions"] = self.normalize_discrete_actions(dict(batch), dataset_index)["actions"]
         batch = self.normalize_targets(batch, dataset_index)
+
+        # Debug aid (log-only; never gates the forward — see CLAUDE.md rule 5):
+        # flag poorly-normalized state/action dims so they can be traced to the
+        # offending dataset/frame.
+        _warn_state_action_outliers(batch, self.config.warn_outlier_threshold)
 
         self._hydrate_optional_conditioning_batch(batch)
 

--- a/tests/datasets/test_action_dim.py
+++ b/tests/datasets/test_action_dim.py
@@ -159,6 +159,43 @@ def test_action_dim_reflects_pre_pad_shape(
     assert item["actions"].shape == (dataset.cfg.action_chunk, dataset.cfg.max_action_dim)
 
 
+def test_provenance_fields_in_standard_format(
+    lerobot_dataset_factory,
+    info_factory,
+    hf_dataset_factory,
+    tasks_factory,
+    episodes_factory,
+    stats_factory,
+    episodes_stats_factory,
+    tmp_path,
+):
+    """Every standardized sample carries provenance: ``source`` (the repo id)
+    plus int ``episode_index`` / ``frame_index``. ``frame_index`` is emitted as
+    the within-episode offset (``idx - ep_start``), so it's checked against the
+    fixture's independently-built ``frame_index`` column to catch an off-by-one.
+    """
+    dataset = _make_dataset(
+        lerobot_dataset_factory,
+        info_factory,
+        hf_dataset_factory,
+        tasks_factory,
+        episodes_factory,
+        stats_factory,
+        episodes_stats_factory,
+        tmp_path,
+        real_action_dim=4,
+        suffix="provenance",
+    )
+    idx = 25
+    raw = dataset.hf_dataset[idx]
+    item = dataset[idx]
+    assert item["source"] == dataset.repo_id
+    assert isinstance(item["episode_index"], int)
+    assert isinstance(item["frame_index"], int)
+    assert item["episode_index"] == int(raw["episode_index"].item())
+    assert item["frame_index"] == int(raw["frame_index"].item())
+
+
 def test_action_dim_default_dataloader_collation(
     lerobot_dataset_factory,
     info_factory,
@@ -299,6 +336,16 @@ def test_cross_dataset_batch_routes_action_dim_into_loss(
     batch = torch.utils.data.default_collate([ds_a[0], ds_b[0]])
     assert batch["real_action_dim"].tolist() == [4, 9]
     assert batch["actions"].shape == (2, chunk, max_action_dim)
+
+    # Provenance fields survive default collation across two datasets: `source`
+    # stays a list[str] (one entry per sample, never stacked into a tensor),
+    # while the int episode/frame indices stack into (B,) int64 tensors. Both
+    # `ds_a[0]` and `ds_b[0]` are the first frame of episode 0.
+    assert isinstance(batch["source"], list)
+    assert batch["source"] == [ds_a.repo_id, ds_b.repo_id]
+    assert batch["episode_index"].dtype == torch.int64
+    assert batch["episode_index"].tolist() == [0, 0]
+    assert batch["frame_index"].tolist() == [0, 0]
 
     # Hand-crafted velocity tensors: u_t - v_t = 1 everywhere → per-element MSE = 1.
     # No frozen prefix, no timestep padding — isolates the action_dim contribution.

--- a/tests/datasets/test_vqa_provenance.py
+++ b/tests/datasets/test_vqa_provenance.py
@@ -1,0 +1,54 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Provenance fields on a VQA sample.
+
+A VQA item has no episode/frame, so `_to_standard_data_format` must emit the
+`-1` sentinel for `episode_index` / `frame_index` while still emitting a real
+`source` (the dataset key). This is the branch that keeps a heterogeneous
+VQA + LeRobot mixture schema-aligned under default collation, and it's the one
+piece of the provenance change that the LeRobot-only tests don't exercise.
+
+``train_pipeline_config`` comes from ``tests/fixtures/config_factory.py``.
+"""
+
+import torch
+
+from opentau.datasets.vqa.dummy import DummyVQADataset
+
+
+def test_vqa_emits_source_and_sentinel_indices(train_pipeline_config):
+    """A VQA sample carries a real ``source`` but the ``-1`` sentinel for the
+    ``episode_index`` / ``frame_index`` it lacks (plain ``int``, not tensor)."""
+    ds = DummyVQADataset(train_pipeline_config)
+    item = ds[0]
+    assert item["source"] == "dummy"
+    assert item["episode_index"] == -1
+    assert item["frame_index"] == -1
+    assert isinstance(item["episode_index"], int)
+    assert isinstance(item["frame_index"], int)
+
+
+def test_vqa_provenance_default_collates(train_pipeline_config):
+    """The VQA provenance fields survive default collation across a batch:
+    ``source`` -> ``list[str]``, the int sentinels -> a ``(B,)`` int64 tensor.
+    This is exactly the alignment a VQA + LeRobot co-training batch relies on.
+    """
+    ds = DummyVQADataset(train_pipeline_config)
+    batch = torch.utils.data.default_collate([ds[0], ds[1]])
+    assert isinstance(batch["source"], list)
+    assert batch["source"] == ["dummy", "dummy"]
+    assert batch["episode_index"].dtype == torch.int64
+    assert batch["episode_index"].tolist() == [-1, -1]
+    assert batch["frame_index"].tolist() == [-1, -1]

--- a/tests/policies/test_pi07_paligemma_outlier_warning.py
+++ b/tests/policies/test_pi07_paligemma_outlier_warning.py
@@ -1,0 +1,99 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU unit tests for the pi07_paligemma low-level outlier warning.
+
+``_warn_state_action_outliers`` is pure tensor + logging, so it's exercised
+directly on constructed batches without building the policy or touching a GPU.
+"""
+
+import logging
+
+import pytest
+import torch
+
+from opentau.policies.pi07_paligemma.low_level.modeling_pi07_low_level import (
+    _warn_state_action_outliers,
+)
+
+
+class TestWarnStateActionOutliers:
+    def test_warns_above_threshold_state_only(self, caplog):
+        batch = {"state": torch.zeros(2, 8), "actions": torch.zeros(2, 4, 8)}
+        batch["state"][1, 3] = 50.0  # one outlier dim in the state
+        with caplog.at_level(logging.WARNING):
+            _warn_state_action_outliers(batch, 10.0)
+        msgs = [r.getMessage() for r in caplog.records if "Outlier" in r.getMessage()]
+        assert any("state" in m and "dims=[3]" in m and "50" in m for m in msgs)
+        # actions are all zero -> never warned.
+        assert not any("actions" in m for m in msgs)
+
+    def test_silent_below_threshold(self, caplog):
+        batch = {"state": torch.full((2, 8), 5.0), "actions": torch.full((2, 4, 8), 9.9)}
+        with caplog.at_level(logging.WARNING):
+            _warn_state_action_outliers(batch, 10.0)
+        assert not any("Outlier" in r.getMessage() for r in caplog.records)
+
+    @pytest.mark.parametrize("threshold", [0.0, -1.0, None])
+    def test_disabled_threshold_is_silent(self, caplog, threshold):
+        # A huge value must NOT warn when the check is disabled.
+        batch = {"state": torch.full((2, 8), 1e3), "actions": torch.zeros(2, 4, 8)}
+        with caplog.at_level(logging.WARNING):
+            _warn_state_action_outliers(batch, threshold)
+        assert not any("Outlier" in r.getMessage() for r in caplog.records)
+
+    def test_names_source_episode_frame(self, caplog):
+        batch = {
+            "state": torch.zeros(2, 8),
+            "actions": torch.zeros(2, 4, 8),
+            "source": ["dsA", "dsB"],
+            "episode_index": torch.tensor([0, 7]),
+            "frame_index": torch.tensor([0, 42]),
+        }
+        batch["actions"][1, 2, 5] = 99.0  # outlier in sample 1
+        with caplog.at_level(logging.WARNING):
+            _warn_state_action_outliers(batch, 10.0)
+        msg = "\n".join(r.getMessage() for r in caplog.records)
+        assert "actions" in msg
+        assert "dims=[5]" in msg
+        assert "source=dsB" in msg
+        assert "episode=7" in msg
+        assert "frame=42" in msg
+
+    def test_missing_provenance_keys_tolerated(self, caplog):
+        # No source/episode/frame keys: must still warn (with None placeholders)
+        # and never raise -- protects existing/test callers that omit them.
+        batch = {"state": torch.zeros(2, 8), "actions": torch.zeros(2, 4, 8)}
+        batch["state"][0, 0] = 100.0
+        with caplog.at_level(logging.WARNING):
+            _warn_state_action_outliers(batch, 10.0)
+        msg = "\n".join(r.getMessage() for r in caplog.records)
+        assert "source=None" in msg
+        assert "episode=None" in msg
+        assert "frame=None" in msg
+
+    @pytest.mark.parametrize("state_shape", [(2, 8), (2, 3, 8)])
+    def test_variable_ndim_state(self, caplog, state_shape):
+        # The `b ... d` reduction must collapse the optional middle (time) axis
+        # for both a 2-D state and a 3-D state-history tensor.
+        batch = {"state": torch.zeros(*state_shape)}
+        if len(state_shape) == 3:
+            batch["state"][1, 2, 7] = 30.0  # outlier in a middle-T slot
+        else:
+            batch["state"][1, 7] = 30.0
+        with caplog.at_level(logging.WARNING):
+            _warn_state_action_outliers(batch, 10.0)
+        msg = "\n".join(r.getMessage() for r in caplog.records if "Outlier" in r.getMessage())
+        assert "state" in msg
+        assert "dims=[7]" in msg

--- a/tests/policies/test_pi07_paligemma_outlier_warning.py
+++ b/tests/policies/test_pi07_paligemma_outlier_warning.py
@@ -23,8 +23,8 @@ import logging
 import pytest
 import torch
 
-import opentau.policies.pi07_paligemma.low_level.modeling_pi07_low_level as pg_ll_modeling
 from opentau.policies.pi07_paligemma.low_level.modeling_pi07_low_level import (
+    _WARNED_OUTLIER_KEYS,
     _warn_state_action_outliers,
 )
 
@@ -34,9 +34,9 @@ class TestWarnStateActionOutliers:
     def _clear_seen(self):
         # The warn-once dedup set is module-global and persists across the
         # process; clear it around every test so cases are order-independent.
-        pg_ll_modeling._WARNED_OUTLIER_KEYS.clear()
+        _WARNED_OUTLIER_KEYS.clear()
         yield
-        pg_ll_modeling._WARNED_OUTLIER_KEYS.clear()
+        _WARNED_OUTLIER_KEYS.clear()
 
     def test_warns_above_threshold_state_only(self, caplog):
         batch = {"state": torch.zeros(2, 8), "actions": torch.zeros(2, 4, 8)}

--- a/tests/policies/test_pi07_paligemma_outlier_warning.py
+++ b/tests/policies/test_pi07_paligemma_outlier_warning.py
@@ -23,12 +23,21 @@ import logging
 import pytest
 import torch
 
+import opentau.policies.pi07_paligemma.low_level.modeling_pi07_low_level as pg_ll_modeling
 from opentau.policies.pi07_paligemma.low_level.modeling_pi07_low_level import (
     _warn_state_action_outliers,
 )
 
 
 class TestWarnStateActionOutliers:
+    @pytest.fixture(autouse=True)
+    def _clear_seen(self):
+        # The warn-once dedup set is module-global and persists across the
+        # process; clear it around every test so cases are order-independent.
+        pg_ll_modeling._WARNED_OUTLIER_KEYS.clear()
+        yield
+        pg_ll_modeling._WARNED_OUTLIER_KEYS.clear()
+
     def test_warns_above_threshold_state_only(self, caplog):
         batch = {"state": torch.zeros(2, 8), "actions": torch.zeros(2, 4, 8)}
         batch["state"][1, 3] = 50.0  # one outlier dim in the state
@@ -97,3 +106,31 @@ class TestWarnStateActionOutliers:
         msg = "\n".join(r.getMessage() for r in caplog.records if "Outlier" in r.getMessage())
         assert "state" in msg
         assert "dims=[7]" in msg
+
+    def test_warns_once_per_source_key_dim(self, caplog):
+        # The same (source, key, dim) offender on a later step is suppressed.
+        batch = {"state": torch.zeros(2, 8), "actions": torch.zeros(2, 4, 8)}
+        batch["state"][1, 3] = 50.0
+        with caplog.at_level(logging.WARNING):
+            _warn_state_action_outliers(batch, 10.0)
+        assert sum("Outlier" in r.getMessage() for r in caplog.records) == 1
+        caplog.clear()
+        with caplog.at_level(logging.WARNING):
+            _warn_state_action_outliers(batch, 10.0)
+        assert not any("Outlier" in r.getMessage() for r in caplog.records)
+
+    def test_fresh_offender_still_warns(self, caplog):
+        # A previously-unseen dim warns even after another dim was already seen.
+        batch = {"state": torch.zeros(2, 8), "actions": torch.zeros(2, 4, 8)}
+        batch["state"][1, 3] = 50.0
+        with caplog.at_level(logging.WARNING):
+            _warn_state_action_outliers(batch, 10.0)
+        caplog.clear()
+        batch["state"][1, 3] = 0.0  # old offender resolved
+        batch["state"][0, 5] = 77.0  # new offender appears
+        with caplog.at_level(logging.WARNING):
+            _warn_state_action_outliers(batch, 10.0)
+        msgs = [r.getMessage() for r in caplog.records if "Outlier" in r.getMessage()]
+        assert len(msgs) == 1
+        assert "dims=[5]" in msgs[0]
+        assert "dims=[3]" not in msgs[0]


### PR DESCRIPTION
## What this does

Two small, interlocking changes to support debugging poorly-normalized state/action values during pi07_paligemma training.

**1. Provenance fields in the dataset's standard data format.** Every standardized sample now carries where it came from:
- `source` (str) — the dataset identity (`repo_id` for `LeRobotDataset`, the dataset key for VQA).
- `episode_index` (int) and `frame_index` (int) — the within-episode frame offset for convenience.

These are emitted from the **shared** `BaseDataset._to_standard_data_format`, so both `LeRobotDataset` and `VQADataset` produce them. That keeps a heterogeneous `WeightedDatasetMixture` (LeRobot + VQA in one batch under default collation) schema-aligned: VQA / missing values emit the sentinel `-1`. Under `default_collate`, `source` becomes a `list[str]` and the two ints stack into a `(B,)` int64 tensor. Previously the standardized item dropped all provenance (the fresh-dict rebuild only re-emitted known keys).

**2. Outlier warning in pi07_paligemma low-level.** New `warn_outlier_threshold` config field (default `10.0`) plus a log-only `_warn_state_action_outliers` helper, called in the training `forward` right after normalization. When any individual **normalized** state/action dim exceeds the threshold (a symptom of bad normalization stats — e.g. near-zero std on a constant dim — or corrupt data), it logs one concise warning per tensor that names the offending `source` / `episode_index` / `frame_index` (wired to the fields from change 1). Set the threshold to `0.0` (or negative) to disable and skip the per-step device sync.

The helper is strictly log-only and never gates the model `forward`, so collective counts stay aligned across ranks under FSDP / ZeRO.

## How it was tested

- Added `tests/policies/test_pi07_paligemma_outlier_warning.py` (`TestWarnStateActionOutliers`, CPU): warns above threshold, silent below / when disabled (`0.0`/negative/`None`), names source/episode/frame of the worst sample, tolerates those keys being absent, and handles both 2-D `(B, D)` and 3-D `(B, T, D)` state.
- Extended `tests/datasets/test_action_dim.py`: a per-sample check that `source`/`episode_index`/`frame_index` are present and correct (`frame_index` validated against the fixture's independent `frame_index` column to catch an off-by-one), and a cross-dataset `default_collate` check that `source` collates to a `list[str]` while the indices stack into `(B,)` int64 tensors.
- CPU suite green: `pytest -m "not gpu"` over `tests/datasets` + `tests/policies` — 897 passed, 9 skipped. The existing mixture membership test stays green.
- GPU pytests (`pytest -m "gpu"`) and the nightly regression suite were dispatched on this branch via `workflow_dispatch` (this is a policy-related change).
- `pre-commit run --all-files` clean (ruff, ruff-format, pyupgrade, bandit, etc.).

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/policies/test_pi07_paligemma_outlier_warning.py
```
```bash
pytest -sx tests/datasets/test_action_dim.py::test_provenance_fields_in_standard_format
pytest -sx tests/datasets/test_action_dim.py::test_cross_dataset_batch_routes_action_dim_into_loss
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [x] My PR includes policy-related changes.
  - [x] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).