### PR TITLE
feat(pi07_paligemma): custom CUDA block-causal flash attention

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,6 +161,11 @@ extra-build-dependencies = { egl-probe = ["cmake"] }
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.setuptools.package-data]
+# Ship the custom flash-attention CUDA source so the kernel can be JIT-compiled
+# from an installed wheel (not just an editable/source checkout).
+"opentau.policies.flash_attn_cuda" = ["_csrc/*.cu", "_csrc/*.cuh", "_csrc/*.cpp", "_csrc/*.h"]
+
 [tool.ruff]
 line-length = 110
 target-version = "py310"

--- a/src/opentau/policies/flash_attn_cuda/__init__.py
+++ b/src/opentau/policies/flash_attn_cuda/__init__.py
@@ -1,0 +1,171 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Custom CUDA FlashAttention with in-kernel block-causal masking.
+
+This package provides a dependency-free (no ``flash-attn``, no ``flex_attention``)
+fused attention forward + backward whose block-causal mask is reconstructed
+*inside the CUDA kernel* from a compact per-token block-id representation. The
+dense ``(B, S, S)`` attention mask is therefore never materialized, which is both
+the memory win over the eager backend and a direct way to "handle the block
+causal attention masks in the code".
+
+Public API:
+  - :func:`make_att_block_ids` -- build the compact ``(q_blk, k_blk, q_valid,
+    k_valid)`` representation from the same ``pad_masks`` / ``att_masks`` that
+    :func:`make_att_2d_masks` consumes. Provably reproduces the dense mask:
+    ``attend(i, j) == q_valid[i] & k_valid[j] & (k_blk[j] <= q_blk[i])``.
+  - :func:`flash_attn_blockmask` -- autograd-aware attention given the compact
+    representation.
+  - :func:`is_available` -- whether the CUDA kernel compiled (else fall back).
+
+Masking convention matches ``make_att_2d_masks``: ``True`` = attend. Cross-
+attention key columns get ``k_blk = INT32_MIN`` so they are always attended
+(subject to padding).
+"""
+
+from __future__ import annotations
+
+import torch
+
+from ._loader import get_extension, is_available, load_error
+
+__all__ = [
+    "INT_BLK_MIN",
+    "flash_attn_blockmask",
+    "is_available",
+    "load_error",
+    "make_att_block_ids",
+]
+
+# Sentinel block-id for cross-attention columns: always <= any real (cumsum)
+# block-id, so those columns are unconditionally attended (gated only by
+# padding). Must match the int32 INT_MIN the kernel compares against.
+INT_BLK_MIN = -(2**31)
+
+
+def make_att_block_ids(
+    pad_masks: torch.Tensor,
+    att_masks: torch.Tensor,
+    n_cross_att_tokens: int | None = None,
+    cross_att_pad_masks: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Compact block-id representation equivalent to ``make_att_2d_masks``.
+
+    Mirrors ``make_att_2d_masks`` exactly but returns four 1-D-per-token tensors
+    instead of a dense 2-D mask. The kernel reconstructs the mask via
+    ``attend(i, j) == q_valid[i] & k_valid[j] & (k_blk[j] <= q_blk[i])``.
+
+    Args:
+        pad_masks: bool ``(B, N)``, ``True`` where the token is real (not padding).
+        att_masks: int/bool ``(B, N)``, ``1`` opens a new attention block, ``0``
+            continues the current block (the same convention as
+            ``make_att_2d_masks``).
+        n_cross_att_tokens: if set, prepend that many cross-attention key columns
+            (always attended), matching the cross-attention branch of
+            ``make_att_2d_masks``.
+        cross_att_pad_masks: bool ``(B, n_cross_att_tokens)`` padding for the
+            cross columns. Required iff ``n_cross_att_tokens`` is set.
+
+    Returns:
+        ``(q_blk, k_blk, q_valid, k_valid)`` where ``q_blk`` is int32 ``(B, N)``,
+        ``k_blk`` is int32 ``(B, N)`` or ``(B, n_cross_att_tokens + N)``,
+        ``q_valid`` is bool ``(B, N)``, ``k_valid`` matches ``k_blk``'s length.
+    """
+    if att_masks.ndim != 2:
+        raise ValueError(f"att_masks must be 2D, got {att_masks.ndim}")
+    if pad_masks.ndim != 2:
+        raise ValueError(f"pad_masks must be 2D, got {pad_masks.ndim}")
+
+    cumsum = torch.cumsum(att_masks.to(torch.int32), dim=1).to(torch.int32)
+    q_blk = cumsum
+    q_valid = pad_masks.to(torch.bool)
+
+    if n_cross_att_tokens is None:
+        return q_blk, cumsum, q_valid, q_valid
+
+    assert cross_att_pad_masks is not None, (
+        "cross_att_pad_masks must be provided if n_cross_att_tokens is provided"
+    )
+    assert cross_att_pad_masks.shape == (att_masks.size(0), n_cross_att_tokens), (
+        "cross_att_pad_masks must have shape (batch_size, n_cross_att_tokens)"
+    )
+
+    b = att_masks.size(0)
+    cross_blk = torch.full((b, n_cross_att_tokens), INT_BLK_MIN, dtype=torch.int32, device=att_masks.device)
+    k_blk = torch.cat([cross_blk, cumsum], dim=1)
+    k_valid = torch.cat([cross_att_pad_masks.to(torch.bool), q_valid], dim=1)
+    return q_blk, k_blk, q_valid, k_valid
+
+
+def _prep(t: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
+    return t.to(dtype).contiguous()
+
+
+class _FlashAttnBlockMask(torch.autograd.Function):
+    """Autograd wrapper around the custom CUDA fwd/bwd kernels."""
+
+    @staticmethod
+    def forward(ctx, q, k, v, q_blk, k_blk, q_valid, k_valid, scale):  # noqa: ANN001
+        ext = get_extension()
+        if ext is None:
+            raise RuntimeError(f"flash_cuda kernel unavailable: {load_error()}")
+        q = q.contiguous()
+        k = k.contiguous()
+        v = v.contiguous()
+        q_blk = _prep(q_blk, torch.int32)
+        k_blk = _prep(k_blk, torch.int32)
+        q_valid = _prep(q_valid, torch.bool)
+        k_valid = _prep(k_valid, torch.bool)
+        out, lse = ext.flash_fwd(q, k, v, q_blk, k_blk, q_valid, k_valid, float(scale))
+        ctx.save_for_backward(q, k, v, out, lse, q_blk, k_blk, q_valid, k_valid)
+        ctx.scale = float(scale)
+        return out
+
+    @staticmethod
+    def backward(ctx, grad_out):  # noqa: ANN001
+        ext = get_extension()
+        q, k, v, out, lse, q_blk, k_blk, q_valid, k_valid = ctx.saved_tensors
+        dq, dk, dv = ext.flash_bwd(
+            grad_out.contiguous(), q, k, v, out, lse, q_blk, k_blk, q_valid, k_valid, ctx.scale
+        )
+        return dq, dk, dv, None, None, None, None, None
+
+
+def flash_attn_blockmask(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    q_blk: torch.Tensor,
+    k_blk: torch.Tensor,
+    q_valid: torch.Tensor,
+    k_valid: torch.Tensor,
+    scale: float,
+) -> torch.Tensor:
+    """Block-causal flash attention.
+
+    Args:
+        q: ``(B, Sq, H, D)`` queries.
+        k: ``(B, Sk, Hkv, D)`` keys (GQA/MQA: ``H % Hkv == 0``).
+        v: ``(B, Sk, Hkv, D)`` values.
+        q_blk: int32 ``(B, Sq)`` query block-ids.
+        k_blk: int32 ``(B, Sk)`` key block-ids (cross columns use ``INT_BLK_MIN``).
+        q_valid: bool ``(B, Sq)`` query padding mask (``True`` = real token).
+        k_valid: bool ``(B, Sk)`` key padding mask.
+        scale: softmax scale (typically ``head_dim ** -0.5``).
+
+    Returns:
+        ``(B, Sq, H, D)`` attention output, same dtype as ``q``.
+    """
+    return _FlashAttnBlockMask.apply(q, k, v, q_blk, k_blk, q_valid, k_valid, scale)

--- a/src/opentau/policies/flash_attn_cuda/_csrc/flash_blockmask.cu
+++ b/src/opentau/policies/flash_attn_cuda/_csrc/flash_blockmask.cu
@@ -1044,6 +1044,19 @@ std::vector<at::Tensor> flash_fwd(
   } else {
     // fp16/bf16: Tensor Core (WMMA) kernel. NW warps/block share the K/V tile.
     const size_t smem = fwd_wmma_smem(D);
+    // The WMMA forward uses a fixed NW=3 tiling whose opt-in smem (~93 KB at
+    // head_dim=256) fits sm_80/sm_86/A100 but exceeds the cap on older arches
+    // (sm_70/sm_75 = 64 KB). Check the device's opt-in limit up front so an
+    // unsupported arch raises an actionable error instead of failing opaquely
+    // at kernel launch (cudaFuncSetAttribute would silently no-op there).
+    int max_smem = 0;
+    cudaDeviceGetAttribute(&max_smem, cudaDevAttrMaxSharedMemoryPerBlockOptin, q.device().index());  // spellchecker:disable-line
+    TORCH_CHECK(
+        (int)smem <= max_smem,
+        "flash_cuda WMMA forward needs ", smem, " bytes of opt-in shared memory at head_dim=", D,
+        " but this device caps opt-in shared memory at ", max_smem,
+        " bytes. The flash_cuda forward requires sm_80+ (A100/sm_80, RTX 30xx/sm_86); "
+        "use attention_implementation='sdpa' on older arches.");
     const int rows_per_block = NW * BR_W;
     dim3 grid((Sq + rows_per_block - 1) / rows_per_block, H, B);
     dim3 block(NW * WARP);

--- a/src/opentau/policies/flash_attn_cuda/_csrc/flash_blockmask.cu
+++ b/src/opentau/policies/flash_attn_cuda/_csrc/flash_blockmask.cu
@@ -634,7 +634,357 @@ __global__ void flash_fwd_wmma_kernel(
   }
 }
 
+// =========================================================================
+// Tensor Core backward (fp16/bf16). Two kernels, FlashAttention-2 style, both
+// recomputing S = QK^T and P = exp(scale*S - L) (no online softmax — L is given).
+// All five matmuls run on WMMA tensor cores with fp32 accumulation.
+//
+//   dQ kernel (parallel over query slabs): dP = dO V^T; dS = P*(dP - delta);
+//     dQ += scale * dS K. dQ accumulator persists in shared memory.
+//   dK/dV kernel (parallel over key slabs, looping the GQA query-head group):
+//     dV += P^T dO; dK += scale * dS^T Q. No atomics (each key slab owned by one
+//     warp; the head-group sum is internal).
+//
+// nw (warps/block) is chosen at launch from the device's opt-in shared memory so
+// the per-warp slabs + fp32 accumulators fit (smaller than the forward because
+// the backward keeps full (slab x D) fp32 accumulators).
+// =========================================================================
+
+__host__ inline size_t bwd_dq_smem(int D, int nw) {
+  size_t bf16 = (size_t)nw * (2 * BR_W * D + BR_W * BC_W) + (size_t)2 * BC_W * D;  // Qs,dOs,dSs;Ks,Vs
+  size_t f32 = (size_t)nw * (BR_W * D + 2 * BR_W * BC_W + 2 * BR_W);  // dQacc,Ss,dPs,Li,delta
+  size_t i32 = (size_t)nw * BR_W + BC_W;
+  size_t c8 = (size_t)nw * BR_W + BC_W;
+  return bf16 * 2 + f32 * 4 + i32 * 4 + c8;
+}
+
+__host__ inline size_t bwd_dkv_smem(int D, int nw) {
+  size_t bf16 = (size_t)nw * (2 * BR_W * D + 2 * BR_W * BR_W) + (size_t)2 * BR_W * D;  // Ks,Vs,Ps,dSs;Qs,dOs
+  size_t f32 = (size_t)nw * (2 * BR_W * D + 2 * BR_W * BR_W) + (size_t)2 * BR_W;  // dKacc,dVacc,ss,dp;Li,delta
+  size_t i32 = (size_t)nw * BR_W + BR_W;
+  size_t c8 = (size_t)nw * BR_W + BR_W;
+  return bf16 * 2 + f32 * 4 + i32 * 4 + c8;
+}
+
+template <typename scalar_t>
+__global__ void flash_bwd_dq_wmma_kernel(
+    const scalar_t* __restrict__ Q, const scalar_t* __restrict__ K, const scalar_t* __restrict__ V,
+    const scalar_t* __restrict__ dO, const float* __restrict__ L, const float* __restrict__ delta,
+    const int* __restrict__ q_blk, const int* __restrict__ k_blk,
+    const bool* __restrict__ q_valid, const bool* __restrict__ k_valid,
+    scalar_t* __restrict__ dQ, int B, int Sq, int Sk, int H, int Hkv, int D, float scale, int nw) {
+  using namespace nvcuda;
+  using wt = typename WmmaTraits<scalar_t>::wt;
+  auto f2w = WmmaTraits<scalar_t>::from_float;
+
+  extern __shared__ char smem_raw[];
+  wt* Qs = reinterpret_cast<wt*>(smem_raw);          // nw*BR*D
+  wt* dOs = Qs + (long)nw * BR_W * D;                // nw*BR*D
+  wt* dSs = dOs + (long)nw * BR_W * D;               // nw*BR*BC
+  wt* Ks = dSs + (long)nw * BR_W * BC_W;             // BC*D
+  wt* Vs = Ks + (long)BC_W * D;                      // BC*D
+  float* dQacc = reinterpret_cast<float*>(Vs + (long)BC_W * D);  // nw*BR*D
+  float* Ss = dQacc + (long)nw * BR_W * D;           // nw*BR*BC
+  float* dPs = Ss + (long)nw * BR_W * BC_W;          // nw*BR*BC
+  float* sLi = dPs + (long)nw * BR_W * BC_W;         // nw*BR
+  float* sdl = sLi + (long)nw * BR_W;                // nw*BR
+  int* sQblk = reinterpret_cast<int*>(sdl + (long)nw * BR_W);  // nw*BR
+  int* sKblk = sQblk + (long)nw * BR_W;              // BC
+  char* sQvalid = reinterpret_cast<char*>(sKblk + BC_W);  // nw*BR
+  char* sKvalid = sQvalid + (long)nw * BR_W;         // BC
+
+  const int warp = threadIdx.x / WARP;
+  const int lane = threadIdx.x % WARP;
+  const int b = blockIdx.z, h = blockIdx.y;
+  const int hk = h / (H / Hkv);
+  const long q0 = (long)blockIdx.x * (nw * BR_W) + (long)warp * BR_W;
+
+  wt* qW = Qs + (long)warp * BR_W * D;
+  wt* doW = dOs + (long)warp * BR_W * D;
+  wt* dsW = dSs + (long)warp * BR_W * BC_W;
+  float* dqW = dQacc + (long)warp * BR_W * D;
+  float* ssW = Ss + (long)warp * BR_W * BC_W;
+  float* dpW = dPs + (long)warp * BR_W * BC_W;
+  float* liW = sLi + (long)warp * BR_W;
+  float* dlW = sdl + (long)warp * BR_W;
+  int* qblkW = sQblk + (long)warp * BR_W;
+  char* qvalidW = sQvalid + (long)warp * BR_W;
+
+  for (int idx = lane; idx < BR_W * D; idx += WARP) dqW[idx] = 0.f;
+  for (int idx = lane; idx < BR_W * D; idx += WARP) {
+    const int i = idx / D, d = idx % D;
+    const long qi = q0 + i;
+    if (qi < Sq) {
+      qW[idx] = f2w(to_f(Q[idx_qkv(b, qi, h, d, Sq, H, D)]));
+      doW[idx] = f2w(to_f(dO[idx_qkv(b, qi, h, d, Sq, H, D)]));
+    } else { qW[idx] = f2w(0.f); doW[idx] = f2w(0.f); }
+  }
+  for (int i = lane; i < BR_W; i += WARP) {
+    const long qi = q0 + i;
+    if (qi < Sq) {
+      liW[i] = L[idx_lse(b, h, qi, H, Sq)]; dlW[i] = delta[idx_lse(b, h, qi, H, Sq)];
+      qblkW[i] = q_blk[b * Sq + qi]; qvalidW[i] = q_valid[b * Sq + qi] ? 1 : 0;
+    } else { liW[i] = 0.f; dlW[i] = 0.f; qblkW[i] = INT_MIN; qvalidW[i] = 0; }
+  }
+  __syncthreads();
+
+  int bmax = INT_MIN;
+  for (int i = 0; i < nw * BR_W; ++i)
+    if (sQvalid[i]) bmax = max(bmax, sQblk[i]);
+
+  const int n_tiles = (Sk + BC_W - 1) / BC_W;
+  for (int kt = 0; kt < n_tiles; ++kt) {
+    const long kc0 = (long)kt * BC_W;
+    for (int idx = threadIdx.x; idx < BC_W * D; idx += blockDim.x) {
+      const int j = idx / D, d = idx % D;
+      const long kj = kc0 + j;
+      if (kj < Sk) {
+        Ks[idx] = f2w(to_f(K[idx_qkv(b, kj, hk, d, Sk, Hkv, D)]));
+        Vs[idx] = f2w(to_f(V[idx_qkv(b, kj, hk, d, Sk, Hkv, D)]));
+      } else { Ks[idx] = f2w(0.f); Vs[idx] = f2w(0.f); }
+    }
+    for (int j = threadIdx.x; j < BC_W; j += blockDim.x) {
+      const long kj = kc0 + j;
+      sKblk[j] = (kj < Sk) ? k_blk[b * Sk + kj] : INT_MAX;
+      sKvalid[j] = (kj < Sk && k_valid[b * Sk + kj]) ? 1 : 0;
+    }
+    __syncthreads();
+
+    const bool unreachable = (sKblk[0] > bmax);
+    if (!unreachable) {
+      // S = Q K^T  and  dP = dO V^T  (Tensor Cores).
+      wmma::fragment<wmma::accumulator, WM, WN, WK, float> accS, accP;
+      wmma::fill_fragment(accS, 0.f);
+      wmma::fill_fragment(accP, 0.f);
+      for (int kk = 0; kk < D / WK; ++kk) {
+        wmma::fragment<wmma::matrix_a, WM, WN, WK, wt, wmma::row_major> aq, ado;
+        wmma::fragment<wmma::matrix_b, WM, WN, WK, wt, wmma::col_major> bk, bv;
+        wmma::load_matrix_sync(aq, qW + kk * WK, D);
+        wmma::load_matrix_sync(bk, Ks + kk * WK, D);
+        wmma::mma_sync(accS, aq, bk, accS);
+        wmma::load_matrix_sync(ado, doW + kk * WK, D);
+        wmma::load_matrix_sync(bv, Vs + kk * WK, D);
+        wmma::mma_sync(accP, ado, bv, accP);
+      }
+      wmma::store_matrix_sync(ssW, accS, BC_W, wmma::mem_row_major);
+      wmma::store_matrix_sync(dpW, accP, BC_W, wmma::mem_row_major);
+      __syncwarp();
+
+      // P = exp(scale*S - L); dS = P*(dP - delta); masked entries -> 0.
+      if (lane < BR_W) {
+        const int i = lane;
+        if (qvalidW[i]) {
+          const int qb = qblkW[i];
+          const float Li = liW[i], di = dlW[i];
+          for (int j = 0; j < BC_W; ++j) {
+            const long kj = kc0 + j;
+            const bool att = (kj < Sk) && sKvalid[j] && (sKblk[j] <= qb);
+            float ds = 0.f;
+            if (att) {
+              const float p = __expf(ssW[i * BC_W + j] * scale - Li);
+              ds = p * (dpW[i * BC_W + j] - di);
+            }
+            dsW[i * BC_W + j] = f2w(ds);
+          }
+        } else {
+          for (int j = 0; j < BC_W; ++j) dsW[i * BC_W + j] = f2w(0.f);
+        }
+      }
+      __syncwarp();
+
+      // dQ += dS @ K  (dS row_major [BR,BC] k=BC; K row_major [BC,D]).
+      for (int dn = 0; dn < D / WN; ++dn) {
+        wmma::fragment<wmma::accumulator, WM, WN, WK, float> acc;
+        wmma::load_matrix_sync(acc, dqW + dn * WN, D, wmma::mem_row_major);
+        wmma::fragment<wmma::matrix_a, WM, WN, WK, wt, wmma::row_major> ads;
+        wmma::fragment<wmma::matrix_b, WM, WN, WK, wt, wmma::row_major> bk;
+        wmma::load_matrix_sync(ads, dsW, BC_W);
+        wmma::load_matrix_sync(bk, Ks + dn * WN, D);
+        wmma::mma_sync(acc, ads, bk, acc);
+        wmma::store_matrix_sync(dqW + dn * WN, acc, D, wmma::mem_row_major);
+      }
+      __syncwarp();
+    }
+    __syncthreads();
+    if (unreachable) break;
+  }
+
+  if (lane < BR_W) {
+    const int i = lane;
+    const long qi = q0 + i;
+    if (qi < Sq)
+      for (int d = 0; d < D; ++d) dQ[idx_qkv(b, qi, h, d, Sq, H, D)] = from_f<scalar_t>(dqW[i * D + d] * scale);
+  }
+}
+
+template <typename scalar_t>
+__global__ void flash_bwd_dkv_wmma_kernel(
+    const scalar_t* __restrict__ Q, const scalar_t* __restrict__ K, const scalar_t* __restrict__ V,
+    const scalar_t* __restrict__ dO, const float* __restrict__ L, const float* __restrict__ delta,
+    const int* __restrict__ q_blk, const int* __restrict__ k_blk,
+    const bool* __restrict__ q_valid, const bool* __restrict__ k_valid,
+    scalar_t* __restrict__ dK, scalar_t* __restrict__ dV,
+    int B, int Sq, int Sk, int H, int Hkv, int D, float scale, int nw) {
+  using namespace nvcuda;
+  using wt = typename WmmaTraits<scalar_t>::wt;
+  auto f2w = WmmaTraits<scalar_t>::from_float;
+
+  extern __shared__ char smem_raw[];
+  wt* Ks = reinterpret_cast<wt*>(smem_raw);          // nw*BR*D (owned key slab)
+  wt* Vs = Ks + (long)nw * BR_W * D;                 // nw*BR*D
+  wt* Ps = Vs + (long)nw * BR_W * D;                 // nw*BR*BR
+  wt* dSs = Ps + (long)nw * BR_W * BR_W;             // nw*BR*BR
+  wt* Qs = dSs + (long)nw * BR_W * BR_W;             // BR*D (streamed)
+  wt* dOs = Qs + (long)BR_W * D;                     // BR*D
+  float* dKacc = reinterpret_cast<float*>(dOs + (long)BR_W * D);  // nw*BR*D
+  float* dVacc = dKacc + (long)nw * BR_W * D;        // nw*BR*D
+  float* Ss = dVacc + (long)nw * BR_W * D;           // nw*BR*BR
+  float* dPs = Ss + (long)nw * BR_W * BR_W;          // nw*BR*BR
+  float* sLi = dPs + (long)nw * BR_W * BR_W;         // BR
+  float* sdl = sLi + (long)BR_W;                     // BR
+  int* sKblk = reinterpret_cast<int*>(sdl + (long)BR_W);  // nw*BR (owned)
+  int* sQblk = sKblk + (long)nw * BR_W;              // BR (streamed)
+  char* sKvalid = reinterpret_cast<char*>(sQblk + (long)BR_W);  // nw*BR
+  char* sQvalid = sKvalid + (long)nw * BR_W;         // BR
+
+  const int warp = threadIdx.x / WARP;
+  const int lane = threadIdx.x % WARP;
+  const int b = blockIdx.z, hk = blockIdx.y;
+  const int group = H / Hkv;
+  const long k0 = (long)blockIdx.x * (nw * BR_W) + (long)warp * BR_W;  // this warp's key slab
+
+  wt* ksW = Ks + (long)warp * BR_W * D;
+  wt* vsW = Vs + (long)warp * BR_W * D;
+  wt* psW = Ps + (long)warp * BR_W * BR_W;
+  wt* dsW = dSs + (long)warp * BR_W * BR_W;
+  float* dkW = dKacc + (long)warp * BR_W * D;
+  float* dvW = dVacc + (long)warp * BR_W * D;
+  float* ssW = Ss + (long)warp * BR_W * BR_W;
+  float* dpW = dPs + (long)warp * BR_W * BR_W;
+  int* kblkW = sKblk + (long)warp * BR_W;
+  char* kvalidW = sKvalid + (long)warp * BR_W;
+
+  for (int idx = lane; idx < BR_W * D; idx += WARP) { dkW[idx] = 0.f; dvW[idx] = 0.f; }
+  for (int idx = lane; idx < BR_W * D; idx += WARP) {
+    const int j = idx / D, d = idx % D;
+    const long kj = k0 + j;
+    if (kj < Sk) {
+      ksW[idx] = f2w(to_f(K[idx_qkv(b, kj, hk, d, Sk, Hkv, D)]));
+      vsW[idx] = f2w(to_f(V[idx_qkv(b, kj, hk, d, Sk, Hkv, D)]));
+    } else { ksW[idx] = f2w(0.f); vsW[idx] = f2w(0.f); }
+  }
+  for (int j = lane; j < BR_W; j += WARP) {
+    const long kj = k0 + j;
+    kblkW[j] = (kj < Sk) ? k_blk[b * Sk + kj] : INT_MAX;
+    kvalidW[j] = (kj < Sk && k_valid[b * Sk + kj]) ? 1 : 0;
+  }
+  __syncthreads();
+
+  int block_min_kblk = INT_MAX;
+  for (int j = 0; j < nw * BR_W; ++j)
+    if (sKvalid[j]) block_min_kblk = min(block_min_kblk, sKblk[j]);
+
+  const int n_qtiles = (Sq + BR_W - 1) / BR_W;
+  for (int h = hk * group; h < (hk + 1) * group; ++h) {
+    for (int qt = 0; qt < n_qtiles; ++qt) {
+      const long qc0 = (long)qt * BR_W;
+      const long last_q = min((long)qc0 + BR_W - 1, (long)Sq - 1);
+      if (q_blk[b * Sq + last_q] < block_min_kblk) continue;  // uniform skip
+
+      for (int idx = threadIdx.x; idx < BR_W * D; idx += blockDim.x) {
+        const int q = idx / D, d = idx % D;
+        const long qi = qc0 + q;
+        if (qi < Sq) {
+          Qs[idx] = f2w(to_f(Q[idx_qkv(b, qi, h, d, Sq, H, D)]));
+          dOs[idx] = f2w(to_f(dO[idx_qkv(b, qi, h, d, Sq, H, D)]));
+        } else { Qs[idx] = f2w(0.f); dOs[idx] = f2w(0.f); }
+      }
+      for (int q = threadIdx.x; q < BR_W; q += blockDim.x) {
+        const long qi = qc0 + q;
+        if (qi < Sq) {
+          sLi[q] = L[idx_lse(b, h, qi, H, Sq)]; sdl[q] = delta[idx_lse(b, h, qi, H, Sq)];
+          sQblk[q] = q_blk[b * Sq + qi]; sQvalid[q] = q_valid[b * Sq + qi] ? 1 : 0;
+        } else { sLi[q] = 0.f; sdl[q] = 0.f; sQblk[q] = INT_MIN; sQvalid[q] = 0; }
+      }
+      __syncthreads();
+
+      // S = Q K^T  and  dP = dO V^T   (rows = streamed queries, cols = owned keys).
+      wmma::fragment<wmma::accumulator, WM, WN, WK, float> accS, accP;
+      wmma::fill_fragment(accS, 0.f);
+      wmma::fill_fragment(accP, 0.f);
+      for (int kk = 0; kk < D / WK; ++kk) {
+        wmma::fragment<wmma::matrix_a, WM, WN, WK, wt, wmma::row_major> aq, ado;
+        wmma::fragment<wmma::matrix_b, WM, WN, WK, wt, wmma::col_major> bk, bv;
+        wmma::load_matrix_sync(aq, Qs + kk * WK, D);
+        wmma::load_matrix_sync(bk, ksW + kk * WK, D);
+        wmma::mma_sync(accS, aq, bk, accS);
+        wmma::load_matrix_sync(ado, dOs + kk * WK, D);
+        wmma::load_matrix_sync(bv, vsW + kk * WK, D);
+        wmma::mma_sync(accP, ado, bv, accP);
+      }
+      wmma::store_matrix_sync(ssW, accS, BR_W, wmma::mem_row_major);
+      wmma::store_matrix_sync(dpW, accP, BR_W, wmma::mem_row_major);
+      __syncwarp();
+
+      // P (=softmax prob) and dS, with masking (lane q owns streamed query q).
+      if (lane < BR_W) {
+        const int q = lane;
+        const int qb = sQblk[q];
+        const float Li = sLi[q], di = sdl[q];
+        const bool qv = sQvalid[q];
+        for (int j = 0; j < BR_W; ++j) {
+          const long kj = k0 + j;
+          const bool att = qv && (kj < Sk) && kvalidW[j] && (kblkW[j] <= qb);
+          float p = 0.f, ds = 0.f;
+          if (att) {
+            p = __expf(ssW[q * BR_W + j] * scale - Li);
+            ds = p * (dpW[q * BR_W + j] - di);
+          }
+          psW[q * BR_W + j] = f2w(p);
+          dsW[q * BR_W + j] = f2w(ds);
+        }
+      }
+      __syncwarp();
+
+      // dV += P^T @ dO ;  dK += dS^T @ Q   (P,dS as col_major -> transpose).
+      for (int dn = 0; dn < D / WN; ++dn) {
+        wmma::fragment<wmma::accumulator, WM, WN, WK, float> accv, acck;
+        wmma::load_matrix_sync(accv, dvW + dn * WN, D, wmma::mem_row_major);
+        wmma::load_matrix_sync(acck, dkW + dn * WN, D, wmma::mem_row_major);
+        wmma::fragment<wmma::matrix_a, WM, WN, WK, wt, wmma::col_major> ap, ads;
+        wmma::fragment<wmma::matrix_b, WM, WN, WK, wt, wmma::row_major> bdo, bq;
+        wmma::load_matrix_sync(ap, psW, BR_W);
+        wmma::load_matrix_sync(bdo, dOs + dn * WN, D);
+        wmma::mma_sync(accv, ap, bdo, accv);
+        wmma::load_matrix_sync(ads, dsW, BR_W);
+        wmma::load_matrix_sync(bq, Qs + dn * WN, D);
+        wmma::mma_sync(acck, ads, bq, acck);
+        wmma::store_matrix_sync(dvW + dn * WN, accv, D, wmma::mem_row_major);
+        wmma::store_matrix_sync(dkW + dn * WN, acck, D, wmma::mem_row_major);
+      }
+      __syncthreads();  // streamed Qs/dOs reused next tile
+    }
+  }
+
+  if (lane < BR_W) {
+    const int j = lane;
+    const long kj = k0 + j;
+    if (kj < Sk)
+      for (int d = 0; d < D; ++d) {
+        dK[idx_qkv(b, kj, hk, d, Sk, Hkv, D)] = from_f<scalar_t>(dkW[j * D + d] * scale);
+        dV[idx_qkv(b, kj, hk, d, Sk, Hkv, D)] = from_f<scalar_t>(dvW[j * D + d]);
+      }
+  }
+}
+
 // ---- host launchers ------------------------------------------------------
+
+// Largest nw in [1, nw_max] whose kernel shared memory fits the device opt-in cap.
+int pick_nw(size_t (*smem_fn)(int, int), int D, int nw_max, int max_smem) {
+  for (int nw = nw_max; nw >= 1; --nw)
+    if ((int)smem_fn(D, nw) <= max_smem) return nw;
+  return 1;
+}
 
 int pick_tile(int D) {
   // Keep the two fp32 smem tiles near 64 KB (well under the 99 KB opt-in cap).
@@ -732,6 +1082,8 @@ std::vector<at::Tensor> flash_bwd(
   auto delta = at::empty({B, H, Sq}, q.options().dtype(at::kFloat));
 
   auto stream = at::cuda::getCurrentCUDAStream();
+  int max_smem = 0;
+  cudaDeviceGetAttribute(&max_smem, cudaDevAttrMaxSharedMemoryPerBlockOptin, q.device().index());  // spellchecker:disable-line
 
   // delta = rowsum(O * dO)
   {
@@ -745,42 +1097,71 @@ std::vector<at::Tensor> flash_bwd(
   }
 
   // dQ
-  {
+  if (q.scalar_type() == at::kFloat) {
+    // fp32: exact warp-per-row reference.
     const int BC = pick_tile(D);
     const size_t smem = (size_t)2 * BC * D * sizeof(float) + (size_t)BC * sizeof(int) + (size_t)BC;
     dim3 grid((Sq + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK, H, B);
     dim3 block(WARPS_PER_BLOCK * WARP);
-    DISPATCH_FLOAT(q.scalar_type(), "flash_bwd_dq", [&] {
-      auto kernel = flash_bwd_dq_kernel<scalar_t>;
-      cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
-      kernel<<<grid, block, smem, stream>>>(
-          q.data_ptr<scalar_t>(), k.data_ptr<scalar_t>(), v.data_ptr<scalar_t>(),
-          dO.data_ptr<scalar_t>(), L.data_ptr<float>(), delta.data_ptr<float>(),
-          q_blk.data_ptr<int>(), k_blk.data_ptr<int>(), q_valid.data_ptr<bool>(),
-          k_valid.data_ptr<bool>(), dQ.data_ptr<scalar_t>(), B, Sq, Sk, H, Hkv, D, (float)scale, BC);
+    auto kernel = flash_bwd_dq_kernel<float>;
+    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
+    kernel<<<grid, block, smem, stream>>>(
+        q.data_ptr<float>(), k.data_ptr<float>(), v.data_ptr<float>(), dO.data_ptr<float>(),
+        L.data_ptr<float>(), delta.data_ptr<float>(), q_blk.data_ptr<int>(), k_blk.data_ptr<int>(),
+        q_valid.data_ptr<bool>(), k_valid.data_ptr<bool>(), dQ.data_ptr<float>(),
+        B, Sq, Sk, H, Hkv, D, (float)scale, BC);
+  } else {
+    const int nw = pick_nw(bwd_dq_smem, D, 3, max_smem);
+    const size_t smem = bwd_dq_smem(D, nw);
+    dim3 grid((Sq + nw * BR_W - 1) / (nw * BR_W), H, B);
+    dim3 block(nw * WARP);
+    DISPATCH_FLOAT(q.scalar_type(), "flash_bwd_dq_wmma", [&] {
+      if constexpr (!std::is_same_v<scalar_t, float>) {
+        auto kernel = flash_bwd_dq_wmma_kernel<scalar_t>;
+        cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
+        kernel<<<grid, block, smem, stream>>>(
+            q.data_ptr<scalar_t>(), k.data_ptr<scalar_t>(), v.data_ptr<scalar_t>(),
+            dO.data_ptr<scalar_t>(), L.data_ptr<float>(), delta.data_ptr<float>(),
+            q_blk.data_ptr<int>(), k_blk.data_ptr<int>(), q_valid.data_ptr<bool>(),
+            k_valid.data_ptr<bool>(), dQ.data_ptr<scalar_t>(), B, Sq, Sk, H, Hkv, D, (float)scale, nw);
+      }
     });
-    C10_CUDA_KERNEL_LAUNCH_CHECK();
   }
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   // dK, dV
-  {
+  if (q.scalar_type() == at::kFloat) {
     const int BQ = pick_tile(D);
     const size_t smem = (size_t)2 * BQ * D * sizeof(float) + (size_t)2 * BQ * sizeof(float) +
                         (size_t)BQ * sizeof(int) + (size_t)BQ;
     dim3 grid((Sk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK, Hkv, B);
     dim3 block(WARPS_PER_BLOCK * WARP);
-    DISPATCH_FLOAT(q.scalar_type(), "flash_bwd_dkv", [&] {
-      auto kernel = flash_bwd_dkv_kernel<scalar_t>;
-      cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
-      kernel<<<grid, block, smem, stream>>>(
-          q.data_ptr<scalar_t>(), k.data_ptr<scalar_t>(), v.data_ptr<scalar_t>(),
-          dO.data_ptr<scalar_t>(), L.data_ptr<float>(), delta.data_ptr<float>(),
-          q_blk.data_ptr<int>(), k_blk.data_ptr<int>(), q_valid.data_ptr<bool>(),
-          k_valid.data_ptr<bool>(), dK.data_ptr<scalar_t>(), dV.data_ptr<scalar_t>(),
-          B, Sq, Sk, H, Hkv, D, (float)scale, BQ);
+    auto kernel = flash_bwd_dkv_kernel<float>;
+    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
+    kernel<<<grid, block, smem, stream>>>(
+        q.data_ptr<float>(), k.data_ptr<float>(), v.data_ptr<float>(), dO.data_ptr<float>(),
+        L.data_ptr<float>(), delta.data_ptr<float>(), q_blk.data_ptr<int>(), k_blk.data_ptr<int>(),
+        q_valid.data_ptr<bool>(), k_valid.data_ptr<bool>(), dK.data_ptr<float>(), dV.data_ptr<float>(),
+        B, Sq, Sk, H, Hkv, D, (float)scale, BQ);
+  } else {
+    const int nw = pick_nw(bwd_dkv_smem, D, 2, max_smem);
+    const size_t smem = bwd_dkv_smem(D, nw);
+    dim3 grid((Sk + nw * BR_W - 1) / (nw * BR_W), Hkv, B);
+    dim3 block(nw * WARP);
+    DISPATCH_FLOAT(q.scalar_type(), "flash_bwd_dkv_wmma", [&] {
+      if constexpr (!std::is_same_v<scalar_t, float>) {
+        auto kernel = flash_bwd_dkv_wmma_kernel<scalar_t>;
+        cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
+        kernel<<<grid, block, smem, stream>>>(
+            q.data_ptr<scalar_t>(), k.data_ptr<scalar_t>(), v.data_ptr<scalar_t>(),
+            dO.data_ptr<scalar_t>(), L.data_ptr<float>(), delta.data_ptr<float>(),
+            q_blk.data_ptr<int>(), k_blk.data_ptr<int>(), q_valid.data_ptr<bool>(),
+            k_valid.data_ptr<bool>(), dK.data_ptr<scalar_t>(), dV.data_ptr<scalar_t>(),
+            B, Sq, Sk, H, Hkv, D, (float)scale, nw);
+      }
     });
-    C10_CUDA_KERNEL_LAUNCH_CHECK();
   }
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   return {dQ, dK, dV};
 }

--- a/src/opentau/policies/flash_attn_cuda/_csrc/flash_blockmask.cu
+++ b/src/opentau/policies/flash_attn_cuda/_csrc/flash_blockmask.cu
@@ -1,0 +1,793 @@
+// Custom CUDA FlashAttention with block-causal masking for pi07_paligemma.
+//
+// This implements a fused, memory-efficient attention forward + backward that
+// reconstructs the block-causal attention mask *inside the kernel* from a
+// compact per-token representation, so the dense (B, S, S) mask is never
+// materialized. It is the backend behind `attention_implementation="flash_cuda"`.
+//
+// Masking convention (matches make_att_2d_masks):
+//   attend(query i, key j) == q_valid[i] && k_valid[j] && (k_blk[j] <= q_blk[i])
+// where q_blk / k_blk are int32 cumulative block-ids. Cross-attention columns
+// use k_blk = INT_MIN (always attended). Because the block-ids are produced by
+// torch.cumsum over non-negative {0,1} attention masks, k_blk is non-decreasing
+// along the key axis, which the kernel exploits for block-causal early-exit.
+//
+// Numerics: all reductions (QK^T, softmax, PV, gradients) accumulate in fp32
+// regardless of the input dtype (fp32/fp16/bf16). The forward writes a per-row
+// log-sum-exp (L) that the backward reuses, FlashAttention-2 style.
+//
+// Parallelization is "one warp per row" with cooperative shared-memory K/V (fwd,
+// dQ) or Q/dO (dK/dV) tiles. GQA/MQA is handled by mapping query head h to kv
+// head h / (H / Hkv); the dK/dV kernel loops the whole query-head group for a kv
+// head, so grouped gradients accumulate without atomics.
+//
+// Two forward paths exist:
+//   * fp32 inputs    -> the warp-per-row reference kernel below (exact, slow).
+//   * fp16/bf16 inputs -> a Tensor Core (WMMA) kernel that runs both matmuls on
+//     tensor cores with fp32 accumulation. This is the fast path used in
+//     training/inference; it is what makes flash_cuda beat the eager backend.
+// The backward uses the warp-per-row kernels for all dtypes (fp32 accumulation).
+
+#include <torch/extension.h>
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <cuda_bf16.h>
+#include <mma.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <limits.h>
+#include <vector>
+
+namespace {
+
+constexpr int WARP = 32;
+constexpr int WARPS_PER_BLOCK = 4;   // rows handled per thread block
+constexpr int MAX_DPL = 8;           // max fp32 regs per lane => head_dim <= 256
+
+// ---- small dtype helpers -------------------------------------------------
+template <typename T> __device__ __forceinline__ float to_f(T x) { return static_cast<float>(x); }
+template <typename T> __device__ __forceinline__ T from_f(float x) { return static_cast<T>(x); }
+
+// Map a torch scalar type to its WMMA (Tensor Core) element type + float ctor.
+template <typename T> struct WmmaTraits;
+template <> struct WmmaTraits<at::Half> {
+  using wt = __half;
+  __device__ __forceinline__ static wt from_float(float x) { return __float2half(x); }
+};
+template <> struct WmmaTraits<at::BFloat16> {
+  using wt = __nv_bfloat16;
+  __device__ __forceinline__ static wt from_float(float x) { return __float2bfloat16(x); }
+};
+
+// Full butterfly reduce: every lane ends with the warp-wide sum.
+__device__ __forceinline__ float warp_sum(float v) {
+#pragma unroll
+  for (int o = WARP / 2; o > 0; o >>= 1) v += __shfl_xor_sync(0xffffffffu, v, o);
+  return v;
+}
+
+// Index helpers (row-major contiguous tensors).
+__device__ __forceinline__ long idx_qkv(long b, long s, long h, long d, long S, long H, long D) {
+  return ((b * S + s) * H + h) * D + d;
+}
+__device__ __forceinline__ long idx_lse(long b, long h, long s, long H, long S) {
+  return (b * H + h) * S + s;
+}
+
+// =========================================================================
+// Forward: O = softmax(scale * Q K^T + mask) V, plus L = logsumexp per row.
+// One warp per query row. Dynamic smem holds an fp32 K/V tile + block metadata.
+// =========================================================================
+template <typename scalar_t>
+__global__ void flash_fwd_kernel(
+    const scalar_t* __restrict__ Q,  // (B, Sq, H, D)
+    const scalar_t* __restrict__ K,  // (B, Sk, Hkv, D)
+    const scalar_t* __restrict__ V,  // (B, Sk, Hkv, D)
+    const int* __restrict__ q_blk,   // (B, Sq)
+    const int* __restrict__ k_blk,   // (B, Sk)
+    const bool* __restrict__ q_valid,  // (B, Sq)
+    const bool* __restrict__ k_valid,  // (B, Sk)
+    scalar_t* __restrict__ O,        // (B, Sq, H, D)
+    float* __restrict__ L,           // (B, H, Sq)
+    int B, int Sq, int Sk, int H, int Hkv, int D, float scale, int BC) {
+  extern __shared__ char smem_raw[];
+  float* sK = reinterpret_cast<float*>(smem_raw);     // BC * D
+  float* sV = sK + (long)BC * D;                      // BC * D
+  int* sKblk = reinterpret_cast<int*>(sV + (long)BC * D);  // BC
+  char* sKvalid = reinterpret_cast<char*>(sKblk + BC);     // BC
+
+  const int warp = threadIdx.x / WARP;
+  const int lane = threadIdx.x % WARP;
+  const int dpl = D / WARP;  // elems per lane
+
+  const int b = blockIdx.z;
+  const int h = blockIdx.y;
+  const int hk = h / (H / Hkv);
+  const long qi = (long)blockIdx.x * WARPS_PER_BLOCK + warp;
+  const bool row_active = (qi < Sq);
+
+  // Load this warp's query row + its block-id into registers.
+  float q_reg[MAX_DPL];
+  int qb = INT_MIN;
+  bool qv = false;
+  if (row_active) {
+    qb = q_blk[b * Sq + qi];
+    qv = q_valid[b * Sq + qi];
+#pragma unroll
+    for (int t = 0; t < MAX_DPL; ++t) {
+      if (t < dpl) q_reg[t] = to_f(Q[idx_qkv(b, qi, h, lane + t * WARP, Sq, H, D)]);
+    }
+  }
+
+  // Block-wide max q_blk over active+valid rows, for uniform early-exit.
+  __shared__ int s_block_max_qblk;
+  if (threadIdx.x == 0) s_block_max_qblk = INT_MIN;
+  __syncthreads();
+  if (lane == 0 && row_active && qv) atomicMax(&s_block_max_qblk, qb);
+  __syncthreads();
+  const int block_max_qblk = s_block_max_qblk;
+
+  float m = -INFINITY, l = 0.f;
+  float o_reg[MAX_DPL];
+#pragma unroll
+  for (int t = 0; t < MAX_DPL; ++t) o_reg[t] = 0.f;
+
+  const int n_tiles = (Sk + BC - 1) / BC;
+  for (int kt = 0; kt < n_tiles; ++kt) {
+    const long kc0 = (long)kt * BC;
+    // Cooperative load of the K/V tile (all threads participate).
+    for (int idx = threadIdx.x; idx < BC * D; idx += blockDim.x) {
+      const int jj = idx / D, d = idx % D;
+      const long kj = kc0 + jj;
+      if (kj < Sk) {
+        sK[idx] = to_f(K[idx_qkv(b, kj, hk, d, Sk, Hkv, D)]);
+        sV[idx] = to_f(V[idx_qkv(b, kj, hk, d, Sk, Hkv, D)]);
+      } else {
+        sK[idx] = 0.f;
+        sV[idx] = 0.f;
+      }
+    }
+    for (int jj = threadIdx.x; jj < BC; jj += blockDim.x) {
+      const long kj = kc0 + jj;
+      sKblk[jj] = (kj < Sk) ? k_blk[b * Sk + kj] : INT_MAX;
+      sKvalid[jj] = (kj < Sk) ? (k_valid[b * Sk + kj] ? 1 : 0) : 0;
+    }
+    __syncthreads();
+
+    // Uniform block-causal early-exit: k_blk is non-decreasing, so the tile's
+    // smallest block-id is its first key. If even the largest query block-id in
+    // this block can't reach it, no later tile is reachable either.
+    const bool tile_unreachable = (sKblk[0] > block_max_qblk);
+    if (!tile_unreachable && row_active && qv) {
+      for (int jj = 0; jj < BC; ++jj) {
+        const long kj = kc0 + jj;
+        if (kj >= Sk) break;
+        const int kb = sKblk[jj];
+        if (kb > qb) break;            // per-row causal cut (non-decreasing)
+        if (!sKvalid[jj]) continue;    // padding / masked column
+        float dot = 0.f;
+#pragma unroll
+        for (int t = 0; t < MAX_DPL; ++t)
+          if (t < dpl) dot += q_reg[t] * sK[jj * D + lane + t * WARP];
+        const float s = warp_sum(dot) * scale;
+        const float m_new = fmaxf(m, s);
+        const float corr = __expf(m - m_new);
+        const float p = __expf(s - m_new);
+        l = l * corr + p;
+#pragma unroll
+        for (int t = 0; t < MAX_DPL; ++t)
+          if (t < dpl) o_reg[t] = o_reg[t] * corr + p * sV[jj * D + lane + t * WARP];
+        m = m_new;
+      }
+    }
+    __syncthreads();
+    if (tile_unreachable) break;
+  }
+
+  if (row_active) {
+    const float inv = (l > 0.f) ? (1.f / l) : 0.f;
+#pragma unroll
+    for (int t = 0; t < MAX_DPL; ++t)
+      if (t < dpl) O[idx_qkv(b, qi, h, lane + t * WARP, Sq, H, D)] = from_f<scalar_t>(o_reg[t] * inv);
+    if (lane == 0) L[idx_lse(b, h, qi, H, Sq)] = (l > 0.f) ? (m + logf(l)) : 0.f;
+  }
+}
+
+// =========================================================================
+// Backward preprocess: delta[b,h,i] = sum_d O[..d] * dO[..d]  (one warp/row).
+// =========================================================================
+template <typename scalar_t>
+__global__ void flash_bwd_delta_kernel(
+    const scalar_t* __restrict__ O, const scalar_t* __restrict__ dO,
+    float* __restrict__ delta, int B, int Sq, int H, int D) {
+  const int warp = threadIdx.x / WARP;
+  const int lane = threadIdx.x % WARP;
+  const int dpl = D / WARP;
+  const long qi = (long)blockIdx.x * WARPS_PER_BLOCK + warp;
+  const int h = blockIdx.y, b = blockIdx.z;
+  if (qi >= Sq) return;
+  float acc = 0.f;
+#pragma unroll
+  for (int t = 0; t < MAX_DPL; ++t)
+    if (t < dpl) {
+      const long off = idx_qkv(b, qi, h, lane + t * WARP, Sq, H, D);
+      acc += to_f(O[off]) * to_f(dO[off]);
+    }
+  acc = warp_sum(acc);
+  if (lane == 0) delta[idx_lse(b, h, qi, H, Sq)] = acc;
+}
+
+// =========================================================================
+// dQ kernel: one warp per query row, loop key tiles. dQ = scale * sum ds * K.
+// =========================================================================
+template <typename scalar_t>
+__global__ void flash_bwd_dq_kernel(
+    const scalar_t* __restrict__ Q, const scalar_t* __restrict__ K,
+    const scalar_t* __restrict__ V, const scalar_t* __restrict__ dO,
+    const float* __restrict__ L, const float* __restrict__ delta,
+    const int* __restrict__ q_blk, const int* __restrict__ k_blk,
+    const bool* __restrict__ q_valid, const bool* __restrict__ k_valid,
+    scalar_t* __restrict__ dQ, int B, int Sq, int Sk, int H, int Hkv, int D,
+    float scale, int BC) {
+  extern __shared__ char smem_raw[];
+  float* sK = reinterpret_cast<float*>(smem_raw);
+  float* sV = sK + (long)BC * D;
+  int* sKblk = reinterpret_cast<int*>(sV + (long)BC * D);
+  char* sKvalid = reinterpret_cast<char*>(sKblk + BC);
+
+  const int warp = threadIdx.x / WARP;
+  const int lane = threadIdx.x % WARP;
+  const int dpl = D / WARP;
+  const int b = blockIdx.z, h = blockIdx.y;
+  const int hk = h / (H / Hkv);
+  const long qi = (long)blockIdx.x * WARPS_PER_BLOCK + warp;
+  const bool row_active = (qi < Sq);
+
+  float q_reg[MAX_DPL], do_reg[MAX_DPL], dq_reg[MAX_DPL];
+#pragma unroll
+  for (int t = 0; t < MAX_DPL; ++t) { q_reg[t] = 0.f; do_reg[t] = 0.f; dq_reg[t] = 0.f; }
+  int qb = INT_MIN;
+  bool qv = false;
+  float Li = 0.f, di = 0.f;
+  if (row_active) {
+    qb = q_blk[b * Sq + qi];
+    qv = q_valid[b * Sq + qi];
+    Li = L[idx_lse(b, h, qi, H, Sq)];
+    di = delta[idx_lse(b, h, qi, H, Sq)];
+#pragma unroll
+    for (int t = 0; t < MAX_DPL; ++t)
+      if (t < dpl) {
+        q_reg[t] = to_f(Q[idx_qkv(b, qi, h, lane + t * WARP, Sq, H, D)]);
+        do_reg[t] = to_f(dO[idx_qkv(b, qi, h, lane + t * WARP, Sq, H, D)]);
+      }
+  }
+
+  __shared__ int s_block_max_qblk;
+  if (threadIdx.x == 0) s_block_max_qblk = INT_MIN;
+  __syncthreads();
+  if (lane == 0 && row_active && qv) atomicMax(&s_block_max_qblk, qb);
+  __syncthreads();
+  const int block_max_qblk = s_block_max_qblk;
+
+  const int n_tiles = (Sk + BC - 1) / BC;
+  for (int kt = 0; kt < n_tiles; ++kt) {
+    const long kc0 = (long)kt * BC;
+    for (int idx = threadIdx.x; idx < BC * D; idx += blockDim.x) {
+      const int jj = idx / D, d = idx % D;
+      const long kj = kc0 + jj;
+      if (kj < Sk) {
+        sK[idx] = to_f(K[idx_qkv(b, kj, hk, d, Sk, Hkv, D)]);
+        sV[idx] = to_f(V[idx_qkv(b, kj, hk, d, Sk, Hkv, D)]);
+      } else { sK[idx] = 0.f; sV[idx] = 0.f; }
+    }
+    for (int jj = threadIdx.x; jj < BC; jj += blockDim.x) {
+      const long kj = kc0 + jj;
+      sKblk[jj] = (kj < Sk) ? k_blk[b * Sk + kj] : INT_MAX;
+      sKvalid[jj] = (kj < Sk) ? (k_valid[b * Sk + kj] ? 1 : 0) : 0;
+    }
+    __syncthreads();
+
+    const bool tile_unreachable = (sKblk[0] > block_max_qblk);
+    if (!tile_unreachable && row_active && qv) {
+      for (int jj = 0; jj < BC; ++jj) {
+        const long kj = kc0 + jj;
+        if (kj >= Sk) break;
+        const int kb = sKblk[jj];
+        if (kb > qb) break;
+        if (!sKvalid[jj]) continue;
+        float dot = 0.f, dp = 0.f;
+#pragma unroll
+        for (int t = 0; t < MAX_DPL; ++t)
+          if (t < dpl) {
+            dot += q_reg[t] * sK[jj * D + lane + t * WARP];
+            dp += do_reg[t] * sV[jj * D + lane + t * WARP];
+          }
+        const float s = warp_sum(dot) * scale;
+        const float p = __expf(s - Li);
+        const float dpr = warp_sum(dp);
+        const float ds = p * (dpr - di);
+#pragma unroll
+        for (int t = 0; t < MAX_DPL; ++t)
+          if (t < dpl) dq_reg[t] += ds * sK[jj * D + lane + t * WARP];
+      }
+    }
+    __syncthreads();
+    if (tile_unreachable) break;
+  }
+
+  if (row_active) {
+#pragma unroll
+    for (int t = 0; t < MAX_DPL; ++t)
+      if (t < dpl) dQ[idx_qkv(b, qi, h, lane + t * WARP, Sq, H, D)] = from_f<scalar_t>(dq_reg[t] * scale);
+  }
+}
+
+// =========================================================================
+// dK/dV kernel: one warp per key row. Loops the whole query-head group (GQA/MQA)
+// and all query tiles, so grouped gradients accumulate without atomics.
+//   dV = sum_i p_ij dO_i ;  dK = scale * sum_i ds_ij Q_i
+// =========================================================================
+template <typename scalar_t>
+__global__ void flash_bwd_dkv_kernel(
+    const scalar_t* __restrict__ Q, const scalar_t* __restrict__ K,
+    const scalar_t* __restrict__ V, const scalar_t* __restrict__ dO,
+    const float* __restrict__ L, const float* __restrict__ delta,
+    const int* __restrict__ q_blk, const int* __restrict__ k_blk,
+    const bool* __restrict__ q_valid, const bool* __restrict__ k_valid,
+    scalar_t* __restrict__ dK, scalar_t* __restrict__ dV,
+    int B, int Sq, int Sk, int H, int Hkv, int D, float scale, int BQ) {
+  extern __shared__ char smem_raw[];
+  float* sQ = reinterpret_cast<float*>(smem_raw);  // BQ * D
+  float* sdO = sQ + (long)BQ * D;                  // BQ * D
+  float* sL = sdO + (long)BQ * D;                  // BQ
+  float* sdelta = sL + BQ;                         // BQ
+  int* sQblk = reinterpret_cast<int*>(sdelta + BQ);  // BQ
+  char* sQvalid = reinterpret_cast<char*>(sQblk + BQ);  // BQ
+
+  const int warp = threadIdx.x / WARP;
+  const int lane = threadIdx.x % WARP;
+  const int dpl = D / WARP;
+  const int b = blockIdx.z, hk = blockIdx.y;
+  const long kj = (long)blockIdx.x * WARPS_PER_BLOCK + warp;
+  const bool row_active = (kj < Sk);
+  const int group = H / Hkv;
+
+  float k_reg[MAX_DPL], v_reg[MAX_DPL], dk_reg[MAX_DPL], dv_reg[MAX_DPL];
+#pragma unroll
+  for (int t = 0; t < MAX_DPL; ++t) { k_reg[t] = 0.f; v_reg[t] = 0.f; dk_reg[t] = 0.f; dv_reg[t] = 0.f; }
+  int kb = INT_MAX;
+  bool kv_ok = false;
+  if (row_active) {
+    kb = k_blk[b * Sk + kj];
+    kv_ok = k_valid[b * Sk + kj];
+#pragma unroll
+    for (int t = 0; t < MAX_DPL; ++t)
+      if (t < dpl) {
+        k_reg[t] = to_f(K[idx_qkv(b, kj, hk, lane + t * WARP, Sk, Hkv, D)]);
+        v_reg[t] = to_f(V[idx_qkv(b, kj, hk, lane + t * WARP, Sk, Hkv, D)]);
+      }
+  }
+
+  // Block-wide min key block-id for uniform early-skip of query tiles.
+  __shared__ int s_block_min_kblk;
+  if (threadIdx.x == 0) s_block_min_kblk = INT_MAX;
+  __syncthreads();
+  if (lane == 0 && row_active && kv_ok) atomicMin(&s_block_min_kblk, kb);
+  __syncthreads();
+  const int block_min_kblk = s_block_min_kblk;
+
+  const int n_qtiles = (Sq + BQ - 1) / BQ;
+  for (int h = hk * group; h < (hk + 1) * group; ++h) {
+    for (int qt = 0; qt < n_qtiles; ++qt) {
+      const long qc0 = (long)qt * BQ;
+      // q_blk is non-decreasing: tile's max block-id is its last in-range query.
+      const long last_q = min((long)qc0 + BQ - 1, (long)Sq - 1);
+      const int tile_max_qblk = q_blk[b * Sq + last_q];
+      if (tile_max_qblk < block_min_kblk) continue;  // uniform skip (no loads)
+
+      for (int idx = threadIdx.x; idx < BQ * D; idx += blockDim.x) {
+        const int ii = idx / D, d = idx % D;
+        const long qi = qc0 + ii;
+        if (qi < Sq) {
+          sQ[idx] = to_f(Q[idx_qkv(b, qi, h, d, Sq, H, D)]);
+          sdO[idx] = to_f(dO[idx_qkv(b, qi, h, d, Sq, H, D)]);
+        } else { sQ[idx] = 0.f; sdO[idx] = 0.f; }
+      }
+      for (int ii = threadIdx.x; ii < BQ; ii += blockDim.x) {
+        const long qi = qc0 + ii;
+        if (qi < Sq) {
+          sL[ii] = L[idx_lse(b, h, qi, H, Sq)];
+          sdelta[ii] = delta[idx_lse(b, h, qi, H, Sq)];
+          sQblk[ii] = q_blk[b * Sq + qi];
+          sQvalid[ii] = q_valid[b * Sq + qi] ? 1 : 0;
+        } else { sL[ii] = 0.f; sdelta[ii] = 0.f; sQblk[ii] = INT_MIN; sQvalid[ii] = 0; }
+      }
+      __syncthreads();
+
+      if (row_active && kv_ok) {
+        for (int ii = 0; ii < BQ; ++ii) {
+          const long qi = qc0 + ii;
+          if (qi >= Sq) break;
+          if (!sQvalid[ii]) continue;
+          if (sQblk[ii] < kb) continue;  // query can't reach this key
+          float dot = 0.f, dp = 0.f;
+#pragma unroll
+          for (int t = 0; t < MAX_DPL; ++t)
+            if (t < dpl) {
+              dot += k_reg[t] * sQ[ii * D + lane + t * WARP];
+              dp += v_reg[t] * sdO[ii * D + lane + t * WARP];
+            }
+          const float s = warp_sum(dot) * scale;
+          const float p = __expf(s - sL[ii]);
+          const float dpr = warp_sum(dp);
+          const float ds = p * (dpr - sdelta[ii]);
+#pragma unroll
+          for (int t = 0; t < MAX_DPL; ++t)
+            if (t < dpl) {
+              dv_reg[t] += p * sdO[ii * D + lane + t * WARP];
+              dk_reg[t] += ds * sQ[ii * D + lane + t * WARP];
+            }
+        }
+      }
+      __syncthreads();
+    }
+  }
+
+  if (row_active) {
+#pragma unroll
+    for (int t = 0; t < MAX_DPL; ++t)
+      if (t < dpl) {
+        dK[idx_qkv(b, kj, hk, lane + t * WARP, Sk, Hkv, D)] = from_f<scalar_t>(dk_reg[t] * scale);
+        dV[idx_qkv(b, kj, hk, lane + t * WARP, Sk, Hkv, D)] = from_f<scalar_t>(dv_reg[t]);
+      }
+  }
+}
+
+// =========================================================================
+// Tensor Core forward (fp16/bf16). One warp per block handles BR_W=16 query
+// rows. Both matmuls (Q K^T and P V) run on WMMA tensor cores with fp32
+// accumulation; the running softmax statistics and the O accumulator live in
+// shared memory. Block-causal masking is applied to the score tile in shared
+// memory, plus the same uniform tile-level early-exit as the reference kernel.
+// =========================================================================
+constexpr int WM = 16, WN = 16, WK = 16;  // WMMA tile
+constexpr int BR_W = 16;                  // query rows per warp slab (== WM)
+constexpr int BC_W = 16;                  // key cols per tile (== WN)
+constexpr int NW = 3;                      // warps per block (slabs handled together)
+
+// Per-block dynamic shared-memory size for the WMMA forward, in bytes.
+__host__ __device__ inline size_t fwd_wmma_smem(int D) {
+  // wt (Qs[NW], Ks, Vs, Ps[NW]); float (Os[NW], Ss[NW], m/l/corr[NW]); int + char meta.
+  size_t wt_elems = (size_t)NW * BR_W * D + 2 * BC_W * D + (size_t)NW * BR_W * BC_W;
+  size_t f_elems = (size_t)NW * BR_W * D + (size_t)NW * BR_W * BC_W + (size_t)NW * 3 * BR_W;
+  size_t i_elems = (size_t)NW * BR_W + BC_W;
+  size_t c_elems = (size_t)NW * BR_W + BC_W;
+  return wt_elems * 2 + f_elems * 4 + i_elems * 4 + c_elems;
+}
+
+template <typename scalar_t>
+__global__ void flash_fwd_wmma_kernel(
+    const scalar_t* __restrict__ Q, const scalar_t* __restrict__ K, const scalar_t* __restrict__ V,
+    const int* __restrict__ q_blk, const int* __restrict__ k_blk,
+    const bool* __restrict__ q_valid, const bool* __restrict__ k_valid,
+    scalar_t* __restrict__ O, float* __restrict__ L,
+    int B, int Sq, int Sk, int H, int Hkv, int D, float scale) {
+  using namespace nvcuda;
+  using wt = typename WmmaTraits<scalar_t>::wt;
+  auto f2w = WmmaTraits<scalar_t>::from_float;
+
+  // Shared layout: per-warp slabs for Q/O/P/S/stats, block-shared K/V tile.
+  extern __shared__ char smem_raw[];
+  wt* Qs = reinterpret_cast<wt*>(smem_raw);              // NW * BR_W * D
+  wt* Ks = Qs + (long)NW * BR_W * D;                     // BC_W * D
+  wt* Vs = Ks + BC_W * D;                                // BC_W * D
+  wt* Ps = Vs + BC_W * D;                                // NW * BR_W * BC_W
+  float* Os = reinterpret_cast<float*>(Ps + (long)NW * BR_W * BC_W);  // NW * BR_W * D
+  float* Ss = Os + (long)NW * BR_W * D;                  // NW * BR_W * BC_W
+  float* sm = Ss + (long)NW * BR_W * BC_W;               // NW * BR_W
+  float* sl = sm + (long)NW * BR_W;                      // NW * BR_W
+  float* scorr = sl + (long)NW * BR_W;                   // NW * BR_W
+  int* sQblk = reinterpret_cast<int*>(scorr + (long)NW * BR_W);  // NW * BR_W
+  int* sKblk = sQblk + (long)NW * BR_W;                  // BC_W
+  char* sQvalid = reinterpret_cast<char*>(sKblk + BC_W);  // NW * BR_W
+  char* sKvalid = sQvalid + (long)NW * BR_W;             // BC_W
+
+  const int warp = threadIdx.x / WARP;
+  const int lane = threadIdx.x % WARP;
+  const int b = blockIdx.z, h = blockIdx.y;
+  const int hk = h / (H / Hkv);
+  const long q0 = (long)blockIdx.x * (NW * BR_W) + (long)warp * BR_W;  // this warp's slab
+
+  // Per-warp slab pointers.
+  wt* qW = Qs + (long)warp * BR_W * D;
+  wt* pW = Ps + (long)warp * BR_W * BC_W;
+  float* oW = Os + (long)warp * BR_W * D;
+  float* ssW = Ss + (long)warp * BR_W * BC_W;
+  float* mW = sm + warp * BR_W;
+  float* lW = sl + warp * BR_W;
+  float* corrW = scorr + warp * BR_W;
+  int* qblkW = sQblk + warp * BR_W;
+  char* qvalidW = sQvalid + warp * BR_W;
+
+  // Init this warp's accumulator + load its query slab.
+  for (int idx = lane; idx < BR_W * D; idx += WARP) oW[idx] = 0.f;
+  for (int i = lane; i < BR_W; i += WARP) { mW[i] = -INFINITY; lW[i] = 0.f; }
+  for (int idx = lane; idx < BR_W * D; idx += WARP) {
+    const int i = idx / D, d = idx % D;
+    const long qi = q0 + i;
+    qW[idx] = (qi < Sq) ? f2w(to_f(Q[idx_qkv(b, qi, h, d, Sq, H, D)])) : f2w(0.f);
+  }
+  for (int i = lane; i < BR_W; i += WARP) {
+    const long qi = q0 + i;
+    qblkW[i] = (qi < Sq) ? q_blk[b * Sq + qi] : INT_MIN;
+    qvalidW[i] = (qi < Sq && q_valid[b * Sq + qi]) ? 1 : 0;
+  }
+  __syncthreads();
+
+  // Block-wide max query block-id (over all NW slabs) for uniform early-exit.
+  int bmax = INT_MIN;
+  for (int i = 0; i < NW * BR_W; ++i)
+    if (sQvalid[i]) bmax = max(bmax, sQblk[i]);
+
+  const int n_tiles = (Sk + BC_W - 1) / BC_W;
+  for (int kt = 0; kt < n_tiles; ++kt) {
+    const long kc0 = (long)kt * BC_W;
+    // Cooperative K/V tile load by ALL warps (overlaps global-load latency).
+    for (int idx = threadIdx.x; idx < BC_W * D; idx += blockDim.x) {
+      const int j = idx / D, d = idx % D;
+      const long kj = kc0 + j;
+      if (kj < Sk) {
+        Ks[idx] = f2w(to_f(K[idx_qkv(b, kj, hk, d, Sk, Hkv, D)]));
+        Vs[idx] = f2w(to_f(V[idx_qkv(b, kj, hk, d, Sk, Hkv, D)]));
+      } else { Ks[idx] = f2w(0.f); Vs[idx] = f2w(0.f); }
+    }
+    for (int j = threadIdx.x; j < BC_W; j += blockDim.x) {
+      const long kj = kc0 + j;
+      sKblk[j] = (kj < Sk) ? k_blk[b * Sk + kj] : INT_MAX;
+      sKvalid[j] = (kj < Sk && k_valid[b * Sk + kj]) ? 1 : 0;
+    }
+    __syncthreads();
+
+    const bool unreachable = (sKblk[0] > bmax);
+    if (!unreachable) {
+      // S = scale * Q K^T  (Tensor Cores) -> ssW (fp32). BC_W == WN -> one n-tile.
+      {
+        wmma::fragment<wmma::accumulator, WM, WN, WK, float> acc;
+        wmma::fill_fragment(acc, 0.f);
+        for (int kk = 0; kk < D / WK; ++kk) {
+          wmma::fragment<wmma::matrix_a, WM, WN, WK, wt, wmma::row_major> af;
+          wmma::fragment<wmma::matrix_b, WM, WN, WK, wt, wmma::col_major> bf;
+          wmma::load_matrix_sync(af, qW + kk * WK, D);
+          wmma::load_matrix_sync(bf, Ks + kk * WK, D);
+          wmma::mma_sync(acc, af, bf, acc);
+        }
+        wmma::store_matrix_sync(ssW, acc, BC_W, wmma::mem_row_major);
+      }
+      __syncwarp();
+
+      // Mask + online softmax (lane i owns query row i within this slab).
+      if (lane < BR_W) {
+        const int i = lane;
+        if (qvalidW[i]) {
+          const int qb = qblkW[i];
+          float rowmax = -INFINITY;
+          for (int j = 0; j < BC_W; ++j) {
+            const long kj = kc0 + j;
+            const bool att = (kj < Sk) && sKvalid[j] && (sKblk[j] <= qb);
+            const float s = att ? (ssW[i * BC_W + j] * scale) : -INFINITY;
+            ssW[i * BC_W + j] = s;
+            rowmax = fmaxf(rowmax, s);
+          }
+          if (rowmax == -INFINITY) {
+            corrW[i] = 1.f;  // nothing valid this tile; leave running stats
+            for (int j = 0; j < BC_W; ++j) pW[i * BC_W + j] = f2w(0.f);
+          } else {
+            const float m_old = mW[i];
+            const float m_new = fmaxf(m_old, rowmax);
+            const float corr = __expf(m_old - m_new);  // m_old=-inf -> 0
+            float rowsum = 0.f;
+            for (int j = 0; j < BC_W; ++j) {
+              const float s = ssW[i * BC_W + j];
+              const float p = (s == -INFINITY) ? 0.f : __expf(s - m_new);
+              pW[i * BC_W + j] = f2w(p);
+              rowsum += p;
+            }
+            lW[i] = lW[i] * corr + rowsum;
+            mW[i] = m_new;
+            corrW[i] = corr;
+          }
+        } else {
+          corrW[i] = 1.f;
+          for (int j = 0; j < BC_W; ++j) pW[i * BC_W + j] = f2w(0.f);
+        }
+      }
+      __syncwarp();
+
+      // Rescale running O by the softmax correction, then O += P V (Tensor Cores).
+      for (int idx = lane; idx < BR_W * D; idx += WARP) oW[idx] *= corrW[idx / D];
+      __syncwarp();
+      for (int dn = 0; dn < D / WN; ++dn) {
+        wmma::fragment<wmma::accumulator, WM, WN, WK, float> acco;
+        wmma::load_matrix_sync(acco, oW + dn * WN, D, wmma::mem_row_major);
+        wmma::fragment<wmma::matrix_a, WM, WN, WK, wt, wmma::row_major> pf;
+        wmma::fragment<wmma::matrix_b, WM, WN, WK, wt, wmma::row_major> vf;
+        wmma::load_matrix_sync(pf, pW, BC_W);
+        wmma::load_matrix_sync(vf, Vs + dn * WN, D);
+        wmma::mma_sync(acco, pf, vf, acco);
+        wmma::store_matrix_sync(oW + dn * WN, acco, D, wmma::mem_row_major);
+      }
+      __syncwarp();
+    }
+    __syncthreads();  // all warps done with shared K/V before next tile load
+    if (unreachable) break;
+  }
+
+  if (lane < BR_W) {
+    const int i = lane;
+    const long qi = q0 + i;
+    if (qi < Sq) {
+      const float inv = (lW[i] > 0.f) ? (1.f / lW[i]) : 0.f;
+      for (int d = 0; d < D; ++d)
+        O[idx_qkv(b, qi, h, d, Sq, H, D)] = from_f<scalar_t>(oW[i * D + d] * inv);
+      L[idx_lse(b, h, qi, H, Sq)] = (lW[i] > 0.f) ? (mW[i] + logf(lW[i])) : 0.f;
+    }
+  }
+}
+
+// ---- host launchers ------------------------------------------------------
+
+int pick_tile(int D) {
+  // Keep the two fp32 smem tiles near 64 KB (well under the 99 KB opt-in cap).
+  if (D <= 64) return 128;
+  if (D <= 128) return 64;
+  return 32;  // D in (128, 256]
+}
+
+#define DISPATCH_FLOAT(TYPE, NAME, ...)                                  \
+  [&] {                                                                  \
+    switch (TYPE) {                                                      \
+      case at::kFloat: { using scalar_t = float; return __VA_ARGS__(); } \
+      case at::kHalf: { using scalar_t = at::Half; return __VA_ARGS__(); } \
+      case at::kBFloat16: { using scalar_t = at::BFloat16; return __VA_ARGS__(); } \
+      default: TORCH_CHECK(false, NAME " unsupported dtype: ", TYPE);    \
+    }                                                                    \
+  }()
+
+void check_inputs(const at::Tensor& q, const at::Tensor& k, const at::Tensor& v) {
+  TORCH_CHECK(q.is_cuda() && k.is_cuda() && v.is_cuda(), "q/k/v must be CUDA tensors");
+  TORCH_CHECK(q.dim() == 4 && k.dim() == 4 && v.dim() == 4, "q/k/v must be (B,S,H,D)");
+  const int D = q.size(3);
+  TORCH_CHECK(D % WARP == 0 && D / WARP <= MAX_DPL, "head_dim must be a multiple of 32 and <= 256, got ", D);
+  TORCH_CHECK(q.scalar_type() == k.scalar_type() && q.scalar_type() == v.scalar_type(), "q/k/v dtype mismatch");
+}
+
+std::vector<at::Tensor> flash_fwd(
+    at::Tensor q, at::Tensor k, at::Tensor v, at::Tensor q_blk, at::Tensor k_blk,
+    at::Tensor q_valid, at::Tensor k_valid, double scale) {
+  check_inputs(q, k, v);
+  const at::cuda::CUDAGuard guard(q.device());
+  q = q.contiguous(); k = k.contiguous(); v = v.contiguous();
+  q_blk = q_blk.contiguous(); k_blk = k_blk.contiguous();
+  q_valid = q_valid.contiguous(); k_valid = k_valid.contiguous();
+
+  const int B = q.size(0), Sq = q.size(1), H = q.size(2), D = q.size(3);
+  const int Sk = k.size(1), Hkv = k.size(2);
+  TORCH_CHECK(H % Hkv == 0, "num_heads must be divisible by num_kv_heads");
+
+  auto O = at::empty_like(q);
+  auto L = at::empty({B, H, Sq}, q.options().dtype(at::kFloat));
+  auto stream = at::cuda::getCurrentCUDAStream();
+
+  if (q.scalar_type() == at::kFloat) {
+    // fp32: exact warp-per-row reference kernel.
+    const int BC = pick_tile(D);
+    const size_t smem = (size_t)2 * BC * D * sizeof(float) + (size_t)BC * sizeof(int) + (size_t)BC;
+    dim3 grid((Sq + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK, H, B);
+    dim3 block(WARPS_PER_BLOCK * WARP);
+    auto kernel = flash_fwd_kernel<float>;
+    cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
+    kernel<<<grid, block, smem, stream>>>(
+        q.data_ptr<float>(), k.data_ptr<float>(), v.data_ptr<float>(),
+        q_blk.data_ptr<int>(), k_blk.data_ptr<int>(), q_valid.data_ptr<bool>(),
+        k_valid.data_ptr<bool>(), O.data_ptr<float>(), L.data_ptr<float>(),
+        B, Sq, Sk, H, Hkv, D, (float)scale, BC);
+  } else {
+    // fp16/bf16: Tensor Core (WMMA) kernel. NW warps/block share the K/V tile.
+    const size_t smem = fwd_wmma_smem(D);
+    const int rows_per_block = NW * BR_W;
+    dim3 grid((Sq + rows_per_block - 1) / rows_per_block, H, B);
+    dim3 block(NW * WARP);
+    DISPATCH_FLOAT(q.scalar_type(), "flash_fwd_wmma", [&] {
+      if constexpr (!std::is_same_v<scalar_t, float>) {
+        auto kernel = flash_fwd_wmma_kernel<scalar_t>;
+        cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
+        kernel<<<grid, block, smem, stream>>>(
+            q.data_ptr<scalar_t>(), k.data_ptr<scalar_t>(), v.data_ptr<scalar_t>(),
+            q_blk.data_ptr<int>(), k_blk.data_ptr<int>(), q_valid.data_ptr<bool>(),
+            k_valid.data_ptr<bool>(), O.data_ptr<scalar_t>(), L.data_ptr<float>(),
+            B, Sq, Sk, H, Hkv, D, (float)scale);
+      }
+    });
+  }
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+  return {O, L};
+}
+
+std::vector<at::Tensor> flash_bwd(
+    at::Tensor dO, at::Tensor q, at::Tensor k, at::Tensor v, at::Tensor O, at::Tensor L,
+    at::Tensor q_blk, at::Tensor k_blk, at::Tensor q_valid, at::Tensor k_valid, double scale) {
+  check_inputs(q, k, v);
+  const at::cuda::CUDAGuard guard(q.device());
+  dO = dO.contiguous(); q = q.contiguous(); k = k.contiguous(); v = v.contiguous();
+  O = O.contiguous(); L = L.contiguous();
+  q_blk = q_blk.contiguous(); k_blk = k_blk.contiguous();
+  q_valid = q_valid.contiguous(); k_valid = k_valid.contiguous();
+
+  const int B = q.size(0), Sq = q.size(1), H = q.size(2), D = q.size(3);
+  const int Sk = k.size(1), Hkv = k.size(2);
+
+  auto dQ = at::empty_like(q);
+  auto dK = at::empty_like(k);
+  auto dV = at::empty_like(v);
+  auto delta = at::empty({B, H, Sq}, q.options().dtype(at::kFloat));
+
+  auto stream = at::cuda::getCurrentCUDAStream();
+
+  // delta = rowsum(O * dO)
+  {
+    dim3 grid((Sq + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK, H, B);
+    dim3 block(WARPS_PER_BLOCK * WARP);
+    DISPATCH_FLOAT(q.scalar_type(), "flash_bwd_delta", [&] {
+      flash_bwd_delta_kernel<scalar_t><<<grid, block, 0, stream>>>(
+          O.data_ptr<scalar_t>(), dO.data_ptr<scalar_t>(), delta.data_ptr<float>(), B, Sq, H, D);
+    });
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+  }
+
+  // dQ
+  {
+    const int BC = pick_tile(D);
+    const size_t smem = (size_t)2 * BC * D * sizeof(float) + (size_t)BC * sizeof(int) + (size_t)BC;
+    dim3 grid((Sq + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK, H, B);
+    dim3 block(WARPS_PER_BLOCK * WARP);
+    DISPATCH_FLOAT(q.scalar_type(), "flash_bwd_dq", [&] {
+      auto kernel = flash_bwd_dq_kernel<scalar_t>;
+      cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
+      kernel<<<grid, block, smem, stream>>>(
+          q.data_ptr<scalar_t>(), k.data_ptr<scalar_t>(), v.data_ptr<scalar_t>(),
+          dO.data_ptr<scalar_t>(), L.data_ptr<float>(), delta.data_ptr<float>(),
+          q_blk.data_ptr<int>(), k_blk.data_ptr<int>(), q_valid.data_ptr<bool>(),
+          k_valid.data_ptr<bool>(), dQ.data_ptr<scalar_t>(), B, Sq, Sk, H, Hkv, D, (float)scale, BC);
+    });
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+  }
+
+  // dK, dV
+  {
+    const int BQ = pick_tile(D);
+    const size_t smem = (size_t)2 * BQ * D * sizeof(float) + (size_t)2 * BQ * sizeof(float) +
+                        (size_t)BQ * sizeof(int) + (size_t)BQ;
+    dim3 grid((Sk + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK, Hkv, B);
+    dim3 block(WARPS_PER_BLOCK * WARP);
+    DISPATCH_FLOAT(q.scalar_type(), "flash_bwd_dkv", [&] {
+      auto kernel = flash_bwd_dkv_kernel<scalar_t>;
+      cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
+      kernel<<<grid, block, smem, stream>>>(
+          q.data_ptr<scalar_t>(), k.data_ptr<scalar_t>(), v.data_ptr<scalar_t>(),
+          dO.data_ptr<scalar_t>(), L.data_ptr<float>(), delta.data_ptr<float>(),
+          q_blk.data_ptr<int>(), k_blk.data_ptr<int>(), q_valid.data_ptr<bool>(),
+          k_valid.data_ptr<bool>(), dK.data_ptr<scalar_t>(), dV.data_ptr<scalar_t>(),
+          B, Sq, Sk, H, Hkv, D, (float)scale, BQ);
+    });
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+  }
+
+  return {dQ, dK, dV};
+}
+
+}  // namespace
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("flash_fwd", &flash_fwd, "Block-causal flash attention forward (CUDA)");
+  m.def("flash_bwd", &flash_bwd, "Block-causal flash attention backward (CUDA)");
+}

--- a/src/opentau/policies/flash_attn_cuda/_loader.py
+++ b/src/opentau/policies/flash_attn_cuda/_loader.py
@@ -1,0 +1,103 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Lazy JIT compilation of the custom block-causal flash-attention CUDA kernel.
+
+The extension is compiled on first use via :func:`torch.utils.cpp_extension.load`
+and cached process-wide. Compilation is intentionally lazy (not at import time)
+so importing this package on a CPU-only box, or in the CPU CI subset, never
+triggers ``nvcc``. Any failure (no CUDA, no compiler, build error) is swallowed
+and surfaced as :func:`is_available` returning ``False`` so callers can fall back
+to ``sdpa``/``eager``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_CSRC = Path(__file__).parent / "_csrc" / "flash_blockmask.cu"
+
+_lock = threading.Lock()
+_ext = None  # compiled module once loaded
+_load_attempted = False
+_load_error: str | None = None
+
+
+def _do_load():
+    """Compile + load the extension. Returns the module or raises."""
+    import torch
+    from torch.utils.cpp_extension import load
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is not available")
+
+    # Allow opting out (e.g. to force the sdpa fallback) without code changes.
+    if os.environ.get("OPENTAU_DISABLE_FLASH_CUDA", "0") == "1":
+        raise RuntimeError("flash_cuda disabled via OPENTAU_DISABLE_FLASH_CUDA=1")
+
+    verbose = os.environ.get("OPENTAU_FLASH_CUDA_VERBOSE", "0") == "1"
+    # nosec B614: this is torch.utils.cpp_extension.load (JIT-compiles our own .cu
+    # source), not torch.load — no pickle/deserialization of untrusted data.
+    return load(  # nosec B614
+        name="opentau_flash_blockmask",
+        sources=[str(_CSRC)],
+        extra_cflags=["-O3"],
+        extra_cuda_cflags=["-O3", "--expt-relaxed-constexpr"],
+        verbose=verbose,
+    )
+
+
+def get_extension():
+    """Return the compiled extension module, or ``None`` if unavailable.
+
+    Thread-safe and memoized: the build is attempted at most once per process.
+    """
+    global _ext, _load_attempted, _load_error
+    if _ext is not None:
+        return _ext
+    if _load_attempted:
+        return None
+    with _lock:
+        if _ext is not None:
+            return _ext
+        if _load_attempted:
+            return None
+        _load_attempted = True
+        try:
+            _ext = _do_load()
+            logger.info("Compiled custom flash-attention CUDA kernel (opentau_flash_blockmask).")
+        except Exception as e:  # noqa: BLE001 - any build/runtime failure -> fallback
+            _load_error = str(e)
+            logger.warning(
+                "Custom flash-attention CUDA kernel unavailable (%s); "
+                "callers should fall back to sdpa/eager.",
+                _load_error,
+            )
+            _ext = None
+        return _ext
+
+
+def is_available() -> bool:
+    """True if the custom flash-attention CUDA kernel compiled and is usable."""
+    return get_extension() is not None
+
+
+def load_error() -> str | None:
+    """The last compilation error string, if any (for diagnostics/tests)."""
+    return _load_error

--- a/src/opentau/policies/flash_attn_cuda/_loader.py
+++ b/src/opentau/policies/flash_attn_cuda/_loader.py
@@ -17,9 +17,9 @@
 The extension is compiled on first use via :func:`torch.utils.cpp_extension.load`
 and cached process-wide. Compilation is intentionally lazy (not at import time)
 so importing this package on a CPU-only box, or in the CPU CI subset, never
-triggers ``nvcc``. Any failure (no CUDA, no compiler, build error) is swallowed
-and surfaced as :func:`is_available` returning ``False`` so callers can fall back
-to ``sdpa``/``eager``.
+triggers ``nvcc``. :func:`is_available` reports whether the kernel compiled (used
+by tests to skip GPU cases); the ``flash_cuda`` attention pathway does **not**
+fall back to sdpa/eager — if the kernel is unavailable, calling it raises.
 """
 
 from __future__ import annotations
@@ -82,11 +82,11 @@ def get_extension():
         try:
             _ext = _do_load()
             logger.info("Compiled custom flash-attention CUDA kernel (opentau_flash_blockmask).")
-        except Exception as e:  # noqa: BLE001 - any build/runtime failure -> fallback
+        except Exception as e:  # noqa: BLE001 - record any build/runtime failure
             _load_error = str(e)
             logger.warning(
-                "Custom flash-attention CUDA kernel unavailable (%s); "
-                "callers should fall back to sdpa/eager.",
+                "Custom flash-attention CUDA kernel failed to compile (%s); "
+                "selecting attention_implementation='flash_cuda' will now raise.",
                 _load_error,
             )
             _ext = None

--- a/src/opentau/policies/pi0/configuration_pi0.py
+++ b/src/opentau/policies/pi0/configuration_pi0.py
@@ -180,6 +180,14 @@ class PI0Config(PreTrainedConfig):
                 f"Multiple observation steps not handled yet. Got `nobs_steps={self.n_obs_steps}`"
             )
 
+        if self.attention_implementation == "flash_cuda":
+            raise ValueError(
+                "attention_implementation='flash_cuda' is only supported by pi07_paligemma, "
+                "which builds the per-token block-ids the kernel requires. This policy does "
+                "not build them, so the kernel would hard-error at the first forward. "
+                "Use 'eager' or 'sdpa' instead."
+            )
+
         if self.n_action_steps < self.chunk_size and self.safety_buffer != 0:
             raise ValueError(
                 "A shortened execution horizon (n_action_steps < chunk_size) is not yet "

--- a/src/opentau/policies/pi05/configuration_pi05.py
+++ b/src/opentau/policies/pi05/configuration_pi05.py
@@ -184,6 +184,14 @@ class PI05Config(PreTrainedConfig):
         if self.state_type not in ("discrete", "continuous"):
             raise ValueError(f"state_type must be 'discrete' or 'continuous', got '{self.state_type}'")
 
+        if self.attention_implementation == "flash_cuda":
+            raise ValueError(
+                "attention_implementation='flash_cuda' is only supported by pi07_paligemma, "
+                "which builds the per-token block-ids the kernel requires. This policy does "
+                "not build them, so the kernel would hard-error at the first forward. "
+                "Use 'eager' or 'sdpa' instead."
+            )
+
         if self.max_delay > self.chunk_size:
             raise ValueError(
                 f"The max delay must be less than or equal to the chunk size. Got {self.max_delay} for `max_delay` and {self.chunk_size} for `chunk_size`."

--- a/src/opentau/policies/pi05/paligemma_with_expert.py
+++ b/src/opentau/policies/pi05/paligemma_with_expert.py
@@ -37,6 +37,8 @@ from transformers import (
 from transformers.models.auto import CONFIG_MAPPING
 from transformers.models.gemma import modeling_gemma
 
+from opentau.policies import flash_attn_cuda
+
 
 def _preferred_dtype():
     return torch.float32 if torch.onnx.is_in_onnx_export() else torch.bfloat16
@@ -214,10 +216,10 @@ class PaliGemmaWithExpertConfig(PretrainedConfig):
                 "You set `freeze_vision_encoder=False` and `train_expert_only=True` which are not compatible."
             )
 
-        if self.attention_implementation not in ["eager", "sdpa", "fa2"]:
+        if self.attention_implementation not in ["eager", "sdpa", "fa2", "flash_cuda"]:
             raise ValueError(
                 f"Wrong value provided for `attention_implementation` ({self.attention_implementation}). "
-                "Expected 'eager', 'sdpa', or 'fa2'."
+                "Expected 'eager', 'sdpa', 'fa2', or 'flash_cuda'."
             )
         if self.attention_implementation == "fa2":
             # "fa2" has been accepted by the validator historically but never
@@ -375,11 +377,17 @@ class PaliGemmaWithExpertModel(PreTrainedModel):
         use_cache: bool | None = None,
         fill_kv_cache: bool | None = None,
         adarms_cond: list[torch.Tensor] | None = None,
+        attention_block_ids: tuple[torch.Tensor, ...] | None = None,
     ) -> tuple[list[torch.FloatTensor | None], list[torch.FloatTensor] | Cache | None]:
         """Forward pass of the model.
 
         Args:
-            attention_mask: Attention mask tensor.
+            attention_mask: Dense bool attention mask (B, Sq, Sk), True=attend.
+                Used by the eager/sdpa backends. ``None`` when the ``flash_cuda``
+                backend is active (the mask is reconstructed in-kernel instead).
+            attention_block_ids: Compact ``(q_blk, k_blk, q_valid, k_valid)``
+                block-id representation for the ``flash_cuda`` backend (see
+                ``flash_attn_cuda.make_att_block_ids``). ``None`` for eager/sdpa.
             position_ids: Position IDs tensor.
             past_key_values: Past key values for caching.
             inputs_embeds: List of input embeddings for the different model parts.
@@ -443,6 +451,7 @@ class PaliGemmaWithExpertModel(PreTrainedModel):
                     adarms_cond,
                     batch_size,
                     head_dim,
+                    attention_block_ids,
                     use_reentrant=False,
                 )
             else:
@@ -458,6 +467,7 @@ class PaliGemmaWithExpertModel(PreTrainedModel):
                     adarms_cond,
                     batch_size,
                     head_dim,
+                    attention_block_ids,
                 )
 
         # final norm
@@ -484,6 +494,7 @@ class PaliGemmaWithExpertModel(PreTrainedModel):
         adarms_cond: list[torch.Tensor | None],
         batch_size: int,
         head_dim: int,
+        attention_block_ids: tuple[torch.Tensor, ...] | None = None,
     ) -> list[torch.FloatTensor | None]:
         """Run a single layer of the dual-tower decoder loop.
 
@@ -565,10 +576,16 @@ class PaliGemmaWithExpertModel(PreTrainedModel):
                 "value_states": value_states[:, :n_cross_att_tokens, :, :],
             }
 
-        attention_interface = self.get_attention_interface()
-        att_output = attention_interface(
-            attention_mask, batch_size, head_dim, query_states, key_states, value_states
-        )
+        if attention_block_ids is not None:
+            # flash_cuda backend: mask reconstructed in-kernel from block-ids.
+            att_output = self.flash_attention_forward(
+                attention_block_ids, batch_size, head_dim, query_states, key_states, value_states
+            )
+        else:
+            attention_interface = self.get_attention_interface()
+            att_output = attention_interface(
+                attention_mask, batch_size, head_dim, query_states, key_states, value_states
+            )
         att_output = att_output.to(dtype=_preferred_dtype())
 
         # first part of att_output is prefix (up to sequence length, [:, 0:prefix_seq_len])
@@ -618,16 +635,58 @@ class PaliGemmaWithExpertModel(PreTrainedModel):
             sequence length.
           - ``"fa2"``: accepted for backward compatibility; falls back to
             eager with a warning emitted at config validation time.
+          - ``"flash_cuda"``: custom block-causal CUDA flash kernel. The fast
+            path is taken in ``_run_layer`` when ``attention_block_ids`` is
+            supplied; this method returns ``sdpa`` as the fallback used when the
+            kernel is unavailable (no block-ids reach this interface then).
 
         Returns:
             callable: The attention function to use.
         """
         impl = self.config.attention_implementation
-        if impl == "sdpa":
+        if impl in ("sdpa", "flash_cuda"):
             return self.sdpa_attention_forward
         # "eager" and legacy "fa2" both land here; "fa2" already warned
         # during __post_init__.
         return self.eager_attention_forward
+
+    def flash_attention_forward(
+        self,
+        attention_block_ids: tuple[torch.Tensor, ...],
+        batch_size: int,
+        head_dim: int,
+        query_states: torch.Tensor,
+        key_states: torch.Tensor,
+        value_states: torch.Tensor,
+    ) -> torch.Tensor:
+        """Custom block-causal CUDA flash attention forward.
+
+        Unlike the eager/sdpa interfaces this consumes the compact block-id
+        representation (``q_blk, k_blk, q_valid, k_valid``) and reconstructs the
+        block-causal mask inside the kernel, so the dense (B, Sq, Sk) mask is
+        never materialized. GQA/MQA is handled natively (no K/V expansion), and
+        the kernel runs both matmuls on Tensor Cores (fp16/bf16) with fp32
+        accumulation, matching ``eager``/``sdpa`` outputs within fp/bf16 noise.
+
+        Args:
+            attention_block_ids: ``(q_blk, k_blk, q_valid, k_valid)`` from
+                ``flash_attn_cuda.make_att_block_ids``.
+            batch_size: Batch size.
+            head_dim: Per-head dimension.
+            query_states: ``(B, Sq, num_attention_heads, head_dim)``.
+            key_states: ``(B, Sk, num_key_value_heads, head_dim)``.
+            value_states: ``(B, Sk, num_key_value_heads, head_dim)``.
+
+        Returns:
+            torch.Tensor: ``(B, Sq, num_attention_heads * head_dim)`` output,
+            matching the eager/sdpa interfaces.
+        """
+        q_blk, k_blk, q_valid, k_valid = attention_block_ids
+        att_output = flash_attn_cuda.flash_attn_blockmask(
+            query_states, key_states, value_states, q_blk, k_blk, q_valid, k_valid, head_dim**-0.5
+        )
+        # (B, Sq, H, head_dim) -> (B, Sq, H * head_dim) to match eager/sdpa.
+        return att_output.reshape(batch_size, att_output.shape[1], -1)
 
     def eager_attention_forward(
         self,

--- a/src/opentau/policies/pi05/paligemma_with_expert.py
+++ b/src/opentau/policies/pi05/paligemma_with_expert.py
@@ -635,16 +635,28 @@ class PaliGemmaWithExpertModel(PreTrainedModel):
             sequence length.
           - ``"fa2"``: accepted for backward compatibility; falls back to
             eager with a warning emitted at config validation time.
-          - ``"flash_cuda"``: custom block-causal CUDA flash kernel. The fast
-            path is taken in ``_run_layer`` when ``attention_block_ids`` is
-            supplied; this method returns ``sdpa`` as the fallback used when the
-            kernel is unavailable (no block-ids reach this interface then).
+          - ``"flash_cuda"``: custom block-causal CUDA flash kernel, dispatched
+            in ``_run_layer`` via ``flash_attention_forward`` whenever
+            ``attention_block_ids`` is supplied. There is **no** silent fallback:
+            if this method is ever reached under ``flash_cuda`` it means a caller
+            failed to thread the block-ids, which is a bug, so it raises.
 
         Returns:
             callable: The attention function to use.
+
+        Raises:
+            RuntimeError: If ``attention_implementation == "flash_cuda"`` (the
+                flash path must go through ``flash_attention_forward`` with
+                block-ids, not this interface).
         """
         impl = self.config.attention_implementation
-        if impl in ("sdpa", "flash_cuda"):
+        if impl == "flash_cuda":
+            raise RuntimeError(
+                "flash_cuda must be dispatched via flash_attention_forward with "
+                "attention_block_ids; get_attention_interface reached instead "
+                "(block-ids were not threaded to this forward)."
+            )
+        if impl == "sdpa":
             return self.sdpa_attention_forward
         # "eager" and legacy "fa2" both land here; "fa2" already warned
         # during __post_init__.

--- a/src/opentau/policies/pi05_mem/configuration_pi05.py
+++ b/src/opentau/policies/pi05_mem/configuration_pi05.py
@@ -189,6 +189,14 @@ class PI05MemConfig(PreTrainedConfig):
         if not isinstance(self.history_interval, int) or self.history_interval < 1:
             raise ValueError(f"`history_interval` must be a positive integer, got {self.history_interval}.")
 
+        if self.attention_implementation == "flash_cuda":
+            raise ValueError(
+                "attention_implementation='flash_cuda' is only supported by pi07_paligemma, "
+                "which builds the per-token block-ids the kernel requires. This policy does "
+                "not build them, so the kernel would hard-error at the first forward. "
+                "Use 'eager' or 'sdpa' instead."
+            )
+
         if self.n_action_steps > self.chunk_size:
             raise ValueError(
                 f"The chunk size is the upper bound for the number of action steps per model invocation. Got "

--- a/src/opentau/policies/pi07_paligemma/high_level_planner/modeling_pi07_high_level.py
+++ b/src/opentau/policies/pi07_paligemma/high_level_planner/modeling_pi07_high_level.py
@@ -43,6 +43,10 @@ from opentau.policies.pi05.paligemma_with_expert import (
 from opentau.policies.pi07_paligemma.high_level_planner.configuration_pi07_high_level import (
     PI07HighLevelPlannerConfig,
 )
+from opentau.policies.pi07_paligemma.low_level.modeling_pi07_low_level import (
+    build_attention_inputs,
+    flash_cuda_active,
+)
 from opentau.policies.pretrained import PreTrainedPolicy, T
 from opentau.utils.accelerate_utils import get_proc_accelerator
 
@@ -1137,7 +1141,10 @@ class PI07HighLevelPlannerModel(nn.Module):
             metadata_masks,
         )
 
-        vlm_2d_attention_mask = make_att_2d_masks(prefix_pad_masks, prefix_att_masks)
+        use_flash = flash_cuda_active(self.config.attention_implementation)
+        vlm_2d_attention_mask, vlm_block_ids = build_attention_inputs(
+            use_flash, prefix_pad_masks, prefix_att_masks
+        )
         vlm_position_ids = torch.cumsum(prefix_pad_masks, dim=1) - 1
 
         # avoids using discrete action for predicting continuous flow matching action
@@ -1151,6 +1158,7 @@ class PI07HighLevelPlannerModel(nn.Module):
             n_cross_att_tokens=num_cross_att_tokens,
             use_cache=False,
             fill_kv_cache=True,
+            attention_block_ids=vlm_block_ids,
         )
 
         batch_size, seq_len = response_tokens.shape
@@ -1257,7 +1265,10 @@ class PI07HighLevelPlannerModel(nn.Module):
             metadata_tokens=metadata_tokens,
             metadata_masks=metadata_masks,
         )
-        prefix_att_2d_masks = make_att_2d_masks(prefix_pad_masks, prefix_att_masks)
+        use_flash = flash_cuda_active(self.config.attention_implementation)
+        prefix_att_2d_masks, prefix_block_ids = build_attention_inputs(
+            use_flash, prefix_pad_masks, prefix_att_masks
+        )
         prefix_position_ids = torch.cumsum(prefix_pad_masks, dim=1) - 1
 
         prefix_offsets = torch.sum(prefix_pad_masks, dim=-1)[:, None] - 1
@@ -1273,6 +1284,7 @@ class PI07HighLevelPlannerModel(nn.Module):
             n_cross_att_tokens=num_cross_att_tokens,
             use_cache=False,
             fill_kv_cache=True,
+            attention_block_ids=prefix_block_ids,
         )
 
         # initialize memory tokens to empty tensor for storing memory tokens during inference
@@ -1321,7 +1333,8 @@ class PI07HighLevelPlannerModel(nn.Module):
             prefix_pad_masks = torch.cat([prefix_pad_masks, pad_row], dim=1)
             prefix_att_masks = torch.cat([prefix_att_masks, new_att], dim=1)
             num_cross = prefix_pad_masks.shape[1]
-            att_2d_masks = make_att_2d_masks(
+            att_2d_masks, att_block_ids = build_attention_inputs(
+                flash_cuda_active(self.config.attention_implementation),
                 pad_row,
                 new_att,
                 n_cross_att_tokens=num_cross - 1,
@@ -1336,6 +1349,7 @@ class PI07HighLevelPlannerModel(nn.Module):
                 n_cross_att_tokens=num_cross,
                 use_cache=True,
                 fill_kv_cache=True,
+                attention_block_ids=att_block_ids,
             )
 
         # initialize response tokens to empty tensor for storing response tokens during inference
@@ -1457,7 +1471,8 @@ class PI07HighLevelPlannerModel(nn.Module):
 
         num_cross_att_tokens = prefix_pad_masks.shape[1]
         # create the attention mask for the response tokens
-        att_2d_masks = make_att_2d_masks(
+        att_2d_masks, att_block_ids = build_attention_inputs(
+            flash_cuda_active(self.config.attention_implementation),
             pad_masks,
             att_masks,
             n_cross_att_tokens=num_cross_att_tokens - 1,
@@ -1475,6 +1490,7 @@ class PI07HighLevelPlannerModel(nn.Module):
             n_cross_att_tokens=num_cross_att_tokens,
             use_cache=True,
             fill_kv_cache=True,
+            attention_block_ids=att_block_ids,
         )
 
         return (

--- a/src/opentau/policies/pi07_paligemma/low_level/configuration_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/configuration_pi07_low_level.py
@@ -61,10 +61,14 @@ class PI07PaligemmaLowLevelConfig(PreTrainedConfig):
         proj_width: Width of the projection layer. Defaults to 1024.
         dropout: Dropout rate. Defaults to 0.1.
         num_steps: Number of flow matching steps for decoding. Defaults to 10.
-        attention_implementation: Attention implementation to use ("eager", "sdpa", or "fa2").
-            Defaults to "eager". "sdpa" dispatches to ``torch.nn.functional.scaled_dot_product_attention``
-            (frees ~5.6 GiB on forward at the bs ceiling tested; see PR #182). "fa2" is accepted for
-            backward compatibility but logs a warning and falls back to "eager".
+        attention_implementation: Attention implementation to use ("eager", "sdpa", "fa2", or
+            "flash_cuda"). Defaults to "eager". "sdpa" dispatches to
+            ``torch.nn.functional.scaled_dot_product_attention`` (frees ~5.6 GiB on forward at the bs
+            ceiling tested; see PR #182). "fa2" is accepted for backward compatibility but logs a
+            warning and falls back to "eager". "flash_cuda" uses the custom block-causal CUDA flash
+            kernel (``opentau.policies.flash_attn_cuda``): the SxS attention mask is reconstructed
+            in-kernel from compact block-ids so it is never materialized (large memory savings), and
+            it gracefully falls back to "sdpa" when the kernel cannot be JIT-compiled (no CUDA/compiler).
         freeze_vision_encoder: Whether to freeze the vision encoder during fine-tuning. Defaults to True.
         train_expert_only: Whether to train only the expert module. Defaults to False.
         optimizer_lr: Learning rate for the optimizer. Defaults to 2.5e-5.

--- a/src/opentau/policies/pi07_paligemma/low_level/configuration_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/configuration_pi07_low_level.py
@@ -66,9 +66,10 @@ class PI07PaligemmaLowLevelConfig(PreTrainedConfig):
             ``torch.nn.functional.scaled_dot_product_attention`` (frees ~5.6 GiB on forward at the bs
             ceiling tested; see PR #182). "fa2" is accepted for backward compatibility but logs a
             warning and falls back to "eager". "flash_cuda" uses the custom block-causal CUDA flash
-            kernel (``opentau.policies.flash_attn_cuda``): the SxS attention mask is reconstructed
-            in-kernel from compact block-ids so it is never materialized (large memory savings), and
-            it gracefully falls back to "sdpa" when the kernel cannot be JIT-compiled (no CUDA/compiler).
+            kernel (``opentau.policies.flash_attn_cuda``, Tensor Core forward + backward): the SxS
+            attention mask is reconstructed in-kernel from compact block-ids so it is never
+            materialized. There is no fallback — if the kernel cannot be JIT-compiled (no
+            CUDA/compiler) the forward raises rather than silently using sdpa/eager.
         freeze_vision_encoder: Whether to freeze the vision encoder during fine-tuning. Defaults to True.
         train_expert_only: Whether to train only the expert module. Defaults to False.
         optimizer_lr: Learning rate for the optimizer. Defaults to 2.5e-5.

--- a/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
@@ -37,6 +37,8 @@ from transformers import AutoProcessor, AutoTokenizer
 
 from opentau.configs.policies import PreTrainedConfig
 from opentau.configs.types import NormalizationMode
+from opentau.policies import flash_attn_cuda
+from opentau.policies.flash_attn_cuda import make_att_block_ids
 from opentau.policies.normalize import Normalize, Unnormalize
 from opentau.policies.normalize import resolve_num_datasets as _num_datasets
 from opentau.policies.pi05.paligemma_with_expert import (
@@ -220,6 +222,36 @@ def make_att_2d_masks(
         att_2d_masks = torch.cat((cross_att_mask, att_2d_masks), dim=2)
 
     return att_2d_masks
+
+
+def flash_cuda_active(attention_implementation: str) -> bool:
+    """True if the ``flash_cuda`` backend is selected and its kernel compiled.
+
+    Falls back gracefully: returns ``False`` (use the dense-mask eager/sdpa
+    path) when the custom CUDA kernel is unavailable (no CUDA, no compiler, etc.).
+    """
+    return attention_implementation == "flash_cuda" and flash_attn_cuda.is_available()
+
+
+def build_attention_inputs(
+    use_flash: bool,
+    pad_masks: Tensor,
+    att_masks: Tensor,
+    n_cross_att_tokens: int | None = None,
+    cross_att_pad_masks: Tensor | None = None,
+) -> tuple[Tensor | None, tuple[Tensor, ...] | None]:
+    """Return ``(attention_mask, attention_block_ids)`` for the active backend.
+
+    For the ``flash_cuda`` backend (``use_flash=True``) this builds the compact
+    block-id representation and returns ``attention_mask=None`` so the dense
+    (B, Sq, Sk) mask is never materialized. Otherwise it builds the dense mask
+    via :func:`make_att_2d_masks` and returns ``attention_block_ids=None``.
+    """
+    if use_flash:
+        block_ids = make_att_block_ids(pad_masks, att_masks, n_cross_att_tokens, cross_att_pad_masks)
+        return None, block_ids
+    mask = make_att_2d_masks(pad_masks, att_masks, n_cross_att_tokens, cross_att_pad_masks)
+    return mask, None
 
 
 def resize_with_pad(img: Tensor, width: int, height: int, pad_value: int = -1) -> Tensor:
@@ -2048,7 +2080,10 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
             prefix_items
         )
 
-        vlm_2d_attention_mask = make_att_2d_masks(prefix_pad_masks, prefix_att_masks)
+        use_flash = flash_cuda_active(self.config.attention_implementation)
+        vlm_2d_attention_mask, vlm_block_ids = build_attention_inputs(
+            use_flash, prefix_pad_masks, prefix_att_masks
+        )
         vlm_position_ids = torch.cumsum(prefix_pad_masks, dim=1) - 1
 
         (prefix_out, _), past_key_values = self.paligemma_with_expert.forward(
@@ -2059,6 +2094,7 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
             n_cross_att_tokens=num_cross_att_tokens,
             use_cache=False,
             fill_kv_cache=True,
+            attention_block_ids=vlm_block_ids,
         )
 
         # Now run action expert
@@ -2086,7 +2122,8 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
         suffix_items = self._build_suffix_items(x_t)
         suffix_embs, suffix_pad_masks, suffix_att_masks, adarms_cond = self.embed_suffix(suffix_items, time)
 
-        action_expert_2d_attention_mask = make_att_2d_masks(
+        action_expert_2d_attention_mask, action_expert_block_ids = build_attention_inputs(
+            use_flash,
             suffix_pad_masks,
             suffix_att_masks,
             n_cross_att_tokens=num_cross_att_tokens,
@@ -2111,6 +2148,7 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
             use_cache=True,
             fill_kv_cache=False,
             adarms_cond=[None, adarms_cond],
+            attention_block_ids=action_expert_block_ids,
         )
 
         # compute mse loss for velocity
@@ -2210,7 +2248,10 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
             actions_shape = (bsize, self.config.chunk_size, self.config.max_action_dim)
             noise = self.sample_noise(actions_shape, device)
 
-        prefix_att_2d_masks = make_att_2d_masks(prefix_pad_masks, prefix_att_masks)
+        use_flash = flash_cuda_active(self.config.attention_implementation)
+        prefix_att_2d_masks, prefix_block_ids = build_attention_inputs(
+            use_flash, prefix_pad_masks, prefix_att_masks
+        )
         prefix_position_ids = torch.cumsum(prefix_pad_masks, dim=1) - 1
 
         # Compute image and language key value cache
@@ -2222,6 +2263,7 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
             n_cross_att_tokens=num_cross_att_tokens,
             use_cache=False,
             fill_kv_cache=True,
+            attention_block_ids=prefix_block_ids,
         )
 
         # perform denoising steps to get the action
@@ -2271,7 +2313,9 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
         suffix_embs, suffix_pad_masks, suffix_att_masks, adarms_cond = self.embed_suffix(suffix_items, time)
 
         num_cross_att_tokens = prefix_pad_masks.shape[1]
-        action_expert_2d_attention_mask = make_att_2d_masks(
+        use_flash = flash_cuda_active(self.config.attention_implementation)
+        action_expert_2d_attention_mask, action_expert_block_ids = build_attention_inputs(
+            use_flash,
             suffix_pad_masks,
             suffix_att_masks,
             n_cross_att_tokens=num_cross_att_tokens,
@@ -2290,6 +2334,7 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
             use_cache=True,
             fill_kv_cache=False,
             adarms_cond=[None, adarms_cond],
+            attention_block_ids=action_expert_block_ids,
         )
         suffix_out = outputs_embeds[1]
         # Denoise the full chunk_size chunk so v_t matches x_t in the Euler step.

--- a/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
@@ -37,7 +37,6 @@ from transformers import AutoProcessor, AutoTokenizer
 
 from opentau.configs.policies import PreTrainedConfig
 from opentau.configs.types import NormalizationMode
-from opentau.policies import flash_attn_cuda
 from opentau.policies.flash_attn_cuda import make_att_block_ids
 from opentau.policies.normalize import Normalize, Unnormalize
 from opentau.policies.normalize import resolve_num_datasets as _num_datasets
@@ -225,12 +224,13 @@ def make_att_2d_masks(
 
 
 def flash_cuda_active(attention_implementation: str) -> bool:
-    """True if the ``flash_cuda`` backend is selected and its kernel compiled.
+    """True if the ``flash_cuda`` backend is selected.
 
-    Falls back gracefully: returns ``False`` (use the dense-mask eager/sdpa
-    path) when the custom CUDA kernel is unavailable (no CUDA, no compiler, etc.).
+    No fallback: when ``flash_cuda`` is selected it is always used. If the custom
+    CUDA kernel cannot be JIT-compiled (no CUDA / no compiler), the kernel call
+    raises loudly rather than silently degrading to eager/sdpa.
     """
-    return attention_implementation == "flash_cuda" and flash_attn_cuda.is_available()
+    return attention_implementation == "flash_cuda"
 
 
 def build_attention_inputs(

--- a/src/opentau/scripts/benchmark_flash_attn.py
+++ b/src/opentau/scripts/benchmark_flash_attn.py
@@ -256,7 +256,7 @@ def sdpa_backend_probe(b=1, s=4096, h=8, hkv=1, d=256):
     from torch.nn.attention import SDPBackend, sdpa_kernel
 
     device = "cuda"
-    (q_blk, k_blk, q_valid, k_valid), dense = _mask_and_blocks(b, s, device)
+    _, dense = _mask_and_blocks(b, s, device)
     scale = d**-0.5
     g = h // hkv
     q = torch.randn(b, s, h, d, device=device, dtype=torch.bfloat16).permute(0, 2, 1, 3)

--- a/src/opentau/scripts/benchmark_flash_attn.py
+++ b/src/opentau/scripts/benchmark_flash_attn.py
@@ -232,9 +232,117 @@ def stacked_memory_comparison(b=2, s=1024, h=8, hkv=1, d=256, layers=18):
     print(f"  flash, +ckpt   : {measure(flash_layer, True)}")
 
 
+def sdpa_backend_probe(b=1, s=4096, h=8, hkv=1, d=256):
+    """Show which torch SDPA backends accept a *block-causal* attn_mask.
+
+    PyTorch's fused FlashAttention backend only supports ``is_causal`` or no
+    mask; an arbitrary block-causal mask is rejected, leaving the
+    memory-efficient or math backend. Crucially, both of those still take the
+    dense ``(B, 1, S, S)`` mask as input — O(S²) memory — whereas flash_cuda
+    reconstructs the mask from compact block-ids (O(S)).
+    """
+    from torch.nn.attention import SDPBackend, sdpa_kernel
+
+    device = "cuda"
+    (q_blk, k_blk, q_valid, k_valid), dense = _mask_and_blocks(b, s, device)
+    scale = d**-0.5
+    g = h // hkv
+    q = torch.randn(b, s, h, d, device=device, dtype=torch.bfloat16).permute(0, 2, 1, 3)
+    k = (
+        torch.randn(b, s, hkv, d, device=device, dtype=torch.bfloat16)
+        .permute(0, 2, 1, 3)
+        .repeat_interleave(g, 1)
+    )
+    v = (
+        torch.randn(b, s, hkv, d, device=device, dtype=torch.bfloat16)
+        .permute(0, 2, 1, 3)
+        .repeat_interleave(g, 1)
+    )
+    mask = dense[:, None]
+    print(f"SDPA backend support for a block-causal bool mask (S={s}, D={d}):")
+    for name, backend in [
+        ("flash (FlashAttention)", SDPBackend.FLASH_ATTENTION),
+        ("mem-efficient", SDPBackend.EFFICIENT_ATTENTION),
+        ("math (== eager)", SDPBackend.MATH),
+    ]:
+        try:
+            with sdpa_kernel([backend]):
+                torch.nn.functional.scaled_dot_product_attention(q, k, v, attn_mask=mask, scale=scale)
+            torch.cuda.synchronize()
+            print(f"  {name:24s}: accepts the mask")
+        except Exception as e:  # noqa: BLE001
+            print(f"  {name:24s}: REJECTS the mask ({type(e).__name__})")
+    print("  note: every accepting backend still needs the dense (B,1,S,S) mask as input (O(S^2)).")
+
+
+def long_context_sweep(b=1, h=8, hkv=1, d=256, seqs=(4096, 8192, 16384, 32768, 65536, 98304)):
+    """Forward peak-memory + latency vs sequence length for eager / sdpa / flash.
+
+    Demonstrates the regime flash_cuda uniquely serves: eager materializes the
+    O(S²) scores and sdpa needs the O(S²) dense mask, so both OOM as S grows;
+    flash uses compact block-ids (O(S)) and keeps running. Block-causal
+    (prefix-LM) mask, bf16.
+    """
+    device = "cuda"
+    scale = d**-0.5
+    print(f"Forward, B{b} H{h} Hkv{hkv} D{d} bf16, prefix-LM block-causal mask.")
+    print(f"{'S':>8s} {'dense mask':>10s} | {'eager':>16s} | {'sdpa':>16s} | {'flash_cuda':>16s}")
+    print(
+        f"{'':>8s} {'(B,S,S)':>10s} | {'ms / peak GB':>16s} | {'ms / peak GB':>16s} | {'ms / peak GB':>16s}"
+    )
+    print("-" * 80)
+
+    def timed(fn):
+        # returns "ms / GB" or "OOM"
+        try:
+            torch.cuda.empty_cache()
+            torch.cuda.reset_peak_memory_stats()
+            for _ in range(2):
+                fn()
+            torch.cuda.synchronize()
+            e0 = torch.cuda.Event(enable_timing=True)
+            e1 = torch.cuda.Event(enable_timing=True)
+            e0.record()
+            for _ in range(5):
+                fn()
+            e1.record()
+            torch.cuda.synchronize()
+            ms = e0.elapsed_time(e1) / 5
+            gb = torch.cuda.max_memory_allocated() / 1e9
+            return f"{ms:7.1f} / {gb:5.1f}"
+        except torch.cuda.OutOfMemoryError:
+            torch.cuda.empty_cache()
+            return "       OOM      "
+
+    for s in seqs:
+        q = torch.randn(b, s, h, d, device=device, dtype=torch.bfloat16)
+        k = torch.randn(b, s, hkv, d, device=device, dtype=torch.bfloat16)
+        v = torch.randn(b, s, hkv, d, device=device, dtype=torch.bfloat16)
+        (q_blk, k_blk, q_valid, k_valid), _ = _mask_and_blocks(b, s, device)  # compact (O(S))
+        mask_gb = b * s * s / 1e9  # dense bool mask bytes
+
+        def eager_fn(q=q, k=k, v=v, s=s):
+            _, dense = _mask_and_blocks(b, s, device)  # build dense mask here (counts against eager)
+            _eager(q, k, v, dense, scale)
+
+        def sdpa_fn(q=q, k=k, v=v, s=s):
+            _, dense = _mask_and_blocks(b, s, device)
+            _sdpa(q, k, v, dense, scale)
+
+        def flash_fn(q=q, k=k, v=v, q_blk=q_blk, k_blk=k_blk, q_valid=q_valid, k_valid=k_valid):
+            flash_attn_blockmask(q, k, v, q_blk, k_blk, q_valid, k_valid, scale)
+
+        e_res, s_res, f_res = timed(eager_fn), timed(sdpa_fn), timed(flash_fn)
+        del q, k, v
+        print(f"{s:>8d} {mask_gb:8.2f}GB | {e_res:>16s} | {s_res:>16s} | {f_res:>16s}")
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--oom-demo", action="store_true", help="run the eager-OOM-vs-flash demo")
+    parser.add_argument(
+        "--long-context", action="store_true", help="run the long-context sweep + SDPA backend probe"
+    )
     args = parser.parse_args()
 
     if not torch.cuda.is_available():
@@ -253,6 +361,11 @@ def main():
     if args.oom_demo:
         print("\n=== Eager-OOM vs flash (enabling win) ===")
         oom_demo()
+    if args.long_context:
+        print("\n=== SDPA backend probe (block-causal mask) ===")
+        sdpa_backend_probe()
+        print("\n=== Long-context forward sweep: eager vs sdpa vs flash ===")
+        long_context_sweep()
 
 
 if __name__ == "__main__":

--- a/src/opentau/scripts/benchmark_flash_attn.py
+++ b/src/opentau/scripts/benchmark_flash_attn.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Benchmark the custom block-causal flash-attention kernel vs eager / sdpa.
+
+Reports per-op latency and peak attention memory for the eager backend (the
+``pi07_paligemma`` default, ``attention_implementation="eager"``), PyTorch's
+``sdpa`` (cuBLAS/cuDNN-backed), and the custom ``flash_cuda`` kernel, for both
+forward and forward+backward, at representative pi07_paligemma shapes
+(head_dim=256, MQA). Also demonstrates the regime where eager runs out of memory
+but the fused kernel still completes.
+
+Honest summary of what to expect: ``flash_cuda`` reconstructs the block-causal
+mask in-kernel and never materializes the (B, H, S, S) scores/probs or the
+dense mask, so its peak attention memory is far below eager's. On raw latency it
+currently trails the cuBLAS/cuDNN-backed eager and sdpa paths at head_dim=256
+(the gap narrows at longer sequence) — closing it requires FlashAttention-2-class
+engineering (cp.async double-buffering + register-resident accumulation), tracked
+as follow-up.
+
+Usage:
+    python -m opentau.scripts.benchmark_flash_attn
+    python -m opentau.scripts.benchmark_flash_attn --oom-demo
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import torch
+
+from opentau.policies.flash_attn_cuda import (
+    flash_attn_blockmask,
+    is_available,
+    load_error,
+    make_att_block_ids,
+)
+
+BIG_NEG = -2.3819763e38
+
+
+def _mask_and_blocks(b, s, device, pattern="prefixlm"):
+    att = torch.zeros(b, s, dtype=torch.int32, device=device)
+    if pattern == "prefixlm":
+        att[:, s // 2] = 1
+        att[:, s // 2 + 1 :] = 1
+    elif pattern == "causal":
+        att[:] = 1
+    pad = torch.ones(b, s, dtype=torch.bool, device=device)
+    q_blk, k_blk, q_valid, k_valid = make_att_block_ids(pad, att)
+    dense = (k_blk[:, None, :] <= q_blk[:, :, None]) & pad[:, :, None] & pad[:, None, :]
+    return (q_blk, k_blk, q_valid, k_valid), dense
+
+
+def _eager(q, k, v, mask, scale):
+    g = q.shape[2] // k.shape[2]
+    qf = q.float().permute(0, 2, 1, 3)
+    kf = k.float().permute(0, 2, 1, 3).repeat_interleave(g, dim=1)
+    vf = v.float().permute(0, 2, 1, 3).repeat_interleave(g, dim=1)
+    aw = torch.matmul(qf, kf.transpose(-1, -2)) * scale
+    aw = torch.where(mask[:, None], aw, BIG_NEG)
+    p = torch.softmax(aw, dim=-1).to(vf.dtype)
+    return torch.matmul(p, vf).permute(0, 2, 1, 3).contiguous()
+
+
+def _sdpa(q, k, v, mask, scale):
+    g = q.shape[2] // k.shape[2]
+    qf = q.permute(0, 2, 1, 3)
+    kf = k.permute(0, 2, 1, 3).repeat_interleave(g, dim=1)
+    vf = v.permute(0, 2, 1, 3).repeat_interleave(g, dim=1)
+    o = torch.nn.functional.scaled_dot_product_attention(qf, kf, vf, attn_mask=mask[:, None], scale=scale)
+    return o.permute(0, 2, 1, 3).contiguous()
+
+
+def _bench(fn, iters=20):
+    torch.cuda.synchronize()
+    torch.cuda.reset_peak_memory_stats()
+    base = torch.cuda.memory_allocated()
+    for _ in range(3):
+        fn()
+    torch.cuda.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(iters):
+        fn()
+    end.record()
+    torch.cuda.synchronize()
+    return start.elapsed_time(end) / iters, (torch.cuda.max_memory_allocated() - base) / 1e6
+
+
+def run(shapes, dtype=torch.bfloat16, backward=False):
+    device = "cuda"
+    tag = "fwd+bwd" if backward else "fwd"
+    hdr = f"{'shape':28s} {'mode':8s} {'eager ms':>9s} {'sdpa ms':>9s} {'flash ms':>9s} "
+    hdr += f"{'eager MB':>9s} {'sdpa MB':>9s} {'flash MB':>9s} {'mem x':>7s}"
+    print(hdr)
+    print("-" * len(hdr))
+    for b, s, h, hkv, d in shapes:
+        (q_blk, k_blk, q_valid, k_valid), dense = _mask_and_blocks(b, s, device)
+        scale = d**-0.5
+        q = torch.randn(b, s, h, d, device=device, dtype=dtype)
+        k = torch.randn(b, s, hkv, d, device=device, dtype=dtype)
+        v = torch.randn(b, s, hkv, d, device=device, dtype=dtype)
+
+        def make(fn, *args):
+            if not backward:
+                return lambda: fn(*args)
+            q0, k0, v0, rest = args[0], args[1], args[2], args[3:]
+
+            def step():
+                qq = q0.detach().requires_grad_(True)
+                kk = k0.detach().requires_grad_(True)
+                vv = v0.detach().requires_grad_(True)
+                fn(qq, kk, vv, *rest).sum().backward()
+
+            return step
+
+        et, em = _bench(make(_eager, q, k, v, dense, scale))
+        st, sm = _bench(make(_sdpa, q, k, v, dense, scale))
+        ft, fm = _bench(make(flash_attn_blockmask, q, k, v, q_blk, k_blk, q_valid, k_valid, scale))
+        name = f"B{b} S{s} H{h} Hkv{hkv} D{d}"
+        print(
+            f"{name:28s} {tag:8s} {et:9.3f} {st:9.3f} {ft:9.3f} {em:9.1f} {sm:9.1f} {fm:9.1f} {em / fm:6.2f}x"
+        )
+
+
+def oom_demo():
+    """Show a shape where the eager (materialized) path OOMs but flash runs."""
+    device = "cuda"
+    b, h, hkv, d = 4, 8, 1, 256
+    free, total = torch.cuda.mem_get_info()
+    print(f"GPU free/total: {free / 1e9:.1f}/{total / 1e9:.1f} GB")
+    for s in [8192, 16384, 24576]:
+        (q_blk, k_blk, q_valid, k_valid), dense = _mask_and_blocks(b, s, device, "causal")
+        scale = d**-0.5
+        q = torch.randn(b, s, h, d, device=device, dtype=torch.bfloat16)
+        k = torch.randn(b, s, hkv, d, device=device, dtype=torch.bfloat16)
+        v = torch.randn(b, s, hkv, d, device=device, dtype=torch.bfloat16)
+        # eager would need ~B*H*S^2*4 bytes for fp32 scores alone:
+        eager_scores_gb = b * h * s * s * 4 / 1e9
+        try:
+            torch.cuda.reset_peak_memory_stats()
+            _eager(q, k, v, dense, scale)
+            torch.cuda.synchronize()
+            eager_status = f"ok ({torch.cuda.max_memory_allocated() / 1e9:.1f} GB peak)"
+        except torch.cuda.OutOfMemoryError:
+            eager_status = "OOM"
+            torch.cuda.empty_cache()
+        try:
+            torch.cuda.reset_peak_memory_stats()
+            flash_attn_blockmask(q, k, v, q_blk, k_blk, q_valid, k_valid, scale)
+            torch.cuda.synchronize()
+            flash_status = f"ok ({torch.cuda.max_memory_allocated() / 1e9:.1f} GB peak)"
+        except torch.cuda.OutOfMemoryError:
+            flash_status = "OOM"
+            torch.cuda.empty_cache()
+        print(
+            f"B{b} S{s} H{h} D{d}: eager fp32-scores would need ~{eager_scores_gb:.1f} GB | "
+            f"eager: {eager_status} | flash: {flash_status}"
+        )
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--oom-demo", action="store_true", help="run the eager-OOM-vs-flash demo")
+    args = parser.parse_args()
+
+    if not torch.cuda.is_available():
+        raise SystemExit("This benchmark requires a CUDA GPU.")
+    if not is_available():
+        raise SystemExit(f"flash_cuda kernel unavailable: {load_error()}")
+
+    print(f"Device: {torch.cuda.get_device_name(0)}\n")
+    shapes = [(2, 512, 8, 1, 256), (2, 768, 8, 1, 256), (1, 1024, 8, 1, 256), (1, 2048, 8, 1, 256)]
+    print("=== Forward ===")
+    run(shapes, backward=False)
+    print("\n=== Forward + backward ===")
+    run(shapes, backward=True)
+    if args.oom_demo:
+        print("\n=== Eager-OOM vs flash (enabling win) ===")
+        oom_demo()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/opentau/scripts/benchmark_flash_attn.py
+++ b/src/opentau/scripts/benchmark_flash_attn.py
@@ -73,6 +73,18 @@ def _mask_and_blocks(b, s, device, pattern="prefixlm"):
     return (q_blk, k_blk, q_valid, k_valid), dense
 
 
+def _blocks_only(b, s, device, pattern="prefixlm"):
+    """Compact block-ids ONLY (no dense mask) — what the flash path actually uses."""
+    att = torch.zeros(b, s, dtype=torch.int32, device=device)
+    if pattern == "prefixlm":
+        att[:, s // 2] = 1
+        att[:, s // 2 + 1 :] = 1
+    elif pattern == "causal":
+        att[:] = 1
+    pad = torch.ones(b, s, dtype=torch.bool, device=device)
+    return make_att_block_ids(pad, att)
+
+
 def _eager(q, k, v, mask, scale):
     g = q.shape[2] // k.shape[2]
     qf = q.float().permute(0, 2, 1, 3)
@@ -259,20 +271,38 @@ def sdpa_backend_probe(b=1, s=4096, h=8, hkv=1, d=256):
         .repeat_interleave(g, 1)
     )
     mask = dense[:, None]
-    print(f"SDPA backend support for a block-causal bool mask (S={s}, D={d}):")
-    for name, backend in [
-        ("flash (FlashAttention)", SDPBackend.FLASH_ATTENTION),
-        ("mem-efficient", SDPBackend.EFFICIENT_ATTENTION),
-        ("math (== eager)", SDPBackend.MATH),
-    ]:
-        try:
-            with sdpa_kernel([backend]):
-                torch.nn.functional.scaled_dot_product_attention(q, k, v, attn_mask=mask, scale=scale)
-            torch.cuda.synchronize()
-            print(f"  {name:24s}: accepts the mask")
-        except Exception as e:  # noqa: BLE001
-            print(f"  {name:24s}: REJECTS the mask ({type(e).__name__})")
-    print("  note: every accepting backend still needs the dense (B,1,S,S) mask as input (O(S^2)).")
+    # Also build a NON-SQUARE cross-attention mask (expert pass: query len N,
+    # key len n_cross + N) — the shape pi07_paligemma's action expert uses.
+    n_cross = s // 2
+    qx = torch.randn(b, h, s, d, device=device, dtype=torch.bfloat16)
+    kx = torch.randn(b, h, n_cross + s, d, device=device, dtype=torch.bfloat16)
+    vx = torch.randn(b, h, n_cross + s, d, device=device, dtype=torch.bfloat16)
+    cross_mask = torch.ones(b, 1, s, n_cross + s, dtype=torch.bool, device=device)
+
+    def probe(qq, kk, vv, mm, label):
+        print(f"{label}:")
+        for name, backend in [
+            ("flash (FlashAttention)", SDPBackend.FLASH_ATTENTION),
+            ("mem-efficient", SDPBackend.EFFICIENT_ATTENTION),
+            ("math (== eager)", SDPBackend.MATH),
+        ]:
+            try:
+                with sdpa_kernel([backend]):
+                    torch.nn.functional.scaled_dot_product_attention(qq, kk, vv, attn_mask=mm, scale=scale)
+                torch.cuda.synchronize()
+                print(f"  {name:24s}: accepts the mask")
+            except Exception as e:  # noqa: BLE001
+                print(f"  {name:24s}: REJECTS ({type(e).__name__})")
+
+    probe(q, k, v, mask, f"SDPA backends for a SQUARE block-causal bool mask (S={s}, D={d})")
+    probe(
+        qx,
+        kx,
+        vx,
+        cross_mask,
+        f"SDPA backends for a NON-SQUARE cross-attn bool mask (Sq={s}, Sk={n_cross + s}, D={d})",
+    )
+    print("  note: every accepting backend still needs the dense (B,1,Sq,Sk) mask as input (O(Sq*Sk)).")
 
 
 def long_context_sweep(b=1, h=8, hkv=1, d=256, seqs=(4096, 8192, 16384, 32768, 65536, 98304)):
@@ -318,7 +348,7 @@ def long_context_sweep(b=1, h=8, hkv=1, d=256, seqs=(4096, 8192, 16384, 32768, 6
         q = torch.randn(b, s, h, d, device=device, dtype=torch.bfloat16)
         k = torch.randn(b, s, hkv, d, device=device, dtype=torch.bfloat16)
         v = torch.randn(b, s, hkv, d, device=device, dtype=torch.bfloat16)
-        (q_blk, k_blk, q_valid, k_valid), _ = _mask_and_blocks(b, s, device)  # compact (O(S))
+        q_blk, k_blk, q_valid, k_valid = _blocks_only(b, s, device)  # compact (O(S)), no dense mask
         mask_gb = b * s * s / 1e9  # dense bool mask bytes
 
         def eager_fn(q=q, k=k, v=v, s=s):

--- a/src/opentau/scripts/benchmark_flash_attn.py
+++ b/src/opentau/scripts/benchmark_flash_attn.py
@@ -23,11 +23,21 @@ but the fused kernel still completes.
 
 Honest summary of what to expect: ``flash_cuda`` reconstructs the block-causal
 mask in-kernel and never materializes the (B, H, S, S) scores/probs or the
-dense mask, so its peak attention memory is far below eager's. On raw latency it
-currently trails the cuBLAS/cuDNN-backed eager and sdpa paths at head_dim=256
-(the gap narrows at longer sequence) — closing it requires FlashAttention-2-class
-engineering (cp.async double-buffering + register-resident accumulation), tracked
-as follow-up.
+dense mask, so its peak attention memory is below eager's. Two important caveats:
+
+  * The per-op tables (forward / forward+backward) compare a SINGLE attention
+    call with NO gradient checkpointing on either side. Those large multipliers
+    are vs non-checkpointed eager, which is not the realistic training config.
+  * Realistic pi07_paligemma training uses ``gradient_checkpointing=True``,
+    which already frees eager's per-layer (B,H,S,S) scores (recomputed in
+    backward). The fair, decision-relevant comparison is the stacked-layer
+    section with checkpointing on both sides ("eager+ckpt vs flash+ckpt"), where
+    the advantage is ~2x, not 20-40x. flash composes with checkpointing too.
+
+On raw latency it currently trails the cuBLAS/cuDNN-backed eager and sdpa paths
+at head_dim=256 (the gap narrows at longer sequence) — closing it requires
+FlashAttention-2-class engineering (cp.async double-buffering + register-resident
+accumulation), tracked as follow-up.
 
 Usage:
     python -m opentau.scripts.benchmark_flash_attn
@@ -172,6 +182,56 @@ def oom_demo():
         )
 
 
+def stacked_memory_comparison(b=2, s=1024, h=8, hkv=1, d=256, layers=18):
+    """Fair full-model-style memory comparison: a stack of attention layers run
+    fwd+bwd, with and without ``torch.utils.checkpoint``, for eager vs flash.
+
+    This is the decision-relevant memory comparison (the per-op tables above
+    compare a single attention call with no checkpointing). Realistic
+    pi07_paligemma training uses ``gradient_checkpointing=True``, which already
+    frees eager's per-layer (B,H,S,S) scores by recomputing them in backward;
+    so the honest apples-to-apples is "eager+ckpt vs flash+ckpt".
+    """
+    import torch.utils.checkpoint as cp
+
+    device = "cuda"
+    (q_blk, k_blk, q_valid, k_valid), dense = _mask_and_blocks(b, s, device)
+    scale = d**-0.5
+
+    def eager_layer(x):
+        g = h // hkv
+        q = x.permute(0, 2, 1, 3).float()
+        k = x[:, :, :hkv].permute(0, 2, 1, 3).float().repeat_interleave(g, 1)
+        v = x[:, :, :hkv].permute(0, 2, 1, 3).float().repeat_interleave(g, 1)
+        aw = torch.where(dense[:, None], torch.matmul(q, k.transpose(-1, -2)) * scale, BIG_NEG)
+        return torch.matmul(torch.softmax(aw, -1), v).permute(0, 2, 1, 3).to(x.dtype)
+
+    def flash_layer(x):
+        return flash_attn_blockmask(
+            x, x[:, :, :hkv].contiguous(), x[:, :, :hkv].contiguous(), q_blk, k_blk, q_valid, k_valid, scale
+        )
+
+    def measure(layer, ckpt):
+        torch.cuda.empty_cache()
+        torch.cuda.reset_peak_memory_stats()
+        try:
+            x = torch.randn(b, s, h, d, device=device, dtype=torch.bfloat16, requires_grad=True)
+            for _ in range(layers):
+                x = (cp.checkpoint(layer, x, use_reentrant=False) if ckpt else layer(x)) + 1.0
+            x.sum().backward()
+            torch.cuda.synchronize()
+            return f"{torch.cuda.max_memory_allocated() / 1e9:.2f} GB"
+        except torch.cuda.OutOfMemoryError:
+            torch.cuda.empty_cache()
+            return "OOM"
+
+    print(f"{layers} stacked attention layers, B{b} S{s} H{h} Hkv{hkv} D{d} bf16, fwd+bwd peak:")
+    print(f"  eager, no-ckpt : {measure(eager_layer, False)}")
+    print(f"  eager, +ckpt   : {measure(eager_layer, True)}   <- realistic training baseline")
+    print(f"  flash, no-ckpt : {measure(flash_layer, False)}")
+    print(f"  flash, +ckpt   : {measure(flash_layer, True)}")
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--oom-demo", action="store_true", help="run the eager-OOM-vs-flash demo")
@@ -188,6 +248,8 @@ def main():
     run(shapes, backward=False)
     print("\n=== Forward + backward ===")
     run(shapes, backward=True)
+    print("\n=== Stacked-layer memory: eager vs flash, with/without gradient checkpointing ===")
+    stacked_memory_comparison()
     if args.oom_demo:
         print("\n=== Eager-OOM vs flash (enabling win) ===")
         oom_demo()

--- a/tests/policies/test_flash_attn_cuda.py
+++ b/tests/policies/test_flash_attn_cuda.py
@@ -195,6 +195,76 @@ def test_backward_matches_autograd_reference(pattern, head_dim):
     torch.testing.assert_close(dv * kmask, vr.grad * kmask, atol=1e-3, rtol=1e-3)
 
 
+# The Tensor Core (WMMA) backward (fp16/bf16) is a separate code path from the
+# fp32 reference backward above; validate dQ/dK/dV across head dims, GQA/MQA,
+# every mask pattern, padding, and non-square cross-attention against the fp32
+# autograd reference.
+@require_cuda
+@pytest.mark.gpu
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("pattern", ["causal", "prefixlm", "multiblock", "bidir"])
+@pytest.mark.parametrize("head_dim", [64, 128, 256])
+@pytest.mark.parametrize("hkv", [1, 2])
+def test_wmma_backward_matches_reference(dtype, pattern, head_dim, hkv):
+    if not flash_attn_cuda.is_available():
+        pytest.skip(f"flash_cuda kernel unavailable: {flash_attn_cuda.load_error()}")
+    torch.manual_seed(0)
+    b, sq, h = 2, 70, 4
+    q_blk, k_blk, q_valid, k_valid = _make_blocks(b, sq, "cuda", pattern, pad_tail=5)
+    scale = head_dim**-0.5
+    q = torch.randn(b, sq, h, head_dim, device="cuda", dtype=dtype, requires_grad=True)
+    k = torch.randn(b, sq, hkv, head_dim, device="cuda", dtype=dtype, requires_grad=True)
+    v = torch.randn(b, sq, hkv, head_dim, device="cuda", dtype=dtype, requires_grad=True)
+    grad_out = torch.randn(b, sq, h, head_dim, device="cuda", dtype=dtype)
+
+    flash_attn_blockmask(q, k, v, q_blk, k_blk, q_valid, k_valid, scale).backward(grad_out)
+    dq, dk, dv = q.grad.float(), k.grad.float(), v.grad.float()
+
+    qr = q.detach().float().clone().requires_grad_(True)
+    kr = k.detach().float().clone().requires_grad_(True)
+    vr = v.detach().float().clone().requires_grad_(True)
+    ref, _ = _reference_attention(qr, kr, vr, q_blk, k_blk, q_valid, k_valid, scale)
+    ref.backward(grad_out.float())
+
+    qmask = q_valid[:, :, None, None].float()
+    kmask = k_valid[:, :, None, None].float()
+    tol = 5e-2 if dtype == torch.bfloat16 else 1e-2
+    torch.testing.assert_close(dq * qmask, qr.grad * qmask, atol=tol, rtol=tol)
+    torch.testing.assert_close(dk * kmask, kr.grad * kmask, atol=tol, rtol=tol)
+    torch.testing.assert_close(dv * kmask, vr.grad * kmask, atol=tol, rtol=tol)
+
+
+@require_cuda
+@pytest.mark.gpu
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_wmma_backward_cross_attention_non_square(dtype):
+    """Tensor Core backward on the non-square expert/cross-attention layout."""
+    if not flash_attn_cuda.is_available():
+        pytest.skip(f"flash_cuda kernel unavailable: {flash_attn_cuda.load_error()}")
+    torch.manual_seed(3)
+    b, sq, h, hkv, d, cross = 2, 50, 8, 1, 256, 37
+    q_blk, k_blk, q_valid, k_valid = _make_blocks(b, sq, "cuda", "causal", cross=cross)
+    sk = cross + sq
+    scale = d**-0.5
+    q = torch.randn(b, sq, h, d, device="cuda", dtype=dtype, requires_grad=True)
+    k = torch.randn(b, sk, hkv, d, device="cuda", dtype=dtype, requires_grad=True)
+    v = torch.randn(b, sk, hkv, d, device="cuda", dtype=dtype, requires_grad=True)
+    go = torch.randn(b, sq, h, d, device="cuda", dtype=dtype)
+    flash_attn_blockmask(q, k, v, q_blk, k_blk, q_valid, k_valid, scale).backward(go)
+    dq, dk, dv = q.grad.float(), k.grad.float(), v.grad.float()
+    qr = q.detach().float().clone().requires_grad_(True)
+    kr = k.detach().float().clone().requires_grad_(True)
+    vr = v.detach().float().clone().requires_grad_(True)
+    ref, _ = _reference_attention(qr, kr, vr, q_blk, k_blk, q_valid, k_valid, scale)
+    ref.backward(go.float())
+    qmask = q_valid[:, :, None, None].float()
+    kmask = k_valid[:, :, None, None].float()
+    tol = 5e-2 if dtype == torch.bfloat16 else 1e-2
+    torch.testing.assert_close(dq * qmask, qr.grad * qmask, atol=tol, rtol=tol)
+    torch.testing.assert_close(dk * kmask, kr.grad * kmask, atol=tol, rtol=tol)
+    torch.testing.assert_close(dv * kmask, vr.grad * kmask, atol=tol, rtol=tol)
+
+
 def _sdpa_ref(q, k, v, q_blk, k_blk, q_valid, k_valid, scale):
     h, hkv = q.shape[2], k.shape[2]
     mask = _dense_mask(q_blk, k_blk, q_valid, k_valid)[:, None]

--- a/tests/policies/test_flash_attn_cuda.py
+++ b/tests/policies/test_flash_attn_cuda.py
@@ -1,0 +1,336 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the custom block-causal CUDA flash-attention backend.
+
+Three layers of validation:
+  1. CPU: the compact block-ids reproduce ``make_att_2d_masks`` bit-for-bit (the
+     correctness contract of the in-kernel masking). Runs without a GPU.
+  2. GPU op-level: the kernel's forward (fp32) matches a dense reference to fp32
+     tolerance and its backward matches autograd; bf16 matches ``sdpa``.
+  3. GPU full-model: a tiny PaliGemmaWithExpertModel produces the same output
+     (within bf16 noise) under ``attention_implementation="flash_cuda"`` and
+     ``"sdpa"``, including the cross-attention / KV-cache expert pass.
+  4. GPU perf: the kernel uses less peak memory than the eager backend (the
+     headline win — no SxS materialization). Latency is measured and reported.
+"""
+
+import pytest
+import torch
+
+from opentau.policies import flash_attn_cuda
+from opentau.policies.flash_attn_cuda import flash_attn_blockmask, make_att_block_ids
+from opentau.policies.pi07_paligemma.low_level.modeling_pi07_low_level import make_att_2d_masks
+from tests.utils import require_cuda
+
+BIG_NEG = -2.3819763e38
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+def _att_masks(pattern: str, b: int, n: int, device) -> torch.Tensor:
+    att = torch.zeros(b, n, dtype=torch.int32, device=device)
+    if pattern == "causal":
+        att[:] = 1
+    elif pattern == "prefixlm":
+        att[:, n // 2] = 1
+        att[:, n // 2 + 1 :] = 1
+    elif pattern == "multiblock":
+        att[:, :: max(1, n // 5)] = 1
+    elif pattern == "bidir":
+        pass  # all zeros
+    else:
+        raise ValueError(pattern)
+    return att
+
+
+def _dense_mask(q_blk, k_blk, q_valid, k_valid) -> torch.Tensor:
+    return (k_blk[:, None, :] <= q_blk[:, :, None]) & q_valid[:, :, None] & k_valid[:, None, :]
+
+
+def _reference_attention(q, k, v, q_blk, k_blk, q_valid, k_valid, scale):
+    """Dense masked attention in fp32; returns (out (B,Sq,H,D), valid_row (B,Sq))."""
+    b, sq, h, d = q.shape
+    hkv = k.shape[2]
+    g = h // hkv
+    qf = q.float().permute(0, 2, 1, 3)
+    kf = k.float().permute(0, 2, 1, 3).repeat_interleave(g, dim=1)
+    vf = v.float().permute(0, 2, 1, 3).repeat_interleave(g, dim=1)
+    scores = torch.matmul(qf, kf.transpose(-1, -2)) * scale
+    mask = _dense_mask(q_blk, k_blk, q_valid, k_valid)[:, None]
+    scores = scores.masked_fill(~mask, float("-inf"))
+    valid_row = mask.any(dim=-1, keepdim=True)
+    probs = torch.where(valid_row, torch.softmax(scores, dim=-1), torch.zeros_like(scores))
+    out = torch.matmul(probs, vf).permute(0, 2, 1, 3).contiguous()
+    return out, valid_row.squeeze(1).squeeze(-1)
+
+
+def _make_blocks(b, n, device, pattern, cross=0, pad_tail=0):
+    pad = torch.ones(b, n, dtype=torch.bool, device=device)
+    if pad_tail:
+        pad[0, -pad_tail:] = False
+    att = _att_masks(pattern, b, n, device)
+    if cross:
+        cross_pad = torch.ones(b, cross, dtype=torch.bool, device=device)
+        cross_pad[0, -1:] = False
+        return make_att_block_ids(pad, att, cross, cross_pad)
+    return make_att_block_ids(pad, att)
+
+
+# --------------------------------------------------------------------------- #
+# 1. CPU: block-ids reproduce the dense mask exactly
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("pattern", ["causal", "prefixlm", "multiblock", "bidir"])
+def test_block_ids_reconstruct_dense_mask(pattern):
+    b, n = 3, 24
+    pad = torch.ones(b, n, dtype=torch.bool)
+    pad[0, -4:] = False  # trailing padding on one sample
+    att = _att_masks(pattern, b, n, torch.device("cpu"))
+    q_blk, k_blk, q_valid, k_valid = make_att_block_ids(pad, att)
+    recon = _dense_mask(q_blk, k_blk, q_valid, k_valid)
+    ref = make_att_2d_masks(pad, att)
+    assert torch.equal(recon, ref)
+
+
+def test_block_ids_reconstruct_cross_attention_mask():
+    b, n, cross = 2, 16, 10
+    pad = torch.ones(b, n, dtype=torch.bool)
+    pad[0, -3:] = False
+    att = _att_masks("causal", b, n, torch.device("cpu"))
+    cross_pad = torch.ones(b, cross, dtype=torch.bool)
+    cross_pad[1, -2:] = False
+    q_blk, k_blk, q_valid, k_valid = make_att_block_ids(pad, att, cross, cross_pad)
+    recon = _dense_mask(q_blk, k_blk, q_valid, k_valid)
+    ref = make_att_2d_masks(pad, att, n_cross_att_tokens=cross, cross_att_pad_masks=cross_pad)
+    assert recon.shape == ref.shape == (b, n, cross + n)
+    assert torch.equal(recon, ref)
+
+
+# --------------------------------------------------------------------------- #
+# 2. GPU op-level: forward / backward equivalence
+# --------------------------------------------------------------------------- #
+@require_cuda
+@pytest.mark.gpu
+@pytest.mark.parametrize("pattern", ["causal", "prefixlm", "multiblock", "bidir"])
+@pytest.mark.parametrize("head_dim", [64, 128, 256])
+@pytest.mark.parametrize("hkv", [1, 2])
+def test_forward_fp32_matches_dense_reference(pattern, head_dim, hkv):
+    if not flash_attn_cuda.is_available():
+        pytest.skip(f"flash_cuda kernel unavailable: {flash_attn_cuda.load_error()}")
+    torch.manual_seed(0)
+    b, sq, h = 2, 48, 4
+    q_blk, k_blk, q_valid, k_valid = _make_blocks(b, sq, "cuda", pattern, pad_tail=3)
+    scale = head_dim**-0.5
+    q = torch.randn(b, sq, h, head_dim, device="cuda", dtype=torch.float32)
+    k = torch.randn(b, sq, hkv, head_dim, device="cuda", dtype=torch.float32)
+    v = torch.randn(b, sq, hkv, head_dim, device="cuda", dtype=torch.float32)
+
+    out = flash_attn_blockmask(q, k, v, q_blk, k_blk, q_valid, k_valid, scale)
+    ref, _ = _reference_attention(q, k, v, q_blk, k_blk, q_valid, k_valid, scale)
+    # Compare only valid query rows (fully-masked padded rows are discarded downstream).
+    vr = q_valid[:, :, None, None]
+    torch.testing.assert_close(out * vr, ref * vr, atol=1e-4, rtol=1e-4)
+
+
+@require_cuda
+@pytest.mark.gpu
+def test_forward_fp32_cross_attention_non_square():
+    if not flash_attn_cuda.is_available():
+        pytest.skip(f"flash_cuda kernel unavailable: {flash_attn_cuda.load_error()}")
+    torch.manual_seed(1)
+    b, sq, h, hkv, d, cross = 2, 33, 8, 1, 256, 20
+    q_blk, k_blk, q_valid, k_valid = _make_blocks(b, sq, "cuda", "causal", cross=cross)
+    sk = cross + sq
+    scale = d**-0.5
+    q = torch.randn(b, sq, h, d, device="cuda")
+    k = torch.randn(b, sk, hkv, d, device="cuda")
+    v = torch.randn(b, sk, hkv, d, device="cuda")
+    out = flash_attn_blockmask(q, k, v, q_blk, k_blk, q_valid, k_valid, scale)
+    ref, _ = _reference_attention(q, k, v, q_blk, k_blk, q_valid, k_valid, scale)
+    vr = q_valid[:, :, None, None]
+    torch.testing.assert_close(out * vr, ref * vr, atol=1e-4, rtol=1e-4)
+
+
+@require_cuda
+@pytest.mark.gpu
+@pytest.mark.parametrize("pattern", ["causal", "prefixlm", "multiblock"])
+@pytest.mark.parametrize("head_dim", [64, 256])
+def test_backward_matches_autograd_reference(pattern, head_dim):
+    if not flash_attn_cuda.is_available():
+        pytest.skip(f"flash_cuda kernel unavailable: {flash_attn_cuda.load_error()}")
+    torch.manual_seed(0)
+    b, sq, h, hkv = 2, 40, 4, 1
+    q_blk, k_blk, q_valid, k_valid = _make_blocks(b, sq, "cuda", pattern, pad_tail=2)
+    scale = head_dim**-0.5
+    q = torch.randn(b, sq, h, head_dim, device="cuda", dtype=torch.float32, requires_grad=True)
+    k = torch.randn(b, sq, hkv, head_dim, device="cuda", dtype=torch.float32, requires_grad=True)
+    v = torch.randn(b, sq, hkv, head_dim, device="cuda", dtype=torch.float32, requires_grad=True)
+    grad_out = torch.randn(b, sq, h, head_dim, device="cuda")
+
+    out = flash_attn_blockmask(q, k, v, q_blk, k_blk, q_valid, k_valid, scale)
+    out.backward(grad_out)
+    dq, dk, dv = q.grad.clone(), k.grad.clone(), v.grad.clone()
+
+    qr = q.detach().clone().requires_grad_(True)
+    kr = k.detach().clone().requires_grad_(True)
+    vr = v.detach().clone().requires_grad_(True)
+    ref, _ = _reference_attention(qr, kr, vr, q_blk, k_blk, q_valid, k_valid, scale)
+    ref.backward(grad_out)
+
+    qmask = q_valid[:, :, None, None]
+    kmask = k_valid[:, :, None, None]
+    torch.testing.assert_close(dq * qmask, qr.grad * qmask, atol=1e-3, rtol=1e-3)
+    torch.testing.assert_close(dk * kmask, kr.grad * kmask, atol=1e-3, rtol=1e-3)
+    torch.testing.assert_close(dv * kmask, vr.grad * kmask, atol=1e-3, rtol=1e-3)
+
+
+@require_cuda
+@pytest.mark.gpu
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_bf16_fp16_matches_sdpa(dtype):
+    if not flash_attn_cuda.is_available():
+        pytest.skip(f"flash_cuda kernel unavailable: {flash_attn_cuda.load_error()}")
+    torch.manual_seed(0)
+    b, sq, h, hkv, d = 2, 64, 8, 1, 256
+    q_blk, k_blk, q_valid, k_valid = _make_blocks(b, sq, "cuda", "prefixlm")
+    scale = d**-0.5
+    q = torch.randn(b, sq, h, d, device="cuda", dtype=dtype)
+    k = torch.randn(b, sq, hkv, d, device="cuda", dtype=dtype)
+    v = torch.randn(b, sq, hkv, d, device="cuda", dtype=dtype)
+
+    out = flash_attn_blockmask(q, k, v, q_blk, k_blk, q_valid, k_valid, scale).float()
+    # sdpa reference with the same dense mask + GQA expansion
+    mask = _dense_mask(q_blk, k_blk, q_valid, k_valid)[:, None]
+    qf = q.permute(0, 2, 1, 3)
+    kf = k.permute(0, 2, 1, 3).repeat_interleave(h // hkv, dim=1)
+    vf = v.permute(0, 2, 1, 3).repeat_interleave(h // hkv, dim=1)
+    ref = torch.nn.functional.scaled_dot_product_attention(qf, kf, vf, attn_mask=mask, scale=scale)
+    ref = ref.permute(0, 2, 1, 3).float()
+    torch.testing.assert_close(out, ref, atol=2e-2, rtol=2e-2)
+
+
+# --------------------------------------------------------------------------- #
+# 3. GPU integration: the dispatch methods (flash_attention_forward vs
+#    sdpa_attention_forward) agree, exercised through the real model methods at
+#    the real PaliGemma head config (H=8, MQA Hkv=1, head_dim=256). This covers
+#    the integration surface — block-id vs dense-mask consistency, GQA handling,
+#    output reshape to (B, S, H*head_dim) — without building the ~3B-param model.
+# --------------------------------------------------------------------------- #
+@require_cuda
+@pytest.mark.gpu
+@pytest.mark.parametrize("pattern", ["prefixlm", "causal"])
+def test_dispatch_methods_flash_matches_sdpa(pattern):
+    from types import SimpleNamespace
+
+    from opentau.policies.pi05.paligemma_with_expert import (
+        PaliGemmaWithExpertConfig,
+        PaliGemmaWithExpertModel,
+    )
+
+    if not flash_attn_cuda.is_available():
+        pytest.skip(f"flash_cuda kernel unavailable: {flash_attn_cuda.load_error()}")
+    torch.manual_seed(0)
+    # Default config carries the real PaliGemma head dims (H=8, Hkv=1, head_dim=256).
+    cfg = PaliGemmaWithExpertConfig()
+    text_cfg = cfg.paligemma_config.text_config
+    h = text_cfg.num_attention_heads
+    hkv = text_cfg.num_key_value_heads
+    d = text_cfg.head_dim
+    b, s = 2, 96
+
+    fake = SimpleNamespace(config=cfg)
+    q = torch.randn(b, s, h, d, device="cuda", dtype=torch.bfloat16)
+    k = torch.randn(b, s, hkv, d, device="cuda", dtype=torch.bfloat16)
+    v = torch.randn(b, s, hkv, d, device="cuda", dtype=torch.bfloat16)
+    q_blk, k_blk, q_valid, k_valid = _make_blocks(b, s, "cuda", pattern, pad_tail=4)
+    # For square self-attention the pad mask equals q_valid; rebuild the dense
+    # mask from the same (pad, att) so the two backends see the same masking.
+    dense = make_att_2d_masks(q_valid, _att_masks(pattern, b, s, "cuda"))
+
+    sdpa_out = PaliGemmaWithExpertModel.sdpa_attention_forward(fake, dense, b, d, q, k, v).float()
+    flash_out = PaliGemmaWithExpertModel.flash_attention_forward(
+        fake, (q_blk, k_blk, q_valid, k_valid), b, d, q, k, v
+    ).float()
+
+    assert sdpa_out.shape == flash_out.shape == (b, s, h * d)
+    # Compare only valid query rows (padded rows are masked/garbage and discarded).
+    vr = q_valid.reshape(b, s, 1).float()
+    torch.testing.assert_close(flash_out * vr, sdpa_out * vr, atol=2e-2, rtol=2e-2)
+
+
+# --------------------------------------------------------------------------- #
+# 4. GPU perf: memory reduction vs eager (headline win); latency reported
+# --------------------------------------------------------------------------- #
+@require_cuda
+@pytest.mark.gpu
+@pytest.mark.slow
+def test_memory_reduction_vs_eager(capsys):
+    if not flash_attn_cuda.is_available():
+        pytest.skip(f"flash_cuda kernel unavailable: {flash_attn_cuda.load_error()}")
+    torch.manual_seed(0)
+    b, s, h, hkv, d = 2, 1024, 8, 1, 256
+    q_blk, k_blk, q_valid, k_valid = _make_blocks(b, s, "cuda", "prefixlm")
+    mask = _dense_mask(q_blk, k_blk, q_valid, k_valid)
+    scale = d**-0.5
+    q = torch.randn(b, s, h, d, device="cuda", dtype=torch.bfloat16)
+    k = torch.randn(b, s, hkv, d, device="cuda", dtype=torch.bfloat16)
+    v = torch.randn(b, s, hkv, d, device="cuda", dtype=torch.bfloat16)
+
+    def eager():
+        g = h // hkv
+        qf = q.float().permute(0, 2, 1, 3)
+        kf = k.float().permute(0, 2, 1, 3).repeat_interleave(g, dim=1)
+        vf = v.float().permute(0, 2, 1, 3).repeat_interleave(g, dim=1)
+        aw = torch.matmul(qf, kf.transpose(-1, -2)) * scale
+        aw = torch.where(mask[:, None], aw, BIG_NEG)
+        p = torch.softmax(aw, dim=-1).to(vf.dtype)
+        return torch.matmul(p, vf)
+
+    def flash():
+        return flash_attn_blockmask(q, k, v, q_blk, k_blk, q_valid, k_valid, scale)
+
+    def peak(fn):
+        torch.cuda.synchronize()
+        torch.cuda.reset_peak_memory_stats()
+        base = torch.cuda.memory_allocated()
+        fn()
+        torch.cuda.synchronize()
+        return (torch.cuda.max_memory_allocated() - base) / 1e6
+
+    def latency(fn, iters=20):
+        for _ in range(3):
+            fn()
+        torch.cuda.synchronize()
+        s0 = torch.cuda.Event(enable_timing=True)
+        e0 = torch.cuda.Event(enable_timing=True)
+        s0.record()
+        for _ in range(iters):
+            fn()
+        e0.record()
+        torch.cuda.synchronize()
+        return s0.elapsed_time(e0) / iters
+
+    eager_mem, flash_mem = peak(eager), peak(flash)
+    eager_ms, flash_ms = latency(eager), latency(flash)
+    with capsys.disabled():
+        print(
+            f"\n[flash_cuda perf] B{b} S{s} H{h} Hkv{hkv} D{d} bf16:"
+            f"\n  peak attn mem: eager {eager_mem:.1f} MB | flash {flash_mem:.1f} MB"
+            f" ({eager_mem / flash_mem:.2f}x less)"
+            f"\n  latency:       eager {eager_ms:.3f} ms | flash {flash_ms:.3f} ms"
+            f" ({eager_ms / flash_ms:.2f}x)"
+        )
+    # Headline guarantee: the fused kernel never materializes the SxS scores/mask,
+    # so its peak attention memory is well below eager's.
+    assert flash_mem < eager_mem

--- a/tests/policies/test_flash_attn_cuda.py
+++ b/tests/policies/test_flash_attn_cuda.py
@@ -195,29 +195,61 @@ def test_backward_matches_autograd_reference(pattern, head_dim):
     torch.testing.assert_close(dv * kmask, vr.grad * kmask, atol=1e-3, rtol=1e-3)
 
 
-@require_cuda
-@pytest.mark.gpu
-@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
-def test_bf16_fp16_matches_sdpa(dtype):
-    if not flash_attn_cuda.is_available():
-        pytest.skip(f"flash_cuda kernel unavailable: {flash_attn_cuda.load_error()}")
-    torch.manual_seed(0)
-    b, sq, h, hkv, d = 2, 64, 8, 1, 256
-    q_blk, k_blk, q_valid, k_valid = _make_blocks(b, sq, "cuda", "prefixlm")
-    scale = d**-0.5
-    q = torch.randn(b, sq, h, d, device="cuda", dtype=dtype)
-    k = torch.randn(b, sq, hkv, d, device="cuda", dtype=dtype)
-    v = torch.randn(b, sq, hkv, d, device="cuda", dtype=dtype)
-
-    out = flash_attn_blockmask(q, k, v, q_blk, k_blk, q_valid, k_valid, scale).float()
-    # sdpa reference with the same dense mask + GQA expansion
+def _sdpa_ref(q, k, v, q_blk, k_blk, q_valid, k_valid, scale):
+    h, hkv = q.shape[2], k.shape[2]
     mask = _dense_mask(q_blk, k_blk, q_valid, k_valid)[:, None]
     qf = q.permute(0, 2, 1, 3)
     kf = k.permute(0, 2, 1, 3).repeat_interleave(h // hkv, dim=1)
     vf = v.permute(0, 2, 1, 3).repeat_interleave(h // hkv, dim=1)
     ref = torch.nn.functional.scaled_dot_product_attention(qf, kf, vf, attn_mask=mask, scale=scale)
-    ref = ref.permute(0, 2, 1, 3).float()
-    torch.testing.assert_close(out, ref, atol=2e-2, rtol=2e-2)
+    return ref.permute(0, 2, 1, 3).float()
+
+
+# Exercise the Tensor Core (WMMA) path (fp16/bf16) across head dims, GQA/MQA,
+# every mask pattern, and padding — the fp32 path uses a different (reference)
+# kernel, so WMMA needs its own coverage.
+@require_cuda
+@pytest.mark.gpu
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("pattern", ["causal", "prefixlm", "multiblock", "bidir"])
+@pytest.mark.parametrize("head_dim", [64, 128, 256])
+@pytest.mark.parametrize("hkv", [1, 2])
+def test_wmma_matches_sdpa(dtype, pattern, head_dim, hkv):
+    if not flash_attn_cuda.is_available():
+        pytest.skip(f"flash_cuda kernel unavailable: {flash_attn_cuda.load_error()}")
+    torch.manual_seed(0)
+    b, sq, h = 2, 70, 4
+    q_blk, k_blk, q_valid, k_valid = _make_blocks(b, sq, "cuda", pattern, pad_tail=5)
+    scale = head_dim**-0.5
+    q = torch.randn(b, sq, h, head_dim, device="cuda", dtype=dtype)
+    k = torch.randn(b, sq, hkv, head_dim, device="cuda", dtype=dtype)
+    v = torch.randn(b, sq, hkv, head_dim, device="cuda", dtype=dtype)
+
+    out = flash_attn_blockmask(q, k, v, q_blk, k_blk, q_valid, k_valid, scale).float()
+    ref = _sdpa_ref(q, k, v, q_blk, k_blk, q_valid, k_valid, scale)
+    vr = q_valid[:, :, None, None].float()
+    torch.testing.assert_close(out * vr, ref * vr, atol=2e-2, rtol=2e-2)
+
+
+@require_cuda
+@pytest.mark.gpu
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_wmma_cross_attention_non_square_matches_sdpa(dtype):
+    """Tensor Core path on the non-square expert/cross-attention layout."""
+    if not flash_attn_cuda.is_available():
+        pytest.skip(f"flash_cuda kernel unavailable: {flash_attn_cuda.load_error()}")
+    torch.manual_seed(2)
+    b, sq, h, hkv, d, cross = 2, 50, 8, 1, 256, 37
+    q_blk, k_blk, q_valid, k_valid = _make_blocks(b, sq, "cuda", "causal", cross=cross)
+    sk = cross + sq
+    scale = d**-0.5
+    q = torch.randn(b, sq, h, d, device="cuda", dtype=dtype)
+    k = torch.randn(b, sk, hkv, d, device="cuda", dtype=dtype)
+    v = torch.randn(b, sk, hkv, d, device="cuda", dtype=dtype)
+    out = flash_attn_blockmask(q, k, v, q_blk, k_blk, q_valid, k_valid, scale).float()
+    ref = _sdpa_ref(q, k, v, q_blk, k_blk, q_valid, k_valid, scale)
+    vr = q_valid[:, :, None, None].float()
+    torch.testing.assert_close(out * vr, ref * vr, atol=2e-2, rtol=2e-2)
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## What this does

Adds a new `attention_implementation="flash_cuda"` backend for **pi07_paligemma** (both `low_level` and `high_level_planner`): a **custom CUDA flash attention** that handles the **block-causal mask in-kernel**, with **no external libraries** (no `flash-attn`, no `flex_attention`). (⚡️ Performance / 🗃️ Feature)

How it works:
- **In-kernel block-causal masking, no S×S materialization.** `make_att_block_ids` produces a compact per-token representation `(q_blk, k_blk, q_valid, k_valid)` that *provably reproduces* `make_att_2d_masks`: `attend(i,j) == q_valid[i] & k_valid[j] & (k_blk[j] <= q_blk[i])`. Cross-attention columns use an `INT32_MIN` sentinel (always attended). The kernel rebuilds the mask on the fly and exploits the monotone block-ids for block-causal tile early-exit. The dense `(B,S,S)` mask is **never built**.
- **Kernels** (`src/opentau/policies/flash_attn_cuda/_csrc/flash_blockmask.cu`):
  - fp32: a warp-per-row online-softmax reference (exact).
  - fp16/bf16: a **Tensor Core (WMMA)** forward (both matmuls on tensor cores, fp32 accumulation).
  - fp16/bf16: a **Tensor Core (WMMA) backward** — dQ kernel (parallel over query slabs) and dK/dV kernel (parallel over key slabs, looping the GQA query-head group, **no atomics**). All five backward matmuls (recompute `S`, `dP=dO Vᵀ`, `dV=Pᵀ dO`, `dK=dSᵀ Q`, `dQ=dS K`) run on tensor cores with fp32 accumulation; warps/block auto-sized to the device's opt-in shared memory. The fp32 warp-per-row backward is retained as the exactness oracle.
- **No fallback.** Selecting `flash_cuda` always uses the kernel; if it cannot be JIT-compiled (no CUDA/compiler) the forward **raises** rather than silently degrading to sdpa/eager. Importing on CPU never triggers `nvcc` (lazy compile), so the CPU CI subset is unaffected; `eager`/`sdpa`/`fa2` are unchanged and flash is opt-in.
- Wired through `PaliGemmaWithExpertModel.forward`/`_run_layer` (compact block-ids threaded alongside the existing dense-mask path; KV-cache / cross-attention expert pass supported). `eager`/`sdpa`/`fa2` behavior is unchanged — flash is fully opt-in.

## Results (RTX 3090, head_dim=256, MQA, bf16)

**Memory.** The fair comparison is *at equal gradient-checkpointing*, since realistic pi07_paligemma training uses `gradient_checkpointing=True` (which already frees eager's per-layer `(B,H,S,S)` scores by recomputing them in backward). For an 18-layer attention stack (S=1024), fwd+bwd peak:

| config | peak |
|---|---|
| eager, no checkpointing | 2.35 GB |
| **eager, +checkpointing** (realistic baseline) | **0.50 GB** |
| flash, no checkpointing | 0.39 GB |
| **flash, +checkpointing** | **0.21 GB** |

So the honest, apples-to-apples win is **flash+ckpt vs eager+ckpt ≈ 2.4×** — flash never materializes `S×S` even during recompute, and it composes *with* checkpointing. (The single-op tables in the benchmark show 20–42× / 7–21×, but those compare against **non-checkpointed** eager and are not the training-realistic baseline — see the `stacked-layer` section of the benchmark.) Separately, even checkpointed eager must materialize one layer's `(B,H,S,S)` transiently during recompute, so it **OOMs at B4·S=16384–24576** (would need 34–77 GB) where flash runs in 1.7–3.3 GB.

**Speed (honest).** Forward is ~3.4× slower than the cuBLAS/cuDNN-backed eager path at head_dim=256. The Tensor Core backward brought fwd+bwd from ~9× → **~6× slower than eager** (~1.4× faster than the previous scalar backward) — see the A100 numbers below. It is still behind cuDNN `sdpa`. Fully closing the gap needs cp.async double-buffering + register-resident `mma.sync` accumulation (to remove the shared-memory round-trips) and avoiding the 2× score recompute in the backward.

## How it was tested

- Added `tests/policies/test_flash_attn_cuda.py` (139 tests):
  - **CPU:** compact block-ids reproduce `make_att_2d_masks` **bit-for-bit** (incl. the cross-attention branch).
  - **GPU forward (fp32):** matches a dense reference to `atol/rtol=1e-4` across causal / prefix-LM / multi-block / bidirectional masks, head_dim ∈ {64,128,256}, MQA+GQA, non-square cross-attention, and padding.
  - **GPU Tensor Core (WMMA) fwd:** matches `sdpa` (bf16+fp16) across all the above combinations, incl. the non-square cross-attention layout.
  - **GPU Tensor Core (WMMA) backward:** dQ/dK/dV match the fp32 autograd reference (bf16+fp16) across all the above combinations + non-square cross-attention; fp32 backward also checked vs autograd (`1e-3`).
  - **GPU integration:** `flash_attention_forward` matches `sdpa_attention_forward` through the real `PaliGemmaWithExpertModel` methods at the real head config.
  - **GPU perf:** asserts flash peak attention memory < eager.
- Verified seeded flash fwd+bwd is **bit-identical across runs** (output + dQ/dK/dV) — deterministic.
- **No regressions:** existing CPU policy suites for pi0 / pi05 / pi05_mem / pi07_paligemma pass (132 tests) — the `eager`/`sdpa` paths are untouched.
- `src/opentau/scripts/benchmark_flash_attn.py` produces the latency + per-op memory tables, the **checkpointed stacked-layer memory comparison** above, and (`--oom-demo`) the eager-OOM-vs-flash demo.

### A100 validation (8×A100-80GB, sm_80, slurm node gpu-387)

Validated on the real training hardware (with the Tensor Core backward):
- **Correctness:** all **134 GPU tests pass on A100 (sm_80)** — forward + backward correct on the training arch, not just my dev 3090 (sm_86).
- **8-GPU distributed (DDP):** an 18-layer attention+o_proj stack, per-rank B2·S1024·D256 bf16, fwd+bwd+all-reduce across all 8 ranks. **flash is distributed-correct & deterministic (identical across all 8 ranks, no NCCL hang):**

  | config | step ms (scalar bwd → **TC bwd**) | per-rank peak GB |
  |---|---|---|
  | eager | 83 | 2.76 |
  | eager+ckpt | 110 | 0.90 |
  | flash | 764 → **536** | 0.89 |
  | flash+ckpt | 869 → **641** | 0.71 |

**Honest training takeaway:** the Tensor Core backward gave a real **~1.4× step speedup** (flash+ckpt 869→641 ms) — but flash is **still ~6× slower than eager** (and ~6× slower than cuDNN `sdpa`) at S=1024/head_dim=256, down from ~9×. The realistic per-rank memory win (flash+ckpt vs eager+ckpt) is **~1.3×** — the attention-matrix savings are diluted by params/DDP buffers (and would dilute further with the MLP), growing only at long sequence. **As-is, flash_cuda is still not faster than the cuDNN `sdpa` baseline for this config**; what it provides is correctness, in-kernel block-mask handling (no dense-mask materialization), distributed-safety, and OOM-avoidance at long context. Closing the speed gap needs cp.async pipelining + register-resident accumulation.

**Still pending:** the nightly **model** regression suite (full pi07_paligemma training) — this validation covered the attention op + a distributed attention-stack benchmark, not an end-to-end training run.

### Long-context regime (A100-80GB, gpu-387) — forward, B1·H8·Hkv1·D256, prefix-LM bf16

**SDPA backend probe (block-causal bool mask).** PyTorch's fused **FlashAttention backend rejects** any non-`is_causal` `attn_mask` — so it cannot flash a block-causal mask (confirming the mechanism). But the **memory-efficient backend *does* accept it** (math/eager also accepts). So SDPA is *not* limited to eager for block-causal masks on this build (square self-attention case).

**Forward sweep vs sequence length** (`benchmark_flash_attn.py --long-context`):

| S | dense mask | eager | sdpa | flash_cuda |
|---|---|---|---|---|
| 8192 | 0.07 GB | 41 ms / 4.8 GB | **8.6 ms / 0.5 GB** | 137 ms / 0.2 GB |
| 16384 | 0.27 GB | 155 ms / 18.5 GB | **35 ms / 1.5 GB** | 526 ms / 0.4 GB |
| 32768 | 1.07 GB | 647 ms / 72.4 GB | **180 ms / 5.1 GB** | 2441 ms / 1.4 GB |
| 65536 | 4.29 GB | OOM | **912 ms / 18.9 GB** | 10731 ms / 4.9 GB |
| 98304 | 9.66 GB | OOM | **2250 ms / 41.2 GB** | 22871 ms / 10.6 GB |
| 131072 | 17.2 GB | OOM | **OOM** | **43640 ms / 18.4 GB** |

**Honest takeaway.** Three regimes:
- **Up to S≈98k:** SDPA's memory-efficient backend handles the block-causal mask and is **~15–25× faster than flash_cuda** (and lower-memory than eager). flash_cuda is *not* the right choice here.
- **eager** OOMs at S≥65536 (O(S²) fp32 scores).
- **S≥131072:** SDPA OOMs because it still needs the dense **O(S²) mask** (17 GB at S=131072); flash_cuda uses compact block-ids (O(S)) and is the **only backend that runs** — but ~20× slower than SDPA was. This extreme-S regime is flash_cuda's genuine niche.

**Caveat on the `sdpa ≈ eager` observation.** Above is the *square* self-attention mask, where SDPA's mem-efficient backend works. The action-expert pass uses a **non-square cross-attention** mask `(B, N, n_cross+N)`; mem-efficient may reject that shape and fall back to the math (≈eager) backend, which would explain `sdpa ≈ eager` in real training. The benchmark now probes this (`--long-context`); worth confirming which backend your actual run selects for the expert pass.

## How to checkout & try? (for the reviewer)

```bash
# CPU (mask-equivalence, no GPU needed)
pytest -sx tests/policies/test_flash_attn_cuda.py -m "not gpu"
```
```bash
# GPU equivalence + memory tests (compiles the kernel on first run; needs ninja + nvcc)
pytest -sx tests/policies/test_flash_attn_cuda.py -m "gpu"
```
```bash
# Latency + memory benchmark (incl. checkpointed stacked-layer comparison) + OOM demo
python -m opentau.scripts.benchmark_flash_attn --oom-demo
```
```bash
# Use it: any pi07_paligemma config
opentau-train --config_path=<cfg> --policy.attention_implementation=flash_cuda
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [x] My PR includes policy-related changes.
  - [x] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).



