### PR TITLE
fix(datasets): dual-split feature-mapping collision + norm-distribution diagnostic

### DIFF
--- a/src/opentau/configs/default.py
+++ b/src/opentau/configs/default.py
@@ -153,11 +153,24 @@ class DatasetConfig:
                 f"got {self.tolerance_s} for {self.repo_id or self.vqa}."
             )
 
-        # If data_features_name_mapping is provided, upsert it into the global DATA_FEATURES_NAME_MAPPING
+        # If data_features_name_mapping is provided, upsert it into the global
+        # DATA_FEATURES_NAME_MAPPING. Register under the plain repo_id (back-compat
+        # fallback, last-wins) AND, when this entry carries a real control mode,
+        # under the composite `repo_id::control_mode` key. The composite key lets
+        # two entries that share a repo_id but use different action columns
+        # (e.g. control_mode="joint" -> action_joint vs control_mode="ee" ->
+        # action_ee) coexist instead of the second silently clobbering the first.
         if self.data_features_name_mapping is not None:
-            from opentau.datasets.standard_data_format_mapping import DATA_FEATURES_NAME_MAPPING
+            from opentau.datasets.standard_data_format_mapping import (
+                DATA_FEATURES_NAME_MAPPING,
+                feature_mapping_key,
+            )
 
             DATA_FEATURES_NAME_MAPPING[self.repo_id] = self.data_features_name_mapping
+            if self.repo_id is not None:
+                key = feature_mapping_key(self.repo_id, self.control_mode)
+                if key != self.repo_id:
+                    DATA_FEATURES_NAME_MAPPING[key] = self.data_features_name_mapping
 
 
 @dataclass

--- a/src/opentau/datasets/dataset_mixture.py
+++ b/src/opentau/datasets/dataset_mixture.py
@@ -77,7 +77,7 @@ from torch.utils.data import ConcatDataset, DataLoader, Dataset, Sampler
 from opentau.configs.train import TrainPipelineConfig
 from opentau.datasets.compute_stats import aggregate_stats
 from opentau.datasets.lerobot_dataset import BaseDataset, DatasetMetadata
-from opentau.datasets.standard_data_format_mapping import DATA_FEATURES_NAME_MAPPING
+from opentau.datasets.standard_data_format_mapping import DATA_FEATURES_NAME_MAPPING, feature_mapping_key
 
 
 class _TaggedDataset(Dataset):
@@ -276,7 +276,8 @@ class DatasetMixtureMetadata:
         # the standardize loop below clobbers `metadata.stats`.
         raw_dims: list[tuple[int, int]] = []
         for m in metadatas:
-            name_map = DATA_FEATURES_NAME_MAPPING[m.repo_id]
+            key = feature_mapping_key(m.repo_id, getattr(m, "info", {}).get("control_mode"))
+            name_map = DATA_FEATURES_NAME_MAPPING[key if key in DATA_FEATURES_NAME_MAPPING else m.repo_id]
             raw_dims.append(
                 (
                     int(m.stats[name_map["state"]]["mean"].shape[-1]),
@@ -286,7 +287,9 @@ class DatasetMixtureMetadata:
 
         # convert each metadata stats to the standard data format
         for metadata in metadatas:
-            metadata.stats = self._to_standard_data_format(metadata.repo_id, metadata.stats)
+            metadata.stats = self._to_standard_data_format(
+                metadata.repo_id, metadata.stats, getattr(metadata, "info", {}).get("control_mode")
+            )
 
         # Per-dataset stats kept for diagnostic / back-compat consumers
         # (e.g. `aggregated_action_stats` for the BPE codec).
@@ -472,7 +475,7 @@ class DatasetMixtureMetadata:
         return agg["actions"]
 
     def _to_standard_data_format(
-        self, repo_id: str, stats: dict[str, dict[str, np.ndarray]]
+        self, repo_id: str, stats: dict[str, dict[str, np.ndarray]], control_mode: str | None = None
     ) -> dict[str, dict[str, np.ndarray]]:
         """Convert statistics to the standard data format.
 
@@ -482,6 +485,10 @@ class DatasetMixtureMetadata:
         Args:
             repo_id: Repository ID used to look up feature name mapping.
             stats: Statistics dictionary with dataset-specific feature names.
+            control_mode: Control mode used (with ``repo_id``) to resolve the
+                feature-name mapping, so dual-split entries (joint vs ee) pick
+                their own action column. ``None`` falls back to the plain
+                ``repo_id`` entry.
 
         Returns:
             Statistics dictionary with standard feature names and padded vectors.
@@ -490,7 +497,8 @@ class DatasetMixtureMetadata:
             KeyError: If a required feature is missing from stats or if required
                 statistics (mean, std, min, max) are missing.
         """
-        name_map = DATA_FEATURES_NAME_MAPPING[repo_id]
+        key = feature_mapping_key(repo_id, control_mode)
+        name_map = DATA_FEATURES_NAME_MAPPING[key if key in DATA_FEATURES_NAME_MAPPING else repo_id]
         features_without_stats = ["prompt", "response", "advantage"]
 
         standard_stats = {}
@@ -854,11 +862,20 @@ class WeightedDatasetMixture:
         return torch.DoubleTensor(all_sample_weights)
 
     def _get_worker_name_mapping_overrides(self) -> dict[str, dict[str, str]]:
-        """Collect per-dataset mapping overrides from config for worker init."""
-        overrides = {}
+        """Collect per-dataset mapping overrides from config for worker init.
+
+        Emits both the plain ``repo_id`` key (back-compat fallback) and the
+        control-mode-aware ``repo_id::control_mode`` key, so that after a
+        ``spawn`` each worker can resolve dual-split entries (joint vs ee) to
+        their own action column instead of last-wins on ``repo_id``.
+        """
+        overrides: dict[str, dict[str, str]] = {}
         for dataset_cfg in self.cfg.dataset_mixture.datasets:
             if dataset_cfg.repo_id and dataset_cfg.data_features_name_mapping is not None:
                 overrides[dataset_cfg.repo_id] = dataset_cfg.data_features_name_mapping
+                key = feature_mapping_key(dataset_cfg.repo_id, dataset_cfg.control_mode)
+                if key != dataset_cfg.repo_id:
+                    overrides[key] = dataset_cfg.data_features_name_mapping
         return overrides
 
     def get_dataloader(self) -> DataLoader:

--- a/src/opentau/datasets/factory.py
+++ b/src/opentau/datasets/factory.py
@@ -82,7 +82,7 @@ from opentau.datasets.lerobot_dataset import (
     LeRobotDatasetMetadata,
     suppress_control_mode_warning,
 )
-from opentau.datasets.standard_data_format_mapping import DATA_FEATURES_NAME_MAPPING
+from opentau.datasets.standard_data_format_mapping import DATA_FEATURES_NAME_MAPPING, feature_mapping_key
 from opentau.datasets.transforms import ImageTransforms
 from opentau.datasets.utils import DeltaTimestampInfo
 
@@ -140,7 +140,11 @@ def resolve_delta_timestamps(
 
     if dataset_cfg.repo_id is None:
         raise ValueError("dataset_cfg.repo_id must not be None when resolving delta timestamps.")
-    name_map = DATA_FEATURES_NAME_MAPPING[dataset_cfg.repo_id]
+    # Runs before `_apply_metadata_overrides`, so prefer the config's control_mode
+    # override, falling back to the on-disk value, to resolve dual-split columns.
+    control_mode = dataset_cfg.control_mode if dataset_cfg.control_mode is not None else ds_meta.control_mode
+    mkey = feature_mapping_key(dataset_cfg.repo_id, control_mode)
+    name_map = DATA_FEATURES_NAME_MAPPING[mkey if mkey in DATA_FEATURES_NAME_MAPPING else dataset_cfg.repo_id]
     reverse_name_map = {v: k for k, v in name_map.items()}
     for key in ds_meta.features:
         if key not in reverse_name_map:

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -117,7 +117,7 @@ from opentau.datasets.speed_percentiles import (
     episode_to_task_index_from_hf_dataset,
     load_or_compute_speed_percentiles,
 )
-from opentau.datasets.standard_data_format_mapping import DATA_FEATURES_NAME_MAPPING
+from opentau.datasets.standard_data_format_mapping import DATA_FEATURES_NAME_MAPPING, feature_mapping_key
 from opentau.datasets.utils import (
     DEFAULT_FEATURES,
     DEFAULT_IMAGE_PATH,
@@ -2245,7 +2245,13 @@ class LeRobotDataset(BaseDataset):
         return item
 
     def _get_feature_mapping_key(self) -> str:
-        return self.repo_id
+        # Control-mode-aware key so two entries sharing a repo_id but different
+        # action columns (joint vs ee) resolve to their own mapping rather than
+        # colliding on repo_id. Falls back to the plain repo_id key when no
+        # per-control-mode entry is registered (built-in defaults / single-mode
+        # datasets). See `feature_mapping_key`.
+        key = feature_mapping_key(self.repo_id, self.control_mode)
+        return key if key in DATA_FEATURES_NAME_MAPPING else self.repo_id
 
     def __repr__(self):
         feature_keys = list(self.features)

--- a/src/opentau/datasets/standard_data_format_mapping.py
+++ b/src/opentau/datasets/standard_data_format_mapping.py
@@ -232,3 +232,49 @@ DATA_FEATURES_NAME_MAPPING = {
         "response": "response",
     },
 }
+
+
+# Case-insensitive sentinels that mean "no control-mode discriminator", mirroring
+# `opentau.datasets.dataset_mixture._NORM_KEY_MISSING_VALUES` so that the column
+# resolution here and the norm-head split there agree on what counts as a real
+# control mode.
+_MISSING_CONTROL_MODE_VALUES: frozenset[str] = frozenset({"unknown"})
+
+
+def feature_mapping_key(repo_id: str, control_mode: str | None) -> str:
+    """Return the ``DATA_FEATURES_NAME_MAPPING`` key for a dataset entry.
+
+    Two mixture entries can share a ``repo_id`` while declaring different
+    ``data_features_name_mapping`` values — e.g. the same robot exposed as
+    ``control_mode="joint"`` (``actions -> action_joint``) and
+    ``control_mode="ee"`` (``actions -> action_ee``). Keying the global mapping
+    by ``repo_id`` alone makes the second registration clobber the first, so the
+    "joint" entry would silently read the end-effector column. Disambiguating by
+    ``control_mode`` lets both coexist.
+
+    Returns ``"<repo_id>::<control_mode>"`` when ``control_mode`` is a real,
+    non-empty label, and the plain ``repo_id`` otherwise (missing / whitespace /
+    ``"unknown"``) — so built-in defaults and single-mode datasets keep their
+    existing ``repo_id`` keys.
+    """
+    cm = (control_mode or "").strip()
+    if cm and cm.casefold() not in _MISSING_CONTROL_MODE_VALUES:
+        return f"{repo_id}::{cm}"
+    return repo_id
+
+
+def resolve_feature_mapping(repo_id: str, control_mode: str | None = None) -> dict[str, str]:
+    """Look up a dataset's feature-name mapping, control-mode-aware.
+
+    Prefers the precise ``"<repo_id>::<control_mode>"`` entry and falls back to
+    the plain ``repo_id`` entry (built-in defaults / single-mode datasets /
+    back-compat). Raises ``KeyError`` if neither is registered.
+    """
+    mapping = DATA_FEATURES_NAME_MAPPING.get(feature_mapping_key(repo_id, control_mode))
+    if mapping is None:
+        mapping = DATA_FEATURES_NAME_MAPPING.get(repo_id)
+    if mapping is None:
+        raise KeyError(
+            f"No feature mapping registered for repo_id={repo_id!r} (control_mode={control_mode!r})."
+        )
+    return mapping

--- a/src/opentau/envs/subgoal.py
+++ b/src/opentau/envs/subgoal.py
@@ -192,6 +192,9 @@ class LiberoLastFrameSubgoalGenerator:
                 f"LiberoLastFrameSubgoalGenerator: repo_id {repo_id!r} has no entry in "
                 f"DATA_FEATURES_NAME_MAPPING; cannot resolve camera{{k}} -> raw key."
             )
+        # TODO: thread control_mode and use `resolve_feature_mapping(repo_id, control_mode)`
+        # for dual-split repos; cameras are identical across control modes so the plain
+        # repo_id entry is correct here today.
         name_map = DATA_FEATURES_NAME_MAPPING[repo_id]
 
         # Resolve camera slots to the raw feature keys the dataset

--- a/src/opentau/scripts/annotate_subtasks.py
+++ b/src/opentau/scripts/annotate_subtasks.py
@@ -422,6 +422,8 @@ def _resolve_camera0_video_key(info: dict, ds_cfg: dict) -> str | None:
     repo_id = ds_cfg.get("repo_id")
     inline_map = ds_cfg.get("data_features_name_mapping") or {}
     inline = inline_map.get("camera0")
+    # TODO: dual-split repos share this repo_id key; camera0 is identical across control
+    # modes, so the plain repo_id entry is fine here (see resolve_feature_mapping).
     global_map = DATA_FEATURES_NAME_MAPPING.get(repo_id, {}) if repo_id else {}
     mapped = inline if inline is not None else global_map.get("camera0")
 

--- a/src/opentau/scripts/diagnose_norm_distribution.py
+++ b/src/opentau/scripts/diagnose_norm_distribution.py
@@ -267,7 +267,15 @@ def _process_dataset(task: dict) -> dict:
 def _build_tasks(args: Args) -> tuple[list[dict], dict, list[str]]:
     """Returns (tasks, head_meta_stats, norm_keys). Reuses the real
     DatasetMixtureMetadata so per-(robot_type, control_mode) head stats and the
-    dual-split column resolution match training exactly."""
+    dual-split column resolution match training exactly.
+
+    NOTE: this is intentionally coupled to ``DatasetMixtureMetadata`` internals
+    (``per_norm_key_stats``, ``norm_key_to_index``, ``dataset_to_norm_index``,
+    ``norm_key_to_dataset_names``) so it mirrors the policy's normalization
+    wiring without building full (video-backed) datasets. If those attributes
+    are renamed this must be updated. The accumulator/worker math is unit-tested;
+    this metadata-wiring half is exercised by running the script end-to-end.
+    """
     from types import SimpleNamespace
 
     from opentau.configs.default import DatasetMixtureConfig

--- a/src/opentau/scripts/diagnose_norm_distribution.py
+++ b/src/opentau/scripts/diagnose_norm_distribution.py
@@ -1,0 +1,557 @@
+#!/usr/bin/env python
+
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU-only diagnostic: the distribution of *normalized* state/action values,
+read from the actual parquet frames, per ``(robot_type, control_mode, dim)``.
+
+Why this exists: every other stats view in the codebase is derived from
+``meta/stats.json`` / ``episodes_stats.jsonl``. If outliers were stripped from
+the parquet data but the stats metadata was never recomputed, those numbers are
+stale. This tool streams the real frames of the configured episode subset,
+applies the policy's normalization using the per-``(robot_type, control_mode)``
+head stats, and summarizes:
+
+  * the distribution of ``z = (x - mean) / (std + eps)`` per dim (histogram), and
+  * the data-derived mean/std/min/max vs the metadata stats (the staleness
+    signal: a fresh dim has ``z_std ~= 1``; a dim whose metadata std was inflated
+    by a since-removed outlier has ``z_std << 1`` and ``meta_max >> data_max``).
+
+It is streaming (fixed-size histograms, never all values in memory), parallel
+(one process per dataset), and reuses the same lightweight metadata + parquet
+machinery as ``fit_fast_tokenizer.py``.
+
+Run (where the parquet data lives, e.g. a training node)::
+
+    python src/opentau/scripts/diagnose_norm_distribution.py \
+        --config=/path/to/train_mixture_snippet.json \
+        --output_dir=outputs/norm_diag --num_workers=16 \
+        --max_episodes_per_dataset=50
+
+``--config`` is a ``DatasetMixtureConfig`` JSON (``$ref`` includes are
+resolved). ``pyarrow`` is already a (transitive) dependency; plotting also needs
+``matplotlib`` (e.g. ``uv sync --extra libero``) — without it the JSON/CSV
+reports are still written and only the figures are skipped.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import logging
+import math
+import os
+import warnings
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from multiprocessing import cpu_count
+from pathlib import Path
+
+import draccus
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+EPS = 1e-8  # must match opentau.policies.normalize.EPS
+
+# Histogram bins on the NORMALIZED value z (std units): a dense linear core for
+# the shape near 0, symmetric log-spaced tails out to 1e5 std for outliers, and
+# two open overflow bins. Shared across every dim so accumulators merge and
+# plots align. Exact z_min / z_max are tracked separately, so the overflow bins
+# only bound the binned view, not the reported extremes.
+_CLIP = 8.0
+_N_LIN = 160
+_Z_MAX = 1e5
+_N_LOG = 30
+
+
+def make_bin_edges() -> np.ndarray:
+    lin = np.linspace(-_CLIP, _CLIP, _N_LIN + 1)
+    log_tail = np.logspace(math.log10(_CLIP), math.log10(_Z_MAX), _N_LOG + 1)[1:]
+    edges = np.concatenate([[-np.inf], -log_tail[::-1], lin[1:-1], log_tail, [np.inf]])
+    return edges.astype(np.float64)
+
+
+BIN_EDGES = make_bin_edges()
+N_BINS = len(BIN_EDGES) - 1
+_BEYOND = (3.0, 5.0, 10.0)
+
+
+@dataclasses.dataclass
+class Args:
+    """CLI for the normalized-distribution diagnostic."""
+
+    config: str  # DatasetMixtureConfig JSON (with $ref includes)
+    output_dir: str = "outputs/norm_diag"
+    num_workers: int | None = None  # default: cpu_count()
+    frame_stride: int = 1  # subsample every Nth frame per episode (speed)
+    max_episodes_per_dataset: int | None = None  # cap episodes/dataset (speed)
+    norm_mode: str = "MEAN_STD"  # MEAN_STD | MIN_MAX (must match the policy)
+    emit_corrected_stats: bool = True  # write data-derived per-head stats override
+    top_n: int = 40  # console: worst-N dims by staleness
+    no_plots: bool = False
+    hf_home: str | None = None  # else inherit $HF_HOME
+
+
+class DimStats:
+    """Streaming per-dim accumulator for one ``(head, feature)``, vectorized over
+    the feature's ``D`` dims. Holds exact raw-x moments (for data-derived stats)
+    and a histogram + moments of the normalized ``z``. All fields combine
+    associatively, so partial results from workers merge order-independently.
+    """
+
+    __slots__ = (
+        "D",
+        "count",
+        "xsum",
+        "xsumsq",
+        "xmin",
+        "xmax",
+        "n_nonfinite",
+        "hist",
+        "zmin",
+        "zmax",
+        "zsum",
+        "zsumsq",
+        "n_beyond",
+    )
+
+    def __init__(self, n_dims: int):
+        d = int(n_dims)
+        self.D = d
+        self.count = np.zeros(d, np.int64)
+        self.xsum = np.zeros(d, np.float64)
+        self.xsumsq = np.zeros(d, np.float64)
+        self.xmin = np.full(d, np.inf, np.float64)
+        self.xmax = np.full(d, -np.inf, np.float64)
+        self.n_nonfinite = np.zeros(d, np.int64)
+        self.hist = np.zeros((d, N_BINS), np.int64)
+        self.zmin = np.full(d, np.inf, np.float64)
+        self.zmax = np.full(d, -np.inf, np.float64)
+        self.zsum = np.zeros(d, np.float64)
+        self.zsumsq = np.zeros(d, np.float64)
+        self.n_beyond = np.zeros((d, len(_BEYOND)), np.int64)
+
+    def update(self, x: np.ndarray, z: np.ndarray) -> None:
+        """Accumulate a ``(n, D)`` batch of raw values ``x`` and their normalized
+        counterparts ``z``. Non-finite raw entries are counted and excluded."""
+        if x.ndim != 2 or x.shape[1] != self.D:
+            raise ValueError(f"expected (n, {self.D}) batch, got {x.shape}")
+        finite = np.isfinite(x) & np.isfinite(z)
+        self.n_nonfinite += (~finite).sum(axis=0)
+        xf = np.where(finite, x, np.nan)
+        zf = np.where(finite, z, np.nan)
+        self.count += finite.sum(axis=0)
+        self.xsum += np.nansum(xf, axis=0)
+        self.xsumsq += np.nansum(xf * xf, axis=0)
+        self.zsum += np.nansum(zf, axis=0)
+        self.zsumsq += np.nansum(zf * zf, axis=0)
+        # Per-dim running extremes (fmin/fmax ignore NaN, so all-NaN cols are no-ops).
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=RuntimeWarning)  # all-NaN column slices
+            self.xmin = np.fmin(self.xmin, np.nanmin(xf, axis=0))
+            self.xmax = np.fmax(self.xmax, np.nanmax(xf, axis=0))
+            self.zmin = np.fmin(self.zmin, np.nanmin(zf, axis=0))
+            self.zmax = np.fmax(self.zmax, np.nanmax(zf, axis=0))
+        for i, k in enumerate(_BEYOND):
+            self.n_beyond[:, i] += (np.abs(zf) > k).sum(axis=0)  # NaN > k is False
+        # Histogram of z via one flat bincount over finite entries.
+        bins = np.clip(np.searchsorted(BIN_EDGES, zf, side="right") - 1, 0, N_BINS - 1)
+        flat = (np.arange(self.D)[None, :] * N_BINS + bins)[finite]
+        if flat.size:
+            self.hist += np.bincount(flat, minlength=self.D * N_BINS).reshape(self.D, N_BINS)
+
+    def merge(self, other: DimStats) -> DimStats:
+        self.count += other.count
+        self.xsum += other.xsum
+        self.xsumsq += other.xsumsq
+        self.zsum += other.zsum
+        self.zsumsq += other.zsumsq
+        self.n_nonfinite += other.n_nonfinite
+        self.n_beyond += other.n_beyond
+        self.hist += other.hist
+        self.xmin = np.fmin(self.xmin, other.xmin)
+        self.xmax = np.fmax(self.xmax, other.xmax)
+        self.zmin = np.fmin(self.zmin, other.zmin)
+        self.zmax = np.fmax(self.zmax, other.zmax)
+        return self
+
+    def data_mean(self) -> np.ndarray:
+        return np.divide(self.xsum, self.count, out=np.full(self.D, np.nan), where=self.count > 0)
+
+    def data_std(self) -> np.ndarray:
+        mean = self.data_mean()
+        var = np.divide(self.xsumsq, self.count, out=np.full(self.D, np.nan), where=self.count > 0) - mean**2
+        return np.sqrt(np.clip(var, 0.0, None))
+
+    def z_mean(self) -> np.ndarray:
+        return np.divide(self.zsum, self.count, out=np.full(self.D, np.nan), where=self.count > 0)
+
+    def z_std(self) -> np.ndarray:
+        zm = self.z_mean()
+        var = np.divide(self.zsumsq, self.count, out=np.full(self.D, np.nan), where=self.count > 0) - zm**2
+        return np.sqrt(np.clip(var, 0.0, None))
+
+
+def _normalize(x: np.ndarray, stat: dict, mode: str) -> np.ndarray:
+    """Apply the policy's normalization to ``x`` (n, D) — mirrors
+    ``opentau.policies.normalize.Normalize.forward``."""
+    if mode == "MEAN_STD":
+        return (x - stat["mean"]) / (stat["std"] + EPS)
+    if mode == "MIN_MAX":
+        return (x - stat["min"]) / (stat["max"] - stat["min"] + EPS) * 2.0 - 1.0
+    raise ValueError(f"unsupported norm_mode {mode!r}")
+
+
+def _slice_stat(stat: dict, dim: int) -> dict:
+    """Slice a (possibly zero-padded) head stat dict down to a feature's native
+    dim, so workers normalize against the real columns only."""
+    return {k: np.asarray(stat[k], np.float64)[:dim].copy() for k in ("mean", "std", "min", "max")}
+
+
+# --------------------------------------------------------------------------- #
+# Worker: stream one dataset's parquet, return per-feature DimStats.
+# --------------------------------------------------------------------------- #
+def _process_dataset(task: dict) -> dict:
+    import pyarrow.parquet as pq  # lazy: keep workers torch-free and fast to spawn
+
+    stride = max(1, int(task["frame_stride"]))
+    mode = task["norm_mode"]
+    out: dict[tuple, DimStats] = {}
+    feats = []
+    for feat in ("state", "actions"):
+        col, dim, stat = task[feat]
+        if col is None or dim <= 0:
+            continue
+        feats.append((feat, col, dim, stat, DimStats(dim)))
+
+    for path in task["parquet_paths"]:
+        if not os.path.exists(path):
+            continue
+        cols = [c for (_f, c, _d, _s, _a) in feats]
+        try:
+            table = pq.read_table(path, columns=cols)
+        except Exception as e:  # noqa: BLE001 -- one bad shard shouldn't sink the dataset
+            logger.warning("skip %s: %r", path, e)
+            continue
+        for _feat, col, dim, stat, acc in feats:
+            arr = np.asarray(table.column(col).to_pylist(), dtype=np.float64)
+            if arr.ndim != 2 or arr.shape[1] != dim:
+                logger.warning("skip %s col %s: shape %s != (n, %d)", path, col, arr.shape, dim)
+                continue
+            if stride > 1:
+                arr = arr[::stride]
+            if arr.shape[0] == 0:
+                continue
+            acc.update(arr, _normalize(arr, stat, mode))
+
+    for feat, _col, _dim, _stat, acc in feats:
+        out[(task["head_key"], feat)] = acc
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Parent: build the lightweight mixture metadata + per-dataset tasks.
+# --------------------------------------------------------------------------- #
+def _build_tasks(args: Args) -> tuple[list[dict], dict, list[str]]:
+    """Returns (tasks, head_meta_stats, norm_keys). Reuses the real
+    DatasetMixtureMetadata so per-(robot_type, control_mode) head stats and the
+    dual-split column resolution match training exactly."""
+    from types import SimpleNamespace
+
+    from opentau.configs.default import DatasetMixtureConfig
+    from opentau.configs.refs import resolve_refs_to_tempfile
+    from opentau.datasets.dataset_mixture import DatasetMixtureMetadata, WeightedDatasetMixture
+    from opentau.datasets.lerobot_dataset import LeRobotDatasetMetadata
+    from opentau.datasets.standard_data_format_mapping import resolve_feature_mapping
+
+    tmp = resolve_refs_to_tempfile(args.config)
+    mix_cfg = draccus.parse(config_class=DatasetMixtureConfig, config_path=str(tmp), args=[])
+    dataset_cfgs = list(mix_cfg.datasets)
+    weights = list(mix_cfg.weights) if mix_cfg.weights is not None else [1.0] * len(dataset_cfgs)
+
+    metadatas, kept_cfgs, kept_w = [], [], []
+    for dc, w in zip(dataset_cfgs, weights, strict=True):
+        try:
+            meta = LeRobotDatasetMetadata(dc.repo_id, root=dc.root, revision=dc.revision)
+        except Exception as e:  # noqa: BLE001
+            logger.warning("metadata load failed for %s: %r", dc.repo_id, e)
+            continue
+        if dc.robot_type is not None:
+            meta.info["robot_type"] = dc.robot_type
+        if dc.control_mode is not None:
+            meta.info["control_mode"] = dc.control_mode
+        metadatas.append(meta)
+        kept_cfgs.append(dc)
+        kept_w.append(w)
+    mix_cfg.datasets = kept_cfgs
+    logger.info("loaded %d/%d dataset metadatas", len(metadatas), len(dataset_cfgs))
+
+    # Raw (pre-padding) columns + dims per entry, via the FIXED resolver so a
+    # joint entry reads action_joint and an ee entry reads action_ee.
+    cols, dims = [], []
+    max_s = max_a = 1
+    for dc, m in zip(kept_cfgs, metadatas, strict=True):
+        nm = resolve_feature_mapping(dc.repo_id, m.info.get("control_mode"))
+        scol, acol = nm.get("state"), nm.get("actions")
+        sdim = int(np.asarray(m.stats[scol]["mean"]).shape[-1]) if scol in m.stats else 0
+        adim = int(np.asarray(m.stats[acol]["mean"]).shape[-1]) if acol in m.stats else 0
+        cols.append((scol, acol))
+        dims.append((sdim, adim))
+        max_s, max_a = max(max_s, sdim), max(max_a, adim)
+
+    cfg_shim = SimpleNamespace(
+        max_state_dim=max_s, max_action_dim=max_a, num_cams=0, resolution=(224, 224), dataset_mixture=mix_cfg
+    )
+    names = WeightedDatasetMixture._make_dataset_names(cfg_shim, metadatas)
+    mm = DatasetMixtureMetadata(cfg_shim, metadatas, kept_w, dataset_names=names)
+    logger.info("%d (robot_type, control_mode) heads over %d datasets", len(mm.norm_keys), len(names))
+
+    # Per-head meta stats, sliced to each head's native dim.
+    head_meta: dict = {}
+    for key in mm.norm_keys:
+        st = mm.per_norm_key_stats[mm.norm_key_to_index[key]]
+        head_meta[key] = st
+
+    tasks: list[dict] = []
+    for dc, m, name, (scol, acol), (sdim, adim) in zip(kept_cfgs, metadatas, names, cols, dims, strict=True):
+        head_key = mm.norm_keys[mm.dataset_to_norm_index[name]]
+        episodes = list(dc.episodes) if dc.episodes is not None else list(m.episodes)
+        if args.max_episodes_per_dataset is not None:
+            episodes = episodes[: args.max_episodes_per_dataset]
+        parquet_paths = [str(m.root / m.get_data_file_path(ep)) for ep in episodes]
+        st = head_meta[head_key]
+        tasks.append(
+            {
+                "head_key": head_key,
+                "parquet_paths": parquet_paths,
+                "frame_stride": args.frame_stride,
+                "norm_mode": args.norm_mode,
+                "state": (scol, sdim, _slice_stat(st["state"], sdim) if sdim else None),
+                "actions": (acol, adim, _slice_stat(st["actions"], adim) if adim else None),
+            }
+        )
+
+    head_info = {
+        key: {
+            "robot_type": key.split("::")[0] if "::" in key else key,
+            "control_mode": key.split("::", 1)[1] if "::" in key else "",
+            "datasets": mm.norm_key_to_dataset_names[key],
+            "meta": head_meta[key],
+        }
+        for key in mm.norm_keys
+    }
+    return tasks, head_info, list(mm.norm_keys)
+
+
+# --------------------------------------------------------------------------- #
+# Reporting + plotting.
+# --------------------------------------------------------------------------- #
+def _finalize_report(merged: dict, head_info: dict, norm_keys: list[str]) -> dict:
+    rows = []
+    for key in norm_keys:
+        for feat in ("state", "actions"):
+            acc = merged.get((key, feat))
+            if acc is None or acc.count.sum() == 0:
+                continue
+            meta = head_info[key]["meta"][feat]
+            dmean, dstd = acc.data_mean(), acc.data_std()
+            zmean, zstd = acc.z_mean(), acc.z_std()
+            for d in range(acc.D):
+                cnt = int(acc.count[d])
+                if cnt == 0:
+                    continue
+                mmax = float(np.asarray(meta["max"])[d])
+                dmax = float(acc.xmax[d])
+                ratio = math.log10(abs(mmax) / abs(dmax)) if dmax and abs(dmax) > 1e-12 and mmax else 0.0
+                rows.append(
+                    {
+                        "robot_type": head_info[key]["robot_type"],
+                        "control_mode": head_info[key]["control_mode"],
+                        "feature": feat,
+                        "dim": d,
+                        "count": cnt,
+                        "n_nonfinite": int(acc.n_nonfinite[d]),
+                        "data_mean": float(dmean[d]),
+                        "data_std": float(dstd[d]),
+                        "data_min": float(acc.xmin[d]),
+                        "data_max": dmax,
+                        "meta_mean": float(np.asarray(meta["mean"])[d]),
+                        "meta_std": float(np.asarray(meta["std"])[d]),
+                        "meta_min": float(np.asarray(meta["min"])[d]),
+                        "meta_max": mmax,
+                        "z_mean": float(zmean[d]),
+                        "z_std": float(zstd[d]),
+                        "z_min": float(acc.zmin[d]),
+                        "z_max": float(acc.zmax[d]),
+                        "frac_gt3": acc.n_beyond[d, 0] / cnt,
+                        "frac_gt5": acc.n_beyond[d, 1] / cnt,
+                        "frac_gt10": acc.n_beyond[d, 2] / cnt,
+                        "log10_meta_over_data_max": ratio,
+                    }
+                )
+    return {"eps": EPS, "bin_edges": BIN_EDGES.tolist(), "rows": rows}
+
+
+def _write_csv(rows: list[dict], path: Path) -> None:
+    import csv
+
+    if not rows:
+        return
+    with open(path, "w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=list(rows[0].keys()))
+        w.writeheader()
+        w.writerows(rows)
+
+
+def _emit_corrected_stats(merged: dict, norm_keys: list[str], path: Path) -> None:
+    out: dict = {}
+    for key in norm_keys:
+        entry = {}
+        for feat in ("state", "actions"):
+            acc = merged.get((key, feat))
+            if acc is None or acc.count.sum() == 0:
+                continue
+            entry[feat] = {
+                "mean": acc.data_mean().tolist(),
+                "std": acc.data_std().tolist(),
+                "min": np.where(np.isfinite(acc.xmin), acc.xmin, np.nan).tolist(),
+                "max": np.where(np.isfinite(acc.xmax), acc.xmax, np.nan).tolist(),
+                "count": int(acc.count.max()),
+            }
+        if entry:
+            out[key] = entry
+    path.write_text(json.dumps(out, indent=2))
+
+
+def _plot(merged: dict, head_info: dict, norm_keys: list[str], rows: list[dict], out_dir: Path) -> None:
+    try:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+    except ImportError:
+        logger.warning("matplotlib not installed; skipping plots (e.g. `uv sync --extra libero`).")
+        return
+
+    for key in norm_keys:
+        feats = [(f, merged.get((key, f))) for f in ("state", "actions")]
+        feats = [(f, a) for f, a in feats if a is not None and a.count.sum() > 0]
+        if not feats:
+            continue
+        fig, axes = plt.subplots(1, len(feats), figsize=(7 * len(feats), 5), squeeze=False)
+        for ax, (feat, acc) in zip(axes[0], feats, strict=False):
+            dens = acc.hist / np.clip(acc.hist.sum(axis=1, keepdims=True), 1, None)
+            im = ax.imshow(np.log10(dens + 1e-6), aspect="auto", origin="lower", cmap="magma")
+            ax.set_title(f"{key}  {feat}  (D={acc.D})")
+            ax.set_xlabel("normalized z (std units)")
+            ax.set_ylabel("dim")
+            zero_bin = int(np.searchsorted(BIN_EDGES, 0.0, side="right") - 1)
+            ax.axvline(zero_bin, color="cyan", lw=0.5, alpha=0.6)
+            fig.colorbar(im, ax=ax, label="log10 density")
+        fig.tight_layout()
+        safe = key.replace("/", "_").replace("::", "__")
+        fig.savefig(out_dir / f"head__{safe}.png", dpi=120)
+        plt.close(fig)
+
+    # Global health heatmap: rows = worst dims, cols = staleness metrics.
+    if rows:
+        ranked = sorted(
+            rows,
+            key=lambda r: -max(abs(r["z_std"] - 1.0), r["frac_gt10"], abs(r["log10_meta_over_data_max"])),
+        )
+        top = ranked[: min(60, len(ranked))]
+        labels = [f"{r['robot_type']}::{r['control_mode']}|{r['feature'][:3]}{r['dim']}" for r in top]
+        cols = ["z_std", "frac_gt10", "log10(meta/data max)", "z_max"]
+        mat = np.array(
+            [[r["z_std"], r["frac_gt10"], r["log10_meta_over_data_max"], min(r["z_max"], 50)] for r in top]
+        )
+        fig, ax = plt.subplots(figsize=(8, max(4, len(top) * 0.25)))
+        im = ax.imshow(mat, aspect="auto", cmap="coolwarm")
+        ax.set_xticks(range(len(cols)), cols, rotation=30, ha="right")
+        ax.set_yticks(range(len(top)), labels, fontsize=6)
+        ax.set_title("Staleness / health (top dims)")
+        fig.colorbar(im, ax=ax)
+        fig.tight_layout()
+        fig.savefig(out_dir / "health_heatmap.png", dpi=120)
+        plt.close(fig)
+
+
+def main(args: Args) -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    if args.hf_home:
+        os.environ["HF_HOME"] = args.hf_home
+    os.environ.setdefault("HF_HUB_OFFLINE", "1")
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    tasks, head_info, norm_keys = _build_tasks(args)
+    if not tasks:
+        logger.error("no datasets to process")
+        return
+
+    n_workers = args.num_workers or cpu_count()
+    merged: dict[tuple, DimStats] = {}
+    logger.info("streaming %d datasets over %d workers", len(tasks), n_workers)
+    done = 0
+    with ProcessPoolExecutor(max_workers=n_workers) as ex:
+        futs = [ex.submit(_process_dataset, t) for t in tasks]
+        for fut in as_completed(futs):
+            for k, acc in fut.result().items():
+                merged[k] = merged[k].merge(acc) if k in merged else acc
+            done += 1
+            if done % 25 == 0 or done == len(tasks):
+                logger.info("  processed %d/%d datasets", done, len(tasks))
+
+    report = _finalize_report(merged, head_info, norm_keys)
+    rows = report["rows"]
+    (out_dir / "report.json").write_text(json.dumps(report, indent=2))
+    _write_csv(rows, out_dir / "report.csv")
+    if args.emit_corrected_stats:
+        _emit_corrected_stats(merged, norm_keys, out_dir / "corrected_stats.json")
+    if not args.no_plots:
+        _plot(merged, head_info, norm_keys, rows, out_dir)
+
+    # Console: worst dims by staleness (z_std far from 1, heavy tails, meta/data max gap).
+    ranked = sorted(
+        rows, key=lambda r: -max(abs(r["z_std"] - 1.0), r["frac_gt10"], abs(r["log10_meta_over_data_max"]))
+    )
+    logger.info("wrote %s (%d dim-rows). Worst %d dims by staleness:", out_dir, len(rows), args.top_n)
+    logger.info(
+        "  %-34s %-7s %3s %9s %9s %9s %10s %10s",
+        "robot::mode",
+        "feat",
+        "dim",
+        "z_std",
+        "frac>10",
+        "z_max",
+        "data_max",
+        "meta_max",
+    )
+    for r in ranked[: args.top_n]:
+        logger.info(
+            "  %-34s %-7s %3d %9.3f %9.4f %9.1f %10.4g %10.4g",
+            f"{r['robot_type']}::{r['control_mode']}"[:34],
+            r["feature"],
+            r["dim"],
+            r["z_std"],
+            r["frac_gt10"],
+            r["z_max"],
+            r["data_max"],
+            r["meta_max"],
+        )
+
+
+if __name__ == "__main__":
+    main(draccus.parse(config_class=Args))

--- a/src/opentau/scripts/fit_fast_tokenizer.py
+++ b/src/opentau/scripts/fit_fast_tokenizer.py
@@ -294,6 +294,8 @@ def _resolve_native_action_key(
 
     if override_mapping is not None and "actions" in override_mapping:
         return override_mapping["actions"]
+    # TODO: dual-split repos (same repo_id, joint vs ee) share this repo_id key; thread
+    # control_mode through `resolve_feature_mapping` for a precise per-mode action column.
     mapping = DATA_FEATURES_NAME_MAPPING.get(repo_id, {}) if repo_id else {}
     if "actions" in mapping:
         return mapping["actions"]

--- a/tests/datasets/test_feature_mapping_dual_split.py
+++ b/tests/datasets/test_feature_mapping_dual_split.py
@@ -45,6 +45,19 @@ def _restore_global_mapping():
         DATA_FEATURES_NAME_MAPPING.update(snapshot)
 
 
+def test_missing_control_mode_sentinels_stay_in_sync():
+    """Column resolution (`feature_mapping_key`) and the norm-head split
+    (`compute_norm_key`) must agree on what counts as "no control mode". If the
+    two sentinel sets drift, the column the data is read from and the head its
+    stats land in can silently disagree -- re-opening exactly the dual-split
+    collision this fixes. The sets are hand-mirrored across modules, so guard it.
+    """
+    from opentau.datasets.dataset_mixture import _NORM_KEY_MISSING_VALUES
+    from opentau.datasets.standard_data_format_mapping import _MISSING_CONTROL_MODE_VALUES
+
+    assert _MISSING_CONTROL_MODE_VALUES == _NORM_KEY_MISSING_VALUES
+
+
 class TestFeatureMappingKey:
     """`feature_mapping_key`: composite key construction + sentinels."""
 

--- a/tests/datasets/test_feature_mapping_dual_split.py
+++ b/tests/datasets/test_feature_mapping_dual_split.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python
+
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Regression tests for the dual-split feature-mapping collision.
+
+Two mixture entries can share a ``repo_id`` while declaring different
+``data_features_name_mapping`` values — the same robot exposed as
+``control_mode="joint"`` (``actions -> action_joint``) and
+``control_mode="ee"`` (``actions -> action_ee``). The global
+``DATA_FEATURES_NAME_MAPPING`` used to be keyed by ``repo_id`` alone, so the
+second ``DatasetConfig.__post_init__`` clobbered the first and BOTH control
+modes silently read ``action_ee``. These tests pin the fix: the two mappings
+coexist under composite keys and each control mode resolves to its own column,
+so ``DatasetMixtureMetadata`` produces distinct joint vs ee action stats.
+"""
+
+import copy
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from opentau.configs.default import DatasetConfig
+from opentau.datasets.dataset_mixture import DatasetMixtureMetadata
+from opentau.datasets.standard_data_format_mapping import (
+    DATA_FEATURES_NAME_MAPPING,
+    feature_mapping_key,
+    resolve_feature_mapping,
+)
+
+
+@pytest.fixture(autouse=True)
+def _restore_global_mapping():
+    """Snapshot/restore the process-global mapping so a test's registrations
+    don't leak into other tests."""
+    snapshot = copy.deepcopy(DATA_FEATURES_NAME_MAPPING)
+    try:
+        yield
+    finally:
+        DATA_FEATURES_NAME_MAPPING.clear()
+        DATA_FEATURES_NAME_MAPPING.update(snapshot)
+
+
+class TestFeatureMappingKey:
+    """`feature_mapping_key`: composite key construction + sentinels."""
+
+    def test_real_control_mode_makes_composite(self):
+        assert feature_mapping_key("repo/x", "joint") == "repo/x::joint"
+        assert feature_mapping_key("repo/x", "ee") == "repo/x::ee"
+
+    def test_strips_whitespace(self):
+        assert feature_mapping_key("repo/x", "  ee ") == "repo/x::ee"
+
+    @pytest.mark.parametrize("cm", [None, "", "   ", "unknown", "Unknown", "UNKNOWN"])
+    def test_missing_or_unknown_falls_back_to_repo_id(self, cm):
+        assert feature_mapping_key("repo/x", cm) == "repo/x"
+
+
+class TestResolveFeatureMapping:
+    """`resolve_feature_mapping`: composite-first lookup with repo_id fallback."""
+
+    def test_prefers_composite(self):
+        DATA_FEATURES_NAME_MAPPING["repo/x"] = {"actions": "action_ee"}
+        DATA_FEATURES_NAME_MAPPING["repo/x::joint"] = {"actions": "action_joint"}
+        assert resolve_feature_mapping("repo/x", "joint")["actions"] == "action_joint"
+        assert resolve_feature_mapping("repo/x", "ee")["actions"] == "action_ee"  # falls back to repo_id
+
+    def test_falls_back_to_repo_id_when_no_composite(self):
+        DATA_FEATURES_NAME_MAPPING["repo/x"] = {"actions": "action"}
+        assert resolve_feature_mapping("repo/x", "joint")["actions"] == "action"
+        assert resolve_feature_mapping("repo/x", None)["actions"] == "action"
+
+    def test_missing_raises(self):
+        with pytest.raises(KeyError):
+            resolve_feature_mapping("repo/does-not-exist", "joint")
+
+
+class TestDualSplitRegistration:
+    """`DatasetConfig.__post_init__`: both mappings coexist after construction."""
+
+    def test_joint_and_ee_coexist(self):
+        repo = "TensorAuto/dual-split-demo"
+        # Order matches the real configs: joint registered first, ee second.
+        DatasetConfig(
+            repo_id=repo,
+            control_mode="joint",
+            data_features_name_mapping={"state": "observation.state", "actions": "action_joint"},
+        )
+        DatasetConfig(
+            repo_id=repo,
+            control_mode="ee",
+            data_features_name_mapping={"state": "observation.state", "actions": "action_ee"},
+        )
+
+        # Both composite keys present and correct (the bug: only one survived).
+        assert DATA_FEATURES_NAME_MAPPING[f"{repo}::joint"]["actions"] == "action_joint"
+        assert DATA_FEATURES_NAME_MAPPING[f"{repo}::ee"]["actions"] == "action_ee"
+        # Plain repo_id retained (last-wins) purely as a back-compat fallback.
+        assert DATA_FEATURES_NAME_MAPPING[repo]["actions"] == "action_ee"
+        # The resolver returns the correct column per mode — this is what the fix buys.
+        assert resolve_feature_mapping(repo, "joint")["actions"] == "action_joint"
+        assert resolve_feature_mapping(repo, "ee")["actions"] == "action_ee"
+
+
+# -- DatasetMixtureMetadata end-to-end -------------------------------------
+
+
+def _feat_stats(dim: int, *, value: float, count: int = 100) -> dict:
+    return {
+        "mean": np.full((dim,), float(value), dtype=np.float32),
+        "std": np.full((dim,), 0.5, dtype=np.float32),
+        "min": np.full((dim,), float(value) - 1.0, dtype=np.float32),
+        "max": np.full((dim,), float(value) + 1.0, dtype=np.float32),
+        "count": np.array([count], dtype=np.int64),
+    }
+
+
+def _make_cfg() -> SimpleNamespace:
+    # num_cams=0 -> `_to_standard_data_format` processes only state + actions.
+    return SimpleNamespace(num_cams=0, max_state_dim=32, max_action_dim=32, resolution=(224, 224))
+
+
+class TestDualSplitMixtureMetadata:
+    """`DatasetMixtureMetadata`: joint vs ee heads get their OWN action stats."""
+
+    def test_joint_and_ee_heads_have_distinct_action_stats(self):
+        repo = "TensorAuto/dual-split-demo"
+        DATA_FEATURES_NAME_MAPPING[repo] = {"state": "observation.state", "actions": "action_ee"}
+        DATA_FEATURES_NAME_MAPPING[f"{repo}::joint"] = {
+            "state": "observation.state",
+            "actions": "action_joint",
+        }
+        DATA_FEATURES_NAME_MAPPING[f"{repo}::ee"] = {
+            "state": "observation.state",
+            "actions": "action_ee",
+        }
+
+        # Raw stats carry BOTH action columns with clearly distinct values.
+        raw_stats = {
+            "observation.state": _feat_stats(7, value=0.0),
+            "action_joint": _feat_stats(7, value=1.0),
+            "action_ee": _feat_stats(7, value=2.0),
+        }
+        m_joint = SimpleNamespace(
+            repo_id=repo,
+            info={"robot_type": "franka", "control_mode": "joint", "total_frames": 100},
+            stats=copy.deepcopy(raw_stats),
+        )
+        m_ee = SimpleNamespace(
+            repo_id=repo,
+            info={"robot_type": "franka", "control_mode": "ee", "total_frames": 100},
+            stats=copy.deepcopy(raw_stats),
+        )
+
+        meta = DatasetMixtureMetadata(
+            _make_cfg(),
+            [m_joint, m_ee],
+            dataset_weights=[1.0, 1.0],
+            dataset_names=[f"{repo}#0", f"{repo}#1"],
+        )
+
+        assert set(meta.norm_keys) == {"franka::joint", "franka::ee"}
+        joint = meta.per_norm_key_stats[meta.norm_key_to_index["franka::joint"]]["actions"]
+        ee = meta.per_norm_key_stats[meta.norm_key_to_index["franka::ee"]]["actions"]
+
+        # The fix: joint head reads action_joint (mean 1.0), ee head reads action_ee (mean 2.0).
+        # Pre-fix both resolved to action_ee, so these would have been identical.
+        np.testing.assert_allclose(joint["mean"][:7], 1.0)
+        np.testing.assert_allclose(ee["mean"][:7], 2.0)
+        assert not np.allclose(joint["mean"][:7], ee["mean"][:7])

--- a/tests/scripts/test_diagnose_norm_distribution.py
+++ b/tests/scripts/test_diagnose_norm_distribution.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python
+
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Unit tests for the streaming normalized-distribution diagnostic.
+
+Covers the pure, CPU-only pieces that need no real dataset: the histogram bin
+layout, the ``DimStats`` accumulator (vs brute-force numpy), merge
+associativity, NaN/Inf handling, and the normalization formulas. A parquet
+round-trip exercises the worker end-to-end without opentau metadata.
+"""
+
+import numpy as np
+import pytest
+
+from opentau.scripts.diagnose_norm_distribution import (
+    BIN_EDGES,
+    EPS,
+    N_BINS,
+    DimStats,
+    _normalize,
+    make_bin_edges,
+)
+
+
+class TestBinEdges:
+    def test_strictly_increasing(self):
+        assert np.all(np.diff(BIN_EDGES) > 0)
+
+    def test_symmetric_about_zero(self):
+        finite = BIN_EDGES[np.isfinite(BIN_EDGES)]
+        np.testing.assert_allclose(finite, -finite[::-1], atol=1e-9)
+
+    def test_open_catchalls_and_count(self):
+        assert BIN_EDGES[0] == -np.inf and BIN_EDGES[-1] == np.inf
+        assert len(BIN_EDGES) == N_BINS + 1
+        assert make_bin_edges().shape == BIN_EDGES.shape
+
+
+class TestNormalize:
+    def test_mean_std(self):
+        x = np.array([[2.0, 4.0]])
+        stat = {"mean": np.array([1.0, 2.0]), "std": np.array([1.0, 2.0])}
+        z = _normalize(x, stat, "MEAN_STD")
+        np.testing.assert_allclose(z, [[1.0 / (1 + EPS), 2.0 / (2 + EPS)]])
+
+    def test_min_max(self):
+        x = np.array([[0.5]])
+        stat = {"min": np.array([0.0]), "max": np.array([1.0])}
+        z = _normalize(x, stat, "MIN_MAX")
+        np.testing.assert_allclose(z, [[0.5 / (1 + EPS) * 2 - 1]], atol=1e-6)
+
+    def test_unknown_mode_raises(self):
+        with pytest.raises(ValueError):
+            _normalize(np.zeros((1, 1)), {}, "NOPE")
+
+
+def _brute(x, z, k):
+    finite = np.isfinite(x) & np.isfinite(z)
+    xf = np.where(finite, x, np.nan)
+    zf = np.where(finite, z, np.nan)
+    return {
+        "count": finite.sum(0),
+        "mean": np.nanmean(xf, 0),
+        "xmin": np.nanmin(xf, 0),
+        "xmax": np.nanmax(xf, 0),
+        "zmean": np.nanmean(zf, 0),
+        "n_beyond10": (np.abs(zf) > 10).sum(0),
+        "n_nonfinite": (~finite).sum(0),
+    }
+
+
+class TestDimStats:
+    def test_matches_bruteforce(self):
+        rng = np.random.default_rng(0)
+        x = rng.normal(size=(500, 4)) * rng.uniform(0.1, 5, size=4)
+        stat = {"mean": x.mean(0), "std": x.std(0), "min": x.min(0), "max": x.max(0)}
+        z = _normalize(x, stat, "MEAN_STD")
+        acc = DimStats(4)
+        acc.update(x, z)
+        b = _brute(x, z, 10)
+        np.testing.assert_array_equal(acc.count, b["count"])
+        np.testing.assert_allclose(acc.data_mean(), b["mean"], rtol=1e-10)
+        np.testing.assert_allclose(acc.xmin, b["xmin"])
+        np.testing.assert_allclose(acc.xmax, b["xmax"])
+        np.testing.assert_allclose(acc.z_mean(), b["zmean"], rtol=1e-10)
+        # data_std vs numpy population std
+        np.testing.assert_allclose(acc.data_std(), x.std(0), rtol=1e-8)
+        # every finite sample lands in exactly one bin
+        np.testing.assert_array_equal(acc.hist.sum(1), b["count"])
+        np.testing.assert_array_equal(acc.n_beyond[:, 2], b["n_beyond10"])
+
+    def test_merge_is_associative(self):
+        rng = np.random.default_rng(1)
+        x = rng.normal(size=(300, 3))
+        stat = {"mean": np.zeros(3), "std": np.ones(3), "min": np.full(3, -3.0), "max": np.full(3, 3.0)}
+        z = _normalize(x, stat, "MEAN_STD")
+        whole = DimStats(3)
+        whole.update(x, z)
+        a, b = DimStats(3), DimStats(3)
+        a.update(x[:111], z[:111])
+        b.update(x[111:], z[111:])
+        merged = a.merge(b)
+        np.testing.assert_array_equal(whole.count, merged.count)
+        np.testing.assert_array_equal(whole.hist, merged.hist)
+        np.testing.assert_allclose(whole.data_mean(), merged.data_mean(), rtol=1e-12)
+        np.testing.assert_allclose(whole.xmax, merged.xmax)
+        np.testing.assert_array_equal(whole.n_beyond, merged.n_beyond)
+
+    def test_nonfinite_excluded(self):
+        x = np.array([[1.0, np.nan], [2.0, np.inf], [3.0, 4.0]])
+        stat = {"mean": np.zeros(2), "std": np.ones(2), "min": np.zeros(2), "max": np.ones(2)}
+        z = _normalize(x, stat, "MEAN_STD")
+        acc = DimStats(2)
+        acc.update(x, z)
+        np.testing.assert_array_equal(acc.count, [3, 1])
+        np.testing.assert_array_equal(acc.n_nonfinite, [0, 2])
+        np.testing.assert_allclose(acc.data_mean(), [2.0, 4.0])
+
+    def test_dim_mismatch_raises(self):
+        acc = DimStats(2)
+        with pytest.raises(ValueError):
+            acc.update(np.zeros((5, 3)), np.zeros((5, 3)))
+
+
+@pytest.mark.slow
+def test_worker_parquet_roundtrip(tmp_path):
+    pa = pytest.importorskip("pyarrow")
+    import pyarrow.parquet as pq
+
+    from opentau.scripts.diagnose_norm_distribution import _process_dataset
+
+    rng = np.random.default_rng(2)
+    state = rng.normal(size=(40, 3))
+    action = rng.normal(size=(40, 2))
+    path = tmp_path / "episode_000000.parquet"
+    pq.write_table(pa.table({"observation.state": list(state), "action": list(action)}), path)
+
+    sstat = {"mean": state.mean(0), "std": state.std(0), "min": state.min(0), "max": state.max(0)}
+    astat = {"mean": action.mean(0), "std": action.std(0), "min": action.min(0), "max": action.max(0)}
+    task = {
+        "head_key": "franka::joint",
+        "parquet_paths": [str(path)],
+        "frame_stride": 1,
+        "norm_mode": "MEAN_STD",
+        "state": ("observation.state", 3, sstat),
+        "actions": ("action", 2, astat),
+    }
+    out = _process_dataset(task)
+    assert set(out) == {("franka::joint", "state"), ("franka::joint", "actions")}
+    sacc = out[("franka::joint", "state")]
+    assert int(sacc.count.sum()) == 40 * 3
+    # normalizing by the data's own mean/std => z ~ mean 0, std 1
+    np.testing.assert_allclose(sacc.z_mean(), 0.0, atol=1e-6)
+    np.testing.assert_allclose(sacc.z_std(), 1.0, atol=1e-6)


### PR DESCRIPTION
## What this does

Two linked changes (🐛 Bug + 🗃️ Feature).

**Bug fix — `(robot_type, control_mode)` feature-mapping collision.**
`DATA_FEATURES_NAME_MAPPING` was keyed by `repo_id` alone. When one `repo_id` is used by two mixture entries with different control modes — e.g. `control_mode="joint"` mapping `actions -> action_joint` and `control_mode="ee"` mapping `actions -> action_ee` — `DatasetConfig.__post_init__` registered both under the same key, so the second clobbered the first and **both control modes silently read `action_ee`**; `action_joint` never reached training. The collision was total: stats standardization, per-sample data loading, and the DataLoader-worker re-injection all resolve via the same `repo_id`-keyed global. On a wide co-training mixture this silently turned every `::joint` head into a duplicate of its `::ee` head, so joint-space action supervision was entirely absent.

Fix: a composite `repo_id::control_mode` key (`feature_mapping_key` / `resolve_feature_mapping` in `standard_data_format_mapping.py`), registered alongside the plain `repo_id` (kept as a back-compat fallback for built-in defaults, single-mode datasets, and camera consumers). Training-critical read sites resolve composite-first against each module's local symbol (so existing patched tests keep working); the aux camera/BPE consumers keep the `repo_id` fallback with TODO breadcrumbs.

**Feature — `scripts/diagnose_norm_distribution.py`.**
A CPU-only, streaming, parallel diagnostic that reads the *real* per-frame state/action values from dataset parquet (the configured episode subset), normalizes them with the per-`(robot_type, control_mode)` head stats, and reports the distribution of normalized values per `(robot_type, control_mode, dim)` — plus per-head plots, a health heatmap, a data-vs-metadata staleness report, and a data-derived corrected-stats artifact. It detects stale `meta/stats.json` / `episodes_stats` (outliers removed from the parquet but never recomputed in the stats metadata), which every metadata-derived view misses. Histograms are fixed-size (bounded memory) and workers are pure-numpy (torch-free).

## How it was tested

- Added `test_feature_mapping_dual_split` in `tests/datasets/test_feature_mapping_dual_split.py`: asserts the two mappings coexist, the resolver returns the correct column per mode, and `DatasetMixtureMetadata` produces distinct joint vs ee action stats (the regression this closes).
- Added accumulator + worker tests in `tests/scripts/test_diagnose_norm_distribution.py`: streaming histogram vs brute-force numpy, merge associativity, NaN/Inf handling, and a parquet round-trip.
- `pre-commit run --all-files` clean; `pytest -m "not gpu" -n auto` green for the dataset/config/script suites (remaining local failures are environment-only: macOS video-decode backends and the uninstalled `libero` extra).
- Verified on a real co-training mixture: every dual-split robot's `::joint` and `::ee` heads went from byte-identical action stats to distinct, and the diagnostic surfaced stale metadata (real data max ≈ O(1) vs metadata max ≈ 3e4 on the affected datasets).
- GPU pytests (`pytest -m "gpu"`) and nightly regression are expected to run in CI (`gpu_test.yml` / `regression_test.yml`); this change is in the shared data/normalization path but touches no policy modeling code, and CUDA was unavailable locally.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/datasets/test_feature_mapping_dual_split.py
pytest -sx tests/scripts/test_diagnose_norm_distribution.py
```
```bash
python src/opentau/scripts/diagnose_norm_distribution.py \
    --config=<DatasetMixtureConfig.json> --output_dir=outputs/norm_diag \
    --num_workers=16 --max_episodes_per_dataset=5
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).