### PR TITLE
fix(datasets): pool norm stats over selected episodes + add excluded_episodes

### DIFF
--- a/src/opentau/configs/default.py
+++ b/src/opentau/configs/default.py
@@ -61,6 +61,9 @@ class DatasetConfig:
             Defaults to None.
         episodes: List of episode indices to use from the dataset. If None, all
             episodes are used. Defaults to None.
+        excluded_episodes: List of episode indices to drop from this dataset.
+            Takes precedence over `episodes`: an index present in both is
+            excluded. If None (default), no episodes are excluded.
         image_transforms: Configuration for image transformations. Defaults to
             ImageTransformsConfig().
         revision: Git revision of the dataset repository to use. Defaults to None.
@@ -109,6 +112,7 @@ class DatasetConfig:
     # Root directory where the dataset will be stored (e.g. 'dataset/path').
     root: str | None = None
     episodes: list[int] | None = None
+    excluded_episodes: list[int] | None = None
     image_transforms: ImageTransformsConfig = field(default_factory=ImageTransformsConfig)
     revision: str | None = None
     use_imagenet_stats: bool = True

--- a/src/opentau/configs/default.py
+++ b/src/opentau/configs/default.py
@@ -63,7 +63,10 @@ class DatasetConfig:
             episodes are used. Defaults to None.
         excluded_episodes: List of episode indices to drop from this dataset.
             Takes precedence over `episodes`: an index present in both is
-            excluded. If None (default), no episodes are excluded.
+            excluded. If None (default), no episodes are excluded. Note: on
+            legacy v2.0 datasets (no per-episode stats) the listed episodes are
+            dropped from training, but normalization stats stay the global
+            (all-episode) aggregate — only v2.1+ can recompute them.
         image_transforms: Configuration for image transformations. Defaults to
             ImageTransformsConfig().
         revision: Git revision of the dataset repository to use. Defaults to None.

--- a/src/opentau/datasets/factory.py
+++ b/src/opentau/datasets/factory.py
@@ -230,6 +230,7 @@ def make_dataset(
             cfg.repo_id,
             root=cfg.root,
             episodes=cfg.episodes,
+            excluded_episodes=cfg.excluded_episodes,
             delta_timestamps=dt_mean,
             delta_timestamps_std=dt_std,
             delta_timestamps_lower=dt_lower,

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -1531,7 +1531,11 @@ class LeRobotDataset(BaseDataset):
             # normalization std. The ImageNet camera override in
             # datasets/factory.py runs afterward and layers onto this same dict.
             # (v2.0 datasets have no per-episode stats, so this block is skipped
-            # and meta.stats stays the global aggregate.)
+            # and meta.stats stays the global aggregate.) This intentionally
+            # aliases `self.stats` and `self.meta.stats` to one object; nothing
+            # reads the `LeRobotDataset.stats` attribute for normalization, so
+            # the shared reference (later padded in place by the mixture) is
+            # benign.
             self.meta.stats = self.stats
 
         if self.episodes is None:

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -90,6 +90,7 @@ import math
 import shutil
 import traceback
 from abc import abstractmethod
+from collections.abc import Iterable
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Callable
@@ -1127,6 +1128,58 @@ class BaseDataset(torch.utils.data.Dataset):
         return new_vector
 
 
+def resolve_selected_episodes(
+    all_episodes: Iterable[int],
+    episodes: list[int] | None,
+    excluded_episodes: list[int] | None,
+    repo_id: str = "",
+) -> list[int] | None:
+    """Resolve the effective episode list for a dataset selection.
+
+    The selection is ``(episodes if not None else all_episodes)`` minus
+    ``excluded_episodes``. ``excluded_episodes`` takes precedence: an index
+    present in both is dropped. Returns a sorted list, or ``None`` when no
+    selection is active (``episodes`` is None and ``excluded_episodes`` is
+    empty), meaning "use every episode".
+
+    Raises:
+        ValueError: if the denylist removes every selected episode.
+    """
+    if not excluded_episodes:
+        return sorted(episodes) if episodes is not None else None
+    excluded = set(excluded_episodes)
+    base = list(episodes) if episodes is not None else list(all_episodes)
+    kept = sorted(e for e in base if e not in excluded)
+    if not kept:
+        raise ValueError(
+            f"excluded_episodes removed every episode from {repo_id!r} "
+            f"(base={len(base)} episodes, excluded={sorted(excluded)})."
+        )
+    return kept
+
+
+def aggregate_selected_stats(
+    meta: "LeRobotDatasetMetadata",
+    episodes: list[int] | None = None,
+    excluded_episodes: list[int] | None = None,
+) -> dict[str, dict[str, np.ndarray]]:
+    """Per-feature stats aggregated over the SELECTED episodes.
+
+    Falls back to ``meta.stats`` (the full-dataset aggregate) when no selection
+    is active, or when the dataset predates per-episode stats (v2.0, which has
+    nothing to recompute from). Mirrors the propagation done in
+    ``LeRobotDataset.__init__`` so off-line consumers (the FAST/BPE tokenizer
+    fit, the norm-distribution diagnostic) normalize over the same episodes the
+    policy trains on.
+    """
+    selected = resolve_selected_episodes(
+        meta.episodes, episodes, excluded_episodes, getattr(meta, "repo_id", "")
+    )
+    if selected is None or meta._version < packaging.version.parse("v2.1"):
+        return meta.stats
+    return aggregate_stats([meta.episodes_stats[ep_idx] for ep_idx in selected])
+
+
 class LeRobotDataset(BaseDataset):
     """Main dataset class for loading and managing robot learning data.
 
@@ -1195,6 +1248,7 @@ class LeRobotDataset(BaseDataset):
         repo_id: str,
         root: str | Path | None = None,
         episodes: list[int] | None = None,
+        excluded_episodes: list[int] | None = None,
         image_transforms: Callable | None = None,
         delta_timestamps: dict[str, np.ndarray | list[float]] | None = None,
         delta_timestamps_std: dict[str, np.ndarray | list[float]] | None = None,
@@ -1297,6 +1351,9 @@ class LeRobotDataset(BaseDataset):
                 '~/.cache/huggingface/opentau'.
             episodes (list[int] | None, optional): If specified, this will only load episodes specified by
                 their episode_index in this list. Defaults to None.
+            excluded_episodes (list[int] | None, optional): Episode indices to drop. Takes precedence over
+                ``episodes`` (an index present in both is excluded); when ``episodes`` is None the denylist
+                is applied to the full episode list. Defaults to None.
             image_transforms (Callable | None, optional): You can pass standard v2 image transforms from
                 torchvision.transforms.v2 here which will be applied to visual modalities (whether they come
                 from videos or images). Defaults to None.
@@ -1452,9 +1509,30 @@ class LeRobotDataset(BaseDataset):
                 self.repo_id,
             )
 
+        # Resolve the effective episode set: `(episodes or all) - excluded`,
+        # with `excluded_episodes` taking precedence (see
+        # `resolve_selected_episodes`). Done before the stats block below so the
+        # selected-episode aggregate — and the frames actually loaded — exclude
+        # the denied set.
+        selected = resolve_selected_episodes(
+            self.meta.episodes, self.episodes, excluded_episodes, self.repo_id
+        )
+        if selected is not None:
+            self.episodes = selected
+            # An explicit subset now exists, so download only the kept episodes.
+            self._episodes_were_specified = True
+
         if self.episodes is not None and self.meta._version >= packaging.version.parse("v2.1"):
-            episodes_stats = [self.meta.episodes_stats[ep_idx] for ep_idx in self.episodes]
-            self.stats = aggregate_stats(episodes_stats)
+            self.stats = aggregate_stats([self.meta.episodes_stats[ep_idx] for ep_idx in self.episodes])
+            # Propagate the selected-episode aggregate onto the metadata so the
+            # mixture normalizer (which pools `ds.meta.stats`) reflects the
+            # episodes actually trained on, not the full on-disk dataset.
+            # Out-of-selection / denylisted episodes otherwise poison the
+            # normalization std. The ImageNet camera override in
+            # datasets/factory.py runs afterward and layers onto this same dict.
+            # (v2.0 datasets have no per-episode stats, so this block is skipped
+            # and meta.stats stays the global aggregate.)
+            self.meta.stats = self.stats
 
         if self.episodes is None:
             self.episodes = list(self.meta.episodes)

--- a/src/opentau/scripts/diagnose_norm_distribution.py
+++ b/src/opentau/scripts/diagnose_norm_distribution.py
@@ -281,7 +281,11 @@ def _build_tasks(args: Args) -> tuple[list[dict], dict, list[str]]:
     from opentau.configs.default import DatasetMixtureConfig
     from opentau.configs.refs import resolve_refs_to_tempfile
     from opentau.datasets.dataset_mixture import DatasetMixtureMetadata, WeightedDatasetMixture
-    from opentau.datasets.lerobot_dataset import LeRobotDatasetMetadata
+    from opentau.datasets.lerobot_dataset import (
+        LeRobotDatasetMetadata,
+        aggregate_selected_stats,
+        resolve_selected_episodes,
+    )
     from opentau.datasets.standard_data_format_mapping import resolve_feature_mapping
 
     tmp = resolve_refs_to_tempfile(args.config)
@@ -300,6 +304,14 @@ def _build_tasks(args: Args) -> tuple[list[dict], dict, list[str]]:
             meta.info["robot_type"] = dc.robot_type
         if dc.control_mode is not None:
             meta.info["control_mode"] = dc.control_mode
+        # Mirror training: pool norm stats over the SELECTED episodes only, so
+        # the diagnostic reflects the policy's actual normalization (honors
+        # `episodes` + `excluded_episodes`).
+        try:
+            meta.stats = aggregate_selected_stats(meta, dc.episodes, dc.excluded_episodes)
+        except ValueError as e:
+            logger.warning("episode selection emptied %s, skipping: %r", dc.repo_id, e)
+            continue
         metadatas.append(meta)
         kept_cfgs.append(dc)
         kept_w.append(w)
@@ -335,7 +347,9 @@ def _build_tasks(args: Args) -> tuple[list[dict], dict, list[str]]:
     tasks: list[dict] = []
     for dc, m, name, (scol, acol), (sdim, adim) in zip(kept_cfgs, metadatas, names, cols, dims, strict=True):
         head_key = mm.norm_keys[mm.dataset_to_norm_index[name]]
-        episodes = list(dc.episodes) if dc.episodes is not None else list(m.episodes)
+        episodes = resolve_selected_episodes(m.episodes, dc.episodes, dc.excluded_episodes) or list(
+            m.episodes
+        )
         if args.max_episodes_per_dataset is not None:
             episodes = episodes[: args.max_episodes_per_dataset]
         parquet_paths = [str(m.root / m.get_data_file_path(ep)) for ep in episodes]

--- a/src/opentau/scripts/diagnose_norm_distribution.py
+++ b/src/opentau/scripts/diagnose_norm_distribution.py
@@ -347,6 +347,9 @@ def _build_tasks(args: Args) -> tuple[list[dict], dict, list[str]]:
     tasks: list[dict] = []
     for dc, m, name, (scol, acol), (sdim, adim) in zip(kept_cfgs, metadatas, names, cols, dims, strict=True):
         head_key = mm.norm_keys[mm.dataset_to_norm_index[name]]
+        # Cannot raise here: datasets whose selection the denylist empties were
+        # already dropped by the `aggregate_selected_stats` call in the metadata
+        # loop above, so every dataset reaching this point resolves non-empty.
         episodes = resolve_selected_episodes(m.episodes, dc.episodes, dc.excluded_episodes) or list(
             m.episodes
         )

--- a/src/opentau/scripts/fit_fast_tokenizer.py
+++ b/src/opentau/scripts/fit_fast_tokenizer.py
@@ -317,13 +317,15 @@ def _load_metadata_stats_and_info(
     ``info_with_overrides`` is a copy of ``meta.info`` with
     ``DatasetConfig.{robot_type,control_mode}`` overrides applied -- mirrors
     ``factory._apply_metadata_overrides`` so the caller can derive the same
-    norm key the training policy does. On full construction failure, the
-    returned ``info`` is empty.
+    norm key the training policy does. The action stats are aggregated over the
+    SELECTED episodes (``DatasetConfig.{episodes,excluded_episodes}``) so the
+    codec range matches training-time normalization. On full construction
+    failure, the returned ``info`` is empty.
     """
     idx, cfg = item
     repo_id = cfg.repo_id or "<no-repo-id>"
     try:
-        from opentau.datasets.lerobot_dataset import LeRobotDatasetMetadata
+        from opentau.datasets.lerobot_dataset import LeRobotDatasetMetadata, aggregate_selected_stats
 
         meta = LeRobotDatasetMetadata(cfg.repo_id, root=cfg.root, revision=cfg.revision)
         info = dict(getattr(meta, "info", {}) or {})
@@ -331,20 +333,23 @@ def _load_metadata_stats_and_info(
             info["robot_type"] = cfg.robot_type
         if cfg.control_mode is not None:
             info["control_mode"] = cfg.control_mode
+        # Fit the codec over the SELECTED-episode action range so it matches the
+        # episodes the policy trains on (honors `episodes` + `excluded_episodes`).
+        stats = aggregate_selected_stats(meta, cfg.episodes, cfg.excluded_episodes)
         key = _resolve_native_action_key(
             cfg.repo_id,
             cfg.data_features_name_mapping,
-            available_keys=set(meta.stats or []),
+            available_keys=set(stats or []),
         )
-        if not meta.stats or key not in meta.stats:
+        if not stats or key not in stats:
             return (
                 idx,
                 repo_id,
                 info,
                 None,
-                f"key {key!r} missing from stats (keys={sorted(meta.stats or [])})",
+                f"key {key!r} missing from stats (keys={sorted(stats or [])})",
             )
-        s = meta.stats[key]
+        s = stats[key]
         return (
             idx,
             repo_id,

--- a/tests/datasets/test_dataset_mixture.py
+++ b/tests/datasets/test_dataset_mixture.py
@@ -30,6 +30,7 @@ from opentau.datasets.dataset_mixture import (
     pad_vector,
 )
 from opentau.datasets.factory import make_dataset
+from tests.fixtures.constants import DUMMY_REPO_ID
 from tests.utils import retry_on_hf_flakiness
 
 
@@ -485,6 +486,36 @@ class TestWeightedDatasetMixtureIntegration:
         assert "actions" in features
         assert f"camera{train_pipeline_config.num_cams - 1}" in features
         assert f"camera{train_pipeline_config.num_cams}" not in features
+
+    @pytest.mark.slow
+    def test_norm_head_stats_use_selected_episodes(
+        self, train_pipeline_config, info_factory, episodes_stats_factory, lerobot_dataset_factory, tmp_path
+    ):
+        """per_norm_key_stats must pool SELECTED-episode stats, not the full on-disk set.
+
+        A corrupt episode left out of `episodes` would otherwise inflate the
+        norm-head std and under-scale every real channel of that head.
+        """
+        info = info_factory(total_episodes=3, total_frames=150, total_tasks=1)
+        episodes_stats = episodes_stats_factory(features=info["features"], total_episodes=3)
+        corrupt = episodes_stats[0]["stats"]["state"]["std"]
+        episodes_stats[0]["stats"]["state"]["std"] = [1000.0] * len(corrupt)
+
+        dataset = lerobot_dataset_factory(
+            root=tmp_path / "corrupt",
+            repo_id=DUMMY_REPO_ID,
+            total_episodes=3,
+            total_frames=150,
+            info=info,
+            episodes_stats=episodes_stats,
+            episodes=[1, 2],  # episode 0 (corrupt) is excluded from training
+        )
+        mixture = WeightedDatasetMixture(train_pipeline_config, [dataset], [1.0], 30.0)
+
+        # Real state dim is 6 (DUMMY_MOTOR_FEATURES); the mixture zero-pads the
+        # tail to max_state_dim, so compare only the real channels.
+        state_std = np.asarray(mixture.meta.per_norm_key_stats[0]["state"]["std"])
+        assert np.allclose(state_std[:6], 0.25)
 
     @pytest.mark.slow  # 3 sec
     def test_integration_large_dataset_mixture(self, train_pipeline_config, datasets_factory):

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -22,6 +22,7 @@ from importlib import import_module
 from unittest.mock import MagicMock, patch
 
 import numpy as np
+import packaging.version
 import pytest
 import torch
 from PIL import Image
@@ -143,6 +144,225 @@ def test_dataset_no_episodes_loads_all(tmp_path, lerobot_dataset_factory):
     )
     assert dataset.episodes == [0, 1, 2, 3]
     _assert_episode_row_alignment(dataset)
+
+
+# ---------------------------------------------------------------------------
+# excluded_episodes denylist + selected-episode normalization stats
+# ---------------------------------------------------------------------------
+
+
+def test_excluded_episodes_trims_from_full_set(tmp_path, lerobot_dataset_factory):
+    """excluded_episodes with episodes=None drops the denied indices from the full list."""
+    dataset = lerobot_dataset_factory(
+        root=tmp_path / "test",
+        repo_id=DUMMY_REPO_ID,
+        total_episodes=5,
+        total_frames=250,
+        excluded_episodes=[1, 3],
+    )
+    assert dataset.episodes == [0, 2, 4]
+    # An explicit subset now exists, so subsequent downloads target only the kept set.
+    assert dataset._episodes_were_specified is True
+    _assert_episode_row_alignment(dataset)
+
+
+def test_excluded_episodes_takes_precedence_over_episodes(tmp_path, lerobot_dataset_factory):
+    """An index present in both `episodes` and `excluded_episodes` is excluded."""
+    dataset = lerobot_dataset_factory(
+        root=tmp_path / "test",
+        repo_id=DUMMY_REPO_ID,
+        total_episodes=5,
+        total_frames=250,
+        episodes=[0, 1, 2],
+        excluded_episodes=[1],
+    )
+    assert dataset.episodes == [0, 2]
+    _assert_episode_row_alignment(dataset)
+
+
+def test_excluded_episodes_none_is_noop(tmp_path, lerobot_dataset_factory):
+    """excluded_episodes=None leaves the selection untouched."""
+    dataset = lerobot_dataset_factory(
+        root=tmp_path / "test",
+        repo_id=DUMMY_REPO_ID,
+        total_episodes=4,
+        total_frames=200,
+        episodes=[1, 2],
+        excluded_episodes=None,
+    )
+    assert dataset.episodes == [1, 2]
+
+
+def test_excluded_episodes_emptying_selection_raises(tmp_path, lerobot_dataset_factory):
+    """Denylisting every selected episode is a config error, not a silent empty dataset."""
+    with pytest.raises(ValueError, match="excluded_episodes removed every episode"):
+        lerobot_dataset_factory(
+            root=tmp_path / "test",
+            repo_id=DUMMY_REPO_ID,
+            total_episodes=4,
+            total_frames=200,
+            episodes=[0, 1],
+            excluded_episodes=[0, 1],
+        )
+
+
+def _corrupt_state_std(episodes_stats: dict, ep_idx: int, value: float = 1000.0) -> None:
+    """Inflate one episode's ``state`` std in-place to simulate a corrupt episode."""
+    std = episodes_stats[ep_idx]["stats"]["state"]["std"]
+    episodes_stats[ep_idx]["stats"]["state"]["std"] = [float(value)] * len(std)
+
+
+def test_out_of_selection_corrupt_episode_excluded_from_norm_stats(
+    tmp_path, info_factory, episodes_stats_factory, lerobot_dataset_factory
+):
+    """A corrupt episode OUTSIDE ``episodes`` must not poison the normalization stats.
+
+    Regression for the norm-head bug: the policy normalizer pools ``ds.meta.stats``,
+    which must reflect the SELECTED-episode aggregate, not the full on-disk set.
+    """
+    info = info_factory(total_episodes=3, total_frames=150, total_tasks=1)
+    episodes_stats = episodes_stats_factory(features=info["features"], total_episodes=3)
+    _corrupt_state_std(episodes_stats, ep_idx=0)  # episode 0 is out of the selection below
+
+    dataset = lerobot_dataset_factory(
+        root=tmp_path / "test",
+        repo_id=DUMMY_REPO_ID,
+        total_episodes=3,
+        total_frames=150,
+        info=info,
+        episodes_stats=episodes_stats,
+        episodes=[1, 2],
+    )
+
+    # Selected-episode aggregate is clean (stats_factory uses std=0.25) ...
+    assert np.allclose(dataset.meta.stats["state"]["std"], 0.25)
+    # ... and that selected aggregate is the exact object the mixture will read.
+    assert dataset.stats is dataset.meta.stats
+
+
+def test_corrupt_episode_inside_selection_is_inflated_without_exclusion(
+    tmp_path, info_factory, episodes_stats_factory, lerobot_dataset_factory
+):
+    """Negative control: a corrupt episode INSIDE the selection DOES inflate the std.
+
+    Guards against a false pass in the test above by proving the fixture really
+    injects a poisoned episode that aggregation would otherwise propagate.
+    """
+    info = info_factory(total_episodes=3, total_frames=150, total_tasks=1)
+    episodes_stats = episodes_stats_factory(features=info["features"], total_episodes=3)
+    _corrupt_state_std(episodes_stats, ep_idx=0)
+
+    dataset = lerobot_dataset_factory(
+        root=tmp_path / "test",
+        repo_id=DUMMY_REPO_ID,
+        total_episodes=3,
+        total_frames=150,
+        info=info,
+        episodes_stats=episodes_stats,
+        episodes=[0, 1, 2],
+    )
+    assert np.max(dataset.meta.stats["state"]["std"]) > 1.0
+
+
+def test_excluded_episodes_removes_corrupt_in_selection_from_norm_stats(
+    tmp_path, info_factory, episodes_stats_factory, lerobot_dataset_factory
+):
+    """A corrupt episode inside ``episodes`` can be denylisted to clean the norm stats.
+
+    This is the OpenTau-side mechanism for dropping corrupt-in-selection episodes
+    without editing the data-side episode selection.
+    """
+    info = info_factory(total_episodes=3, total_frames=150, total_tasks=1)
+    episodes_stats = episodes_stats_factory(features=info["features"], total_episodes=3)
+    _corrupt_state_std(episodes_stats, ep_idx=0)
+
+    dataset = lerobot_dataset_factory(
+        root=tmp_path / "test",
+        repo_id=DUMMY_REPO_ID,
+        total_episodes=3,
+        total_frames=150,
+        info=info,
+        episodes_stats=episodes_stats,
+        episodes=[0, 1, 2],
+        excluded_episodes=[0],
+    )
+    assert dataset.episodes == [1, 2]
+    assert np.allclose(dataset.meta.stats["state"]["std"], 0.25)
+
+
+# --- shared selection helpers (also used by fit_fast_tokenizer / diagnose_norm_distribution) ---
+
+
+def test_resolve_selected_episodes_precedence_and_none():
+    from opentau.datasets.lerobot_dataset import resolve_selected_episodes
+
+    # No selection at all -> None ("use everything").
+    assert resolve_selected_episodes([0, 1, 2], None, None) is None
+    # episodes only -> sorted copy.
+    assert resolve_selected_episodes([0, 1, 2, 3], [3, 1], None) == [1, 3]
+    # excluded_episodes only -> full set minus denylist.
+    assert resolve_selected_episodes([0, 1, 2, 3], None, [1, 3]) == [0, 2]
+    # both -> excluded wins on overlap.
+    assert resolve_selected_episodes([0, 1, 2, 3], [0, 1, 2], [1]) == [0, 2]
+    # excluding an index absent from the base is a no-op.
+    assert resolve_selected_episodes([0, 1, 2], [0, 1], [99]) == [0, 1]
+
+
+def test_resolve_selected_episodes_empty_raises():
+    from opentau.datasets.lerobot_dataset import resolve_selected_episodes
+
+    with pytest.raises(ValueError, match="excluded_episodes removed every episode"):
+        resolve_selected_episodes([0, 1], [0, 1], [0, 1], repo_id="x/y")
+
+
+class _StubMeta:
+    """Minimal duck-typed stand-in for LeRobotDatasetMetadata."""
+
+    def __init__(self, version: str, episodes_stats: dict, stats: dict, repo_id: str = "stub/repo"):
+        self.repo_id = repo_id
+        self.episodes_stats = episodes_stats
+        self.episodes = list(episodes_stats)
+        self.stats = stats
+        self._version = packaging.version.parse(version)
+
+
+def _state_stat(std: float, dim: int = 2) -> dict:
+    return {
+        "state": {
+            "min": np.zeros(dim, dtype=np.float32),
+            "max": np.ones(dim, dtype=np.float32),
+            "mean": np.full(dim, 0.5, dtype=np.float32),
+            "std": np.full(dim, float(std), dtype=np.float32),
+            "count": np.array([10]),
+        }
+    }
+
+
+def test_aggregate_selected_stats_v21_excludes_unselected():
+    from opentau.datasets.lerobot_dataset import aggregate_selected_stats
+
+    ep_stats = {0: _state_stat(1000.0), 1: _state_stat(0.25), 2: _state_stat(0.25)}
+    meta = _StubMeta("v2.1", ep_stats, stats=_state_stat(999.0))  # global stats poisoned
+    out = aggregate_selected_stats(meta, episodes=[1, 2])
+    assert np.allclose(out["state"]["std"], 0.25)
+
+
+def test_aggregate_selected_stats_no_selection_returns_meta_stats():
+    from opentau.datasets.lerobot_dataset import aggregate_selected_stats
+
+    sentinel = _state_stat(0.5)
+    meta = _StubMeta("v2.1", {0: _state_stat(0.25)}, stats=sentinel)
+    # No selection -> the global aggregate object is returned verbatim (no recompute).
+    assert aggregate_selected_stats(meta, episodes=None, excluded_episodes=None) is sentinel
+
+
+def test_aggregate_selected_stats_v20_falls_back_to_meta_stats():
+    from opentau.datasets.lerobot_dataset import aggregate_selected_stats
+
+    sentinel = _state_stat(0.5)
+    # v2.0 has no usable per-episode stats; a selection cannot recompute -> fallback.
+    meta = _StubMeta("v2.0", {0: _state_stat(1000.0), 1: _state_stat(0.25)}, stats=sentinel)
+    assert aggregate_selected_stats(meta, episodes=[1]) is sentinel
 
 
 def test_download_files_skips_present_files(tmp_path, lerobot_dataset_factory):

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -306,6 +306,9 @@ def test_resolve_selected_episodes_precedence_and_none():
     assert resolve_selected_episodes([0, 1, 2, 3], [0, 1, 2], [1]) == [0, 2]
     # excluding an index absent from the base is a no-op.
     assert resolve_selected_episodes([0, 1, 2], [0, 1], [99]) == [0, 1]
+    # an empty denylist behaves like None (no-op), preserving the episodes arg.
+    assert resolve_selected_episodes([0, 1, 2], [0, 1], []) == [0, 1]
+    assert resolve_selected_episodes([0, 1, 2], None, []) is None
 
 
 def test_resolve_selected_episodes_empty_raises():


### PR DESCRIPTION
## What this does

Two coupled changes to dataset normalization (🐛 Bug + 🗃️ Feature):

**1. Normalization now pools SELECTED-episode stats, not all-episode.**
Per-norm-head normalization constants were pooled from each dataset's all-episode aggregate (`LeRobotDatasetMetadata.stats`), not the selected-episode subset the mixture actually trains on (`DatasetConfig.episodes`, typically a ~10% slice). A single corrupt or out-of-selection episode could inflate the normalization `std` by 20–4600×, under-scaling real channels until they were effectively dead to the policy.

`LeRobotDataset.__init__` already computed the selected-episode aggregate (`self.stats`) but discarded it for normalization. It now propagates that aggregate onto `self.meta.stats` — the single channel every consumer reads (the mixture's `per_norm_key_stats`, `aggregated_action_stats`, the BPE codec, and the norm diagnostic). The ImageNet camera override in `datasets/factory.py` runs afterward and layers onto the same dict, so cameras stay ImageNet-normalized; val-split `Subset`s and VQA datasets are unaffected.

**2. New `DatasetConfig.excluded_episodes` denylist.**
A per-dataset list of episode indices to drop. It takes precedence over `episodes` (an index present in both is excluded) and removes those episodes from both the training frames and the stats aggregate. This lets operators drop corrupt episodes that fall *inside* the trained selection via config, without editing the dataset on disk.

Both behaviors share two helpers in `lerobot_dataset.py` — `resolve_selected_episodes` and `aggregate_selected_stats` — so the dataset loader, `fit_fast_tokenizer.py`, and `diagnose_norm_distribution.py` use one implementation of the selection logic (including the v2.0 fallback, since v2.0 datasets have no per-episode stats to recompute from).

## How it was tested

CPU suite (`pytest -m "not gpu"`), all green, plus `pre-commit run --all-files` clean:

- Added 12 tests in `tests/datasets/test_datasets.py`: `excluded_episodes` precedence / None / empty-raise; out-of-selection corrupt episode excluded from `meta.stats`; corrupt-in-selection dropped via `excluded_episodes`; a negative control proving the fixture injects real poison; and unit tests for `resolve_selected_episodes` / `aggregate_selected_stats` (incl. no-selection identity and v2.0 fallback).
- Added `test_norm_head_stats_use_selected_episodes` in `tests/datasets/test_dataset_mixture.py`: end-to-end, `per_norm_key_stats` pools the selected episodes.
- `tests/datasets/` → 508 passed, 7 skipped; `tests/scripts/` tokenizer + norm-diagnostic tests → 20 passed.

Not a policy-code change, so the GPU / regression suites were not run locally (no local GPU); they run in nightly CI.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/datasets/test_datasets.py -k "excluded_episodes or selected"
pytest -sx "tests/datasets/test_dataset_mixture.py::TestWeightedDatasetMixtureIntegration::test_norm_head_stats_use_selected_episodes"
```

Config usage — drop known-bad episodes from a mixture dataset:
```json
{ "repo_id": "your-org/dataset-with-bad-eps", "excluded_episodes": [12, 47] }
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).