### PR TITLE
fix: history_state_drop masks history, keeps current state, zeros post-norm

### DIFF
--- a/src/opentau/configs/default.py
+++ b/src/opentau/configs/default.py
@@ -219,11 +219,16 @@ class DatasetMixtureConfig:
             ``history_interval`` attribute (defaults to 1 when the policy
             doesn't define one), so observations are sampled at timesteps
             :math:`t - (T-1)k,\; t - (T-2)k,\; \ldots,\; t`.
-        history_state_drop_prob: Probability of dropping historical frames and
-            ``observation.state`` together during a single ``__getitem__`` call
-            (zeros out ``state`` and historical camera frames; sets
-            ``obs_history_is_pad`` to all True). Must be in ``[0, 1]``. Defaults
-            to 0.3.
+        history_state_drop_prob: Probability of dropping the observation
+            *history* during a single ``__getitem__`` call. When it fires, the
+            historical steps are masked via ``obs_history_is_pad`` (set all True)
+            and the historical camera frames are zeroed; the current step —
+            current ``observation.state`` and current camera frame — is kept.
+            ``state`` is deliberately NOT zeroed here: it is MEAN_STD-normalized
+            downstream, so the dropped history is zeroed *after* normalization
+            inside the policy (zeroing a raw state pre-normalization would map
+            0 to ``-mean/std``, an out-of-distribution extreme). Must be in
+            ``[0, 1]``. Defaults to 0.3.
         subgoal_drop_prob: Probability of dropping all subgoal images during a
             single ``__getitem__`` call. Must be in ``[0, 1]``. Defaults to 0.75.
         subgoal_end_of_segment_prob: Probability of sampling the subgoal frame

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -951,8 +951,13 @@ class BaseDataset(torch.utils.data.Dataset):
         ``prepare_metadata`` falls through to its default-pad path).
 
         Dropout order:
-            1. ``history_state_drop_prob``: zero ``state`` and historical camera
-               frames; mark ``obs_history_is_pad`` all True.
+            1. ``history_state_drop_prob``: mark ``obs_history_is_pad`` all True
+               (the policy masks the historical steps) and zero the historical
+               camera frames. ``state`` is left intact here — the dropped history
+               is zeroed *after* normalization inside the policy's
+               ``embed_prefix``, since zeroing a raw ``state`` before MEAN_STD
+               normalization would map 0 to ``-mean/std``. The current step
+               (current state + current camera frame) is always kept.
             2. ``subgoal_drop_prob``: zero every ``subgoalK`` and set the
                single ``subgoal_is_pad`` flag to True (subgoals are all-or-none).
             3. ``response_drop_prob``: only when subgoals were NOT dropped, mask
@@ -983,10 +988,15 @@ class BaseDataset(torch.utils.data.Dataset):
                 return False
             return bool(torch.rand(()) < prob)
 
-        # (1) History + observation.state drop.
+        # (1) History drop. Mark the historical observation steps as padded via
+        # `obs_history_is_pad` (the policy masks them out) and zero the historical
+        # *camera* frames. We deliberately do NOT zero `state` here: state is
+        # MEAN_STD-normalized downstream, so zeroing a raw state would map
+        # 0 -> -mean/std (an out-of-distribution extreme). The dropped history is
+        # instead zeroed *after* normalization inside the policy's `embed_prefix`.
+        # The current step — current state and current camera frame — is kept.
         drop_hist = _roll(self.history_state_drop_prob)
         if drop_hist:
-            standard_item["state"] = torch.zeros_like(standard_item["state"])
             if self.n_obs_history is not None:
                 standard_item["obs_history_is_pad"] = torch.ones(self.n_obs_history, dtype=torch.bool)
                 if self.n_obs_history > 1:

--- a/src/opentau/policies/pi05_mem/modeling_pi05.py
+++ b/src/opentau/policies/pi05_mem/modeling_pi05.py
@@ -990,24 +990,36 @@ class PI05MemFlowMatching(nn.Module):
         num_lang_embs = lang_emb.shape[1]
         att_masks += [0] * num_lang_embs
 
-        # Project each timestep's state into a separate VLM token
-        # state: (B, T, max_state_dim) -> state_emb: (B, T, vlm_hidden_size)
-        state_emb = self.state_proj(state.to(dtype=_preferred_dtype()))
-        num_state_tokens = state_emb.shape[1]  # T
+        # Build the state pad mask first so masked (dropped / historical) steps
+        # can be zeroed *after* normalization but *before* projection.
+        # state: (B, T, max_state_dim); num_state_tokens == T.
+        num_state_tokens = state.shape[1]  # T
         if obs_history_is_pad is not None:
             state_mask = ~obs_history_is_pad  # (B, T) — `~` allocates a fresh tensor
         else:
             # Absent → assume all history is padded; only current step is real.
             state_mask = torch.zeros(bsize, num_state_tokens, dtype=torch.bool, device=state.device)
         # Current step (t = T-1) is ALWAYS real even when the dataset's
-        # history_state_drop_prob augmentation flips obs_history_is_pad to
-        # all-True. Without this override the policy would condition on no
-        # state at all, since attention to the current state token would be
-        # masked out — defeating the purpose of preserving the current frame.
-        # Both branches above produce fresh tensors (`~` allocates;
-        # `torch.zeros` allocates), so the `[:, -1] = True` write below does
-        # not reach the caller's `obs_history_is_pad`.
+        # history_state_drop_prob augmentation marks obs_history_is_pad all-True.
+        # Without this override the policy would condition on no state at all,
+        # since attention to the current state token would be masked out —
+        # defeating the purpose of preserving the current frame. Both branches
+        # above produce fresh tensors (`~` allocates; `torch.zeros` allocates),
+        # so the `[:, -1] = True` write below does not reach the caller's
+        # `obs_history_is_pad`.
         state_mask[:, -1] = True
+
+        # Defense-in-depth: zero the (already-normalized) state at masked steps so
+        # no historical proprioception leaks even if the attention mask later
+        # regresses. The current step is preserved by `state_mask[:, -1] = True`.
+        # This runs AFTER normalize_inputs and BEFORE state_proj, so a masked slot
+        # becomes a clean post-norm zero — never the ill `-mean/std` that zeroing a
+        # *raw* state before normalization would produce.
+        state = state.masked_fill(rearrange(~state_mask, "b t -> b t 1"), 0.0)
+
+        # Project each timestep's state into a separate VLM token
+        # state: (B, T, max_state_dim) -> state_emb: (B, T, vlm_hidden_size)
+        state_emb = self.state_proj(state.to(dtype=_preferred_dtype()))
 
         embs.append(state_emb)
         pad_masks.append(state_mask)

--- a/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
@@ -1500,24 +1500,36 @@ class PI07LowLevelFlowMatching(nn.Module):
         # "State: " indicator is text → causal per paper §VI.B.
         att_masks += [1] * num_state_start_embs
 
-        # Project each timestep's state into a separate VLM token
-        # state: (B, T, max_state_dim) -> state_emb: (B, T, vlm_hidden_size)
-        state_emb = self.state_proj(state.to(dtype=_preferred_dtype()))
-        num_state_tokens = state_emb.shape[1]  # T
+        # Build the state pad mask first so masked (dropped / historical) steps
+        # can be zeroed *after* normalization but *before* projection.
+        # state: (B, T, max_state_dim); num_state_tokens == T.
+        num_state_tokens = state.shape[1]  # T
         if obs_history_is_pad is not None:
             state_mask = ~obs_history_is_pad  # (B, T) — `~` allocates a fresh tensor
         else:
             # Absent → assume all history is padded; only current step is real.
             state_mask = torch.zeros(bsize, num_state_tokens, dtype=torch.bool, device=state.device)
         # Current step (t = T-1) is ALWAYS real even when the dataset's
-        # history_state_drop_prob augmentation flips obs_history_is_pad to
-        # all-True. Without this override the policy would condition on no
-        # state at all, since attention to the current state token would be
-        # masked out — defeating the purpose of preserving the current frame.
-        # Both branches above produce fresh tensors (`~` allocates;
-        # `torch.zeros` allocates), so the `[:, -1] = True` write below does
-        # not reach the caller's `obs_history_is_pad`.
+        # history_state_drop_prob augmentation marks obs_history_is_pad all-True.
+        # Without this override the policy would condition on no state at all,
+        # since attention to the current state token would be masked out —
+        # defeating the purpose of preserving the current frame. Both branches
+        # above produce fresh tensors (`~` allocates; `torch.zeros` allocates),
+        # so the `[:, -1] = True` write below does not reach the caller's
+        # `obs_history_is_pad`.
         state_mask[:, -1] = True
+
+        # Defense-in-depth: zero the (already-normalized) state at masked steps so
+        # no historical proprioception leaks even if the attention mask later
+        # regresses. The current step is preserved by `state_mask[:, -1] = True`.
+        # This runs AFTER normalize_inputs and BEFORE state_proj, so a masked slot
+        # becomes a clean post-norm zero — never the ill `-mean/std` that zeroing a
+        # *raw* state before normalization would produce.
+        state = state.masked_fill(rearrange(~state_mask, "b t -> b t 1"), 0.0)
+
+        # Project each timestep's state into a separate VLM token
+        # state: (B, T, max_state_dim) -> state_emb: (B, T, vlm_hidden_size)
+        state_emb = self.state_proj(state.to(dtype=_preferred_dtype()))
 
         embs.append(state_emb)
         pad_masks.append(state_mask)

--- a/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
@@ -921,6 +921,13 @@ class PI07PaligemmaLowLevelPolicy(PreTrainedPolicy):
         else:
             state_mask = torch.zeros(bsize, t_steps, dtype=torch.bool, device=device)
         state_mask[:, -1] = True
+        # Defense-in-depth: zero the (already-normalized) state at masked steps so
+        # no historical proprioception leaks even if the attention mask later
+        # regresses. The current step is preserved by `state_mask[:, -1] = True`.
+        # This runs AFTER normalize_inputs, so a masked slot becomes a clean
+        # post-norm zero — never the ill `-mean/std` that zeroing a *raw* state
+        # before normalization would produce.
+        state = state.masked_fill(rearrange(~state_mask, "b t -> b t 1"), 0.0)
         items.append(ContextItem(data=state, item_type="state", pad_mask=state_mask, attention="continue"))
 
         # Response block: gated by sample_has_response.

--- a/tests/datasets/test_optional_keys.py
+++ b/tests/datasets/test_optional_keys.py
@@ -196,11 +196,19 @@ class TestAllProbsZero:
 
 
 class TestForcedDropouts:
-    def test_history_drop_zeros_state(self):
+    def test_history_drop_marks_pad_keeps_state_content(self):
+        """history_state_drop marks the history padded but does NOT zero ``state``.
+
+        Zeroing a raw state would normalize to ``-mean/std`` downstream, so the
+        dropped history is instead zeroed *after* normalization inside the
+        policy. At the dataset level the state content is left intact and only
+        ``obs_history_is_pad`` flips to all-True.
+        """
         ds = _DummyBaseDataset(history_state_drop_prob=1.0)
         standard_item = _prepopulate_standard_item(ds)
+        original_state = standard_item["state"].clone()
         ds._emit_optional_keys(_raw_item(ds), standard_item)
-        assert torch.all(standard_item["state"] == 0)
+        assert torch.equal(standard_item["state"], original_state)
         assert standard_item["obs_history_is_pad"].all().item() is True
 
     def test_history_drop_zeros_historical_cameras_when_temporal(self):
@@ -225,6 +233,10 @@ class TestForcedDropouts:
             # Current frame is left intact.
             assert torch.all(standard_item[f"camera{k}"][-1] == 1)
         assert standard_item["obs_history_is_pad"].all().item() is True
+        # State is NOT zeroed at the dataset level (a raw zero would normalize to
+        # -mean/std); the dropped history is zeroed post-normalization in the
+        # policy. Every temporal state step stays intact here.
+        assert torch.all(standard_item["state"] == 1)
 
     def test_absent_subgoal_raw_marks_all_slots_padded(self):
         """If ``_load_subgoal_frames`` dropped (returned {}), every subgoal{k}

--- a/tests/policies/test_pi05_mem.py
+++ b/tests/policies/test_pi05_mem.py
@@ -421,6 +421,35 @@ class TestStateMaskCurrentStepAlwaysReal:
             )
         assert (~state_mask[:, :-1]).all().item() is True
 
+    def test_masked_state_zeroed_before_projection_current_preserved(self):
+        """Defense-in-depth (pi05_mem): masked state steps are zeroed *after*
+        normalization but *before* ``state_proj``; the current step keeps its
+        real value, so dropped history cannot leak even if the attention mask
+        later regresses.
+        """
+        from opentau.policies.pi05_mem.modeling_pi05 import PI05MemFlowMatching
+
+        fake = _make_embed_prefix_stub()
+        bsize = 2
+        t_state = 4
+        kwargs = _embed_prefix_default_inputs(batch_size=bsize, t_state=t_state)
+        state = torch.arange(1, bsize * t_state * 7 + 1, dtype=torch.float32).reshape(bsize, t_state, 7)
+        kwargs["state"] = state
+        kwargs["obs_history_is_pad"] = torch.ones(bsize, t_state, dtype=torch.bool)
+
+        captured = {}
+
+        def _spy_state_proj(s):
+            captured["state"] = s.clone()
+            return torch.zeros(s.shape[0], s.shape[1], 4, dtype=torch.float32)
+
+        fake.state_proj = _spy_state_proj
+        PI05MemFlowMatching.embed_prefix(fake, **kwargs)
+
+        seen = captured["state"]
+        assert torch.all(seen[:, :-1] == 0)
+        assert torch.equal(seen[:, -1], state[:, -1].to(seen.dtype))
+
     def test_state_mask_none_branch_assumes_history_padded_keeps_current_real(self):
         """``obs_history_is_pad = None`` means the caller didn't tell us
         which slots are real. Post-fix: assume all history is padded so the

--- a/tests/policies/test_pi07_cpu.py
+++ b/tests/policies/test_pi07_cpu.py
@@ -1657,6 +1657,44 @@ class TestStateMaskCurrentStepAlwaysReal:
             torch.tensor([[False, False, True, True], [False, True, True, True]]),
         )
 
+    def test_masked_state_zeroed_before_projection_current_preserved(self):
+        """Defense-in-depth: when history is padded, the (already-normalized)
+        state handed to ``state_proj`` is zeroed at the masked steps while the
+        current step (T-1) keeps its real value. Runs *after* normalization, so
+        a masked slot is a clean zero — never the ``-mean/std`` a pre-norm raw
+        zero would give — and dropped history cannot leak even if the attention
+        mask later regresses.
+        """
+        method = _embed_prefix_method()
+        fake = _make_fake_flow_matching()
+        bsize = 2
+        t_state = 4
+        kwargs = _build_default_inputs(batch_size=bsize, t_state=t_state)
+        # Distinct non-zero per-step values so the zeroing is observable.
+        state = torch.arange(1, bsize * t_state * 7 + 1, dtype=torch.float32).reshape(bsize, t_state, 7)
+        kwargs["state"] = state
+        kwargs["obs_history_is_pad"] = torch.ones(bsize, t_state, dtype=torch.bool)
+        kwargs["response_tokens"] = None
+        kwargs["response_masks"] = None
+        kwargs["metadata_tokens"] = None
+        kwargs["metadata_masks"] = None
+
+        # Spy on state_proj to capture the post-masking state it receives.
+        captured = {}
+
+        def _spy_state_proj(s):
+            captured["state"] = s.clone()
+            return torch.zeros(s.shape[0], s.shape[1], 4, dtype=torch.float32)
+
+        fake.state_proj = _spy_state_proj
+        method(fake, **kwargs)
+
+        seen = captured["state"]
+        # Historical steps (all but current) are zeroed post-normalization.
+        assert torch.all(seen[:, :-1] == 0)
+        # The current step keeps its real (normalized) value.
+        assert torch.equal(seen[:, -1], state[:, -1].to(seen.dtype))
+
     def test_state_mask_does_not_mutate_obs_history_is_pad(self):
         """The override path uses .clone() to avoid mutating the caller's
         ``obs_history_is_pad`` tensor (which is also threaded into

--- a/tests/policies/test_pi07_paligemma_low_level.py
+++ b/tests/policies/test_pi07_paligemma_low_level.py
@@ -851,6 +851,26 @@ class TestPI07PaligemmaLowLevelStateEmbedding:
         assert torch.all(state_mask[:, -1]), "current state token must be unmasked"
         assert not torch.all(state_slice[:, -1] == 0), "current state embedding should be non-zero"
 
+    def test_masked_history_state_zeroed_before_projection(self):
+        """Defense-in-depth: with history padded, the masked state steps are
+        zeroed *after* normalization and *before* ``state_proj``. The stub
+        projection has zero bias, so ``proj(0) == 0`` surfaces the masked
+        (historical) tokens as exactly-zero state embeddings while the current
+        token stays non-zero. Keeps dropped history from leaking even if the
+        attention mask regresses, and avoids the ``-mean/std`` that zeroing a
+        raw state *before* normalization would produce.
+        """
+        t = 4
+        pad = torch.ones(1, t, dtype=torch.bool)  # all-True: history_state_drop fired
+
+        (embs, _pad_masks, _att), meta = self._call_embed_prefix(n_obs_steps=t, obs_history_is_pad=pad)
+
+        state_slice = embs[:, meta["state_start"] : meta["state_end"]]
+        assert state_slice.shape == (1, t, meta["hidden_size"])
+        # Zero-bias stub proj: masked (historical) steps surface as exactly zero.
+        assert torch.all(state_slice[:, :-1] == 0), "masked history state must be zeroed pre-projection"
+        assert not torch.all(state_slice[:, -1] == 0), "current state embedding should be non-zero"
+
     def test_state_embedding_all_pad_true_matches_history_padded(self):
         """T>1 with all-True pad [True, True, True, True]: the last timestep is
         still forced unmasked by ``state_mask[:, -1] = True``, so the state mask


### PR DESCRIPTION
## What this does

🐛 Bug fix for the `history_state_drop_prob` augmentation (default `0.3`).

When the drop fired, the dataset zeroed the **entire** `observation.state` — including the *current* step — in **raw, pre-normalization** units. Because state is `MEAN_STD`-normalized inside the policy, a raw `0` maps to `(0 - mean)/(std + EPS) = -mean/std`, an out-of-distribution extreme (unbounded as `std → 0`). The model's force-unmask (`state_mask[:, -1] = True`) then conditioned the *current* state token on that garbage value — so ~30% of training steps saw a corrupted "current" proprioceptive state instead of merely dropping the history.

The image path was already correct (`IDENTITY`-normalized, historical frames zeroed, current frame kept, masked) and is unchanged.

Fix — drop history by **masking**, never by a pre-normalization zero:

- **Dataset** (`_emit_optional_keys`): no longer zeros `state`; it only marks `obs_history_is_pad` all-True (the drop signal). Historical camera zeroing is unchanged.
- **Each temporal policy** (`pi07`, `pi05_mem`, `pi07_paligemma`): in `embed_prefix` / `_build_prefix_items`, *after* `normalize_inputs` and *before* `state_proj`, zeros the masked (historical) state via `masked_fill` while keeping the current step real and attended. Defense-in-depth: the masked history is provably ignored by attention, and even if that mask regressed the content is a clean post-norm zero — no history leak, no `-mean/std`.

Verified that boundary history padding is **clamped** (real rows via `np.clip`), so no raw zero ever reaches normalization after this change.

Behavioral note: during drop steps the model now conditions on the real current state instead of the `-mean/std` ghost — an intended change in training dynamics, so loss curves will differ from pre-fix runs.

## How it was tested

- Rewrote `test_history_drop_zeros_state` → `test_history_drop_marks_pad_keeps_state_content` (asserts `state` is untouched and `obs_history_is_pad` flips all-True) and added a temporal-state-preserved assertion to the camera test, in `tests/datasets/test_optional_keys.py`.
- Added a post-norm-zero test to each temporal policy: `tests/policies/test_pi07_cpu.py`, `tests/policies/test_pi05_mem.py`, `tests/policies/test_pi07_paligemma_low_level.py` (masked steps → zero at/before projection, current step preserved).
- CPU suite: `pytest -m "not gpu and not slow" tests/datasets tests/policies tests/configs` → **1000 passed, 9 skipped**.
- Determinism (repo policy for data-path / modeling changes): the change adds/removes only deterministic tensor ops (drops a `torch.zeros_like`, adds a `masked_fill`) and touches no RNG, so the augmentation draw sequence is unchanged. Confirmed empirically on the real `_emit_optional_keys` drop path — same seed → bit-identical augmentation sequence, different seed diverges, state preserved on every sample.
- GPU pytests (`pytest -m "gpu"`) for the three changed policies are running on internal GPU infra; the checklist box is checked ahead of their completion as agreed.

## How to checkout & try? (for the reviewer)

```bash
# CPU coverage for the change
pytest -sx tests/datasets/test_optional_keys.py tests/policies/test_pi07_cpu.py \
          tests/policies/test_pi05_mem.py tests/policies/test_pi07_paligemma_low_level.py
```

```bash
# GPU coverage (CUDA box)
pytest -m "gpu" -n 0 tests/policies/test_pi07_low_level.py \
                     tests/policies/test_pi05_mem_gpu.py \
                     tests/policies/test_pi07_paligemma_low_level.py
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [x] My PR includes policy-related changes.
  - [x] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).