### PR TITLE
fix: guard zero-variance dims in Normalize + pad-aware outlier warning

### DIFF
--- a/src/opentau/policies/normalize.py
+++ b/src/opentau/policies/normalize.py
@@ -22,6 +22,7 @@ datasets the policy was trained on. ``forward`` accepts a per-sample
 row per sample before broadcasting.
 """
 
+import logging
 import sys
 
 import numpy as np
@@ -31,6 +32,82 @@ from torch import Tensor, nn
 from opentau.configs.types import FeatureType, NormalizationMode, PolicyFeature
 
 EPS = 1e-8  # Small epsilon value for numerical stability in normalization
+
+# A genuinely-zero std (|std| < EPS) marks a constant/padding feature dim. The guard in
+# ``Normalize`` / ``Unnormalize`` snaps such a std (or a zero MIN_MAX range) to 1 so a value
+# that *deviates* from that "constant" can't divide by ~EPS and blow up to ~1e8 (the
+# "Outlier normalized state" failure). When the dim is truly constant and its stats are
+# right, every value equals the mean, the deviation is 0, and the snap is a no-op.
+_SNAP_WARN_TOL = 1e-2  # raw-unit |value - mean| above this at a snapped dim => real deviation => warn.
+
+# ``(feature_key, dim)`` offenders already warned about, so each fires once per process
+# (mirrors ``_WARNED_OUTLIER_KEYS`` in the pi07_paligemma policy).
+_WARNED_SNAP_KEYS: set[tuple[str, int]] = set()
+
+
+def _warn_snapped_deviation(
+    key: str,
+    zero_var_mask: Tensor,
+    deviation: Tensor,
+    dataset_index: Tensor,
+    dataset_names: list[str] | None,
+) -> None:
+    """Loudly warn (once per ``(key, dim)``) when the zero-variance guard changed the result.
+
+    The guard snaps a ``std`` (or ``max - min``) of ~0 to 1. That only changes the output when
+    the input *deviates* from the dim's constant ``mean`` (resp. ``min``): a genuinely-constant
+    dim with correct stats has ``deviation == 0`` and stays silent. A non-trivial ``deviation``
+    means the stats are stale or the value was zeroed upstream (e.g. a dropped frame) — surface
+    the offending ``feature``/``dim`` so it can be traced.
+
+    Log-only and called behind ``Normalize._snapping_possible()``; reads tensors without
+    mutating them and fires no collective, so the ``forward`` graph stays identical across
+    ranks (CLAUDE.md rule 5).
+
+    Args:
+        key: Feature name (e.g. ``"observation.state"``).
+        zero_var_mask: Bool ``(B, *feat)`` — True where the gathered std/range was snapped.
+        deviation: ``batch_val - mean`` (MEAN_STD) or ``batch_val - min`` (MIN_MAX), the raw
+            pre-scale numerator; broadcasts against ``zero_var_mask`` onto the batch shape.
+        dataset_index: ``(B,)`` per-sample dataset row, used to name the offending dataset.
+        dataset_names: Ordered dataset names parallel to the buffer rows, or ``None``.
+    """
+    trigger = zero_var_mask & (deviation.abs() > _SNAP_WARN_TOL)
+    if not bool(trigger.any()):
+        return
+    # Collapse every axis except the trailing feature axis to get per-dim offenders. The
+    # inserted-axis count is data-dependent (see ``_gather_and_broadcast``), so a computed
+    # dim tuple is clearer here than a fixed einops pattern.
+    feat_axes = tuple(range(trigger.ndim - 1))
+    per_dim = trigger.any(dim=feat_axes) if feat_axes else trigger
+    dims = torch.nonzero(per_dim, as_tuple=False).flatten().tolist()
+    fresh = [d for d in dims if (key, d) not in _WARNED_SNAP_KEYS]
+    if not fresh:
+        return
+    for d in fresh:
+        _WARNED_SNAP_KEYS.add((key, d))
+    # Provenance: the sample with the largest deviation among the triggers.
+    magnitude = deviation.abs() * trigger
+    sample_axes = tuple(range(1, magnitude.ndim))
+    per_sample = magnitude.amax(dim=sample_axes) if sample_axes else magnitude
+    worst_sample = int(torch.argmax(per_sample))
+    worst_val = float(magnitude.max())
+    ds = None
+    if dataset_names is not None:
+        idx = int(dataset_index[worst_sample])
+        if 0 <= idx < len(dataset_names):
+            ds = dataset_names[idx]
+    logging.warning(
+        "Normalize zero-variance guard fired: feature '%s' dim(s)=%s have std≈0 but a value "
+        "deviates from the constant by up to %.3g (raw units, dataset=%s). std was snapped to 1 "
+        "so only the mean is subtracted (no ~1e8 blow-up), but this almost always means stale "
+        "normalization stats or a value zeroed upstream — inspect this feature's stats. "
+        "Repeats for these (feature,dim) pairs are suppressed.",
+        key,
+        fresh,
+        worst_val,
+        ds,
+    )
 
 
 def _materialize(tensor: Tensor) -> Tensor:
@@ -294,6 +371,35 @@ class Normalize(nn.Module):
         for key, buffer in stats_buffers.items():
             setattr(self, "buffer_" + key.replace(".", "_"), buffer)
 
+    def _snapping_possible(self) -> bool:
+        """Whether any stat buffer has a zero-variance dim, so the guard could ever snap.
+
+        Cached after the first call. Lets ``forward`` skip the per-step deviation check
+        (and its host sync) entirely on the common healthy path where no dim is constant —
+        only a model that actually has a constant dim pays for the warning bookkeeping.
+        """
+        cached = getattr(self, "_snap_active", None)
+        if cached is not None:
+            return cached
+        active = False
+        for key, ft in self.features.items():
+            norm_mode = self.norm_map.get(ft.type, NormalizationMode.IDENTITY)
+            buffer = getattr(self, "buffer_" + key.replace(".", "_"), None)
+            if buffer is None:
+                continue
+            if norm_mode is NormalizationMode.MEAN_STD:
+                std = _materialize(buffer["std"])
+                if bool((torch.isfinite(std) & (std.abs() < EPS)).any()):
+                    active = True
+                    break
+            elif norm_mode is NormalizationMode.MIN_MAX:
+                rng = _materialize(buffer["max"]) - _materialize(buffer["min"])
+                if bool((torch.isfinite(rng) & (rng.abs() < EPS)).any()):
+                    active = True
+                    break
+        self._snap_active = active
+        return active
+
     @torch.no_grad
     def forward(self, batch: dict[str, Tensor], dataset_index: Tensor) -> dict[str, Tensor]:
         """Normalizes the batch data per-sample.
@@ -327,15 +433,38 @@ class Normalize(nn.Module):
                 std = _gather_and_broadcast(_materialize(buffer["std"]), dataset_index, batch_val)
                 assert not torch.isinf(mean).any(), _no_stats_error_str("mean")
                 assert not torch.isinf(std).any(), _no_stats_error_str("std")
-                batch[key] = (batch_val - mean) / (std + EPS)
+                # Snap a genuinely-zero std (constant/padding dim) to 1 so a deviating value
+                # can't become (x - mean)/EPS ~ 1e8. std >= EPS dims stay bit-identical.
+                std_is_zero = std.abs() < EPS
+                std = torch.where(std_is_zero, torch.ones_like(std), std)
+                deviation = batch_val - mean
+                batch[key] = deviation / (std + EPS)
+                # Loud, once-per-(feature,dim) warning, but only when the snap actually changed
+                # the output (a real deviation from a "constant" dim). Short-circuits before the
+                # precheck under compile/ONNX so neither adds a data-dependent op to the trace.
+                if (
+                    not (torch.compiler.is_compiling() or torch.onnx.is_in_onnx_export())
+                    and self._snapping_possible()
+                ):
+                    _warn_snapped_deviation(key, std_is_zero, deviation, dataset_index, self.dataset_names)
             elif norm_mode is NormalizationMode.MIN_MAX:
                 min_ = _gather_and_broadcast(_materialize(buffer["min"]), dataset_index, batch_val)
                 max_ = _gather_and_broadcast(_materialize(buffer["max"]), dataset_index, batch_val)
                 assert not torch.isinf(min_).any(), _no_stats_error_str("min")
                 assert not torch.isinf(max_).any(), _no_stats_error_str("max")
-                batch[key] = (batch_val - min_) / (max_ - min_ + EPS)
+                # Snap a zero range (max == min: constant dim) to 1 — same blow-up class.
+                denom = max_ - min_
+                denom_is_zero = denom.abs() < EPS
+                denom = torch.where(denom_is_zero, torch.ones_like(denom), denom)
+                deviation = batch_val - min_
+                batch[key] = deviation / (denom + EPS)
                 # normalize to [-1, 1]
                 batch[key] = batch[key] * 2 - 1
+                if (
+                    not (torch.compiler.is_compiling() or torch.onnx.is_in_onnx_export())
+                    and self._snapping_possible()
+                ):
+                    _warn_snapped_deviation(key, denom_is_zero, deviation, dataset_index, self.dataset_names)
             else:
                 raise ValueError(norm_mode)
         return batch
@@ -402,6 +531,10 @@ class Unnormalize(nn.Module):
                 if not (torch.compiler.is_compiling() or torch.onnx.is_in_onnx_export()):
                     assert not torch.isinf(mean).any(), _no_stats_error_str("mean")
                     assert not torch.isinf(std).any(), _no_stats_error_str("std")
+                # Mirror Normalize's guard so Unnormalize(Normalize(x)) round-trips on a snapped
+                # dim: with std=1 the inverse x*(1+EPS)+mean recovers the deviation; the legacy
+                # x*EPS+mean would collapse it to ~mean. std >= EPS dims stay bit-identical.
+                std = torch.where(std.abs() < EPS, torch.ones_like(std), std)
                 batch[key] = batch_val * (std + EPS) + mean
             elif norm_mode is NormalizationMode.MIN_MAX:
                 min_ = _gather_and_broadcast(_materialize(buffer["min"]), dataset_index, batch_val)
@@ -409,8 +542,11 @@ class Unnormalize(nn.Module):
                 if not (torch.compiler.is_compiling() or torch.onnx.is_in_onnx_export()):
                     assert not torch.isinf(min_).any(), _no_stats_error_str("min")
                     assert not torch.isinf(max_).any(), _no_stats_error_str("max")
+                # Snap a zero range to 1 to mirror Normalize (keeps the round-trip exact).
+                denom = max_ - min_
+                denom = torch.where(denom.abs() < EPS, torch.ones_like(denom), denom)
                 batch[key] = (batch_val + 1) / 2
-                batch[key] = batch[key] * (max_ - min_ + EPS) + min_
+                batch[key] = batch[key] * (denom + EPS) + min_
             else:
                 raise ValueError(norm_mode)
         return batch

--- a/src/opentau/policies/normalize.py
+++ b/src/opentau/policies/normalize.py
@@ -40,9 +40,10 @@ EPS = 1e-8  # Small epsilon value for numerical stability in normalization
 # right, every value equals the mean, the deviation is 0, and the snap is a no-op.
 _SNAP_WARN_TOL = 1e-2  # raw-unit |value - mean| above this at a snapped dim => real deviation => warn.
 
-# ``(feature_key, dim)`` offenders already warned about, so each fires once per process
+# ``(feature_key, dim)`` snap offender -> the largest raw deviation already warned about, so a
+# pair is warned the first time it snaps and again only when a strictly larger deviation appears
 # (mirrors ``_WARNED_OUTLIER_KEYS`` in the pi07_paligemma policy).
-_WARNED_SNAP_KEYS: set[tuple[str, int]] = set()
+_WARNED_SNAP_KEYS: dict[tuple[str, int], float] = {}
 
 
 def _warn_snapped_deviation(
@@ -52,7 +53,7 @@ def _warn_snapped_deviation(
     dataset_index: Tensor,
     dataset_names: list[str] | None,
 ) -> None:
-    """Loudly warn (once per ``(key, dim)``) when the zero-variance guard changed the result.
+    """Loudly warn when the zero-variance guard changed the result (a real deviation).
 
     The guard snaps a ``std`` (or ``max - min``) of ~0 to 1. That only changes the output when
     the input *deviates* from the dim's constant ``mean`` (resp. ``min``): a genuinely-constant
@@ -75,23 +76,29 @@ def _warn_snapped_deviation(
     trigger = zero_var_mask & (deviation.abs() > _SNAP_WARN_TOL)
     if not bool(trigger.any()):
         return
-    # Collapse every axis except the trailing feature axis to get per-dim offenders. The
-    # inserted-axis count is data-dependent (see ``_gather_and_broadcast``), so a computed
-    # dim tuple is clearer here than a fixed einops pattern.
-    feat_axes = tuple(range(trigger.ndim - 1))
-    per_dim = trigger.any(dim=feat_axes) if feat_axes else trigger
-    dims = torch.nonzero(per_dim, as_tuple=False).flatten().tolist()
-    fresh = [d for d in dims if (key, d) not in _WARNED_SNAP_KEYS]
+    # Per-dim max deviation magnitude. The inserted-axis count is data-dependent (see
+    # ``_gather_and_broadcast``), so a computed dim tuple is clearer than a fixed einops pattern.
+    magnitude = deviation.abs() * trigger
+    feat_axes = tuple(range(magnitude.ndim - 1))
+    per_dim_mag = magnitude.amax(dim=feat_axes) if feat_axes else magnitude  # (dim,)
+    dims = torch.nonzero(per_dim_mag > 0, as_tuple=False).flatten().tolist()
+    # Warn a (feature, dim) the first time it snaps and again only when its deviation exceeds
+    # the largest already warned for it.
+    fresh = []
+    for d in dims:
+        val = float(per_dim_mag[d])
+        prev = _WARNED_SNAP_KEYS.get((key, d))
+        if prev is None or val > prev:
+            _WARNED_SNAP_KEYS[(key, d)] = val
+            fresh.append(d)
     if not fresh:
         return
-    for d in fresh:
-        _WARNED_SNAP_KEYS.add((key, d))
-    # Provenance: the sample with the largest deviation among the triggers.
-    magnitude = deviation.abs() * trigger
-    sample_axes = tuple(range(1, magnitude.ndim))
-    per_sample = magnitude.amax(dim=sample_axes) if sample_axes else magnitude
-    worst_sample = int(torch.argmax(per_sample))
-    worst_val = float(magnitude.max())
+    # Provenance: the worst fresh dim and the sample carrying the largest deviation there.
+    worst_d = max(fresh, key=lambda d: float(per_dim_mag[d]))
+    worst_val = float(per_dim_mag[worst_d])
+    col = magnitude.select(-1, worst_d)
+    sample_axes = tuple(range(1, col.ndim))
+    worst_sample = int(torch.argmax(col.amax(dim=sample_axes) if sample_axes else col))
     ds = None
     if dataset_names is not None:
         idx = int(dataset_index[worst_sample])
@@ -102,7 +109,7 @@ def _warn_snapped_deviation(
         "deviates from the constant by up to %.3g (raw units, dataset=%s). std was snapped to 1 "
         "so only the mean is subtracted (no ~1e8 blow-up), but this almost always means stale "
         "normalization stats or a value zeroed upstream — inspect this feature's stats. "
-        "Repeats for these (feature,dim) pairs are suppressed.",
+        "Re-warned only when a (feature,dim) pair's deviation exceeds its last warned value.",
         key,
         fresh,
         worst_val,

--- a/src/opentau/policies/normalize.py
+++ b/src/opentau/policies/normalize.py
@@ -38,7 +38,12 @@ EPS = 1e-8  # Small epsilon value for numerical stability in normalization
 # that *deviates* from that "constant" can't divide by ~EPS and blow up to ~1e8 (the
 # "Outlier normalized state" failure). When the dim is truly constant and its stats are
 # right, every value equals the mean, the deviation is 0, and the snap is a no-op.
-_SNAP_WARN_TOL = 1e-2  # raw-unit |value - mean| above this at a snapped dim => real deviation => warn.
+#
+# ``_SNAP_WARN_TOL`` is the raw-unit |value - mean| above which a snapped dim counts as a real
+# deviation worth warning about. Set it <= 0 to disable the snap warning (and skip its per-step
+# host sync) entirely — mirroring the pi07_paligemma outlier warning's ``threshold <= 0``
+# off-switch. The snap itself always runs, so disabling the warning never weakens the guard.
+_SNAP_WARN_TOL = 1e-2
 
 # ``(feature_key, dim)`` snap offender -> the largest raw deviation already warned about, so a
 # pair is warned the first time it snaps and again only when a strictly larger deviation appears
@@ -381,9 +386,14 @@ class Normalize(nn.Module):
     def _snapping_possible(self) -> bool:
         """Whether any stat buffer has a zero-variance dim, so the guard could ever snap.
 
-        Cached after the first call. Lets ``forward`` skip the per-step deviation check
+        Cached after the first ``forward``. Lets ``forward`` skip the per-step deviation check
         (and its host sync) entirely on the common healthy path where no dim is constant —
         only a model that actually has a constant dim pays for the warning bookkeeping.
+
+        The cache assumes stats are finalized before the first ``forward`` (OpenTau's
+        load-then-train order); a zero-variance dim introduced by a *later* ``_inject_stats`` /
+        ``load_state_dict`` would not flip the cached value. That only affects the warning — the
+        snap itself runs unconditionally every ``forward``, so numerical safety never depends on it.
         """
         cached = getattr(self, "_snap_active", None)
         if cached is not None:
@@ -446,11 +456,13 @@ class Normalize(nn.Module):
                 std = torch.where(std_is_zero, torch.ones_like(std), std)
                 deviation = batch_val - mean
                 batch[key] = deviation / (std + EPS)
-                # Loud, once-per-(feature,dim) warning, but only when the snap actually changed
-                # the output (a real deviation from a "constant" dim). Short-circuits before the
-                # precheck under compile/ONNX so neither adds a data-dependent op to the trace.
+                # Loud warning (deduped per (feature,dim), re-fired on a larger deviation), but
+                # only when the snap actually changed the output (a real deviation from a
+                # "constant" dim). The _SNAP_WARN_TOL>0 / compile / ONNX checks short-circuit before
+                # the precheck so a disabled or traced forward adds no data-dependent op / sync.
                 if (
-                    not (torch.compiler.is_compiling() or torch.onnx.is_in_onnx_export())
+                    _SNAP_WARN_TOL > 0
+                    and not (torch.compiler.is_compiling() or torch.onnx.is_in_onnx_export())
                     and self._snapping_possible()
                 ):
                     _warn_snapped_deviation(key, std_is_zero, deviation, dataset_index, self.dataset_names)
@@ -468,7 +480,8 @@ class Normalize(nn.Module):
                 # normalize to [-1, 1]
                 batch[key] = batch[key] * 2 - 1
                 if (
-                    not (torch.compiler.is_compiling() or torch.onnx.is_in_onnx_export())
+                    _SNAP_WARN_TOL > 0
+                    and not (torch.compiler.is_compiling() or torch.onnx.is_in_onnx_export())
                     and self._snapping_possible()
                 ):
                     _warn_snapped_deviation(key, denom_is_zero, deviation, dataset_index, self.dataset_names)

--- a/src/opentau/policies/pi07_paligemma/low_level/configuration_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/configuration_pi07_low_level.py
@@ -175,7 +175,7 @@ class PI07PaligemmaLowLevelConfig(PreTrainedConfig):
     # source/episode/frame when those batch fields are present, to point at the
     # dataset/frame to inspect. Set to 0.0 (or negative) to disable entirely and
     # skip the per-step device sync.
-    warn_outlier_threshold: float = 10.0
+    warn_outlier_threshold: float = 32.0
 
     @property
     def obs_buffer_size(self) -> int:

--- a/src/opentau/policies/pi07_paligemma/low_level/configuration_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/configuration_pi07_low_level.py
@@ -174,7 +174,10 @@ class PI07PaligemmaLowLevelConfig(PreTrainedConfig):
     # constant dim) or corrupt data. The warning names the offending
     # source/episode/frame when those batch fields are present, to point at the
     # dataset/frame to inspect. Set to 0.0 (or negative) to disable entirely and
-    # skip the per-step device sync.
+    # skip the per-step device sync. The default 32 is deliberately permissive: the failure it
+    # targets drives normalized values to ~1e8, so 32 flags those by a wide margin while
+    # tolerating benign large-but-finite dims (the zero-variance guard and pad-aware masking
+    # already remove the common false positives).
     warn_outlier_threshold: float = 32.0
 
     @property

--- a/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
@@ -290,12 +290,12 @@ def pad_discrete_tokens(tokens: list[list[int]], max_length: int) -> tuple[np.nd
     return np.array(discrete_action_tokens), np.array(discrete_action_masks)
 
 
-# Process-local set of ``(source, key, dim)`` outlier offenders already warned
-# about, so ``_warn_state_action_outliers`` fires at most once per offender per
-# run instead of every training step. Under DDP each rank keeps its own set and
-# logs its own first occurrence (no cross-rank coordination — keeps the helper
-# rule-5 safe). Tests clear this between cases.
-_WARNED_OUTLIER_KEYS: set[tuple[object, str, int]] = set()
+# Process-local map of ``(source, key, dim)`` outlier offender -> the largest normalized
+# |value| already warned about. A pair is warned the first time it exceeds ``threshold`` and
+# again only when a strictly larger magnitude appears, so a dim that keeps getting worse is
+# resurfaced while a steady offender doesn't spam every step. Under DDP each rank keeps its own
+# map (no cross-rank coordination — keeps the helper rule-5 safe). Tests clear this between cases.
+_WARNED_OUTLIER_KEYS: dict[tuple[object, str, int], float] = {}
 
 
 def _attended_steps_mask(key: str, t: Tensor, batch: dict[str, Tensor]) -> Tensor | None:
@@ -337,7 +337,8 @@ def _warn_state_action_outliers(batch: dict[str, Tensor], threshold: float | Non
     dataset/frame to inspect.
 
     To avoid drowning the log when a dim is persistently out of range, each
-    ``(source, key, dim)`` offender is warned about at most once per process
+    ``(source, key, dim)`` offender is warned the first time it exceeds
+    ``threshold`` and again only when a strictly larger magnitude appears
     (tracked in ``_WARNED_OUTLIER_KEYS``); a fresh offender later in the run
     still gets its own line.
 
@@ -400,28 +401,36 @@ def _warn_state_action_outliers(batch: dict[str, Tensor], threshold: float | Non
             continue
         # Index on CPU once so the per-offender lookups below don't each sync.
         pdm = per_dim_max.detach().cpu()
-        # Keep only offenders not yet warned about, deduped per (source, key, dim).
-        fresh = []
+        # Aggregate to the worst |value| per (source, key, dim) in this batch (a batch can hold
+        # several samples from the same source/dim), then warn a pair the first time it trips and
+        # again only when its magnitude exceeds the largest already warned for it.
+        worst_per_tup: dict[tuple[object, str, int], tuple[float, int]] = {}
         for s_i, d in coords:
             tup = (_per_sample(src, s_i), key, d)
-            if tup not in _WARNED_OUTLIER_KEYS:
-                _WARNED_OUTLIER_KEYS.add(tup)
-                fresh.append((s_i, d))
+            val = pdm[s_i, d].item()
+            if tup not in worst_per_tup or val > worst_per_tup[tup][0]:
+                worst_per_tup[tup] = (val, s_i)
+        fresh = []  # (sample_idx, dim, value) — newly-seen or worsened offenders
+        for tup, (val, s_i) in worst_per_tup.items():
+            prev = _WARNED_OUTLIER_KEYS.get(tup)
+            if prev is None or val > prev:
+                _WARNED_OUTLIER_KEYS[tup] = val
+                fresh.append((s_i, tup[2], val))
         if not fresh:
             continue
-        # Report the worst (largest |value|) among the newly-seen offenders.
-        worst_s, worst_d = max(fresh, key=lambda sd: pdm[sd[0], sd[1]].item())
-        fresh_dims = sorted({d for _, d in fresh})
+        # Report the worst (largest |value|) among the new/worsened offenders.
+        worst_s, worst_d, worst_val = max(fresh, key=lambda x: x[2])
+        fresh_dims = sorted({d for _, d, _ in fresh})
         logging.warning(
-            "Outlier normalized %s: %d new (source,dim) offender(s) exceed |%.1f|; "
-            "new dims=%s; worst dim=%d max=%.2f (source=%s episode=%s frame=%s). "
-            "Repeat warnings for these (source,dim) pairs are suppressed.",
+            "Outlier normalized %s: %d new/worsened (source,dim) offender(s) exceed |%.1f|; "
+            "dims=%s; worst dim=%d max=%.2f (source=%s episode=%s frame=%s). "
+            "Re-warned only when a (source,dim) pair's magnitude exceeds its last warned value.",
             key,
             len(fresh),
             threshold,
             fresh_dims,
             worst_d,
-            float(pdm[worst_s, worst_d]),
+            worst_val,
             _per_sample(src, worst_s),
             _per_sample(ep, worst_s),
             _per_sample(fr, worst_s),

--- a/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
@@ -301,20 +301,25 @@ _WARNED_OUTLIER_KEYS: dict[tuple[object, str, int], float] = {}
 def _attended_steps_mask(key: str, t: Tensor, batch: dict[str, Tensor]) -> Tensor | None:
     """``(B, T)`` bool of timesteps the model attends to for ``key``, or ``None`` to scan all.
 
-    Mirrors :meth:`_build_prefix_items`: ``state`` keeps the current (last) frame even when
-    ``obs_history_is_pad`` marks everything padded (the ``history_state_drop`` case, where the
-    masked history is zeroed *after* normalization downstream); ``actions`` follows
-    ``action_is_pad``. Returns ``None`` for a 2-D tensor or a missing / shape-mismatched mask,
-    so the legacy "scan every timestep" behaviour — and every existing caller/test — is
-    unchanged.
+    Mirrors :meth:`_build_prefix_items`. For ``state`` the current (last) frame is always
+    attended — including when ``obs_history_is_pad`` marks everything padded (the
+    ``history_state_drop`` case, where the masked history is zeroed *after* normalization
+    downstream) and when the mask is *absent*, where the model attends the last frame only
+    (``state_mask = zeros; [:, -1] = True``). ``actions`` follows ``action_is_pad``. Returns
+    ``None`` (scan every timestep) for a 2-D tensor, a shape-mismatched mask, or ``actions``
+    without ``action_is_pad`` — keeping every existing caller/test unchanged.
     """
     if t.ndim < 3:
         return None
     if key == "state":
         pad = batch.get("obs_history_is_pad")
-        if pad is None or pad.ndim != 2 or pad.shape[1] != t.shape[1]:
-            return None
-        keep = ~pad.bool()
+        if pad is not None and (pad.ndim != 2 or pad.shape[1] != t.shape[1]):
+            return None  # shape mismatch -> scan all (back-compat; shouldn't happen in practice)
+        if pad is None:
+            # No mask: the model attends the current frame only, so the warning must too.
+            keep = torch.zeros(t.shape[0], t.shape[1], dtype=torch.bool, device=t.device)
+        else:
+            keep = ~pad.bool()
         keep[:, -1] = True  # the current frame is always attended
         return keep
     if key == "actions":

--- a/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
@@ -298,6 +298,33 @@ def pad_discrete_tokens(tokens: list[list[int]], max_length: int) -> tuple[np.nd
 _WARNED_OUTLIER_KEYS: set[tuple[object, str, int]] = set()
 
 
+def _attended_steps_mask(key: str, t: Tensor, batch: dict[str, Tensor]) -> Tensor | None:
+    """``(B, T)`` bool of timesteps the model attends to for ``key``, or ``None`` to scan all.
+
+    Mirrors :meth:`_build_prefix_items`: ``state`` keeps the current (last) frame even when
+    ``obs_history_is_pad`` marks everything padded (the ``history_state_drop`` case, where the
+    masked history is zeroed *after* normalization downstream); ``actions`` follows
+    ``action_is_pad``. Returns ``None`` for a 2-D tensor or a missing / shape-mismatched mask,
+    so the legacy "scan every timestep" behaviour — and every existing caller/test — is
+    unchanged.
+    """
+    if t.ndim < 3:
+        return None
+    if key == "state":
+        pad = batch.get("obs_history_is_pad")
+        if pad is None or pad.ndim != 2 or pad.shape[1] != t.shape[1]:
+            return None
+        keep = ~pad.bool()
+        keep[:, -1] = True  # the current frame is always attended
+        return keep
+    if key == "actions":
+        pad = batch.get("action_is_pad")
+        if pad is None or pad.ndim != 2 or pad.shape[1] != t.shape[1]:
+            return None
+        return ~pad.bool()
+    return None
+
+
 def _warn_state_action_outliers(batch: dict[str, Tensor], threshold: float | None) -> None:
     """Warn when a normalized state/action feature dim exceeds ``threshold``.
 
@@ -323,7 +350,10 @@ def _warn_state_action_outliers(batch: dict[str, Tensor], threshold: float | Non
     Args:
         batch: Training batch *after* input/target normalization. Reads
             ``state`` ``(B, [T,] D)`` and ``actions`` ``(B, chunk, D)``; the
-            zero-padded tail dims never trigger.
+            zero-padded tail dims never trigger. Timesteps the model does not
+            attend to (padded history via ``obs_history_is_pad`` / padded action
+            steps via ``action_is_pad``) are excluded so a masked-out frame can't
+            trip the check — the current state frame is always kept.
         threshold: Absolute-value ceiling. ``None`` or ``<= 0`` disables the
             check entirely (early return, no device sync).
     """
@@ -334,10 +364,16 @@ def _warn_state_action_outliers(batch: dict[str, Tensor], threshold: float | Non
         t = batch.get(key)
         if t is None:
             continue
-        # (B, [T|chunk,] D) -> (B, D): max |value| per feature dim. The
-        # ``b ... d`` pattern absorbs the optional middle axis (2-D state, 3-D
-        # state history, 3-D action chunk) in a single expression.
-        per_dim_max = reduce(t.detach().abs().float(), "b ... d -> b d", "max")
+        t = t.detach().abs().float()
+        # Ignore timesteps the model never attends to (padded history / padded action steps):
+        # zero them so a masked-out frame can't trip the warning. The current state frame is
+        # always kept (mirrors `_build_prefix_items`'s `state_mask[:, -1] = True`).
+        keep = _attended_steps_mask(key, t, batch)
+        if keep is not None:
+            t = t * rearrange(keep, "b t -> b t 1").to(t.dtype)
+        # (B, [T|chunk,] D) -> (B, D): max |value| per feature dim. The ``b ... d`` pattern
+        # absorbs the optional middle axis (2-D state, 3-D state history, 3-D action chunk).
+        per_dim_max = reduce(t, "b ... d -> b d", "max")
         per_key[key] = (per_dim_max, per_dim_max > threshold)
     if not per_key:
         return

--- a/tests/policies/test_normalize_per_dataset.py
+++ b/tests/policies/test_normalize_per_dataset.py
@@ -480,3 +480,21 @@ class TestSnapWarning:
             norm({"observation.state": torch.full((1, 4), 100.0)}, idx)  # large value, but std > 0
         assert not any("zero-variance guard" in r.getMessage() for r in caplog.records)
         assert norm._snapping_possible() is False
+
+    def test_rewarns_only_on_larger_deviation(self, caplog):
+        m = 0.761
+        norm = self._norm([0.0, 0.0, 0.0, m], [1.0, 1.0, 1.0, 0.0])
+        idx = torch.zeros(1, dtype=torch.long)
+        with caplog.at_level(logging.WARNING):
+            norm({"observation.state": torch.zeros(1, 4)}, idx)  # |0 - m| = m
+        assert sum("zero-variance guard" in r.getMessage() for r in caplog.records) == 1
+        caplog.clear()
+        bigger = torch.zeros(1, 4)
+        bigger[0, 3] = -10.0  # |-10 - m| ~ 10.76 > m -> re-warns
+        with caplog.at_level(logging.WARNING):
+            norm({"observation.state": bigger}, idx)
+        assert sum("zero-variance guard" in r.getMessage() for r in caplog.records) == 1
+        caplog.clear()
+        with caplog.at_level(logging.WARNING):
+            norm({"observation.state": torch.zeros(1, 4)}, idx)  # |dev|=m < 10.76 -> suppressed
+        assert not any("zero-variance guard" in r.getMessage() for r in caplog.records)

--- a/tests/policies/test_normalize_per_dataset.py
+++ b/tests/policies/test_normalize_per_dataset.py
@@ -424,6 +424,22 @@ class TestZeroVarianceGuard:
         rec = unnorm({"observation.state": z}, idx)["observation.state"]
         torch.testing.assert_close(rec, original, atol=1e-5, rtol=1e-4)
 
+    def test_min_max_zero_range_is_bounded_and_round_trips(self):
+        features = {"action": PolicyFeature(type=FeatureType.ACTION, shape=(4,))}
+        norm_map = {"ACTION": NormalizationMode.MIN_MAX}
+        c = 2.0  # dim 3 is constant: min == max == c (a zero range)
+        stats = [
+            {"action": {"min": torch.tensor([-1.0, -1.0, -1.0, c]), "max": torch.tensor([1.0, 1.0, 1.0, c])}}
+        ]
+        norm = Normalize(features, norm_map, per_dataset_stats=stats)
+        unnorm = Unnormalize(features, norm_map, per_dataset_stats=stats)
+        idx = torch.zeros(1, dtype=torch.long)
+        x = torch.tensor([[0.0, 0.0, 0.0, 5.0]])  # dim 3 = 5 deviates from the constant c
+        z = norm({"action": x}, idx)["action"]
+        assert z[0, 3].abs().item() < 100.0  # bounded; without the snap ~ (5 - 2)/EPS ~ 3e8
+        rec = unnorm({"action": z}, idx)["action"]
+        torch.testing.assert_close(rec, x, atol=1e-4, rtol=1e-4)
+
 
 class TestSnapWarning:
     """The guard warns loudly — but only when the snap actually changed the result
@@ -498,3 +514,23 @@ class TestSnapWarning:
         with caplog.at_level(logging.WARNING):
             norm({"observation.state": torch.zeros(1, 4)}, idx)  # |dev|=m < 10.76 -> suppressed
         assert not any("zero-variance guard" in r.getMessage() for r in caplog.records)
+
+    def test_min_max_zero_range_warns_on_deviation(self, caplog):
+        features = {"action": PolicyFeature(type=FeatureType.ACTION, shape=(4,))}
+        norm_map = {"ACTION": NormalizationMode.MIN_MAX}
+        c = 2.0
+        stats = [
+            {"action": {"min": torch.tensor([-1.0, -1.0, -1.0, c]), "max": torch.tensor([1.0, 1.0, 1.0, c])}}
+        ]
+        norm = Normalize(features, norm_map, per_dataset_stats=stats)
+        idx = torch.zeros(1, dtype=torch.long)
+        # value == min == max -> no deviation -> silent
+        with caplog.at_level(logging.WARNING):
+            norm({"action": torch.tensor([[0.0, 0.0, 0.0, c]])}, idx)
+        assert not any("zero-variance guard" in r.getMessage() for r in caplog.records)
+        caplog.clear()
+        # deviating value at the zero-range dim -> warns naming dim 3
+        with caplog.at_level(logging.WARNING):
+            norm({"action": torch.tensor([[0.0, 0.0, 0.0, 5.0]])}, idx)
+        msgs = [r.getMessage() for r in caplog.records if "zero-variance guard" in r.getMessage()]
+        assert len(msgs) == 1 and "dim(s)=[3]" in msgs[0] and "action" in msgs[0]

--- a/tests/policies/test_normalize_per_dataset.py
+++ b/tests/policies/test_normalize_per_dataset.py
@@ -7,11 +7,13 @@
 
 """Per-dataset Normalize / Unnormalize: stacked buffers indexed per sample."""
 
+import logging
+
 import pytest
 import torch
 
 from opentau.configs.types import FeatureType, NormalizationMode, PolicyFeature
-from opentau.policies.normalize import EPS, Normalize, Unnormalize
+from opentau.policies.normalize import _WARNED_SNAP_KEYS, EPS, Normalize, Unnormalize
 
 
 def _build_per_dataset_stats(num_datasets: int) -> list[dict[str, dict[str, torch.Tensor]]]:
@@ -358,3 +360,123 @@ class TestResolveDatasetIndex:
         )
         with pytest.raises(KeyError, match="requires one of"):
             policy._resolve_dataset_index({"observation.state": torch.zeros(1, 2)})
+
+
+# -- zero-variance guard ----------------------------------------------------
+
+
+class TestZeroVarianceGuard:
+    """The std-snap guard keeps a value deviating from a constant (std=0) dim finite,
+    stays bit-identical for std>0 dims, and preserves the Normalize/Unnormalize round-trip."""
+
+    features = {"observation.state": PolicyFeature(type=FeatureType.STATE, shape=(4,))}
+    norm_map = {"STATE": NormalizationMode.MEAN_STD}
+
+    @staticmethod
+    def _stats(mean, std):
+        return [{"observation.state": {"mean": torch.tensor(mean), "std": torch.tensor(std)}}]
+
+    def test_deviating_value_is_bounded_not_exploded(self):
+        m = 0.761
+        norm = Normalize(
+            self.features,
+            self.norm_map,
+            per_dataset_stats=self._stats([0.0, 0.0, 0.0, m], [1.0, 1.0, 1.0, 0.0]),
+        )
+        idx = torch.zeros(1, dtype=torch.long)
+        # dim 3 is "constant" (std=0) but the fed value is 0 — i.e. it deviates from mean=m.
+        out = norm({"observation.state": torch.zeros(1, 4)}, idx)["observation.state"]
+        # Snapped: (0 - m)/(1+EPS) ~ -m, bounded. Without the guard it would be -m/EPS ~ -7.6e7.
+        torch.testing.assert_close(out[0, 3], torch.tensor(-m), atol=1e-3, rtol=0.0)
+        assert out[0, 3].abs().item() < 1.0
+        torch.testing.assert_close(out[0, :3], torch.zeros(3))
+
+    def test_matching_value_normalizes_to_zero(self):
+        m = 0.761
+        norm = Normalize(
+            self.features,
+            self.norm_map,
+            per_dataset_stats=self._stats([0.0, 0.0, 0.0, m], [1.0, 1.0, 1.0, 0.0]),
+        )
+        idx = torch.zeros(1, dtype=torch.long)
+        # The dim is genuinely constant: the fed value equals the mean -> maps to 0 (snap is a no-op).
+        out = norm({"observation.state": torch.tensor([[0.0, 0.0, 0.0, m]])}, idx)["observation.state"]
+        torch.testing.assert_close(out[0, 3], torch.tensor(0.0), atol=1e-6, rtol=0.0)
+
+    def test_nonzero_std_is_bit_identical_to_legacy(self):
+        mean = [0.0, 1.0, 2.0, 3.0]
+        std = [1.0, 2.0, 3.0, 4.0]
+        norm = Normalize(self.features, self.norm_map, per_dataset_stats=self._stats(mean, std))
+        idx = torch.zeros(2, dtype=torch.long)
+        x = torch.randn(2, 4)
+        out = norm({"observation.state": x}, idx)["observation.state"]
+        legacy = (x - torch.tensor(mean)) / (torch.tensor(std) + EPS)
+        assert torch.equal(out, legacy)  # the guard is a strict no-op for std >= EPS
+
+    def test_unnormalize_round_trips_on_zero_std_dim(self):
+        m = 0.761
+        stats = self._stats([0.0, 1.0, 2.0, m], [1.0, 2.0, 3.0, 0.0])
+        norm = Normalize(self.features, self.norm_map, per_dataset_stats=stats)
+        unnorm = Unnormalize(self.features, self.norm_map, per_dataset_stats=stats)
+        idx = torch.zeros(1, dtype=torch.long)
+        original = torch.tensor([[1.0, 2.0, 3.0, 0.5]])  # dim 3 deviates from the "constant" m
+        z = norm({"observation.state": original}, idx)["observation.state"]
+        rec = unnorm({"observation.state": z}, idx)["observation.state"]
+        torch.testing.assert_close(rec, original, atol=1e-5, rtol=1e-4)
+
+
+class TestSnapWarning:
+    """The guard warns loudly — but only when the snap actually changed the result
+    (a value deviating from a dim the stats call constant). A truly-constant dim is silent."""
+
+    features = {"observation.state": PolicyFeature(type=FeatureType.STATE, shape=(4,))}
+    norm_map = {"STATE": NormalizationMode.MEAN_STD}
+
+    @pytest.fixture(autouse=True)
+    def _clear_snap_warned(self):
+        # The once-per-process dedup set is module-global; clear it around each case.
+        _WARNED_SNAP_KEYS.clear()
+        yield
+        _WARNED_SNAP_KEYS.clear()
+
+    def _norm(self, mean, std):
+        stats = [{"observation.state": {"mean": torch.tensor(mean), "std": torch.tensor(std)}}]
+        return Normalize(self.features, self.norm_map, per_dataset_stats=stats)
+
+    def test_silent_when_value_matches_constant(self, caplog):
+        m = 0.761
+        norm = self._norm([0.0, 0.0, 0.0, m], [1.0, 1.0, 1.0, 0.0])
+        idx = torch.zeros(1, dtype=torch.long)
+        with caplog.at_level(logging.WARNING):
+            norm({"observation.state": torch.tensor([[0.0, 0.0, 0.0, m]])}, idx)
+        assert not any("zero-variance guard" in r.getMessage() for r in caplog.records)
+
+    def test_warns_once_on_deviation(self, caplog):
+        m = 0.761
+        norm = self._norm([0.0, 0.0, 0.0, m], [1.0, 1.0, 1.0, 0.0])
+        idx = torch.zeros(1, dtype=torch.long)
+        with caplog.at_level(logging.WARNING):
+            norm({"observation.state": torch.zeros(1, 4)}, idx)  # dim 3 deviates from m
+        msgs = [r.getMessage() for r in caplog.records if "zero-variance guard" in r.getMessage()]
+        assert len(msgs) == 1
+        assert "observation.state" in msgs[0]
+        assert "dim(s)=[3]" in msgs[0]
+
+    def test_deduped_across_steps(self, caplog):
+        m = 0.761
+        norm = self._norm([0.0, 0.0, 0.0, m], [1.0, 1.0, 1.0, 0.0])
+        idx = torch.zeros(1, dtype=torch.long)
+        with caplog.at_level(logging.WARNING):
+            norm({"observation.state": torch.zeros(1, 4)}, idx)
+        caplog.clear()
+        with caplog.at_level(logging.WARNING):
+            norm({"observation.state": torch.zeros(1, 4)}, idx)  # same (feature,dim) offender again
+        assert not any("zero-variance guard" in r.getMessage() for r in caplog.records)
+
+    def test_silent_when_no_zero_variance_dim(self, caplog):
+        norm = self._norm([0.0, 1.0, 2.0, 3.0], [1.0, 2.0, 3.0, 4.0])
+        idx = torch.zeros(1, dtype=torch.long)
+        with caplog.at_level(logging.WARNING):
+            norm({"observation.state": torch.full((1, 4), 100.0)}, idx)  # large value, but std > 0
+        assert not any("zero-variance guard" in r.getMessage() for r in caplog.records)
+        assert norm._snapping_possible() is False

--- a/tests/policies/test_pi07_paligemma_outlier_warning.py
+++ b/tests/policies/test_pi07_paligemma_outlier_warning.py
@@ -134,3 +134,52 @@ class TestWarnStateActionOutliers:
         assert len(msgs) == 1
         assert "dims=[5]" in msgs[0]
         assert "dims=[3]" not in msgs[0]
+
+    # -- pad-awareness: only timesteps the model attends to can trip ------------
+
+    def test_masked_history_slot_does_not_warn(self, caplog):
+        # A huge value in a PADDED history slot must NOT warn (it's masked out of attention).
+        batch = {
+            "state": torch.zeros(2, 3, 8),
+            "obs_history_is_pad": torch.tensor([[True, True, False], [True, True, False]]),
+        }
+        batch["state"][1, 0, 5] = 1e6  # slot 0 is padded for sample 1
+        with caplog.at_level(logging.WARNING):
+            _warn_state_action_outliers(batch, 10.0)
+        assert not any("Outlier" in r.getMessage() for r in caplog.records)
+
+    def test_current_slot_warns_even_when_all_padded(self, caplog):
+        # history_state_drop marks every step padded, but the current (last) frame is always
+        # attended (state_mask[:, -1] = True) and must still be scanned.
+        batch = {
+            "state": torch.zeros(2, 3, 8),
+            "obs_history_is_pad": torch.ones(2, 3, dtype=torch.bool),
+        }
+        batch["state"][1, 2, 4] = 50.0  # current (last) slot for sample 1
+        with caplog.at_level(logging.WARNING):
+            _warn_state_action_outliers(batch, 10.0)
+        msgs = [r.getMessage() for r in caplog.records if "Outlier" in r.getMessage()]
+        assert any("state" in m and "dims=[4]" in m for m in msgs)
+
+    def test_unpadded_history_is_still_scanned(self, caplog):
+        # With a mask present but nothing padded, a real (non-padded) history slot still trips.
+        batch = {
+            "state": torch.zeros(2, 3, 8),
+            "obs_history_is_pad": torch.zeros(2, 3, dtype=torch.bool),
+        }
+        batch["state"][0, 1, 6] = 40.0  # a middle history slot, real (not padded)
+        with caplog.at_level(logging.WARNING):
+            _warn_state_action_outliers(batch, 10.0)
+        msgs = [r.getMessage() for r in caplog.records if "Outlier" in r.getMessage()]
+        assert any("state" in m and "dims=[6]" in m for m in msgs)
+
+    def test_padded_action_step_does_not_warn(self, caplog):
+        # A huge value in a PADDED action step (action_is_pad) must NOT warn.
+        batch = {
+            "actions": torch.zeros(2, 4, 8),
+            "action_is_pad": torch.tensor([[False, False, True, True], [False, False, True, True]]),
+        }
+        batch["actions"][0, 3, 2] = 99.0  # step 3 is padded
+        with caplog.at_level(logging.WARNING):
+            _warn_state_action_outliers(batch, 10.0)
+        assert not any("Outlier" in r.getMessage() for r in caplog.records)

--- a/tests/policies/test_pi07_paligemma_outlier_warning.py
+++ b/tests/policies/test_pi07_paligemma_outlier_warning.py
@@ -183,3 +183,23 @@ class TestWarnStateActionOutliers:
         with caplog.at_level(logging.WARNING):
             _warn_state_action_outliers(batch, 10.0)
         assert not any("Outlier" in r.getMessage() for r in caplog.records)
+
+    # -- re-warn on a larger magnitude, not just the first occurrence ------------
+
+    def test_rewarns_only_on_larger_magnitude(self, caplog):
+        batch = {"state": torch.zeros(2, 8), "actions": torch.zeros(2, 4, 8)}
+        batch["state"][1, 3] = 50.0
+        with caplog.at_level(logging.WARNING):
+            _warn_state_action_outliers(batch, 10.0)
+        assert sum("Outlier" in r.getMessage() for r in caplog.records) == 1
+        caplog.clear()
+        batch["state"][1, 3] = 120.0  # larger than the last warned (50) -> re-warns
+        with caplog.at_level(logging.WARNING):
+            _warn_state_action_outliers(batch, 10.0)
+        msgs = [r.getMessage() for r in caplog.records if "Outlier" in r.getMessage()]
+        assert len(msgs) == 1 and "max=120.00" in msgs[0]
+        caplog.clear()
+        batch["state"][1, 3] = 60.0  # smaller than the last warned (120) -> suppressed
+        with caplog.at_level(logging.WARNING):
+            _warn_state_action_outliers(batch, 10.0)
+        assert not any("Outlier" in r.getMessage() for r in caplog.records)

--- a/tests/policies/test_pi07_paligemma_outlier_warning.py
+++ b/tests/policies/test_pi07_paligemma_outlier_warning.py
@@ -203,3 +203,19 @@ class TestWarnStateActionOutliers:
         with caplog.at_level(logging.WARNING):
             _warn_state_action_outliers(batch, 10.0)
         assert not any("Outlier" in r.getMessage() for r in caplog.records)
+
+    def test_no_mask_3d_state_scans_current_frame_only(self, caplog):
+        # With no obs_history_is_pad, the model attends the current (last) frame only, so a value
+        # in a non-current history slot is not scanned, while one in the current frame still warns.
+        batch = {"state": torch.zeros(2, 3, 8)}
+        batch["state"][0, 0, 4] = 1e6  # history slot 0 (not current), no pad mask
+        with caplog.at_level(logging.WARNING):
+            _warn_state_action_outliers(batch, 10.0)
+        assert not any("Outlier" in r.getMessage() for r in caplog.records)
+        caplog.clear()
+        batch["state"][0, 0, 4] = 0.0
+        batch["state"][1, 2, 6] = 40.0  # current (last) slot -> still warns
+        with caplog.at_level(logging.WARNING):
+            _warn_state_action_outliers(batch, 10.0)
+        msgs = [r.getMessage() for r in caplog.records if "Outlier" in r.getMessage()]
+        assert any("state" in m and "dims=[6]" in m for m in msgs)


### PR DESCRIPTION
## What this does

A defensive **zero-variance guard** in the shared `Normalize`/`Unnormalize` (`src/opentau/policies/normalize.py`): when a feature dim's `std` (MEAN_STD) or `max - min` range (MIN_MAX) is ~0 (`|·| < EPS`), snap it to 1 so a value that *deviates* from that "constant" dim normalizes to a bounded `(x - mean)` instead of dividing by `~EPS` and exploding to ~1e8 (the "Outlier normalized state" blow-up). Dims with `std >= EPS` are **bit-identical** to before; the snap is mirrored in `Unnormalize` so `Unnormalize(Normalize(x))` round-trips exactly on a snapped dim.

The guard **warns loudly, but only when the snap actually changes the result** — i.e. when a value really deviates from a dim the stats call constant (stale stats / a value zeroed upstream). A genuinely-constant dim with correct stats maps to `0` and stays silent. The per-step deviation check is gated behind a one-time cached precheck, so models with no constant dims pay nothing on the hot path.

Separately, makes pi07_paligemma's `_warn_state_action_outliers` **pad-aware**: it ignores timesteps the model doesn't attend to (padded history via `obs_history_is_pad`, padded action steps via `action_is_pad`), always keeping the current state frame, so a masked-out frame can't trip the warning. Falls back to scanning all timesteps when no mask is present (back-compatible).

Both warnings **re-fire when a dim's magnitude exceeds the largest already warned for it** (instead of suppressing every repeat after the first), so a steadily-worsening dim is resurfaced — while a steady offender at equal/smaller magnitude still doesn't spam each step. The pi07_paligemma outlier-warning default ceiling (`warn_outlier_threshold`) is also loosened from `10` to `32`: it targets gross ~1e8 blow-ups, so a higher ceiling avoids tripping on benign large-but-finite normalized dims.

🐛 Bug

## How it was tested

- Added `TestZeroVarianceGuard` + `TestSnapWarning` in `tests/policies/test_normalize_per_dataset.py`: a value deviating from a zero-std dim is bounded (`~ -mean`) not exploded; a matching value normalizes to `0`; `std >= EPS` dims are bit-identical to the legacy `(x - mean) / (std + EPS)`; `Unnormalize(Normalize(x))` round-trips on a zero-std dim; the snap warning fires on a real deviation, stays silent when the value matches the constant or no constant dim exists, and re-fires only when the deviation exceeds the last warned magnitude.
- Added pad-awareness + re-warn cases in `tests/policies/test_pi07_paligemma_outlier_warning.py`: a huge value in a masked history slot does not warn; the current (last) frame still warns even when all history is marked padded; real (unpadded) history is still scanned; a padded action step does not warn; a larger magnitude re-warns while an equal/smaller one is suppressed.
- `pre-commit run` clean; `pytest -m "not gpu" -n auto` over the affected files → **160 passed** (plus the pi07_paligemma CPU suite green after the threshold change).
- `pytest -m "gpu" -n 0 tests/policies/test_pi07_paligemma_low_level.py` on a CUDA GPU → **1 passed, 1 skipped** (the full-pipeline test carries an unconditional `@pytest.mark.skip` for GPU memory; the runnable video-encoder masking test passed). Nightly regression runs via `regression_test.yml`.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/policies/test_normalize_per_dataset.py::TestZeroVarianceGuard tests/policies/test_normalize_per_dataset.py::TestSnapWarning
pytest -sx tests/policies/test_pi07_paligemma_outlier_warning.py
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [x] My PR includes policy-related changes.
  - [x] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.