### PR TITLE
Fix fake_tensor_training.py crash on torch 2.10 (FakeTensor .to swap)

### DIFF
--- a/src/opentau/scripts/fake_tensor_training.py
+++ b/src/opentau/scripts/fake_tensor_training.py
@@ -44,12 +44,18 @@ def main(args: Args):
     # ---------------------------------------------------------------
     # Everything inside this context will use FakeTensorMode
     with FakeTensorContext():
-        # Create a model in FakeTensorContext shouldn't cost real memory for model parameters.
+        # Build the layers directly on `device` rather than constructing on CPU and calling
+        # `.to(device)` afterwards. Modern torch routes Module.to() for FakeTensor params through
+        # torch.utils.swap_tensors, which rejects them ("Cannot swap t1 because it has weakref
+        # associated with it") — and it hardcodes that swap path for FakeTensors, so the
+        # set_{overwrite,swap}_module_params_on_conversion flags can't avoid it. Creating the
+        # params on `device` inside FakeTensorMode keeps them symbolic, so the huge
+        # `large_hidden_dim` weights still cost no real memory.
         model = torch.nn.Sequential(
-            torch.nn.Linear(args.dim_in, args.large_hidden_dim),
-            torch.nn.Linear(args.large_hidden_dim, args.large_hidden_dim),
-            torch.nn.Linear(args.large_hidden_dim, args.dim_out),
-        ).to(device)
+            torch.nn.Linear(args.dim_in, args.large_hidden_dim, device=device),
+            torch.nn.Linear(args.large_hidden_dim, args.large_hidden_dim, device=device),
+            torch.nn.Linear(args.large_hidden_dim, args.dim_out, device=device),
+        )
         optimizer = torch.optim.SGD(model.parameters(), lr=0.001)
     # End of FakeTensorContext
     # ---------------------------------------------------------------

--- a/src/opentau/utils/monkey_patch.py
+++ b/src/opentau/utils/monkey_patch.py
@@ -134,12 +134,21 @@ def torch_full_patch():
 
 @_run_once_only
 def torch_fake_tensor_module_to_patch():
-    """Fix torch.nn.Module.to(device) behavior in FakeTensorMode.
+    """Prefer overwriting (not in-place updating) module params on `.to()` conversion.
 
-    Without this patch, Module.to(device) is a no-op in FakeTensorMode, leading
-    to device mismatch errors. This patch enables proper device conversion.
+    Historically this flag made ``Module.to(device)`` behave sensibly in FakeTensorMode
+    (see https://github.com/pytorch/pytorch/issues/119665). On modern torch (confirmed on
+    the locked 2.10) it is no longer sufficient: ``nn.Module._apply`` hardcodes the
+    ``torch.utils.swap_tensors`` path for any ``FakeTensor`` param
+    (``... or isinstance(param, FakeTensor)``), and ``swap_tensors`` rejects them because
+    ``FakeTensorMode`` tracks them with weakrefs — neither this flag nor
+    ``set_swap_module_params_on_conversion`` can steer around it. So the supported pattern
+    is to construct modules directly on the target device inside FakeTensorMode
+    (``nn.Linear(..., device=device)``) rather than building on CPU and calling
+    ``.to(device)`` afterwards.
 
-    See https://github.com/pytorch/pytorch/issues/119665 for more details.
+    The flag is retained as a harmless, defensive default (it is a no-op for FakeTensor
+    params); it only affects the now-unused ``Module._apply`` conversion path.
     """
     torch.__future__.set_overwrite_module_params_on_conversion(True)
 

--- a/tests/scripts/test_fake_tensor_training.py
+++ b/tests/scripts/test_fake_tensor_training.py
@@ -1,0 +1,55 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the fake_tensor_training.py diagnostic script.
+
+Run the script in a subprocess: ``FakeTensorContext`` installs process-global
+monkey patches (``torch.isinf``, ``FakeTensor.numpy``, ``Beta.__init__``, and the
+module-conversion flag) that are never undone, so exercising it in-process would
+leak that state into the rest of the pytest session.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "src" / "opentau" / "scripts" / "fake_tensor_training.py"
+
+
+@pytest.mark.slow
+def test_fake_tensor_training_runs_on_cpu():
+    """The no-allocation smoke should run end-to-end on CPU and exit cleanly.
+
+    Guards against torch API drift in ``nn.Module._apply`` / FakeTensor handling
+    (the swap-tensors regression this script hit on torch 2.10). ``--device=cpu``
+    is explicit because ``auto_torch_device()`` returns ``mps`` on Apple Silicon.
+    """
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--device=cpu"],
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\n\nstderr:\n{result.stderr}"
+    # Params must stay symbolic (no real allocation of the giant hidden dim) ...
+    assert "FakeTensor" in result.stdout
+    # ... and the symbolic training loop must reach the end.
+    assert "Symbolic mean loss" in result.stdout
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## What this does

`src/opentau/scripts/fake_tensor_training.py` crashed on the currently-locked torch (2.10.0), so the no-allocation training smoke it provides was unusable:

```
RuntimeError: Cannot swap t1 because it has weakref associated with it
RuntimeError: _apply(): Couldn't swap Linear.weight
```

Root cause: modern torch's `nn.Module._apply` hardcodes the `torch.utils.swap_tensors` path for `FakeTensor` parameters (`... or isinstance(param, FakeTensor)`), and `swap_tensors` rejects them because `FakeTensorMode` tracks them with weakrefs. The `set_overwrite_module_params_on_conversion` / `set_swap_module_params_on_conversion` flags can't steer around it, so the existing `torch_fake_tensor_module_to_patch()` no longer makes the post-hoc `.to(device)` work — and disabling the swap flag does **not** help.

Fix: build the `nn.Linear` layers directly on `device` inside the `FakeTensorContext` instead of constructing on CPU and calling `.to(device)`. The params are created as FakeTensors already on the target device — no swap, and the huge `large_hidden_dim` weights still cost no real memory. Only this one script uses `FakeTensorContext`, so nothing else is affected. (🐛 Bug)

## How it was tested

CPU-only, no network, no GPU:

```bash
uv run python src/opentau/scripts/fake_tensor_training.py --device=cpu
```

- Exits 0 and prints the FakeTensor params (size `1e9`, i.e. no real allocation), per-step `symbolic loss = zuf0..zuf4`, and the final `Symbolic mean loss: FloatTrueDiv(zuf0 + ... + zuf4, 5.0)`.
- Ran twice: the symbolic loss series is bit-identical. The "dummy numpy array" column differs run-to-run by design — that is the pre-existing `torch_fake_tensor_to_numpy_patch`, which returns `np.random.rand(...)`; unrelated to this change.
- `pre-commit run --files src/opentau/scripts/fake_tensor_training.py` passes (ruff lint + format, line-length, typos, license header, bandit).

Note: `auto_torch_device()` returns `mps` on Apple Silicon, so the repro uses explicit `--device=cpu`.

## How to checkout & try? (for the reviewer)

```bash
uv run python src/opentau/scripts/fake_tensor_training.py --device=cpu
```

Before this PR it raises `RuntimeError: _apply(): Couldn't swap Linear.weight`; after it, it prints the symbolic per-step losses and a final symbolic mean loss without raising.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
