### PR TITLE
feat(pi07_paligemma): per-(robot_type, control_mode) state/action projections

### DIFF
--- a/src/opentau/policies/layers.py
+++ b/src/opentau/policies/layers.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Reusable parametric layers shared across VLA policies.
+
+:class:`PerGroupLinear` is a drop-in replacement for ``nn.Linear`` that keeps an
+independent ``(weight, bias)`` per group and selects one row per sample with a
+``(B,)`` long index — the same per-sample group axis the stacked
+Normalize/Unnormalize stat buffers use (see :mod:`opentau.policies.normalize`).
+Its state_dict key names match ``nn.Linear`` exactly (``<name>.weight`` /
+``<name>.bias``) but carry a leading group axis, so the legacy single-group
+promotion shim (``unsqueeze(0)``-style, see
+``PreTrainedPolicy._promote_legacy_norm_buffers_in_state_dict``) applies to it.
+"""
+
+import math
+
+import einops
+import torch
+import torch.nn.functional as F  # noqa: N812
+from torch import Tensor, nn
+
+
+class PerGroupLinear(nn.Module):
+    """``nn.Linear`` with one independent ``(weight, bias)`` per group.
+
+    Args:
+        in_features: Size of each input sample.
+        out_features: Size of each output sample.
+        num_groups: Number of independent linear maps. ``1`` makes this
+            numerically identical to a plain ``nn.Linear`` — the forward takes
+            an ``F.linear`` fast path with the un-cast parameters, so its dtype
+            / autocast behavior matches a plain ``nn.Linear`` bit-for-bit.
+        bias: If ``True`` (default), adds a per-group learnable bias.
+
+    Shape:
+        - weight: ``(num_groups, out_features, in_features)``
+        - bias: ``(num_groups, out_features)``
+
+        These are an ``nn.Linear`` parameter with a leading group axis, which is
+        why the state_dict keys stay identical to ``nn.Linear`` (just one rank
+        higher). A legacy ``nn.Linear`` checkpoint promotes into a
+        ``num_groups=1`` ``PerGroupLinear`` by prepending that axis.
+
+    Forward:
+        ``forward(x, group_index=None)`` where ``x`` is ``(B, *, in_features)``
+        and ``group_index`` is a ``(B,)`` long tensor in ``[0, num_groups)``.
+        ``group_index=None`` routes every sample to group ``0`` (the
+        single-group default; used by direct-call unit tests and any caller
+        that has not threaded an index).
+    """
+
+    def __init__(self, in_features: int, out_features: int, num_groups: int, bias: bool = True):
+        super().__init__()
+        if num_groups < 1:
+            raise ValueError(f"num_groups must be >= 1, got {num_groups}.")
+        self.in_features = in_features
+        self.out_features = out_features
+        self.num_groups = num_groups
+        self.weight = nn.Parameter(torch.empty(num_groups, out_features, in_features))
+        if bias:
+            self.bias = nn.Parameter(torch.empty(num_groups, out_features))
+        else:
+            self.register_parameter("bias", None)
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        """Initialize every group exactly like ``nn.Linear.reset_parameters``.
+
+        Per-row kaiming-uniform weight (``a=sqrt(5)``) + fan-in-scaled uniform
+        bias, so a freshly built per-group module matches ``nn.Linear``'s init
+        distribution on each row.
+        """
+        for g in range(self.num_groups):
+            nn.init.kaiming_uniform_(self.weight[g], a=math.sqrt(5))
+            if self.bias is not None:
+                fan_in, _ = nn.init._calculate_fan_in_and_fan_out(self.weight[g])
+                bound = 1.0 / math.sqrt(fan_in) if fan_in > 0 else 0.0
+                nn.init.uniform_(self.bias[g], -bound, bound)
+
+    def forward(self, x: Tensor, group_index: Tensor | None = None) -> Tensor:
+        if self.num_groups == 1:
+            # Bit-identical to a plain nn.Linear: same op, same un-cast params,
+            # so the autocast / dtype promotion matches the pre-flag baseline.
+            bias = None if self.bias is None else self.bias[0]
+            return F.linear(x, self.weight[0], bias)
+
+        if group_index is None:
+            group_index = torch.zeros(x.shape[0], dtype=torch.long, device=x.device)
+
+        # Per-sample gather of the (out, in) map. `index_select` on a (B,) index
+        # is the same op normalize._gather_and_broadcast uses for the stacked
+        # stat buffers — ONNX/dynamo-traceable and collective-safe under FSDP
+        # (fixed shape regardless of which groups appear in the local batch).
+        # Cast to x's dtype so the matmul runs at the same precision the
+        # autocast baseline would (and works without an active autocast too).
+        weight = self.weight.index_select(0, group_index).to(dtype=x.dtype)  # (B, out, in)
+        out = einops.einsum(x, weight, "b ... i, b o i -> b ... o")
+        if self.bias is not None:
+            bias = self.bias.index_select(0, group_index).to(dtype=x.dtype)  # (B, out)
+            # Broadcast the per-sample bias across x's interior dims. Computed-
+            # rank reshape (not an einops pattern) because the number of
+            # interior dims is data-dependent — same rationale as
+            # normalize._gather_and_broadcast.
+            extra = out.ndim - bias.ndim
+            bias = bias.reshape(bias.shape[0], *((1,) * extra), bias.shape[-1])
+            out = out + bias
+        return out
+
+    def extra_repr(self) -> str:
+        return (
+            f"in_features={self.in_features}, out_features={self.out_features}, "
+            f"num_groups={self.num_groups}, bias={self.bias is not None}"
+        )

--- a/src/opentau/policies/pi07_paligemma/low_level/configuration_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/configuration_pi07_low_level.py
@@ -59,6 +59,9 @@ class PI07PaligemmaLowLevelConfig(PreTrainedConfig):
         prompt_max_length: Maximum length for tokenizer. Defaults to 256.
         discrete_action_max_length: Maximum length for discrete action tokens. Defaults to 32.
         proj_width: Width of the projection layer. Defaults to 1024.
+        per_group_projection: When True, use an independent state/action
+            projection per (robot_type, control_mode) group (shares the
+            normalization-head grouping). Defaults to False.
         dropout: Dropout rate. Defaults to 0.1.
         num_steps: Number of flow matching steps for decoding. Defaults to 10.
         attention_implementation: Attention implementation to use ("eager", "sdpa", or "fa2").
@@ -130,6 +133,22 @@ class PI07PaligemmaLowLevelConfig(PreTrainedConfig):
 
     # Projector
     proj_width: int = 1024
+
+    # When True, give the continuous STATE/ACTION projections (state_proj,
+    # action_in_proj, action_out_proj) an independent (weight, bias) per
+    # (robot_type, control_mode) group — the same grouping the stacked
+    # Normalize/Unnormalize heads use, selected per-sample by
+    # `_resolve_dataset_index`. The number of groups is len(dataset_names)
+    # (falls back to 1 when dataset_names is unset). time_mlp_in/out stay
+    # shared. Defaults to False: when off the three projections are plain
+    # nn.Linear and the model is byte-identical to the pre-flag version (same
+    # params, same state_dict keys, same numerics). Flipping it on changes the
+    # param count and the projection state_dict shapes (leading group axis);
+    # legacy single-group checkpoints are promoted + duplicated on load, and a
+    # group new to the checkpoint gets a fresh row copied from row 0. Loading a
+    # per-group checkpoint with this flag off raises rather than silently
+    # collapsing the group axis.
+    per_group_projection: bool = False
 
     # Dropout
     dropout: float = 0.1

--- a/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
@@ -468,14 +468,19 @@ class PI07PaligemmaLowLevelPolicy(PreTrainedPolicy):
         # Now manually load and remap the state dict
         acc = get_proc_accelerator()
         is_main_process = acc.is_main_process if acc else True
-        # When per-group projections are on, read the checkpoint's own group
-        # ordering (its `dataset_names`) so projection rows can be remapped by
-        # name onto this policy's (possibly superset / reordered) groups. The
-        # continue-training path passes the *new* cfg, so the old ordering must
-        # be read from the source config explicitly. Best-effort: a legacy /
-        # unreadable config leaves it None (handled as single-group / unknown).
+        # When per-group projections are on, reconcile projection rows by group
+        # name. The checkpoint's own group ordering is its `dataset_names`; seed
+        # with the already-loaded `config.dataset_names` — which on an inference
+        # / resume round-trip *is* the checkpoint's ordering — so a transient
+        # failure of the source-config read below doesn't turn a loadable
+        # same-group checkpoint into a hard ProjectionRemapError. The explicit
+        # read still recovers the true old ordering for the continue-training
+        # path, where the passed cfg carries the *new* (superset / reordered)
+        # groups.
         old_dataset_names: list[str] | None = None
         if getattr(config, "per_group_projection", False):
+            seeded = getattr(config, "dataset_names", None)
+            old_dataset_names = list(seeded) if seeded else None
             try:
                 source_config = PreTrainedConfig.from_pretrained(
                     pretrained_name_or_path=pretrained_name_or_path,
@@ -487,12 +492,12 @@ class PI07PaligemmaLowLevelPolicy(PreTrainedPolicy):
                     local_files_only=local_files_only,
                     revision=revision,
                 )
-                old_dataset_names = getattr(source_config, "dataset_names", None)
+                old_dataset_names = getattr(source_config, "dataset_names", None) or old_dataset_names
             except Exception as e:  # noqa: BLE001
                 if is_main_process:
                     logging.warning(
-                        "Could not read checkpoint dataset_names for per-group projection "
-                        "remap (%s); falling back to single-group / positional handling.",
+                        "Could not read checkpoint dataset_names for per-group projection remap "
+                        "(%s); falling back to the policy's current dataset_names ordering.",
                         e,
                     )
         # Populated inside the try block when skip_normalization_weights fires;

--- a/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
@@ -37,6 +37,7 @@ from transformers import AutoProcessor, AutoTokenizer
 
 from opentau.configs.policies import PreTrainedConfig
 from opentau.configs.types import NormalizationMode
+from opentau.policies.layers import PerGroupLinear
 from opentau.policies.normalize import Normalize, Unnormalize
 from opentau.policies.normalize import resolve_num_datasets as _num_datasets
 from opentau.policies.outlier_utils import detect_state_action_outliers
@@ -49,7 +50,7 @@ from opentau.policies.pi07.video_encoder import SpaceTimeSiglipVideoEncoder
 from opentau.policies.pi07_paligemma.low_level.configuration_pi07_low_level import (
     PI07PaligemmaLowLevelConfig,
 )
-from opentau.policies.pretrained import PreTrainedPolicy, T
+from opentau.policies.pretrained import PreTrainedPolicy, ProjectionRemapError, T
 from opentau.policies.utils import flow_matching_masked_mse
 from opentau.utils.accelerate_utils import get_proc_accelerator
 from opentau.utils.utils import get_safe_dtype
@@ -297,6 +298,16 @@ class PI07PaligemmaLowLevelPolicy(PreTrainedPolicy):
     config_class = PI07PaligemmaLowLevelConfig
     name = "pi07_paligemma_low_level"
 
+    # Per-(robot_type, control_mode) projections live on the inner
+    # `self.model` (PerGroupLinear when `config.per_group_projection`), so their
+    # state-dict keys are `model.<proj>.weight` / `.bias`. The load path uses
+    # these to reconcile a checkpoint's projection rows with the policy's groups.
+    _PER_GROUP_PROJECTION_PREFIXES = (
+        "model.state_proj.",
+        "model.action_in_proj.",
+        "model.action_out_proj.",
+    )
+
     def __init__(
         self,
         config: PI07PaligemmaLowLevelConfig,
@@ -353,7 +364,7 @@ class PI07PaligemmaLowLevelPolicy(PreTrainedPolicy):
         # Get vocab size from processor
         discrete_action_vocab_size = getattr(self.discrete_action_processor, "vocab_size", None)
         self.model = PI07PaligemmaLowLevelFlowMatching(
-            config, discrete_action_vocab_size=discrete_action_vocab_size
+            config, discrete_action_vocab_size=discrete_action_vocab_size, num_datasets=num_datasets
         )
 
         self.reset()
@@ -425,6 +436,33 @@ class PI07PaligemmaLowLevelPolicy(PreTrainedPolicy):
         # Now manually load and remap the state dict
         acc = get_proc_accelerator()
         is_main_process = acc.is_main_process if acc else True
+        # When per-group projections are on, read the checkpoint's own group
+        # ordering (its `dataset_names`) so projection rows can be remapped by
+        # name onto this policy's (possibly superset / reordered) groups. The
+        # continue-training path passes the *new* cfg, so the old ordering must
+        # be read from the source config explicitly. Best-effort: a legacy /
+        # unreadable config leaves it None (handled as single-group / unknown).
+        old_dataset_names: list[str] | None = None
+        if getattr(config, "per_group_projection", False):
+            try:
+                source_config = PreTrainedConfig.from_pretrained(
+                    pretrained_name_or_path=pretrained_name_or_path,
+                    force_download=force_download,
+                    resume_download=resume_download,
+                    proxies=proxies,
+                    token=token,
+                    cache_dir=cache_dir,
+                    local_files_only=local_files_only,
+                    revision=revision,
+                )
+                old_dataset_names = getattr(source_config, "dataset_names", None)
+            except Exception as e:  # noqa: BLE001
+                if is_main_process:
+                    logging.warning(
+                        "Could not read checkpoint dataset_names for per-group projection "
+                        "remap (%s); falling back to single-group / positional handling.",
+                        e,
+                    )
         # Populated inside the try block when skip_normalization_weights fires;
         # used outside the try/except to gate the inf-buffer guard so the
         # ValueError is not swallowed by the broad `except Exception` that
@@ -492,6 +530,13 @@ class PI07PaligemmaLowLevelPolicy(PreTrainedPolicy):
             # `(*feat_shape,)` to the new `(1, *feat_shape)` stacked layout so pre-PR
             # checkpoints load via `model.load_state_dict(...)`.
             model._promote_legacy_norm_buffers_in_state_dict(remapped_state_dict)
+            # Reconcile per-(robot_type, control_mode) projection rows with this
+            # policy's groups: tile a legacy single head to all groups, name-remap
+            # an existing multi-head onto the new ordering, etc. Raises
+            # ProjectionRemapError on an irreconcilable shape; re-raised below so
+            # the broad handler does not swallow it into a warning + broken model.
+            # No-op when the policy declares no per-group projection prefixes.
+            model._remap_per_group_projection_weights_in_state_dict(remapped_state_dict, old_dataset_names)
             missing_keys, unexpected_keys = model.load_state_dict(remapped_state_dict, strict=False)
 
             # Hide deliberately-stripped buffer keys from the missing-keys
@@ -517,6 +562,11 @@ class PI07PaligemmaLowLevelPolicy(PreTrainedPolicy):
             if not unintended_missing and not unexpected_keys and is_main_process:
                 logging.info("All keys loaded successfully!")
 
+        except ProjectionRemapError:
+            # Deliberate, fatal incompatibility (e.g. a per-group checkpoint
+            # loaded into a non-per-group policy) — must not be swallowed into a
+            # warning + silently-broken model by the broad handler below.
+            raise
         except Exception as e:
             if is_main_process:
                 logging.warning("Could not remap state dict keys: %s", e)
@@ -1025,6 +1075,7 @@ class PI07PaligemmaLowLevelPolicy(PreTrainedPolicy):
             action_prefix=action_prefix,
             delay=delay,
             noise=noise,
+            group_index=dataset_index,
         )
 
         # Unpad actions
@@ -1081,6 +1132,7 @@ class PI07PaligemmaLowLevelPolicy(PreTrainedPolicy):
             noise=noise,
             time=time,
             real_action_dim=batch.get("real_action_dim"),
+            group_index=dataset_index,
         )
 
         mse_loss = losses["MSE"]
@@ -1659,15 +1711,26 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
     └────────────────────────────────────────────────────────────┘
     """
 
-    def __init__(self, config: PI07PaligemmaLowLevelConfig, discrete_action_vocab_size: int | None = None):
+    def __init__(
+        self,
+        config: PI07PaligemmaLowLevelConfig,
+        discrete_action_vocab_size: int | None = None,
+        num_datasets: int = 1,
+    ):
         """Initializes the PI07PaligemmaLowLevelFlowMatching model.
 
         Args:
             config: Model configuration.
             discrete_action_vocab_size: Size of the discrete action vocabulary.
+            num_datasets: Number of (robot_type, control_mode) groups — the
+                leading dim of the stacked Normalize/Unnormalize buffers. Used
+                as the number of per-group projection heads when
+                ``config.per_group_projection`` is set, so the projection axis
+                stays in lockstep with the norm-head axis. Defaults to 1.
         """
         super().__init__()
         self.config = config
+        self.num_datasets = num_datasets
 
         paligemma_with_expert_config = PaliGemmaWithExpertConfig(
             freeze_vision_encoder=self.config.freeze_vision_encoder,
@@ -1689,11 +1752,23 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
         )
 
         vlm_hidden_size = self.paligemma_with_expert.config.paligemma_config.text_config.hidden_size
-        self.state_proj = nn.Linear(self.config.max_state_dim, vlm_hidden_size)
+
+        # Per-(robot_type, control_mode) state/action projections share the
+        # norm-head grouping: when `per_group_projection` is on, each of the
+        # three projections holds one (weight, bias) per group, selected
+        # per-sample by the same index that picks the norm head. When off they
+        # are plain nn.Linear, byte-identical to the pre-flag model. time_mlp_*
+        # stay shared either way.
+        def _make_proj(in_features: int, out_features: int) -> nn.Module:
+            if self.config.per_group_projection:
+                return PerGroupLinear(in_features, out_features, num_groups=self.num_datasets)
+            return nn.Linear(in_features, out_features)
+
+        self.state_proj = _make_proj(self.config.max_state_dim, vlm_hidden_size)
 
         # Projections are float32
-        self.action_in_proj = nn.Linear(self.config.max_action_dim, self.config.proj_width)
-        self.action_out_proj = nn.Linear(self.config.proj_width, self.config.max_action_dim)
+        self.action_in_proj = _make_proj(self.config.max_action_dim, self.config.proj_width)
+        self.action_out_proj = _make_proj(self.config.proj_width, self.config.max_action_dim)
 
         self.time_mlp_in = nn.Linear(self.config.proj_width, self.config.proj_width)
         self.time_mlp_out = nn.Linear(self.config.proj_width, self.config.proj_width)
@@ -1794,7 +1869,24 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
         )
         return run_image_tower
 
-    def _embed_item(self, item: ContextItem, *, run_image_tower: bool | None = None) -> tuple[Tensor, Tensor]:
+    @staticmethod
+    def _apply_proj(proj: nn.Module, x: Tensor, group_index: Tensor | None) -> Tensor:
+        """Call a projection that may be a plain ``nn.Linear`` or a ``PerGroupLinear``.
+
+        Keeps the call sites uniform: a ``PerGroupLinear`` additionally receives
+        the per-sample ``group_index``; any other callable (plain ``nn.Linear``,
+        or the 1-arg lambda / ``nn.Identity`` stubs the unit tests inject) is
+        called as ``proj(x)`` and ignores the index. The dispatch is on module
+        *type* (a construction-time, rank-invariant property), not on batch
+        data, so it fires no collective (CLAUDE.md rule 5).
+        """
+        if isinstance(proj, PerGroupLinear):
+            return proj(x, group_index)
+        return proj(x)
+
+    def _embed_item(
+        self, item: ContextItem, *, run_image_tower: bool | None = None, group_index: Tensor | None = None
+    ) -> tuple[Tensor, Tensor]:
         """Embed a single ``ContextItem`` and return ``(emb, expanded_pad_mask)``.
 
         Dispatches on ``item.item_type``:
@@ -1838,13 +1930,13 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
             emb = emb * math.sqrt(emb.shape[-1])
             return emb, item.pad_mask
         if t == "state":
-            emb = self.state_proj(item.data.to(dtype=_preferred_dtype()))
+            emb = self._apply_proj(self.state_proj, item.data.to(dtype=_preferred_dtype()), group_index)
             return emb, item.pad_mask
         if t == "discrete_action":
             emb = self.paligemma_with_expert.embed_discrete_actions(item.data)
             return emb.to(dtype=_preferred_dtype()), item.pad_mask
         if t == "action":
-            emb = self.action_in_proj(item.data.to(dtype=_preferred_dtype()))
+            emb = self._apply_proj(self.action_in_proj, item.data.to(dtype=_preferred_dtype()), group_index)
             return emb, item.pad_mask
         if t == "image":
             # Subgoal images: 4-D (B, C, H, W) in [-1, 1] through the VLM's
@@ -1924,7 +2016,9 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
             return [1] * length
         raise ValueError(f"Unknown attention mode: {mode!r}")
 
-    def embed_prefix(self, items: list[ContextItem]) -> tuple[Tensor, Tensor, Tensor, int]:
+    def embed_prefix(
+        self, items: list[ContextItem], group_index: Tensor | None = None
+    ) -> tuple[Tensor, Tensor, Tensor, int]:
         """Embed a layout-agnostic list of ``ContextItem``s into the prefix.
 
         The policy decides what blocks go into the prefix and in what
@@ -1957,7 +2051,7 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
         cross_att_running = 0
         cross_att_locked = False
         for item in items:
-            emb, mask = self._embed_item(item, run_image_tower=run_image_tower)
+            emb, mask = self._embed_item(item, run_image_tower=run_image_tower, group_index=group_index)
             length = emb.shape[1]
             embs.append(emb)
             pad_masks.append(mask)
@@ -1978,7 +2072,7 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
         return embs_cat, pad_masks_cat, att_masks, cross_att_running
 
     def embed_suffix(
-        self, items: list[ContextItem], timestep: Tensor
+        self, items: list[ContextItem], timestep: Tensor, group_index: Tensor | None = None
     ) -> tuple[Tensor, Tensor, Tensor, Tensor]:
         """Embed the action expert's suffix from a list of ``ContextItem``s.
 
@@ -2018,7 +2112,7 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
         att_masks_flat: list[int] = []
 
         for item in items:
-            emb, mask = self._embed_item(item)
+            emb, mask = self._embed_item(item, group_index=group_index)
             length = emb.shape[1]
             embs.append(emb)
             pad_masks.append(mask)
@@ -2042,6 +2136,7 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
         noise: Tensor | None = None,
         time: Tensor | None = None,
         real_action_dim: Tensor | None = None,
+        group_index: Tensor | None = None,
     ) -> dict[str, Tensor]:
         """Do a full training forward pass and compute the loss.
 
@@ -2063,7 +2158,7 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
             A dictionary containing the loss components ("MSE" and "CE").
         """
         prefix_embs, prefix_pad_masks, prefix_att_masks, num_cross_att_tokens = self.embed_prefix(
-            prefix_items
+            prefix_items, group_index=group_index
         )
 
         vlm_2d_attention_mask = make_att_2d_masks(prefix_pad_masks, prefix_att_masks)
@@ -2102,7 +2197,9 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
         u_t = noise - actions
 
         suffix_items = self._build_suffix_items(x_t)
-        suffix_embs, suffix_pad_masks, suffix_att_masks, adarms_cond = self.embed_suffix(suffix_items, time)
+        suffix_embs, suffix_pad_masks, suffix_att_masks, adarms_cond = self.embed_suffix(
+            suffix_items, time, group_index=group_index
+        )
 
         action_expert_2d_attention_mask = make_att_2d_masks(
             suffix_pad_masks,
@@ -2137,7 +2234,7 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
         # training target (chunk_size is the prediction horizon).
         suffix_out = suffix_out[:, -self.config.chunk_size :]
         # Original openpi code, upcast attention output
-        v_t = self.action_out_proj(suffix_out)
+        v_t = self._apply_proj(self.action_out_proj, suffix_out, group_index)
         v_t = v_t.to(dtype=torch.float32)
 
         # Shared masked-MSE reduction; see pi05 for the rationale.
@@ -2204,6 +2301,7 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
         action_prefix: Tensor,
         delay: Tensor,
         noise: Tensor | None = None,
+        group_index: Tensor | None = None,
     ) -> Tensor:
         """Do a full inference forward and compute the action.
 
@@ -2219,7 +2317,7 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
             The sampled action tensor.
         """
         prefix_embs, prefix_pad_masks, prefix_att_masks, num_cross_att_tokens = self.embed_prefix(
-            prefix_items
+            prefix_items, group_index=group_index
         )
         bsize = prefix_embs.shape[0]
         device = prefix_embs.device
@@ -2258,6 +2356,7 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
                 past_key_values,
                 x_t,
                 masked_time,
+                group_index=group_index,
             )
 
             # Euler step
@@ -2274,6 +2373,7 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
         past_key_values: list[dict[str, Tensor]],
         x_t: Tensor,
         time: Tensor,
+        group_index: Tensor | None = None,
     ) -> Tensor:
         """Apply one denoising step of the noise `x_t` at a given timestep.
 
@@ -2286,7 +2386,9 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
             The predicted velocity tensor (v_t).
         """
         suffix_items = self._build_suffix_items(x_t)
-        suffix_embs, suffix_pad_masks, suffix_att_masks, adarms_cond = self.embed_suffix(suffix_items, time)
+        suffix_embs, suffix_pad_masks, suffix_att_masks, adarms_cond = self.embed_suffix(
+            suffix_items, time, group_index=group_index
+        )
 
         num_cross_att_tokens = prefix_pad_masks.shape[1]
         action_expert_2d_attention_mask = make_att_2d_masks(
@@ -2314,6 +2416,6 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
         # n_action_steps (execution horizon) is applied later in select_action, not
         # at decode time.
         suffix_out = suffix_out[:, -self.config.chunk_size :]
-        v_t = self.action_out_proj(suffix_out)
+        v_t = self._apply_proj(self.action_out_proj, suffix_out, group_index)
         v_t = v_t.to(dtype=torch.float32)
         return v_t

--- a/src/opentau/policies/pretrained.py
+++ b/src/opentau/policies/pretrained.py
@@ -69,6 +69,16 @@ def is_norm_buffer_key(key: str) -> bool:
     return any(key.startswith(prefix) for prefix in NORM_BUFFER_PREFIXES)
 
 
+class ProjectionRemapError(ValueError):
+    """Raised when a per-(robot_type, control_mode) projection weight in a
+    checkpoint cannot be reconciled with the policy's current group set
+    (e.g. a per-group checkpoint loaded into a non-per-group policy, or a
+    multi-group source whose group ordering is unknown). Subclasses
+    ``ValueError`` so existing ``except ValueError`` handlers still catch it,
+    but is distinct so the load path can re-raise it past the broad
+    ``except Exception`` that otherwise swallows load errors into a warning."""
+
+
 DEFAULT_POLICY_CARD = """
 ---
 # For reference on model card metadata, see the spec: https://github.com/huggingface/hub-docs/blob/main/modelcard.md?plain=1
@@ -97,6 +107,15 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
 
     name: None
     """The name of the policy. Must be defined in subclasses."""
+
+    _PER_GROUP_PROJECTION_PREFIXES: tuple[str, ...] = ()
+    """State-dict key prefixes for per-(robot_type, control_mode) projection
+    weights (``PerGroupLinear``: ``<prefix>weight`` shaped ``(G, out, in)`` and
+    ``<prefix>bias`` shaped ``(G, out)``). Empty by default so policies without
+    per-group projections are untouched; a subclass that opts in sets the
+    prefixes of its grouped projections and the load path then reconciles a
+    checkpoint's projection rows with the policy's current group set via
+    :meth:`_remap_per_group_projection_weights_in_state_dict`."""
 
     def __init__(self, config: PreTrainedConfig, *inputs, **kwargs):
         """Initializes the PreTrainedPolicy.
@@ -654,6 +673,130 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
                 len(promoted),
                 promoted[:3],
             )
+
+    def _remap_per_group_projection_weights_in_state_dict(
+        self,
+        state_dict_to_load: dict,
+        old_dataset_names: list[str] | None,
+    ) -> None:
+        """Reconcile per-(robot_type, control_mode) projection weights with the
+        policy's current group set, in place.
+
+        Analogous to :meth:`_promote_legacy_norm_buffers_in_state_dict` but for
+        *learned* projection weights (``PerGroupLinear``), which must be
+        duplicated / name-remapped rather than recomputed. Only keys under
+        :attr:`_PER_GROUP_PROJECTION_PREFIXES` are touched, so policies that do
+        not declare any (the default) are unaffected.
+
+        For each matching ``*.weight`` / ``*.bias`` key, given the loaded tensor
+        and the in-memory target with ``D`` group rows and per-group trailing
+        shape ``feat``:
+
+        - **Target is plain (feature off):** an exactly-matching tensor loads
+          as-is; a tensor carrying an extra leading (group) axis is a per-group
+          checkpoint loaded into a non-per-group policy — raise
+          :class:`ProjectionRemapError` (no silent collapse).
+        - **Target is per-group (feature on):**
+            * legacy single ``nn.Linear`` (rank-shy) or a single group row →
+              promote (if needed) and tile to ``D`` identical rows (duplicate).
+            * ``D`` rows with the same group ordering → load as-is.
+            * a different ordering / count with a known old ordering → build the
+              ``D`` rows by name (existing groups copied by name; a group new to
+              the checkpoint duplicates row 0).
+            * a multi-row source with an unknown old ordering, or a trailing
+              shape mismatch → raise :class:`ProjectionRemapError`.
+
+        Args:
+            state_dict_to_load: state dict about to be loaded; mutated in place.
+            old_dataset_names: the checkpoint's own ``config.dataset_names`` (its
+                group ordering), or ``None`` for legacy / unknown checkpoints.
+        """
+        prefixes = self._PER_GROUP_PROJECTION_PREFIXES
+        if not prefixes:
+            return
+        own_state = dict(self.state_dict())
+        new_names = getattr(self.config, "dataset_names", None)
+        remapped: list[str] = []
+        for key in list(state_dict_to_load):
+            if not any(key.startswith(p) for p in prefixes):
+                continue
+            target = own_state.get(key)
+            if target is None:
+                continue
+            loaded = state_dict_to_load[key]
+            new_tensor = self._reconcile_projection_tensor(key, loaded, target, old_dataset_names, new_names)
+            if new_tensor is not loaded:
+                state_dict_to_load[key] = new_tensor
+                remapped.append(key)
+        if remapped:
+            logging.info(
+                "Reconciled %d per-group projection tensor(s) to the policy's %s group(s). Sample keys: %s",
+                len(remapped),
+                len(new_names) if new_names else "?",
+                remapped[:3],
+            )
+
+    @staticmethod
+    def _reconcile_projection_tensor(
+        key: str,
+        loaded: Tensor,
+        target: Tensor,
+        old_names: list[str] | None,
+        new_names: list[str] | None,
+    ) -> Tensor:
+        """Return the tensor to load for one per-group projection key.
+
+        See :meth:`_remap_per_group_projection_weights_in_state_dict` for the
+        full case table. Returns ``loaded`` unchanged when no surgery is needed.
+        """
+        # Plain-Linear param rank: weight -> 2 (out, in), bias -> 1 (out,). A
+        # per-group target carries one extra leading (group) axis on top.
+        plain_rank = 2 if key.endswith(".weight") else 1
+        is_per_group_target = target.ndim == plain_rank + 1
+
+        if not is_per_group_target:
+            if loaded.ndim > target.ndim:
+                raise ProjectionRemapError(
+                    f"Projection key {key!r}: checkpoint carries a per-group axis "
+                    f"(shape {tuple(loaded.shape)}) but this policy has a single shared "
+                    f"projection (shape {tuple(target.shape)}). Set `per_group_projection=True` "
+                    "to keep the per-group heads, or load a non-per-group checkpoint."
+                )
+            return loaded
+
+        num_groups = target.shape[0]
+        feat = tuple(target.shape[1:])
+
+        # Legacy single nn.Linear (no group axis): promote then duplicate to all.
+        if loaded.ndim == target.ndim - 1 and tuple(loaded.shape) == feat:
+            return loaded.unsqueeze(0).expand(num_groups, *feat).contiguous()
+
+        if loaded.ndim != target.ndim or tuple(loaded.shape[1:]) != feat:
+            raise ProjectionRemapError(
+                f"Projection key {key!r}: checkpoint shape {tuple(loaded.shape)} is "
+                f"incompatible with target shape {tuple(target.shape)}."
+            )
+
+        num_loaded = loaded.shape[0]
+        if num_loaded == 1:
+            # Single trained head duplicated into every group (compat #1).
+            return loaded.expand(num_groups, *feat).contiguous()
+
+        if old_names is not None and new_names is not None:
+            if list(old_names) == list(new_names):
+                return loaded  # identical group set & order (compat #3 round-trip)
+            # Name-based remap (compat #5): existing groups carried by name, a
+            # group new to the checkpoint duplicates the reference row 0.
+            old_index = {name: i for i, name in enumerate(old_names)}
+            rows = [loaded[old_index[name]] if name in old_index else loaded[0] for name in new_names]
+            return torch.stack(rows, dim=0).contiguous()
+
+        raise ProjectionRemapError(
+            f"Projection key {key!r}: checkpoint has {num_loaded} group rows but the policy "
+            f"expects {num_groups}, and the checkpoint's group ordering is unknown (no "
+            "dataset_names in its config). Rebuild via make_policy(cfg, ds_meta=...) or re-save "
+            "the source checkpoint with dataset_names."
+        )
 
     @classmethod
     def _strip_normalization_buffers_from_state_dict(

--- a/tests/policies/test_layers.py
+++ b/tests/policies/test_layers.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Unit tests for :class:`opentau.policies.layers.PerGroupLinear`."""
+
+import math
+
+import pytest
+import torch
+import torch.nn.functional as F  # noqa: N812
+from torch import nn
+
+from opentau.policies.layers import PerGroupLinear
+
+
+def test_single_group_bit_identical_to_nn_linear():
+    """num_groups==1 with copied weights matches nn.Linear bit-for-bit."""
+    torch.manual_seed(0)
+    lin = nn.Linear(8, 5)
+    pgl = PerGroupLinear(8, 5, num_groups=1)
+    with torch.no_grad():
+        pgl.weight.copy_(lin.weight[None])
+        pgl.bias.copy_(lin.bias[None])
+    x = torch.randn(4, 3, 8)
+    assert torch.equal(pgl(x), lin(x))  # group_index=None -> fast path
+    assert torch.equal(pgl(x, torch.zeros(4, dtype=torch.long)), lin(x))
+
+
+def test_multi_group_per_sample_routing_matches_reference():
+    """Each sample's output uses the row picked by its group_index."""
+    torch.manual_seed(0)
+    g, b, t, i, o = 3, 5, 2, 8, 6
+    pgl = PerGroupLinear(i, o, num_groups=g)
+    x = torch.randn(b, t, i)
+    idx = torch.tensor([0, 2, 1, 2, 0], dtype=torch.long)
+    out = pgl(x, idx)
+    ref = torch.stack([F.linear(x[k], pgl.weight[idx[k]], pgl.bias[idx[k]]) for k in range(b)])
+    torch.testing.assert_close(out, ref)
+
+
+def test_group_index_none_routes_to_group_zero():
+    torch.manual_seed(0)
+    pgl = PerGroupLinear(4, 4, num_groups=3)
+    x = torch.randn(2, 4)
+    ref = torch.stack([F.linear(x[k], pgl.weight[0], pgl.bias[0]) for k in range(2)])
+    torch.testing.assert_close(pgl(x), ref)
+
+
+def test_bias_broadcasts_over_extra_middle_dims():
+    pgl = PerGroupLinear(3, 2, num_groups=2)
+    x = torch.randn(4, 5, 7, 3)
+    idx = torch.tensor([0, 1, 0, 1], dtype=torch.long)
+    out = pgl(x, idx)
+    assert out.shape == (4, 5, 7, 2)
+    ref = torch.stack([F.linear(x[k], pgl.weight[idx[k]], pgl.bias[idx[k]]) for k in range(4)])
+    torch.testing.assert_close(out, ref)
+
+
+def test_no_bias_variant():
+    pgl = PerGroupLinear(3, 2, num_groups=2, bias=False)
+    assert pgl.bias is None
+    x = torch.randn(2, 3)
+    idx = torch.tensor([0, 1], dtype=torch.long)
+    out = pgl(x, idx)
+    ref = torch.stack([F.linear(x[k], pgl.weight[idx[k]], None) for k in range(2)])
+    torch.testing.assert_close(out, ref)
+
+
+def test_state_dict_keys_match_nn_linear():
+    """Keys are `weight`/`bias` (just one rank higher) so the legacy promotion
+    shim that prepends a leading axis applies."""
+    pgl = PerGroupLinear(3, 2, num_groups=2)
+    assert set(pgl.state_dict()) == {"weight", "bias"}
+    assert pgl.weight.shape == (2, 2, 3)
+    assert pgl.bias.shape == (2, 2)
+
+
+def test_legacy_nn_linear_promotes_into_single_group():
+    """An nn.Linear state_dict loads into a 1-group PerGroupLinear after the
+    unsqueeze(0) promotion, and forwards identically."""
+    torch.manual_seed(0)
+    lin = nn.Linear(8, 5)
+    promoted = {k: v.unsqueeze(0) for k, v in lin.state_dict().items()}
+    pgl = PerGroupLinear(8, 5, num_groups=1)
+    missing, unexpected = pgl.load_state_dict(promoted, strict=True)
+    assert not missing and not unexpected
+    x = torch.randn(3, 8)
+    torch.testing.assert_close(pgl(x), lin(x))
+
+
+def test_num_groups_must_be_positive():
+    with pytest.raises(ValueError, match="num_groups"):
+        PerGroupLinear(3, 2, num_groups=0)
+
+
+def test_construction_is_seed_deterministic():
+    torch.manual_seed(123)
+    a = PerGroupLinear(6, 4, num_groups=3)
+    torch.manual_seed(123)
+    b = PerGroupLinear(6, 4, num_groups=3)
+    assert torch.equal(a.weight, b.weight)
+    assert torch.equal(a.bias, b.bias)
+
+
+def test_init_matches_nn_linear_bounds_per_row():
+    """Every group is kaiming-uniform like nn.Linear: |w| <= 1/sqrt(fan_in)."""
+    pgl = PerGroupLinear(16, 8, num_groups=4)
+    bound = 1.0 / math.sqrt(16)
+    assert pgl.weight.abs().max().item() <= bound + 1e-6

--- a/tests/policies/test_per_group_projection.py
+++ b/tests/policies/test_per_group_projection.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python
+
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Per-(robot_type, control_mode) state/action projections for pi07_paligemma.
+
+Covers the checkpoint-compat remap (the 5 forward/backward-compat cases), the
+state-dict wiring through a stub policy, and the per-sample routing through the
+inner model's `_embed_item` / `_apply_proj`.
+"""
+
+import pytest
+import torch
+from torch import nn
+
+from opentau.policies.layers import PerGroupLinear
+from opentau.policies.pretrained import PreTrainedPolicy, ProjectionRemapError
+
+_rec = PreTrainedPolicy._reconcile_projection_tensor
+
+
+# --- _reconcile_projection_tensor: the compat case table --------------------
+
+
+def test_reconcile_legacy_single_linear_tiles_to_all_groups():
+    """compat #1: a legacy nn.Linear weight (out, in) duplicates into D rows."""
+    out, inn, d = 6, 4, 3
+    legacy = torch.randn(out, inn)
+    r = _rec("model.state_proj.weight", legacy, torch.empty(d, out, inn), None, None)
+    assert r.shape == (d, out, inn)
+    assert r.is_contiguous()
+    for i in range(d):
+        assert torch.equal(r[i], legacy)
+
+
+def test_reconcile_legacy_bias_tiles():
+    out, d = 5, 3
+    r = _rec("model.state_proj.bias", torch.randn(out), torch.empty(d, out), None, None)
+    assert r.shape == (d, out)
+
+
+def test_reconcile_single_row_tiles_to_all_groups():
+    out, inn, d = 6, 4, 3
+    src = torch.randn(1, out, inn)
+    r = _rec("model.action_in_proj.weight", src, torch.empty(d, out, inn), ["a"], ["a", "b", "c"])
+    assert r.shape == (d, out, inn)
+    for i in range(d):
+        assert torch.equal(r[i], src[0])
+
+
+def test_reconcile_same_order_is_identity():
+    """compat #3: identical group set & order loads unchanged (same object)."""
+    src = torch.randn(3, 6, 4)
+    r = _rec("model.state_proj.weight", src, torch.empty(3, 6, 4), ["a", "b", "c"], ["a", "b", "c"])
+    assert r is src
+
+
+def test_reconcile_name_remap_reorder_and_add_new_group():
+    """compat #5: existing groups carried by name; a new group copies row 0."""
+    out, inn = 2, 2
+    src = torch.stack([torch.zeros(out, inn), torch.ones(out, inn)])  # a -> 0s, b -> 1s
+    r = _rec("model.state_proj.weight", src, torch.empty(3, out, inn), ["a", "b"], ["b", "a", "c"])
+    assert torch.equal(r[0], src[1])  # b
+    assert torch.equal(r[1], src[0])  # a
+    assert torch.equal(r[2], src[0])  # c -> reference row 0
+    assert r.is_contiguous()
+
+
+def test_reconcile_downgrade_raises():
+    """A per-group checkpoint into a non-per-group (flag-off) policy must raise."""
+    with pytest.raises(ProjectionRemapError, match="per-group axis"):
+        _rec("model.state_proj.weight", torch.randn(3, 6, 4), torch.empty(6, 4), ["a", "b", "c"], None)
+
+
+def test_reconcile_unknown_ordering_multirow_raises():
+    with pytest.raises(ProjectionRemapError, match="ordering is unknown"):
+        _rec("model.state_proj.weight", torch.randn(2, 6, 4), torch.empty(3, 6, 4), None, None)
+
+
+def test_reconcile_flag_off_normal_load_is_identity():
+    src = torch.randn(6, 4)
+    r = _rec("model.state_proj.weight", src, torch.empty(6, 4), None, None)
+    assert r is src
+
+
+def test_reconcile_trailing_shape_mismatch_raises():
+    with pytest.raises(ProjectionRemapError, match="incompatible"):
+        _rec(
+            "model.state_proj.weight",
+            torch.randn(3, 9, 4),
+            torch.empty(3, 6, 4),
+            ["a", "b", "c"],
+            ["a", "b", "c"],
+        )
+
+
+# --- _remap_..._in_state_dict: wiring through a stub policy ------------------
+
+
+def _make_stub_policy(*, num_groups, per_group, dataset_names):
+    """Minimal PreTrainedPolicy carrying the three (Per)GroupLinear projections.
+
+    Mirrors the `_DummyPolicy` harness in test_normalize_per_dataset.py.
+    """
+    from opentau.configs.policies import PreTrainedConfig
+
+    class _Cfg(PreTrainedConfig):
+        @property
+        def observation_delta_indices(self):
+            return None
+
+        @property
+        def action_delta_indices(self):
+            return None
+
+        @property
+        def reward_delta_indices(self):
+            return None
+
+        def get_optimizer_preset(self):
+            raise NotImplementedError
+
+        def get_scheduler_preset(self):
+            return None
+
+        def validate_features(self):
+            return None
+
+    class _Stub(PreTrainedPolicy):
+        config_class = _Cfg
+        name = "stub-per-group-proj"
+        _PER_GROUP_PROJECTION_PREFIXES = ("state_proj.", "action_in_proj.", "action_out_proj.")
+
+        def __init__(self, config):
+            super().__init__(config)
+
+            def mk(i, o):
+                return PerGroupLinear(i, o, num_groups=num_groups) if per_group else nn.Linear(i, o)
+
+            self.state_proj = mk(4, 6)
+            self.action_in_proj = mk(4, 8)
+            self.action_out_proj = mk(8, 4)
+
+        def get_optim_params(self):
+            return {}
+
+        def reset(self):
+            pass
+
+        def forward(self, batch):
+            raise NotImplementedError
+
+        def select_action(self, batch):
+            raise NotImplementedError
+
+    cfg = _Cfg()
+    cfg.dataset_names = list(dataset_names) if dataset_names is not None else None
+    cfg.dataset_to_norm_index = None
+    return _Stub(cfg)
+
+
+def test_remap_tiles_legacy_state_dict_into_per_group_policy():
+    """compat #1 end-to-end: a single-Linear checkpoint loads into a flag-on policy."""
+    legacy = _make_stub_policy(num_groups=1, per_group=False, dataset_names=["a"])
+    target = _make_stub_policy(num_groups=3, per_group=True, dataset_names=["a", "b", "c"])
+    sd = dict(legacy.state_dict())  # 2-D projection weights
+    target._remap_per_group_projection_weights_in_state_dict(sd, old_dataset_names=["a"])
+    missing, unexpected = target.load_state_dict(sd, strict=True)
+    assert not missing and not unexpected
+    for i in range(3):
+        assert torch.equal(target.state_proj.weight[i], legacy.state_proj.weight)
+        assert torch.equal(target.action_out_proj.weight[i], legacy.action_out_proj.weight)
+
+
+def test_remap_name_remaps_existing_and_adds_new_group():
+    """compat #5 end-to-end: reorder + add a new group."""
+    src = _make_stub_policy(num_groups=2, per_group=True, dataset_names=["a", "b"])
+    target = _make_stub_policy(num_groups=3, per_group=True, dataset_names=["b", "a", "c"])
+    sd = dict(src.state_dict())
+    target._remap_per_group_projection_weights_in_state_dict(sd, old_dataset_names=["a", "b"])
+    target.load_state_dict(sd, strict=True)
+    assert torch.equal(target.state_proj.weight[0], src.state_proj.weight[1])  # b
+    assert torch.equal(target.state_proj.weight[1], src.state_proj.weight[0])  # a
+    assert torch.equal(target.state_proj.weight[2], src.state_proj.weight[0])  # c -> row 0
+
+
+def test_remap_same_groups_round_trips():
+    """compat #3 end-to-end: identical groups load unchanged."""
+    src = _make_stub_policy(num_groups=2, per_group=True, dataset_names=["a", "b"])
+    target = _make_stub_policy(num_groups=2, per_group=True, dataset_names=["a", "b"])
+    sd = dict(src.state_dict())
+    target._remap_per_group_projection_weights_in_state_dict(sd, old_dataset_names=["a", "b"])
+    target.load_state_dict(sd, strict=True)
+    torch.testing.assert_close(target.state_proj.weight, src.state_proj.weight)
+
+
+def test_remap_downgrade_raises():
+    src = _make_stub_policy(num_groups=2, per_group=True, dataset_names=["a", "b"])
+    target = _make_stub_policy(num_groups=1, per_group=False, dataset_names=["a"])
+    sd = dict(src.state_dict())
+    with pytest.raises(ProjectionRemapError):
+        target._remap_per_group_projection_weights_in_state_dict(sd, old_dataset_names=["a", "b"])
+
+
+def test_remap_noop_when_policy_declares_no_prefixes():
+    """A policy that hasn't opted in (empty prefixes) is untouched."""
+    stub = _make_stub_policy(num_groups=1, per_group=False, dataset_names=["a"])
+    stub._PER_GROUP_PROJECTION_PREFIXES = ()  # simulate a non-opted-in policy
+    sd = dict(stub.state_dict())
+    before = {k: v.clone() for k, v in sd.items()}
+    stub._remap_per_group_projection_weights_in_state_dict(sd, old_dataset_names=None)
+    for k in sd:
+        assert torch.equal(sd[k], before[k])
+
+
+# --- inner-model threading: group_index reaches the projection --------------
+
+
+def test_apply_proj_dispatches_on_module_type():
+    """_apply_proj passes the index only to PerGroupLinear; other callables get x."""
+    from opentau.policies.pi07_paligemma.low_level.modeling_pi07_low_level import (
+        PI07PaligemmaLowLevelFlowMatching as Model,
+    )
+
+    x = torch.randn(2, 3)
+    idx = torch.tensor([0, 1], dtype=torch.long)
+    pgl = PerGroupLinear(3, 3, num_groups=2)
+    lin = nn.Linear(3, 3)
+    torch.testing.assert_close(Model._apply_proj(pgl, x, idx), pgl(x, idx))
+    torch.testing.assert_close(Model._apply_proj(lin, x, idx), lin(x))
+    # The 1-arg lambda / Identity monkeypatch contract: called as proj(x).
+    assert torch.equal(Model._apply_proj(lambda z: z * 2, x, idx), x * 2)
+
+
+def test_embed_item_routes_state_projection_per_group():
+    """`_embed_item` applies the per-sample group row to the state projection."""
+    from opentau.policies.pi07_paligemma.low_level.modeling_pi07_low_level import (
+        ContextItem,
+        PI07PaligemmaLowLevelFlowMatching,
+    )
+
+    model = object.__new__(PI07PaligemmaLowLevelFlowMatching)
+    nn.Module.__init__(model)  # set up _modules so we can attach a submodule
+    state_dim, h = 4, 5
+    pgl = PerGroupLinear(state_dim, h, num_groups=2)
+    with torch.no_grad():
+        pgl.weight[0].zero_()  # group 0 -> zeros
+        pgl.bias[0].zero_()
+        pgl.weight[1].fill_(1.0)  # group 1 -> sum over the (all-ones) inputs
+        pgl.bias[1].zero_()
+    model.state_proj = pgl
+
+    b, t = 2, 1
+    item = ContextItem(
+        data=torch.ones(b, t, state_dim),
+        item_type="state",
+        pad_mask=torch.ones(b, t, dtype=torch.bool),
+    )
+    idx = torch.tensor([0, 1], dtype=torch.long)
+    emb, mask = model._embed_item(item, group_index=idx)
+    emb = emb.float()
+    assert emb.shape == (b, t, h)
+    assert torch.allclose(emb[0], torch.zeros(t, h))
+    assert torch.allclose(emb[1], torch.full((t, h), float(state_dim)))
+    assert torch.equal(mask, item.pad_mask)


### PR DESCRIPTION
## What this does

Adds an **opt-in, per-(robot_type, control_mode) state/action projection** to the `pi07_paligemma` low_level policy, mirroring the existing per-(robot_type, control_mode) normalization heads (#347). When enabled, `state_proj`, `action_in_proj`, and `action_out_proj` each hold one `(weight, bias)` per group, selected per-sample by the **same** index that selects the normalization head (`_resolve_dataset_index` → `config.dataset_names`). `time_mlp_*` stay shared.

Gated by a new config flag `per_group_projection: bool = False`. **Default off → the model is byte-identical to before** (plain `nn.Linear`, same state-dict keys, same numerics). Scoped to `pi07_paligemma` low_level for now; the `PerGroupLinear` layer and the load-side remap are written generically so other policies can adopt them later. The high_level planner is excluded — it has no state/action projections (pure VLM language planner).

New `PerGroupLinear` (`src/opentau/policies/layers.py`): a drop-in `nn.Linear` with a leading group axis (state-dict keys stay `weight`/`bias`, one rank higher). `num_groups == 1` takes an `F.linear` fast path (bit-identical to `nn.Linear`); multi-group does a per-sample `index_select` + `einops.einsum` — a fixed-shape op that keeps collective counts aligned across ranks under FSDP/ZeRO (no per-rank branch on which groups are present).

Forward/backward compatibility (all unit-tested):

| Case | Behavior |
|------|----------|
| Checkpoint predates this feature (single projection), continue training with flag on | duplicate the single projection into every group |
| Checkpoint without per-group projection, used for inference | plain `nn.Linear`, unchanged |
| Checkpoint with per-group projections, inference | look up the correct row by `(robot_type, control_mode)` |
| New `(robot_type, control_mode)` at inference, not in checkpoint | raise (free via `_resolve_dataset_index`) |
| New `(robot_type, control_mode)` at training, not in checkpoint | add a new row, copied from row 0; config updated via the existing norm-key machinery |
| Per-group checkpoint loaded with the flag off | raise `ProjectionRemapError` (no silent collapse) |

The load-side reconciliation lives in `pretrained.py` (`_remap_per_group_projection_weights_in_state_dict`, driven by a `_PER_GROUP_PROJECTION_PREFIXES` class attr that is empty for every other policy) and is wired into the `pi07_paligemma` `from_pretrained` override, where its fatal error is re-raised past the broad `except` so a mismatch can't be swallowed into a silently-broken model.

## How it was tested

- `pre-commit run --all-files`: clean (ruff lint + format, bandit, license, typos).
- CPU suite (`pytest -m "not gpu"`), all green:
  - New `tests/policies/test_layers.py` (`PerGroupLinear`: `num_groups==1` ≡ `nn.Linear`, per-sample routing, bias broadcast over extra dims, legacy-promotion round-trip, seeded-construction determinism) and `tests/policies/test_per_group_projection.py` (the full compat table at both the tensor-reconcile and state-dict-surgery levels, plus `_embed_item` per-group routing) — 26 tests.
  - Existing `tests/policies/test_pi07_paligemma_low_level.py` — 54 pass (the projection-monkeypatch / mock-model contracts are preserved by an `isinstance`-dispatch helper).
  - Norm/resolve regression (`test_normalize_per_dataset.py`, `test_norm_key_aggregation.py`) — pass.
- GPU pytests (`pytest -m "gpu"`) + nightly regression: run on CI (`gpu_test.yml` / `regression_test.yml`, CUDA runners); the local dev box is CPU-only. The default-off path is byte-identical to before, and the flag-on path uses only deterministic ops (`index_select` + `einsum`); a same-seed smoke-config determinism check should be confirmed on GPU.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/policies/test_layers.py tests/policies/test_per_group_projection.py
```
```bash
pytest -sx tests/policies/test_pi07_paligemma_low_level.py
```
Enable the feature with `--policy.per_group_projection=true` over a `(robot_type, control_mode)` dataset mixture; leave it unset for the unchanged default.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [x] My PR includes policy-related changes.
  - [x] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
