### PR TITLE
feat(pi07): per-(robot_type, control_mode) state/action projections

### DIFF
--- a/src/opentau/policies/pi07/low_level/configuration_pi07_low_level.py
+++ b/src/opentau/policies/pi07/low_level/configuration_pi07_low_level.py
@@ -94,6 +94,9 @@ class PI07LowLevelConfig(PreTrainedConfig):
             Gemma-v1 action expert's ``hidden_size`` so that suffix embeddings
             are compatible with the expert's transformer layers.  Defaults to
             1280 (the expert hidden size in ``Gemma3WithExpertConfig``).
+        per_group_projection: When True, use an independent state/action
+            projection per (robot_type, control_mode) group (shares the
+            normalization-head grouping). Defaults to False.
         dropout: Dropout rate. Defaults to 0.1.
         num_steps: Number of flow-matching denoising steps. Defaults to 5.
         max_delay: Maximum number of prefix action steps for real-time
@@ -176,6 +179,22 @@ class PI07LowLevelConfig(PreTrainedConfig):
 
     # Projector
     proj_width: int = 1280
+
+    # When True, give the continuous STATE/ACTION projections (state_proj,
+    # action_in_proj, action_out_proj) an independent (weight, bias) per
+    # (robot_type, control_mode) group — the same grouping the stacked
+    # Normalize/Unnormalize heads use, selected per-sample by
+    # `_resolve_dataset_index`. The number of groups is len(dataset_names)
+    # (falls back to 1 when dataset_names is unset). time_mlp_in/out stay
+    # shared. Defaults to False: when off the three projections are plain
+    # nn.Linear and the model is byte-identical to the pre-flag version (same
+    # params, same state_dict keys, same numerics). Flipping it on changes the
+    # param count and the projection state_dict shapes (leading group axis);
+    # legacy single-group checkpoints are promoted + duplicated on load, and a
+    # group new to the checkpoint gets a fresh row copied from row 0. Loading a
+    # per-group checkpoint with this flag off raises rather than silently
+    # collapsing the group axis.
+    per_group_projection: bool = False
 
     # Dropout
     dropout: float = 0.1

--- a/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
@@ -51,6 +51,7 @@ from transformers import AutoProcessor, AutoTokenizer
 
 from opentau.configs.policies import PreTrainedConfig
 from opentau.configs.types import NormalizationMode
+from opentau.policies.layers import PerGroupLinear
 from opentau.policies.normalize import Normalize, Unnormalize
 from opentau.policies.normalize import resolve_num_datasets as _num_datasets
 from opentau.policies.outlier_utils import detect_state_action_outliers
@@ -61,7 +62,7 @@ from opentau.policies.pi07.low_level.configuration_pi07_low_level import (
     PI07LowLevelConfig,
 )
 from opentau.policies.pi07.video_encoder import SpaceTimeSiglipVideoEncoder
-from opentau.policies.pretrained import PreTrainedPolicy, T
+from opentau.policies.pretrained import PreTrainedPolicy, ProjectionRemapError, T
 from opentau.policies.utils import flow_matching_masked_mse
 from opentau.utils.accelerate_utils import get_proc_accelerator
 from opentau.utils.utils import get_safe_dtype
@@ -317,6 +318,16 @@ class PI07LowLevelPolicy(PreTrainedPolicy):
     config_class = PI07LowLevelConfig
     name = "pi07_low_level"
 
+    # Per-(robot_type, control_mode) projections live on the inner
+    # `self.model` (PerGroupLinear when `config.per_group_projection`), so their
+    # state-dict keys are `model.<proj>.weight` / `.bias`. The load path uses
+    # these to reconcile a checkpoint's projection rows with the policy's groups.
+    _PER_GROUP_PROJECTION_PREFIXES = (
+        "model.state_proj.",
+        "model.action_in_proj.",
+        "model.action_out_proj.",
+    )
+
     def __init__(
         self,
         config: PI07LowLevelConfig,
@@ -362,7 +373,9 @@ class PI07LowLevelPolicy(PreTrainedPolicy):
             config.discrete_action_tokenizer_path, trust_remote_code=True
         )
         discrete_action_vocab_size = getattr(self.discrete_action_processor, "vocab_size", None)
-        self.model = PI07LowLevelFlowMatching(config, discrete_action_vocab_size=discrete_action_vocab_size)
+        self.model = PI07LowLevelFlowMatching(
+            config, discrete_action_vocab_size=discrete_action_vocab_size, num_datasets=num_datasets
+        )
 
         self.reset()
 
@@ -410,6 +423,38 @@ class PI07LowLevelPolicy(PreTrainedPolicy):
 
         acc = get_proc_accelerator()
         is_main_process = acc.is_main_process if acc else True
+        # When per-group projections are on, reconcile projection rows by group
+        # name. The checkpoint's own group ordering is its `dataset_names`; seed
+        # with the already-loaded `config.dataset_names` — which on an inference
+        # / resume round-trip *is* the checkpoint's ordering — so a transient
+        # failure of the source-config read below doesn't turn a loadable
+        # same-group checkpoint into a hard ProjectionRemapError. The explicit
+        # read still recovers the true old ordering for the continue-training
+        # path, where the passed cfg carries the *new* (superset / reordered)
+        # groups.
+        old_dataset_names: list[str] | None = None
+        if getattr(config, "per_group_projection", False):
+            seeded = getattr(config, "dataset_names", None)
+            old_dataset_names = list(seeded) if seeded else None
+            try:
+                source_config = PreTrainedConfig.from_pretrained(
+                    pretrained_name_or_path=pretrained_name_or_path,
+                    force_download=force_download,
+                    resume_download=resume_download,
+                    proxies=proxies,
+                    token=token,
+                    cache_dir=cache_dir,
+                    local_files_only=local_files_only,
+                    revision=revision,
+                )
+                old_dataset_names = getattr(source_config, "dataset_names", None) or old_dataset_names
+            except Exception as e:  # noqa: BLE001
+                if is_main_process:
+                    logging.warning(
+                        "Could not read checkpoint dataset_names for per-group projection remap "
+                        "(%s); falling back to the policy's current dataset_names ordering.",
+                        e,
+                    )
         # Populated inside the try block when skip_normalization_weights fires;
         # used outside the try/except to gate the inf-buffer guard so the
         # ValueError is not swallowed by the broad except below.
@@ -467,6 +512,13 @@ class PI07LowLevelPolicy(PreTrainedPolicy):
             # (outside the `if remap_count > 0` block) — promotion is needed
             # whether or not any other keys were renamed.
             model._promote_legacy_norm_buffers_in_state_dict(remapped_state_dict)
+            # Reconcile per-(robot_type, control_mode) projection rows with this
+            # policy's groups: tile a legacy single head to all groups, name-remap
+            # an existing multi-head onto the new ordering, etc. Raises
+            # ProjectionRemapError on an irreconcilable shape; re-raised below so
+            # the broad handler does not swallow it into a warning + broken model.
+            # No-op when the policy declares no per-group projection prefixes.
+            model._remap_per_group_projection_weights_in_state_dict(remapped_state_dict, old_dataset_names)
 
             # Strip saved normalize/unnormalize buffers when the user opted in
             # via config.skip_normalization_weights — see PreTrainedConfig and
@@ -499,6 +551,11 @@ class PI07LowLevelPolicy(PreTrainedPolicy):
             if not unintended_missing and not unexpected_keys and is_main_process:
                 logging.info("All keys loaded successfully!")
 
+        except ProjectionRemapError:
+            # Deliberate, fatal incompatibility (e.g. a per-group checkpoint
+            # loaded into a non-per-group policy) — must not be swallowed into a
+            # warning + silently-broken model by the broad handler below.
+            raise
         except Exception as e:
             if is_main_process:
                 logging.warning("Could not remap state dict keys: %s", e)
@@ -789,6 +846,7 @@ class PI07LowLevelPolicy(PreTrainedPolicy):
             response_tokens=response_tokens,
             response_masks=response_masks,
             obs_history_is_pad=obs_history_is_pad,
+            group_index=dataset_index,
         )
 
         action_feature = self.config.action_feature
@@ -864,6 +922,7 @@ class PI07LowLevelPolicy(PreTrainedPolicy):
             response_tokens=response_tokens,
             response_masks=response_masks,
             real_action_dim=batch.get("real_action_dim"),
+            group_index=dataset_index,
         )
 
         mse_loss = losses["MSE"]
@@ -1261,9 +1320,26 @@ class PI07LowLevelFlowMatching(nn.Module):
     predict the velocity field.
     """
 
-    def __init__(self, config: PI07LowLevelConfig, discrete_action_vocab_size: int | None = None):
+    def __init__(
+        self,
+        config: PI07LowLevelConfig,
+        discrete_action_vocab_size: int | None = None,
+        num_datasets: int = 1,
+    ):
+        """Initializes the PI07LowLevelFlowMatching model.
+
+        Args:
+            config: Model configuration.
+            discrete_action_vocab_size: Size of the discrete action vocabulary.
+            num_datasets: Number of (robot_type, control_mode) groups — the
+                leading dim of the stacked Normalize/Unnormalize buffers. Used
+                as the number of per-group projection heads when
+                ``config.per_group_projection`` is set, so the projection axis
+                stays in lockstep with the norm-head axis. Defaults to 1.
+        """
         super().__init__()
         self.config = config
+        self.num_datasets = num_datasets
 
         self.config.vlm_config.discrete_action_vocab_size = discrete_action_vocab_size
         self.gemma3_with_expert = Gemma3WithExpertModel(self.config.vlm_config)
@@ -1286,11 +1362,22 @@ class PI07LowLevelFlowMatching(nn.Module):
             gradient_checkpointing=config.gradient_checkpointing,
         )
 
-        # Per-timestep state projection: each of the T state vectors becomes one token
-        self.state_proj = nn.Linear(self.config.max_state_dim, vlm_hidden_size)
+        # Per-(robot_type, control_mode) state/action projections share the
+        # norm-head grouping: when `per_group_projection` is on, each of the
+        # three projections holds one (weight, bias) per group, selected
+        # per-sample by the same index that picks the norm head. When off they
+        # are plain nn.Linear, byte-identical to the pre-flag model. time_mlp_*
+        # stay shared either way.
+        def _make_proj(in_features: int, out_features: int) -> nn.Module:
+            if self.config.per_group_projection:
+                return PerGroupLinear(in_features, out_features, num_groups=self.num_datasets)
+            return nn.Linear(in_features, out_features)
 
-        self.action_in_proj = nn.Linear(self.config.max_action_dim, self.config.proj_width)
-        self.action_out_proj = nn.Linear(self.config.proj_width, self.config.max_action_dim)
+        # Per-timestep state projection: each of the T state vectors becomes one token
+        self.state_proj = _make_proj(self.config.max_state_dim, vlm_hidden_size)
+
+        self.action_in_proj = _make_proj(self.config.max_action_dim, self.config.proj_width)
+        self.action_out_proj = _make_proj(self.config.proj_width, self.config.max_action_dim)
 
         self.time_mlp_in = nn.Linear(self.config.proj_width, self.config.proj_width)
         self.time_mlp_out = nn.Linear(self.config.proj_width, self.config.proj_width)
@@ -1331,6 +1418,21 @@ class PI07LowLevelFlowMatching(nn.Module):
         """
         return self.video_encoder(video, obs_history_is_pad=obs_history_is_pad)
 
+    @staticmethod
+    def _apply_proj(proj: nn.Module, x: Tensor, group_index: Tensor | None) -> Tensor:
+        """Call a projection that may be a plain ``nn.Linear`` or a ``PerGroupLinear``.
+
+        Keeps the call sites uniform: a ``PerGroupLinear`` additionally receives
+        the per-sample ``group_index``; any other callable (plain ``nn.Linear``,
+        or the 1-arg lambda / ``nn.Identity`` stubs the unit tests inject) is
+        called as ``proj(x)`` and ignores the index. The dispatch is on module
+        *type* (a construction-time, rank-invariant property), not on batch
+        data, so it fires no collective (CLAUDE.md rule 5).
+        """
+        if isinstance(proj, PerGroupLinear):
+            return proj(x, group_index)
+        return proj(x)
+
     def embed_prefix(
         self,
         videos: list[Tensor],
@@ -1347,6 +1449,7 @@ class PI07LowLevelFlowMatching(nn.Module):
         obs_history_is_pad: Tensor | None = None,
         subgoal_images: list[Tensor] | None = None,
         subgoal_img_masks: list[Tensor] | None = None,
+        group_index: Tensor | None = None,
     ) -> tuple[Tensor, Tensor, Tensor]:
         """Embed all prefix modalities and build the 1-D attention pattern.
 
@@ -1540,7 +1643,7 @@ class PI07LowLevelFlowMatching(nn.Module):
 
         # Project each timestep's state into a separate VLM token
         # state: (B, T, max_state_dim) -> state_emb: (B, T, vlm_hidden_size)
-        state_emb = self.state_proj(state.to(dtype=_preferred_dtype()))
+        state_emb = self._apply_proj(self.state_proj, state.to(dtype=_preferred_dtype()), group_index)
 
         embs.append(state_emb)
         pad_masks.append(state_mask)
@@ -1732,7 +1835,9 @@ class PI07LowLevelFlowMatching(nn.Module):
 
         return embs, pad_masks, att_masks
 
-    def embed_suffix(self, noisy_actions: Tensor, timestep: Tensor) -> tuple[Tensor, Tensor, Tensor, Tensor]:
+    def embed_suffix(
+        self, noisy_actions: Tensor, timestep: Tensor, group_index: Tensor | None = None
+    ) -> tuple[Tensor, Tensor, Tensor, Tensor]:
         """Embed noisy actions and flow-matching timestep for the action expert.
 
         Projects actions through ``action_in_proj`` and computes an
@@ -1763,7 +1868,7 @@ class PI07LowLevelFlowMatching(nn.Module):
         )
 
         noisy_actions = noisy_actions.to(dtype=dtype)
-        action_emb = self.action_in_proj(noisy_actions)
+        action_emb = self._apply_proj(self.action_in_proj, noisy_actions, group_index)
 
         def time_mlp_func(time_emb):
             x = self.time_mlp_in(time_emb)
@@ -1810,6 +1915,7 @@ class PI07LowLevelFlowMatching(nn.Module):
         response_tokens: Tensor | None = None,
         response_masks: Tensor | None = None,
         real_action_dim: Tensor | None = None,
+        group_index: Tensor | None = None,
     ) -> dict[str, Tensor]:
         """Training forward pass: embed all modalities and compute losses.
 
@@ -1860,6 +1966,7 @@ class PI07LowLevelFlowMatching(nn.Module):
             obs_history_is_pad=obs_history_is_pad,
             subgoal_images=subgoal_images,
             subgoal_img_masks=subgoal_img_masks,
+            group_index=group_index,
         )
 
         vlm_2d_attention_mask = make_att_2d_masks(prefix_pad_masks, prefix_att_masks)
@@ -1900,7 +2007,9 @@ class PI07LowLevelFlowMatching(nn.Module):
         x_t = time_expanded * noise + (1 - time_expanded) * actions
         u_t = noise - actions
 
-        suffix_embs, suffix_pad_masks, suffix_att_masks, adarms_cond = self.embed_suffix(x_t, time)
+        suffix_embs, suffix_pad_masks, suffix_att_masks, adarms_cond = self.embed_suffix(
+            x_t, time, group_index=group_index
+        )
 
         action_expert_2d_attention_mask = make_att_2d_masks(
             suffix_pad_masks,
@@ -1935,7 +2044,7 @@ class PI07LowLevelFlowMatching(nn.Module):
         # is the inference-time execution horizon only and must not truncate the
         # training target (chunk_size is the prediction horizon).
         suffix_out = suffix_out[:, -self.config.chunk_size :]
-        v_t = self.action_out_proj(suffix_out)
+        v_t = self._apply_proj(self.action_out_proj, suffix_out, group_index)
         v_t = v_t.to(dtype=torch.float32)
 
         # Shared masked-MSE reduction; see pi05 for the rationale.
@@ -1988,6 +2097,7 @@ class PI07LowLevelFlowMatching(nn.Module):
         response_tokens: Tensor | None = None,
         response_masks: Tensor | None = None,
         obs_history_is_pad: Tensor | None = None,
+        group_index: Tensor | None = None,
     ) -> Tensor:
         """Inference: iteratively denoise to produce a continuous action chunk.
 
@@ -2043,6 +2153,7 @@ class PI07LowLevelFlowMatching(nn.Module):
             subgoal_images=subgoal_images,
             subgoal_img_masks=subgoal_img_masks,
             obs_history_is_pad=obs_history_is_pad,
+            group_index=group_index,
         )
         prefix_att_2d_masks = make_att_2d_masks(prefix_pad_masks, prefix_att_masks)
         prefix_position_ids = torch.cumsum(prefix_pad_masks, dim=1) - 1
@@ -2074,6 +2185,7 @@ class PI07LowLevelFlowMatching(nn.Module):
                 past_key_values,
                 x_t,
                 masked_time,
+                group_index=group_index,
             )
 
             x_t += dt * v_t
@@ -2088,6 +2200,7 @@ class PI07LowLevelFlowMatching(nn.Module):
         past_key_values: list[dict[str, Tensor]],
         x_t: Tensor,
         time: Tensor,
+        group_index: Tensor | None = None,
     ) -> Tensor:
         """Run one action-expert forward pass to predict the velocity field.
 
@@ -2105,7 +2218,9 @@ class PI07LowLevelFlowMatching(nn.Module):
         Returns:
             Predicted velocity ``(B, n_action_steps, max_action_dim)``.
         """
-        suffix_embs, suffix_pad_masks, suffix_att_masks, adarms_cond = self.embed_suffix(x_t, time)
+        suffix_embs, suffix_pad_masks, suffix_att_masks, adarms_cond = self.embed_suffix(
+            x_t, time, group_index=group_index
+        )
 
         num_cross_att_tokens = prefix_pad_masks.shape[1]
         action_expert_2d_attention_mask = make_att_2d_masks(
@@ -2132,6 +2247,6 @@ class PI07LowLevelFlowMatching(nn.Module):
         # n_action_steps (execution horizon) is applied later in select_action, not
         # at decode time.
         suffix_out = suffix_out[:, -self.config.chunk_size :]
-        v_t = self.action_out_proj(suffix_out)
+        v_t = self._apply_proj(self.action_out_proj, suffix_out, group_index)
         v_t = v_t.to(dtype=torch.float32)
         return v_t

--- a/tests/policies/test_pi07_cpu.py
+++ b/tests/policies/test_pi07_cpu.py
@@ -764,12 +764,20 @@ def _make_fake_flow_matching(*, hidden: int = 4, n_video_tokens: int = 3):
         del obs_history_is_pad
         return torch.zeros(video.shape[0], n_video_tokens, hidden, dtype=torch.float32)
 
+    # The real `_apply_proj` static dispatch: with a plain-callable `state_proj`
+    # (not a PerGroupLinear) it routes to `proj(x)`, matching the pre-per-group
+    # behaviour while letting the real `embed_prefix` run against this fake.
+    from opentau.policies.pi07.low_level.modeling_pi07_low_level import (
+        PI07LowLevelFlowMatching,
+    )
+
     fake = types.SimpleNamespace(
         gemma3_with_expert=_FakeGemma3WithExpert(),
         language_tokenizer=_FakeTokenizer(),
         state_proj=_state_proj,
         embed_video=_embed_video,
         config=types.SimpleNamespace(discrete_action_max_length=2),
+        _apply_proj=PI07LowLevelFlowMatching._apply_proj,
     )
     return fake
 

--- a/tests/policies/test_pi07_per_group_projection.py
+++ b/tests/policies/test_pi07_per_group_projection.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python
+
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Per-(robot_type, control_mode) state/action projections for primary pi07.
+
+Ports the pi07_paligemma coverage (see ``test_per_group_projection.py``) to the
+primary ``pi07`` low-level policy: the ``_apply_proj`` dispatch, the state-dict
+remap wired through pi07's ``model.*`` projection prefixes, the per-sample
+routing through the inner model's ``embed_suffix`` (pi07 embeds inline -- there
+is no ``_embed_item``), and the train==eval head-consistency invariant the
+per-group feature relies on (a given ``(robot_type, control_mode)`` resolves to
+the same head whether tagged by the training ``dataset_index`` or by the eval
+``(robot_type, control_mode)`` pair). All CPU-only -- no Gemma3 backbone.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+from opentau.policies.layers import PerGroupLinear
+from opentau.policies.pretrained import PreTrainedPolicy, ProjectionRemapError
+
+# --- a stub policy carrying pi07's nested `model.<proj>` projections ----------
+
+
+def _make_pi07_stub_policy(*, num_groups, per_group, dataset_names):
+    """Minimal PreTrainedPolicy whose projections live on ``self.model`` so the
+    state-dict keys are ``model.state_proj.*`` etc. -- exactly pi07's layout and
+    :attr:`PI07LowLevelPolicy._PER_GROUP_PROJECTION_PREFIXES`.
+
+    Mirrors the ``_make_stub_policy`` harness in ``test_per_group_projection.py``
+    but nests the projections one level deeper (under ``model``).
+    """
+    from opentau.configs.policies import PreTrainedConfig
+
+    class _Cfg(PreTrainedConfig):
+        @property
+        def observation_delta_indices(self):
+            return None
+
+        @property
+        def action_delta_indices(self):
+            return None
+
+        @property
+        def reward_delta_indices(self):
+            return None
+
+        def get_optimizer_preset(self):
+            raise NotImplementedError
+
+        def get_scheduler_preset(self):
+            return None
+
+        def validate_features(self):
+            return None
+
+    class _Stub(PreTrainedPolicy):
+        config_class = _Cfg
+        name = "stub-pi07-per-group-proj"
+        _PER_GROUP_PROJECTION_PREFIXES = (
+            "model.state_proj.",
+            "model.action_in_proj.",
+            "model.action_out_proj.",
+        )
+
+        def __init__(self, config):
+            super().__init__(config)
+
+            def mk(i, o):
+                return PerGroupLinear(i, o, num_groups=num_groups) if per_group else nn.Linear(i, o)
+
+            self.model = nn.Module()
+            self.model.state_proj = mk(4, 6)
+            self.model.action_in_proj = mk(4, 8)
+            self.model.action_out_proj = mk(8, 4)
+
+        def get_optim_params(self):
+            return {}
+
+        def reset(self):
+            pass
+
+        def forward(self, batch):
+            raise NotImplementedError
+
+        def select_action(self, batch):
+            raise NotImplementedError
+
+    cfg = _Cfg()
+    cfg.dataset_names = list(dataset_names) if dataset_names is not None else None
+    cfg.dataset_to_norm_index = None
+    return _Stub(cfg)
+
+
+# --- the policy opts in with the right prefixes -------------------------------
+
+
+def test_pi07_policy_declares_per_group_prefixes():
+    from opentau.policies.pi07.low_level.modeling_pi07_low_level import PI07LowLevelPolicy
+
+    assert PI07LowLevelPolicy._PER_GROUP_PROJECTION_PREFIXES == (
+        "model.state_proj.",
+        "model.action_in_proj.",
+        "model.action_out_proj.",
+    )
+
+
+# --- _remap_..._in_state_dict wired through pi07's prefixes -------------------
+
+
+def test_pi07_remap_tiles_legacy_state_dict_into_per_group_policy():
+    """compat #1 end-to-end: a single-Linear checkpoint loads into a flag-on policy."""
+    legacy = _make_pi07_stub_policy(num_groups=1, per_group=False, dataset_names=["a"])
+    target = _make_pi07_stub_policy(num_groups=3, per_group=True, dataset_names=["a", "b", "c"])
+    sd = dict(legacy.state_dict())  # 2-D projection weights under model.*
+    target._remap_per_group_projection_weights_in_state_dict(sd, old_dataset_names=["a"])
+    missing, unexpected = target.load_state_dict(sd, strict=True)
+    assert not missing and not unexpected
+    for i in range(3):
+        assert torch.equal(target.model.state_proj.weight[i], legacy.model.state_proj.weight)
+        assert torch.equal(target.model.action_out_proj.weight[i], legacy.model.action_out_proj.weight)
+
+
+def test_pi07_remap_name_remaps_existing_and_adds_new_group():
+    """compat #5 end-to-end: reorder + add a new group (new group copies row 0)."""
+    src = _make_pi07_stub_policy(num_groups=2, per_group=True, dataset_names=["a", "b"])
+    target = _make_pi07_stub_policy(num_groups=3, per_group=True, dataset_names=["b", "a", "c"])
+    sd = dict(src.state_dict())
+    target._remap_per_group_projection_weights_in_state_dict(sd, old_dataset_names=["a", "b"])
+    target.load_state_dict(sd, strict=True)
+    assert torch.equal(target.model.state_proj.weight[0], src.model.state_proj.weight[1])  # b
+    assert torch.equal(target.model.state_proj.weight[1], src.model.state_proj.weight[0])  # a
+    assert torch.equal(target.model.state_proj.weight[2], src.model.state_proj.weight[0])  # c -> row 0
+
+
+def test_pi07_remap_downgrade_raises():
+    """A per-group checkpoint loaded into a flag-off pi07 policy must raise."""
+    src = _make_pi07_stub_policy(num_groups=2, per_group=True, dataset_names=["a", "b"])
+    target = _make_pi07_stub_policy(num_groups=1, per_group=False, dataset_names=["a"])
+    sd = dict(src.state_dict())
+    with pytest.raises(ProjectionRemapError):
+        target._remap_per_group_projection_weights_in_state_dict(sd, old_dataset_names=["a", "b"])
+
+
+# --- inner-model threading: group_index reaches the projection ---------------
+
+
+def test_pi07_apply_proj_dispatches_on_module_type():
+    """_apply_proj passes the index only to PerGroupLinear; other callables get x."""
+    from opentau.policies.pi07.low_level.modeling_pi07_low_level import (
+        PI07LowLevelFlowMatching as Model,
+    )
+
+    x = torch.randn(2, 3)
+    idx = torch.tensor([0, 1], dtype=torch.long)
+    pgl = PerGroupLinear(3, 3, num_groups=2)
+    lin = nn.Linear(3, 3)
+    torch.testing.assert_close(Model._apply_proj(pgl, x, idx), pgl(x, idx))
+    torch.testing.assert_close(Model._apply_proj(lin, x, idx), lin(x))
+    # The 1-arg lambda / Identity monkeypatch contract: called as proj(x).
+    assert torch.equal(Model._apply_proj(lambda z: z * 2, x, idx), x * 2)
+
+
+def test_pi07_embed_suffix_routes_action_in_proj_per_group(monkeypatch):
+    """`embed_suffix` applies the per-sample group row to ``action_in_proj``.
+
+    pi07 has no ``_embed_item``; the action projection lives inside
+    ``embed_suffix`` (shared by both the training ``forward`` and the inference
+    ``denoise_step``). Build a backbone-free model carrying only the suffix's
+    own submodules and confirm ``group_index`` selects the right row.
+    """
+    import opentau.policies.pi07.low_level.modeling_pi07_low_level as mod
+    from opentau.policies.pi07.low_level.modeling_pi07_low_level import PI07LowLevelFlowMatching
+
+    # Keep everything float32 so the float32 time_mlp doesn't clash with the
+    # default bf16 _preferred_dtype the suffix path casts inputs to.
+    monkeypatch.setattr(mod, "_preferred_dtype", lambda: torch.float32)
+
+    model = object.__new__(PI07LowLevelFlowMatching)
+    nn.Module.__init__(model)
+    action_dim, proj_width, chunk = 4, 8, 3
+    model.config = SimpleNamespace(proj_width=proj_width, chunk_size=chunk)
+
+    pgl = PerGroupLinear(action_dim, proj_width, num_groups=2)
+    with torch.no_grad():
+        pgl.weight[0].zero_()  # group 0 -> zeros
+        pgl.bias[0].zero_()
+        pgl.weight[1].fill_(1.0)  # group 1 -> sum over the (all-ones) inputs
+        pgl.bias[1].zero_()
+    model.action_in_proj = pgl
+    model.time_mlp_in = nn.Linear(proj_width, proj_width)
+    model.time_mlp_out = nn.Linear(proj_width, proj_width)
+
+    noisy = torch.ones(2, chunk, action_dim)
+    timestep = torch.zeros(2, chunk)
+    idx = torch.tensor([0, 1], dtype=torch.long)
+    embs, pad_masks, _att_masks, _adarms = model.embed_suffix(noisy, timestep, group_index=idx)
+
+    assert embs.shape == (2, chunk, proj_width)
+    assert torch.allclose(embs[0], torch.zeros(chunk, proj_width))  # routed to group 0
+    assert torch.allclose(embs[1], torch.full((chunk, proj_width), float(action_dim)))  # group 1
+    assert pad_masks.shape == (2, chunk)
+
+
+# --- train==eval head consistency (the property the feature relies on) --------
+
+
+def test_pi07_train_and_eval_resolve_same_head_and_projection_row():
+    """The same (robot_type, control_mode) selects the same head in both paths.
+
+    Training tags each sample with the norm-head ``dataset_index``; eval supplies
+    ``(robot_type, control_mode)``. Both flow through the shared
+    ``_resolve_dataset_index`` and must yield the same index -- and feeding that
+    index to the per-group ``state_proj`` must pick the same projection row, so
+    the head used at train time matches the head used at eval time.
+    """
+    # dataset_names ARE the norm keys "robot::control"; group 0 = panda::joint,
+    # group 1 = ur5::ee.
+    stub = _make_pi07_stub_policy(num_groups=2, per_group=True, dataset_names=["panda::joint", "ur5::ee"])
+
+    state = torch.randn(2, 4)
+    # Training-style batch: explicit per-sample norm-head row (sample 0 -> ur5::ee,
+    # sample 1 -> panda::joint).
+    train_batch = {"state": state, "dataset_index": torch.tensor([1, 0], dtype=torch.long)}
+    # Eval-style batch: the matching (robot_type, control_mode) pairs, same order.
+    eval_batch = {
+        "state": state,
+        "robot_type": ["ur5", "panda"],
+        "control_mode": ["ee", "joint"],
+    }
+
+    i_train = stub._resolve_dataset_index(train_batch)
+    i_eval = stub._resolve_dataset_index(eval_batch)
+
+    assert torch.equal(i_train, torch.tensor([1, 0]))
+    assert torch.equal(i_train, i_eval)
+
+    # And the resolved index drives the projection identically across paths.
+    x = torch.randn(2, 4)
+    out_train = stub.model.state_proj(x, i_train)
+    out_eval = stub.model.state_proj(x, i_eval)
+    torch.testing.assert_close(out_train, out_eval)
+    # Per-sample distinct rows actually fired (sanity: the two samples differ).
+    assert not torch.allclose(out_train[0], out_train[1])


### PR DESCRIPTION
## What this does

Ports the `per_group_projection` feature (added to `pi07_paligemma` in #370) to the **primary `pi07`** low-level policy, whose state/action projections were still plain `nn.Linear`.

When `policy.per_group_projection=true`, the three continuous projections (`state_proj`, `action_in_proj`, `action_out_proj`) each keep an independent `(weight, bias)` per `(robot_type, control_mode)` group — the same grouping the stacked `Normalize`/`Unnormalize` heads use — selected per-sample by `group_index` (the value `_resolve_dataset_index` returns). Because the training `forward` and the inference denoise loop both resolve that index the same way and thread it through `embed_prefix` / `embed_suffix` / the denoise loop and all three projections, a given `(robot_type, control_mode)` always routes to the **same projection head at train and eval time**, in lockstep with the norm head. `time_mlp_*` stay shared.

Off by default → byte-identical to the pre-flag model (same params, state-dict keys, numerics). The feature reuses the shared `PerGroupLinear` (`policies/layers.py`) and the checkpoint projection-remap / `ProjectionRemapError` load path (`policies/pretrained.py`): a legacy single-head checkpoint tiles into all groups, a multi-head checkpoint name-remaps onto the new ordering, and loading a per-group checkpoint into a flag-off policy raises rather than silently collapsing the group axis. No changes to the shared `layers.py` / `pretrained.py` machinery — this PR only wires `pi07` into it.

Label: 🗃️ Feature

## How it was tested

- Added `tests/policies/test_pi07_per_group_projection.py` (7 CPU tests): `_apply_proj` dispatch, the state-dict reconciliation through pi07's `model.*` projection prefixes (tile legacy single head → all groups; name-remap reorder + add a new group; downgrade into a flag-off policy raises), per-sample routing through the real `embed_suffix`, and a **train==eval head-consistency lock-in** — a given `(robot_type, control_mode)` resolves to the same head whether tagged by the training `dataset_index` or the eval `(robot_type, control_mode)` pair, and that index selects the same projection row.
- `pytest -m "not gpu" tests/policies/` → **481 passed, 2 skipped** (includes the new file). The flag-off path is byte-identical — existing pi07 tests are unchanged apart from a 1-line test-harness fix in `test_pi07_cpu.py` (its `embed_prefix` fake now carries `_apply_proj`).
- GPU pytests on the GPU dev box: `pytest -m "gpu" -n 0 tests/policies/test_pi07_low_level.py` passes on the real Gemma 3 backbone — the edited `embed_suffix` / `embed_prefix` and the FSDP-wrap forward/backward.
- Determinism (CLAUDE.md rule 3): the new `PerGroupLinear` op is bit-identical across two same-seed CUDA runs — forward and the `index_add` backward, including a same-group collision — and the real `embed_suffix` per-group routing is likewise bit-identical + correct on GPU. A full-model training determinism smoke and a LIBERO sim rollout require multi-GPU (full pi07 does not fit a single dev GPU's optimizer state), so they are left to the nightly GPU + regression CI.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/policies/test_pi07_per_group_projection.py
```

```bash
pytest -m "gpu" -n 0 tests/policies/test_pi07_low_level.py
```

Enable the feature by setting `--policy.per_group_projection=true` on a `pi07_low_level` config whose dataset mixture spans more than one `(robot_type, control_mode)` group (so `len(dataset_names) > 1`); leave it unset for the existing single-head behaviour.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [x] My PR includes policy-related changes.
  - [x] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
