### PR TITLE
test(pi07): use one import style in per-group projection test

### DIFF
--- a/tests/policies/test_pi07_per_group_projection.py
+++ b/tests/policies/test_pi07_per_group_projection.py
@@ -176,12 +176,16 @@ def test_pi07_embed_suffix_routes_action_in_proj_per_group(monkeypatch):
     ``denoise_step``). Build a backbone-free model carrying only the suffix's
     own submodules and confirm ``group_index`` selects the right row.
     """
-    import opentau.policies.pi07.low_level.modeling_pi07_low_level as mod
     from opentau.policies.pi07.low_level.modeling_pi07_low_level import PI07LowLevelFlowMatching
 
     # Keep everything float32 so the float32 time_mlp doesn't clash with the
-    # default bf16 _preferred_dtype the suffix path casts inputs to.
-    monkeypatch.setattr(mod, "_preferred_dtype", lambda: torch.float32)
+    # default bf16 _preferred_dtype the suffix path casts inputs to. Patch the
+    # module global via its dotted path so this file imports the modeling module
+    # one way only (`from ... import ...`).
+    monkeypatch.setattr(
+        "opentau.policies.pi07.low_level.modeling_pi07_low_level._preferred_dtype",
+        lambda: torch.float32,
+    )
 
     model = object.__new__(PI07LowLevelFlowMatching)
     nn.Module.__init__(model)


### PR DESCRIPTION
## What this does

Tiny test-only follow-up to #371. The new `tests/policies/test_pi07_per_group_projection.py` imported the modeling module two ways inside one test — `import opentau.policies.pi07.low_level.modeling_pi07_low_level as mod` **and** `from ...modeling_pi07_low_level import PI07LowLevelFlowMatching` — which the `github-code-quality` reviewer flagged (mixed import styles for one module). This drops the `import ... as mod` and instead patches the module global through its dotted path (`monkeypatch.setattr("opentau.policies.pi07.low_level.modeling_pi07_low_level._preferred_dtype", ...)`), so the file imports the modeling module a single way (`from ... import ...`), consistent with the other tests in it. No production code changes; the test's behaviour is unchanged.

Label: test/chore (cleanup).

## How it was tested

- `pytest -m "not gpu" tests/policies/test_pi07_per_group_projection.py` → 7 passed.
- `pre-commit` (ruff lint + format, etc.) clean.
- Test-only change — no policy/model code touched, so no GPU run is needed.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/policies/test_pi07_per_group_projection.py
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
