### PR TITLE
feat(envs): auto-download RoboCasa assets to a relocatable external store

### DIFF
--- a/src/opentau/envs/configs.py
+++ b/src/opentau/envs/configs.py
@@ -345,6 +345,11 @@ class RoboCasaEnv(EnvConfig):
         obj_registries: Object-mesh registries to sample assets from. Defaults to
             ``["lightwheel"]`` (the pack the asset downloader ships by default);
             add ``"objaverse"`` only after downloading that ~30GB pack.
+        assets_root: Directory to store/read RoboCasa kitchen assets, kept outside the
+            (ephemeral) uv venv. ``None`` resolves to the ``ROBOCASA_ASSETS_ROOT`` env
+            var, else ``HF_OPENTAU_HOME/robocasa/assets``.
+        auto_download_assets: If ``True`` (default), the asset packs ``obj_registries``
+            needs are downloaded automatically (once) on first env build.
         features: Mapping from logical feature names to ``PolicyFeature`` definitions.
         features_map: Mapping from environment keys to standardized OpenTau keys.
     """
@@ -361,6 +366,8 @@ class RoboCasaEnv(EnvConfig):
     visualization_width: int = 512
     split: str | None = None
     obj_registries: list[str] = field(default_factory=lambda: ["lightwheel"])
+    assets_root: str | None = None
+    auto_download_assets: bool = True
     features: dict[str, PolicyFeature] = field(
         default_factory=lambda: {
             "action": PolicyFeature(type=FeatureType.ACTION, shape=(12,)),

--- a/src/opentau/envs/factory.py
+++ b/src/opentau/envs/factory.py
@@ -95,6 +95,8 @@ def make_envs(
             env_cls=env_cls,
             episode_length=cfg.episode_length,
             obj_registries=tuple(cfg.obj_registries),
+            assets_root=cfg.assets_root,
+            auto_download_assets=cfg.auto_download_assets,
         )
 
     try:

--- a/src/opentau/envs/robocasa.py
+++ b/src/opentau/envs/robocasa.py
@@ -30,15 +30,23 @@ this module (e.g. in the CPU test suite) never requires the sim to be installed.
 
 from __future__ import annotations
 
+import importlib.util
+import json
+import os
+import shutil
 from collections import defaultdict
 from collections.abc import Callable, Sequence
 from functools import partial
+from pathlib import Path
 from typing import Any
+from urllib.request import urlretrieve
+from zipfile import ZipFile
 
 import gymnasium as gym
 import numpy as np
 from gymnasium import spaces
 
+from opentau.constants import HF_OPENTAU_HOME
 from opentau.utils.accelerate_utils import acc_print, get_proc_accelerator
 
 # Flat action/state vector dimensions for the PandaOmron mobile manipulator
@@ -107,6 +115,111 @@ def _default_camera_name_mapping(camera_names: Sequence[str]) -> dict[str, list[
     return {cam: [f"camera{i}"] for i, cam in enumerate(camera_names)}
 
 
+ROBOCASA_ASSETS_ROOT_ENV = "ROBOCASA_ASSETS_ROOT"
+
+
+def _resolve_robocasa_assets_root() -> Path:
+    r"""Directory where RoboCasa kitchen assets live, *outside* the ephemeral uv venv.
+
+    Resolution order: the ``ROBOCASA_ASSETS_ROOT`` env var, else a stable default under
+    OpenTau's HuggingFace cache (``HF_OPENTAU_HOME/robocasa/assets``). Deterministic in
+    every process — the main process and each ``AsyncVectorEnv`` spawn worker (which
+    inherits the env var) — so the per-process loader redirect and the one-time download
+    always agree on the same path.
+    """
+    env = os.environ.get(ROBOCASA_ASSETS_ROOT_ENV)
+    if env:
+        return Path(env).expanduser()
+    return HF_OPENTAU_HOME / "robocasa" / "assets"
+
+
+def _robocasa_pkg_assets_dir() -> Path:
+    r"""Locate ``<robocasa-pkg>/models/assets`` *without importing* robocasa.
+
+    Importing robocasa eagerly builds its object registry by scanning this directory at
+    import time (``kitchen_object_utils`` walks ``assets/objects`` to populate every
+    category's ``mjcf_paths``). So relocation has to be a symlink that is already in place
+    *before* the first import — which means locating the package via its import spec, not
+    via ``robocasa.__path__`` (that would require importing it).
+    """
+    spec = importlib.util.find_spec("robocasa")
+    if spec is None or not spec.submodule_search_locations:
+        raise ModuleNotFoundError("robocasa is not installed; cannot locate its assets dir.")
+    return Path(next(iter(spec.submodule_search_locations))) / "models" / "assets"
+
+
+def _direct_download_url(shared_url: str) -> str:
+    r"""Convert a Box shared link into a direct-download ``.zip`` URL.
+
+    Reimplements ``download_kitchen_assets._get_direct_download_url`` so we never import
+    that module — importing it imports robocasa, which would build the object registry
+    against the not-yet-relocated assets dir.
+    """
+    shared_id = shared_url.rstrip("/").split("/")[-1]
+    base = shared_url.split("/s/")[0]
+    return f"{base}/shared/static/{shared_id}.zip"
+
+
+def _download_and_extract_zip(url: str, dest: Path) -> None:
+    r"""Download ``url`` (a ``.zip``) and extract it so its top-level dir lands at ``dest``.
+
+    Mirrors robocasa's own downloader (extract into ``dest.parent``; the zip's single
+    top-level directory matches ``dest.name``) but without importing anything from robocasa.
+    """
+    download_dir = dest.parent
+    download_dir.mkdir(parents=True, exist_ok=True)
+    zip_path = download_dir / f"{dest.name}.zip"
+    try:
+        urlretrieve(url, filename=str(zip_path))  # noqa: S310  # nosec B310 - trusted UT-Austin Box URL
+        with ZipFile(zip_path) as zf:
+            zf.extractall(path=str(download_dir))  # noqa: S202  # nosec B202 - trusted first-party archive
+    finally:
+        if zip_path.exists():
+            zip_path.unlink()
+
+
+def _load_box_links(pkg_assets: Path, external_root: Path) -> dict:
+    r"""Load robocasa's ``box_links_assets.json`` (the per-pack download URLs)."""
+    for base in (external_root, pkg_assets):
+        path = base / "box_links" / "box_links_assets.json"
+        if path.is_file():
+            with open(path) as f:
+                return json.load(f)
+    raise FileNotFoundError(f"box_links_assets.json not found under {external_root} or {pkg_assets}.")
+
+
+def _symlink_pkg_assets_to(pkg_assets: Path, external_root: Path) -> None:
+    r"""Make ``pkg_assets`` (``<venv>/robocasa/models/assets``) a symlink to ``external_root``.
+
+    This is what relocates assets out of the ephemeral venv: robocasa keeps reading its
+    hardcoded ``models/assets`` path, but that path now points at the external store, so
+    even the import-time object-registry scan sees the downloaded packs. Idempotent.
+    """
+    target = external_root.resolve()
+    if pkg_assets.is_symlink():
+        if pkg_assets.resolve() == target:
+            return
+        pkg_assets.unlink()
+    elif pkg_assets.exists():
+        shutil.rmtree(pkg_assets)
+    pkg_assets.parent.mkdir(parents=True, exist_ok=True)
+    pkg_assets.symlink_to(target, target_is_directory=True)
+
+
+def _maybe_relink_robocasa_assets() -> None:
+    r"""Point robocasa's assets dir at the external store, *if* that store is ready.
+
+    Runs in every process right before robocasa is imported (notably ``AsyncVectorEnv``
+    spawn workers, which import robocasa fresh and must see the symlink the main process
+    created). It only acts once the store has been seeded by ``_ensure_robocasa_assets``,
+    so a plain install with no relocation keeps its wheel-bundled assets untouched.
+    """
+    external_root = _resolve_robocasa_assets_root()
+    if not (external_root / ".opentau_seeded").exists():
+        return
+    _symlink_pkg_assets_to(_robocasa_pkg_assets_dir(), external_root)
+
+
 def _import_robocasa_with_version_shim() -> None:
     """Import the top-level ``robocasa`` package despite its over-strict pins.
 
@@ -130,6 +243,11 @@ def _import_robocasa_with_version_shim() -> None:
     try:
         mujoco.__version__ = "3.3.1"
         numpy.__version__ = "2.2.5"
+        # Relocate robocasa's assets dir to the external store (a symlink) BEFORE importing
+        # it: the import eagerly builds its object registry by scanning models/assets, so
+        # the symlink must already be in place or the registry comes up empty (every object
+        # category gets zero candidates -> "Probabilities contain NaN" at sampling time).
+        _maybe_relink_robocasa_assets()
         import robocasa  # noqa: F401  (runs robocasa's version asserts once)
     finally:
         mujoco.__version__, numpy.__version__ = saved
@@ -162,6 +280,94 @@ def _resolve_tasks(task: str) -> tuple[list[str], str | None]:
     if not names:
         raise ValueError("`task` must contain at least one RoboCasa task name.")
     return names, None
+
+
+# RoboCasa ships its assets as separately-downloaded packs. Every kitchen scene needs the
+# base textures (plain + AI-generated wall/floor textures) and lightwheel fixtures; object
+# meshes depend on which registries the env samples from (``obj_registries``). Keys below
+# are the registry names accepted in ``RoboCasaEnv.obj_registries``; values map to packs.
+_BASE_ASSET_PACKS: tuple[str, ...] = ("textures", "tex_generative", "fixtures_lw")
+_REGISTRY_TO_PACK: dict[str, str] = {
+    "lightwheel": "objs_lw",
+    "objaverse": "objs_objaverse",
+    "aigen": "objs_aigen",
+    "aigen_objs": "objs_aigen",
+}
+# pack name -> (key into robocasa's ``BOX_LINKS``, destination subdir under assets_root)
+_PACK_DEST: dict[str, tuple[str, str]] = {
+    "textures": ("textures", "textures"),
+    "tex_generative": ("generative_textures", "generative_textures"),
+    "fixtures_lw": ("fixtures_lightwheel", "fixtures"),
+    "objs_lw": ("objects_lightwheel", "objects/lightwheel"),
+    "objs_objaverse": ("objaverse", "objects/objaverse"),
+    "objs_aigen": ("aigen_objs", "objects/aigen_objs"),
+}
+
+
+def _needed_asset_packs(obj_registries: Sequence[str]) -> list[str]:
+    r"""Asset packs required for ``obj_registries``: the base packs + per-registry objects."""
+    packs = list(_BASE_ASSET_PACKS)
+    for reg in obj_registries:
+        pack = _REGISTRY_TO_PACK.get(reg)
+        if pack is not None and pack not in packs:
+            packs.append(pack)
+    return packs
+
+
+def _ensure_robocasa_assets(assets_root: Path, obj_registries: Sequence[str]) -> None:
+    r"""Download the asset packs ``obj_registries`` needs into ``assets_root`` and relocate.
+
+    One-time, idempotent, and safe under distributed eval: only the main (or solo) process
+    seeds / downloads / symlinks, and **every** rank meets at a barrier afterwards (so
+    callers must invoke this before any per-rank early return, or non-main ranks desync at
+    NCCL).
+
+    robocasa ships some assets inside the wheel (fixture / scene / arena XML) that no
+    download pack contains, so the external store is first seeded from the installed
+    package, then the heavy packs (object meshes, textures, fixture meshes) are downloaded
+    into it, and finally the venv's ``models/assets`` is replaced by a symlink to the
+    store. Nothing here imports robocasa — that would build its object registry against the
+    not-yet-relocated assets dir — so the package is located via its import spec instead.
+    Per-pack marker files make re-runs (and the mixed ``fixtures`` dir, which holds both
+    shipped XML and downloaded meshes) skip cleanly.
+    """
+    pkg_assets = _robocasa_pkg_assets_dir()
+    needed = _needed_asset_packs(obj_registries)
+
+    acc = get_proc_accelerator()
+    distributed = acc is not None and acc.num_processes > 1
+    is_main_or_solo = (not distributed) or acc.is_main_process
+    try:
+        if is_main_or_solo:
+            assets_root.mkdir(parents=True, exist_ok=True)
+            # 1) Seed the wheel-shipped stubs (XML not in any pack) from the real venv dir.
+            seed_marker = assets_root / ".opentau_seeded"
+            if not pkg_assets.is_symlink() and pkg_assets.exists() and not seed_marker.exists():
+                shutil.copytree(pkg_assets, assets_root, dirs_exist_ok=True)
+                seed_marker.touch()
+            # 2) Download each missing pack into the external store.
+            box_links = _load_box_links(pkg_assets, assets_root)
+            for pack in needed:
+                pack_marker = assets_root / f".opentau_pack_{pack}.done"
+                if pack_marker.exists():
+                    continue
+                box_key, subdir = _PACK_DEST[pack]
+                dest = assets_root / subdir
+                acc_print(f"[opentau] downloading RoboCasa asset pack '{pack}' -> {dest}")
+                _download_and_extract_zip(_direct_download_url(box_links[box_key]), dest)
+                pack_marker.touch()
+            # 3) Relocate: point the venv's assets dir at the populated external store so
+            #    robocasa's import-time registry scan reads it.
+            if seed_marker.exists():
+                _symlink_pkg_assets_to(pkg_assets, assets_root)
+        if distributed:
+            acc.wait_for_everyone()
+    except Exception:
+        # Keep ranks in lockstep even if the main process fails here, so non-main ranks
+        # don't hang at the next collective; the exception still aborts the main process.
+        if distributed:
+            acc.wait_for_everyone()
+        raise
 
 
 def convert_action(flat_action: np.ndarray) -> dict[str, Any]:
@@ -453,6 +659,8 @@ def create_robocasa_envs(
     env_cls: type[gym.vector.SyncVectorEnv] | type[gym.vector.AsyncVectorEnv] | None = None,
     episode_length: int | None = None,
     obj_registries: Sequence[str] = DEFAULT_OBJ_REGISTRIES,
+    assets_root: str | None = None,
+    auto_download_assets: bool = True,
 ) -> dict[str, dict[int, gym.vector.VectorEnv]]:
     r"""Create vectorized RoboCasa365 environments with a consistent return shape.
 
@@ -475,6 +683,20 @@ def create_robocasa_envs(
         raise ValueError("env_cls must be a callable that wraps a list of environment factory callables.")
     if not isinstance(n_envs, int) or n_envs <= 0:
         raise ValueError(f"n_envs must be a positive int; got {n_envs}.")
+
+    # Relocate RoboCasa assets out of the (ephemeral) uv venv and make the packs the
+    # requested registries need available. Resolve + export the root, then run the download
+    # BEFORE `_resolve_tasks` (or any other) robocasa import, so the assets-dir symlink is
+    # already in place when robocasa builds its object registry at import. Propagate the
+    # root via os.environ so AsyncVectorEnv spawn workers relink to the same store. The
+    # download is rank-0 gated with an internal barrier, run before the per-rank task
+    # sharding / empty-rank early return below so every rank reaches that barrier.
+    resolved_assets_root = (
+        _resolve_robocasa_assets_root() if assets_root is None else Path(assets_root).expanduser()
+    )
+    os.environ[ROBOCASA_ASSETS_ROOT_ENV] = str(resolved_assets_root)
+    if auto_download_assets:
+        _ensure_robocasa_assets(resolved_assets_root, obj_registries)
 
     gym_kwargs = dict(gym_kwargs or {})
     obs_type = gym_kwargs.pop("obs_type", "pixels_agent_pos")

--- a/src/opentau/envs/robocasa.py
+++ b/src/opentau/envs/robocasa.py
@@ -40,7 +40,7 @@ from functools import partial
 from pathlib import Path
 from typing import Any
 from urllib.request import urlretrieve
-from zipfile import ZipFile
+from zipfile import BadZipFile, ZipFile
 
 import gymnasium as gym
 import numpy as np
@@ -160,22 +160,34 @@ def _direct_download_url(shared_url: str) -> str:
     return f"{base}/shared/static/{shared_id}.zip"
 
 
-def _download_and_extract_zip(url: str, dest: Path) -> None:
+def _download_and_extract_zip(url: str, dest: Path, retries: int = 3) -> None:
     r"""Download ``url`` (a ``.zip``) and extract it so its top-level dir lands at ``dest``.
 
     Mirrors robocasa's own downloader (extract into ``dest.parent``; the zip's single
-    top-level directory matches ``dest.name``) but without importing anything from robocasa.
+    top-level directory matches ``dest.name``, and the download is retried a few times for
+    these multi-GB packs) but without importing anything from robocasa. ``extractall`` is
+    not atomic, but the caller only writes the pack's done-marker after this returns cleanly,
+    so a failed/partial extract is simply retried and overwritten on the next attempt/run.
     """
     download_dir = dest.parent
     download_dir.mkdir(parents=True, exist_ok=True)
     zip_path = download_dir / f"{dest.name}.zip"
-    try:
-        urlretrieve(url, filename=str(zip_path))  # noqa: S310  # nosec B310 - trusted UT-Austin Box URL
-        with ZipFile(zip_path) as zf:
-            zf.extractall(path=str(download_dir))  # noqa: S202  # nosec B202 - trusted first-party archive
-    finally:
-        if zip_path.exists():
-            zip_path.unlink()
+    last_err: Exception | None = None
+    for attempt in range(1, retries + 1):
+        try:
+            urlretrieve(url, filename=str(zip_path))  # noqa: S310  # nosec B310 - trusted UT-Austin Box URL
+            with ZipFile(zip_path) as zf:
+                zf.extractall(path=str(download_dir))  # noqa: S202  # nosec B202 - trusted first-party archive
+            return
+        except (OSError, BadZipFile) as err:
+            last_err = err
+            acc_print(f"[opentau] RoboCasa asset download attempt {attempt}/{retries} failed: {err}")
+        finally:
+            if zip_path.exists():
+                zip_path.unlink()
+    raise RuntimeError(
+        f"Failed to download RoboCasa assets from {url} after {retries} attempts"
+    ) from last_err
 
 
 def _load_box_links(pkg_assets: Path, external_root: Path) -> dict:
@@ -330,6 +342,11 @@ def _ensure_robocasa_assets(assets_root: Path, obj_registries: Sequence[str]) ->
     not-yet-relocated assets dir — so the package is located via its import spec instead.
     Per-pack marker files make re-runs (and the mixed ``fixtures`` dir, which holds both
     shipped XML and downloaded meshes) skip cleanly.
+
+    Note: only the *global* main process downloads, so under multi-node eval ``assets_root``
+    must be on storage shared by all nodes. The default (under ``HF_OPENTAU_HOME``) is fine
+    for single-node eval; for a node-local ``HF_OPENTAU_HOME``, point ``ROBOCASA_ASSETS_ROOT``
+    at a shared path so non-zero nodes find the seeded store.
     """
     pkg_assets = _robocasa_pkg_assets_dir()
     needed = _needed_asset_packs(obj_registries)

--- a/src/opentau/envs/robocasa.py
+++ b/src/opentau/envs/robocasa.py
@@ -34,6 +34,7 @@ import importlib.util
 import json
 import os
 import shutil
+import socket
 from collections import defaultdict
 from collections.abc import Callable, Sequence
 from functools import partial
@@ -160,34 +161,45 @@ def _direct_download_url(shared_url: str) -> str:
     return f"{base}/shared/static/{shared_id}.zip"
 
 
+# Per-attempt socket timeout for asset downloads: a wedged connection (no data, no error)
+# raises socket.timeout (an OSError) and falls into the retry loop instead of hanging.
+_DOWNLOAD_TIMEOUT_S = 120
+
+
 def _download_and_extract_zip(url: str, dest: Path, retries: int = 3) -> None:
     r"""Download ``url`` (a ``.zip``) and extract it so its top-level dir lands at ``dest``.
 
     Mirrors robocasa's own downloader (extract into ``dest.parent``; the zip's single
-    top-level directory matches ``dest.name``, and the download is retried a few times for
-    these multi-GB packs) but without importing anything from robocasa. ``extractall`` is
-    not atomic, but the caller only writes the pack's done-marker after this returns cleanly,
-    so a failed/partial extract is simply retried and overwritten on the next attempt/run.
+    top-level directory matches ``dest.name``, and the download is retried a few times —
+    each attempt bounded by a socket timeout so a hung connection still fails over) but
+    without importing anything from robocasa. ``extractall`` is not atomic, but the caller
+    only writes the pack's done-marker after this returns cleanly, so a failed/partial
+    extract is simply retried and overwritten on the next attempt/run.
     """
     download_dir = dest.parent
     download_dir.mkdir(parents=True, exist_ok=True)
     zip_path = download_dir / f"{dest.name}.zip"
     last_err: Exception | None = None
-    for attempt in range(1, retries + 1):
-        try:
-            urlretrieve(url, filename=str(zip_path))  # noqa: S310  # nosec B310 - trusted UT-Austin Box URL
-            with ZipFile(zip_path) as zf:
-                zf.extractall(path=str(download_dir))  # noqa: S202  # nosec B202 - trusted first-party archive
-            return
-        except (OSError, BadZipFile) as err:
-            last_err = err
-            acc_print(f"[opentau] RoboCasa asset download attempt {attempt}/{retries} failed: {err}")
-        finally:
-            if zip_path.exists():
-                zip_path.unlink()
-    raise RuntimeError(
-        f"Failed to download RoboCasa assets from {url} after {retries} attempts"
-    ) from last_err
+    old_timeout = socket.getdefaulttimeout()
+    socket.setdefaulttimeout(_DOWNLOAD_TIMEOUT_S)
+    try:
+        for attempt in range(1, retries + 1):
+            try:
+                urlretrieve(url, filename=str(zip_path))  # noqa: S310  # nosec B310 - trusted Box URL
+                with ZipFile(zip_path) as zf:
+                    zf.extractall(path=str(download_dir))  # noqa: S202  # nosec B202 - trusted archive
+                return
+            except (OSError, BadZipFile) as err:
+                last_err = err
+                acc_print(f"[opentau] RoboCasa asset download attempt {attempt}/{retries} failed: {err}")
+            finally:
+                if zip_path.exists():
+                    zip_path.unlink()
+        raise RuntimeError(
+            f"Failed to download RoboCasa assets from {url} after {retries} attempts"
+        ) from last_err
+    finally:
+        socket.setdefaulttimeout(old_timeout)
 
 
 def _load_box_links(pkg_assets: Path, external_root: Path) -> dict:

--- a/src/opentau/scripts/download_robocasa_assets.py
+++ b/src/opentau/scripts/download_robocasa_assets.py
@@ -1,0 +1,66 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+r"""Pre-download RoboCasa365 kitchen assets into the venv-external assets root.
+
+The same download happens lazily on the first RoboCasa env build (see
+``opentau.envs.robocasa._ensure_robocasa_assets``), but warming the cache up front — e.g.
+on a login node before launching a multi-rank eval — means non-zero ranks never block on
+rank-0's first download.
+
+Examples::
+
+    python -m opentau.scripts.download_robocasa_assets
+    python -m opentau.scripts.download_robocasa_assets --obj_registries '["lightwheel","objaverse"]'
+    ROBOCASA_ASSETS_ROOT=/data/robocasa python -m opentau.scripts.download_robocasa_assets
+    python -m opentau.scripts.download_robocasa_assets --assets_root /data/robocasa
+"""
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from opentau.configs import parser
+from opentau.envs.robocasa import (
+    ROBOCASA_ASSETS_ROOT_ENV,
+    _ensure_robocasa_assets,
+    _needed_asset_packs,
+    _resolve_robocasa_assets_root,
+)
+
+
+@dataclass
+class Args:
+    # External directory to download into. ``None`` -> ROBOCASA_ASSETS_ROOT env var, else
+    # the HF_OPENTAU_HOME default (kept outside the ephemeral uv venv).
+    assets_root: str | None = None
+    # Object-mesh registries whose packs to fetch (matches RoboCasaEnv.obj_registries).
+    obj_registries: list[str] = field(default_factory=lambda: ["lightwheel"])
+
+
+@parser.wrap()
+def main(args: Args):
+    root = Path(args.assets_root).expanduser() if args.assets_root else _resolve_robocasa_assets_root()
+    # Export before downloading so the loader redirect (run during the robocasa import in
+    # `_ensure_robocasa_assets`) and the download destinations agree on the same path.
+    os.environ[ROBOCASA_ASSETS_ROOT_ENV] = str(root)
+
+    print("RoboCasa assets root:", root)
+    print("Asset packs to ensure:", _needed_asset_packs(args.obj_registries))
+    _ensure_robocasa_assets(root, args.obj_registries)
+    print("Done. RoboCasa assets ready at:", root)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/envs/test_robocasa.py
+++ b/tests/envs/test_robocasa.py
@@ -41,6 +41,7 @@ from opentau.envs.robocasa import (
     OBS_STATE_DIM,
     ROBOCASA_ASSETS_ROOT_ENV,
     _default_camera_name_mapping,
+    _direct_download_url,
     _ensure_robocasa_assets,
     _import_robocasa_with_version_shim,
     _maybe_relink_robocasa_assets,
@@ -353,6 +354,22 @@ class TestNeededAssetPacks:
             "fixtures_lw",
             "objs_lw",
         ]
+
+
+class TestDirectDownloadUrl:
+    """``_direct_download_url`` rewrites a Box share link to a direct-download ``.zip``."""
+
+    def test_rewrites_box_share_url(self):
+        assert (
+            _direct_download_url("https://utexas.box.com/s/abc123")
+            == "https://utexas.box.com/shared/static/abc123.zip"
+        )
+
+    def test_tolerates_trailing_slash(self):
+        assert (
+            _direct_download_url("https://utexas.box.com/s/xyz789/")
+            == "https://utexas.box.com/shared/static/xyz789.zip"
+        )
 
 
 class TestEnsureRoboCasaAssets:

--- a/tests/envs/test_robocasa.py
+++ b/tests/envs/test_robocasa.py
@@ -23,6 +23,9 @@ action/camera helpers are all exercisable without a GPU or the sim installed.
 Real sim rollouts are validated separately on a CUDA box.
 """
 
+import json
+import os
+from pathlib import Path
 from unittest.mock import Mock, patch
 
 import numpy as np
@@ -30,16 +33,23 @@ import pytest
 
 from opentau.configs.train import TrainPipelineConfig
 from opentau.configs.types import FeatureType
-from opentau.constants import ACTION, OBS_IMAGES, OBS_STATE
+from opentau.constants import ACTION, HF_OPENTAU_HOME, OBS_IMAGES, OBS_STATE
 from opentau.envs.configs import EnvConfig, RoboCasaEnv
 from opentau.envs.factory import make_env_config, make_envs
 from opentau.envs.robocasa import (
     ACTION_DIM,
     OBS_STATE_DIM,
+    ROBOCASA_ASSETS_ROOT_ENV,
     _default_camera_name_mapping,
+    _ensure_robocasa_assets,
     _import_robocasa_with_version_shim,
+    _maybe_relink_robocasa_assets,
+    _needed_asset_packs,
     _parse_camera_names,
+    _resolve_robocasa_assets_root,
     _resolve_tasks,
+    _robocasa_pkg_assets_dir,
+    _symlink_pkg_assets_to,
     convert_action,
     create_robocasa_envs,
 )
@@ -192,14 +202,15 @@ class TestCreateRoboCasaEnvs:
     """``create_robocasa_envs`` return shape and per-rank task sharding.
 
     ``env_cls`` is mocked so the env factories are never invoked — no
-    ``RoboCasaEnv`` is constructed and the sim is never imported.
+    ``RoboCasaEnv`` is constructed and the sim is never imported. Asset
+    auto-download is disabled here (its own tests cover it) so these stay sim-free.
     """
 
     def test_returns_one_vec_env_per_task(self):
         sentinel = Mock(name="vec_env")
         env_cls = Mock(return_value=sentinel)
         with patch("opentau.envs.robocasa.get_proc_accelerator", return_value=None):
-            out = create_robocasa_envs(task="A,B", n_envs=3, env_cls=env_cls)
+            out = create_robocasa_envs(task="A,B", n_envs=3, env_cls=env_cls, auto_download_assets=False)
         assert set(out.keys()) == {"A", "B"}
         assert out["A"][0] is sentinel and out["B"][0] is sentinel
         # Each task built one vec env from exactly n_envs factory callables.
@@ -216,14 +227,14 @@ class TestCreateRoboCasaEnvs:
         env_cls = Mock(return_value=Mock())
         acc = _mock_accelerator(num_processes=2, process_index=process_index)
         with patch("opentau.envs.robocasa.get_proc_accelerator", return_value=acc):
-            out = create_robocasa_envs(task="A,B,C,D", n_envs=1, env_cls=env_cls)
+            out = create_robocasa_envs(task="A,B,C,D", n_envs=1, env_cls=env_cls, auto_download_assets=False)
         assert set(out.keys()) == expected
 
     def test_more_ranks_than_tasks_returns_empty(self):
         env_cls = Mock(return_value=Mock())
         acc = _mock_accelerator(num_processes=4, process_index=2)
         with patch("opentau.envs.robocasa.get_proc_accelerator", return_value=acc):
-            out = create_robocasa_envs(task="A", n_envs=1, env_cls=env_cls)
+            out = create_robocasa_envs(task="A", n_envs=1, env_cls=env_cls, auto_download_assets=False)
         assert out == {}
         env_cls.assert_not_called()
 
@@ -256,7 +267,306 @@ class TestMakeEnvsDispatch:
         assert kwargs["n_envs"] == 2
         assert kwargs["episode_length"] == 1000
         assert kwargs["obj_registries"] == ("lightwheel",)
+        assert kwargs["assets_root"] is None
+        assert kwargs["auto_download_assets"] is True
         # SyncVectorEnv path: env_cls is the class itself.
         import gymnasium as gym
 
         assert kwargs["env_cls"] is gym.vector.SyncVectorEnv
+
+
+def _fake_robocasa_assets(monkeypatch, tmp_path: Path) -> tuple[Path, list[dict]]:
+    """Point ``_ensure_robocasa_assets`` at a throwaway pkg dir with a stubbed downloader.
+
+    Mirrors a real robocasa install enough to exercise seed -> download -> symlink without
+    the sim or the network: ``_robocasa_pkg_assets_dir`` resolves to a fake ``models/assets``
+    dir holding the box-links JSON + a shipped stub, and ``_download_and_extract_zip`` just
+    records its calls and creates the destination. Returns ``(pkg_assets, recorded_calls)``.
+    """
+    pkg_assets = tmp_path / "pkg" / "models" / "assets"
+    (pkg_assets / "box_links").mkdir(parents=True)
+    (pkg_assets / "box_links" / "box_links_assets.json").write_text(
+        json.dumps(
+            {
+                "textures": "https://x.box.com/s/tex",
+                "generative_textures": "https://x.box.com/s/gentex",
+                "fixtures_lightwheel": "https://x.box.com/s/fix",
+                "objects_lightwheel": "https://x.box.com/s/objlw",
+                "objaverse": "https://x.box.com/s/obja",
+                "aigen_objs": "https://x.box.com/s/aig",
+            }
+        )
+    )
+    (pkg_assets / "shipped_stub.xml").write_text("<mujoco/>")
+
+    calls: list[dict] = []
+
+    def _fake_download(url, dest):
+        calls.append({"url": url, "dest": str(dest)})
+        Path(dest).mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr("opentau.envs.robocasa._robocasa_pkg_assets_dir", lambda: pkg_assets)
+    monkeypatch.setattr("opentau.envs.robocasa._download_and_extract_zip", _fake_download)
+    return pkg_assets, calls
+
+
+class TestResolveAssetsRoot:
+    """``_resolve_robocasa_assets_root`` env-var resolution + default location."""
+
+    def test_env_var_takes_precedence(self, monkeypatch, tmp_path):
+        monkeypatch.setenv(ROBOCASA_ASSETS_ROOT_ENV, str(tmp_path))
+        assert _resolve_robocasa_assets_root() == tmp_path
+
+    def test_default_under_hf_opentau_home(self, monkeypatch):
+        monkeypatch.delenv(ROBOCASA_ASSETS_ROOT_ENV, raising=False)
+        assert _resolve_robocasa_assets_root() == HF_OPENTAU_HOME / "robocasa" / "assets"
+
+    def test_env_var_is_expanduser(self, monkeypatch):
+        monkeypatch.setenv(ROBOCASA_ASSETS_ROOT_ENV, "~/robocasa_assets_xyz")
+        out = _resolve_robocasa_assets_root()
+        assert "~" not in str(out)
+        assert str(out).endswith("robocasa_assets_xyz")
+
+
+class TestNeededAssetPacks:
+    """``_needed_asset_packs`` maps obj_registries to downloader pack names."""
+
+    def test_lightwheel_default(self):
+        assert _needed_asset_packs(["lightwheel"]) == ["textures", "tex_generative", "fixtures_lw", "objs_lw"]
+
+    def test_objaverse_appends_pack(self):
+        assert _needed_asset_packs(["lightwheel", "objaverse"]) == [
+            "textures",
+            "tex_generative",
+            "fixtures_lw",
+            "objs_lw",
+            "objs_objaverse",
+        ]
+
+    def test_unknown_registry_ignored(self):
+        assert _needed_asset_packs(["nonsuch"]) == ["textures", "tex_generative", "fixtures_lw"]
+
+    def test_duplicates_collapsed(self):
+        assert _needed_asset_packs(["lightwheel", "lightwheel"]) == [
+            "textures",
+            "tex_generative",
+            "fixtures_lw",
+            "objs_lw",
+        ]
+
+
+class TestEnsureRoboCasaAssets:
+    """``_ensure_robocasa_assets`` seeds stubs, downloads packs, symlinks, and is rank-safe."""
+
+    def test_seeds_downloads_and_symlinks_when_absent(self, monkeypatch, tmp_path):
+        pkg_assets, calls = _fake_robocasa_assets(monkeypatch, tmp_path)
+        monkeypatch.setattr("opentau.envs.robocasa.get_proc_accelerator", lambda: None)
+        root = tmp_path / "external"
+
+        _ensure_robocasa_assets(root, ["lightwheel"])
+
+        # wheel-shipped stub seeded into the external store + seed marker written
+        assert (root / "shipped_stub.xml").is_file()
+        assert (root / ".opentau_seeded").is_file()
+        # lightwheel -> textures, tex_generative, fixtures_lw, objs_lw downloaded + marked
+        assert len(calls) == 4
+        for pack in ("textures", "tex_generative", "fixtures_lw", "objs_lw"):
+            assert (root / f".opentau_pack_{pack}.done").is_file()
+        # relocation: the venv assets dir is now a symlink to the external store
+        assert pkg_assets.is_symlink()
+        assert pkg_assets.resolve() == root.resolve()
+
+    def test_skips_packs_with_existing_markers(self, monkeypatch, tmp_path):
+        pkg_assets, calls = _fake_robocasa_assets(monkeypatch, tmp_path)
+        monkeypatch.setattr("opentau.envs.robocasa.get_proc_accelerator", lambda: None)
+        root = tmp_path / "external"
+        root.mkdir()
+        (root / ".opentau_seeded").touch()
+        for pack in ("textures", "tex_generative", "fixtures_lw", "objs_lw"):
+            (root / f".opentau_pack_{pack}.done").touch()
+
+        _ensure_robocasa_assets(root, ["lightwheel"])
+
+        assert calls == []  # everything already present, nothing re-downloaded
+        assert pkg_assets.is_symlink()  # still (re)linked to the store
+
+    def test_non_main_rank_does_nothing_but_barriers(self, monkeypatch, tmp_path):
+        pkg_assets, calls = _fake_robocasa_assets(monkeypatch, tmp_path)
+        acc = Mock()
+        acc.num_processes = 2
+        acc.is_main_process = False
+        monkeypatch.setattr("opentau.envs.robocasa.get_proc_accelerator", lambda: acc)
+        root = tmp_path / "external"
+
+        _ensure_robocasa_assets(root, ["lightwheel"])
+
+        assert calls == []
+        assert not root.exists()  # non-main rank does not seed/download/mkdir
+        assert not pkg_assets.is_symlink()  # nor relink
+        acc.wait_for_everyone.assert_called_once()
+
+    def test_main_rank_distributed_downloads_and_barriers(self, monkeypatch, tmp_path):
+        pkg_assets, calls = _fake_robocasa_assets(monkeypatch, tmp_path)
+        acc = Mock()
+        acc.num_processes = 2
+        acc.is_main_process = True
+        monkeypatch.setattr("opentau.envs.robocasa.get_proc_accelerator", lambda: acc)
+        root = tmp_path / "external"
+
+        _ensure_robocasa_assets(root, ["lightwheel"])
+
+        assert len(calls) == 4
+        assert pkg_assets.is_symlink()
+        acc.wait_for_everyone.assert_called_once()
+
+
+class TestSymlinkAndRelink:
+    """``_symlink_pkg_assets_to`` / ``_maybe_relink_robocasa_assets`` relocation behaviour."""
+
+    def test_symlink_replaces_real_dir(self, tmp_path):
+        pkg_assets = tmp_path / "pkg" / "assets"
+        pkg_assets.mkdir(parents=True)
+        (pkg_assets / "stub.txt").write_text("x")
+        external = tmp_path / "external"
+        external.mkdir()
+
+        _symlink_pkg_assets_to(pkg_assets, external)
+
+        assert pkg_assets.is_symlink()
+        assert pkg_assets.resolve() == external.resolve()
+
+    def test_symlink_is_idempotent(self, tmp_path):
+        pkg_assets = tmp_path / "pkg" / "assets"
+        pkg_assets.mkdir(parents=True)
+        external = tmp_path / "external"
+        external.mkdir()
+
+        _symlink_pkg_assets_to(pkg_assets, external)
+        _symlink_pkg_assets_to(pkg_assets, external)  # second call is a no-op
+
+        assert pkg_assets.is_symlink()
+        assert pkg_assets.resolve() == external.resolve()
+
+    def test_maybe_relink_noop_when_store_not_seeded(self, monkeypatch, tmp_path):
+        pkg_assets = tmp_path / "pkg" / "assets"
+        pkg_assets.mkdir(parents=True)
+        external = tmp_path / "external"  # never created / not seeded
+        monkeypatch.setattr("opentau.envs.robocasa._resolve_robocasa_assets_root", lambda: external)
+        monkeypatch.setattr("opentau.envs.robocasa._robocasa_pkg_assets_dir", lambda: pkg_assets)
+
+        _maybe_relink_robocasa_assets()
+
+        assert not pkg_assets.is_symlink()  # bundled assets left untouched
+
+    def test_maybe_relink_symlinks_when_seeded(self, monkeypatch, tmp_path):
+        pkg_assets = tmp_path / "pkg" / "assets"
+        pkg_assets.mkdir(parents=True)
+        external = tmp_path / "external"
+        external.mkdir()
+        (external / ".opentau_seeded").touch()
+        monkeypatch.setattr("opentau.envs.robocasa._resolve_robocasa_assets_root", lambda: external)
+        monkeypatch.setattr("opentau.envs.robocasa._robocasa_pkg_assets_dir", lambda: pkg_assets)
+
+        _maybe_relink_robocasa_assets()
+
+        assert pkg_assets.is_symlink()
+        assert pkg_assets.resolve() == external.resolve()
+
+
+class TestCreateRoboCasaEnvsAssets:
+    """``create_robocasa_envs`` exports the assets root and gates the download."""
+
+    def test_sets_env_var_and_calls_ensure(self, monkeypatch, tmp_path):
+        monkeypatch.delenv(ROBOCASA_ASSETS_ROOT_ENV, raising=False)
+        ensure = Mock()
+        monkeypatch.setattr("opentau.envs.robocasa._ensure_robocasa_assets", ensure)
+        monkeypatch.setattr("opentau.envs.robocasa.get_proc_accelerator", lambda: None)
+        env_cls = Mock(return_value=Mock(name="vec_env"))
+
+        create_robocasa_envs(task="CloseFridge", n_envs=1, env_cls=env_cls, assets_root=str(tmp_path))
+
+        assert os.environ[ROBOCASA_ASSETS_ROOT_ENV] == str(tmp_path)
+        ensure.assert_called_once()
+        assert ensure.call_args.args[0] == tmp_path
+
+    def test_auto_download_false_skips_ensure_but_still_sets_env(self, monkeypatch, tmp_path):
+        monkeypatch.delenv(ROBOCASA_ASSETS_ROOT_ENV, raising=False)
+        ensure = Mock()
+        monkeypatch.setattr("opentau.envs.robocasa._ensure_robocasa_assets", ensure)
+        monkeypatch.setattr("opentau.envs.robocasa.get_proc_accelerator", lambda: None)
+        env_cls = Mock(return_value=Mock())
+
+        create_robocasa_envs(
+            task="CloseFridge",
+            n_envs=1,
+            env_cls=env_cls,
+            assets_root=str(tmp_path),
+            auto_download_assets=False,
+        )
+
+        ensure.assert_not_called()
+        assert os.environ[ROBOCASA_ASSETS_ROOT_ENV] == str(tmp_path)
+
+    def test_default_assets_root_uses_resolver(self, monkeypatch):
+        monkeypatch.delenv(ROBOCASA_ASSETS_ROOT_ENV, raising=False)
+        monkeypatch.setattr("opentau.envs.robocasa._ensure_robocasa_assets", Mock())
+        monkeypatch.setattr("opentau.envs.robocasa.get_proc_accelerator", lambda: None)
+        env_cls = Mock(return_value=Mock())
+
+        create_robocasa_envs(task="CloseFridge", n_envs=1, env_cls=env_cls)
+
+        assert os.environ[ROBOCASA_ASSETS_ROOT_ENV] == str(HF_OPENTAU_HOME / "robocasa" / "assets")
+
+    def test_ensure_runs_before_empty_rank_return(self, monkeypatch):
+        # A rank with no assigned tasks still runs `_ensure_robocasa_assets` (and thus its
+        # barrier) before the empty-rank early return — otherwise ranks desync at NCCL.
+        ensure = Mock()
+        monkeypatch.setattr("opentau.envs.robocasa._ensure_robocasa_assets", ensure)
+        acc = _mock_accelerator(num_processes=4, process_index=2)
+        monkeypatch.setattr("opentau.envs.robocasa.get_proc_accelerator", lambda: acc)
+        env_cls = Mock(return_value=Mock())
+
+        out = create_robocasa_envs(task="A", n_envs=1, env_cls=env_cls)
+
+        assert out == {}  # this rank got no task
+        ensure.assert_called_once()  # but the asset/barrier step still ran
+
+
+@pytest.mark.gpu
+@pytest.mark.slow
+def test_robocasa_autodownload_and_rollout_from_relocated_root(monkeypatch):
+    """End-to-end on a CUDA box (needs the sim + EGL + network on a cold cache).
+
+    Auto-downloads the lightwheel asset packs into the venv-external assets root, then a
+    real ``CloseFridge`` reset+step reads from there — proving both the auto-download and
+    the relocation (``robocasa.models.assets_root`` points outside ``site-packages``).
+    The packs are cached across runs via the per-pack marker files.
+    """
+    monkeypatch.setenv("MUJOCO_GL", "egl")
+    from opentau.envs.robocasa import RoboCasaEnv as RoboCasaGymEnv
+
+    root = _resolve_robocasa_assets_root()
+    monkeypatch.setenv(ROBOCASA_ASSETS_ROOT_ENV, str(root))
+    _ensure_robocasa_assets(root, ["lightwheel"])
+
+    # Relocation: the venv assets dir is a symlink into the external (out-of-venv) store.
+    pkg_assets = _robocasa_pkg_assets_dir()
+    assert pkg_assets.is_symlink()
+    assert pkg_assets.resolve() == root.resolve()
+    assert "site-packages" not in str(root)
+    assert (root / "objects" / "lightwheel").is_dir()
+
+    # robocasa's hardcoded assets_root resolves to the external store via the symlink.
+    _import_robocasa_with_version_shim()
+    import robocasa.models
+
+    assert Path(robocasa.models.assets_root).resolve() == root.resolve()
+
+    env = RoboCasaGymEnv(task="CloseFridge", observation_width=128, observation_height=128)
+    try:
+        obs, _info = env.reset(seed=0)
+        assert "pixels" in obs
+        obs, _rew, _term, _trunc, _info = env.step(np.zeros(ACTION_DIM, dtype=np.float32))
+        assert "pixels" in obs
+    finally:
+        env.close()


### PR DESCRIPTION
## What this does

Running a RoboCasa env (`env.type=robocasa`) crashed on the first scene build with `FileNotFoundError` / `ValueError: Probabilities contain NaN`: robocasa's multi-GB kitchen asset packs are not installed by `uv sync` and robocasa ships no auto-download — and even when downloaded, they land *inside* the venv and are lost whenever it is recreated.

This makes the assets **download automatically, once**, into a **venv-external, relocatable** store:

- `_ensure_robocasa_assets` (rank-0 gated, with a cross-rank barrier so distributed eval stays in NCCL lockstep) seeds the wheel-shipped stubs, then downloads exactly the packs an env's `obj_registries` need — `textures`, `tex_generative`, `fixtures_lw`, and the per-registry object packs (e.g. `objs_lw`) — into the store, guarded by per-pack marker files.
- It then **symlinks** `<venv>/robocasa/models/assets` → the store. A symlink (rather than patching `robocasa.models.assets_root`) is required because robocasa builds its object registry by scanning `models/assets` **at import time**, so the relocation must be in place *before* robocasa is imported — done in the version shim, in every process including `AsyncVectorEnv` spawn workers.
- The store defaults to `$HF_OPENTAU_HOME/robocasa/assets`, overridable via the `ROBOCASA_ASSETS_ROOT` env var or the new `env.assets_root` config field. Because it lives outside the venv, ephemeral `uv` envs no longer lose or re-download assets.

Adds `RoboCasaEnv` config fields `assets_root` and `auto_download_assets` (default on), forwarded through the env factory, plus a `opentau.scripts.download_robocasa_assets` warm-up script for pre-fetching on a login node before a multi-rank eval.

Label: 🗃️ Feature

## How it was tested

- Added 14 CPU tests + 1 `@pytest.mark.gpu` end-to-end test in `tests/envs/test_robocasa.py` (env-var resolver, symlink/relink, needed-packs mapping, rank-0-gated download with barrier, factory wiring). `pytest -m "not gpu"` → 45 passed locally; 50 with `robocasa` + `libero` installed (including `test_factory`).
- End-to-end on a CUDA box (sim + EGL): the `@pytest.mark.gpu` test auto-downloads the lightwheel pack set (~4.4G) into the external store and runs a real `CloseFridge` reset+step — **passed**. Confirmed the venv's `models/assets` is a symlink into the external store (outside `site-packages`).
- Ephemeral / idempotent: a second run did **0 re-downloads** (marker-guarded) and passed in ~12s.
- `pre-commit run --all-files` clean (ruff, ruff-format, bandit, …).

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/envs/test_robocasa.py -m "not gpu"
```

On a CUDA box with the sim installed (downloads ~4.4G of assets to `$HF_OPENTAU_HOME/robocasa/assets` on first run, cached thereafter):

```bash
MUJOCO_GL=egl pytest -sx tests/envs/test_robocasa.py -m gpu
```

Or pre-fetch the assets without running an eval:

```bash
python -m opentau.scripts.download_robocasa_assets
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
