### PR TITLE
Fixing success rate logging bug in robocasa

### DIFF
--- a/src/opentau/envs/robocasa.py
+++ b/src/opentau/envs/robocasa.py
@@ -118,21 +118,50 @@ def _import_robocasa_with_version_shim() -> None:
     only for the one-time package import, then restore them. A robocasa packaging
     fork that drops the asserts makes this shim unnecessary; until then it lets
     the integration run on a stock ``pip install robocasa``. No-op once imported.
+
+    Also guards against a name collision: OpenTau ships an internal
+    ``opentau/scripts/robocasa`` package (the inference WebSocket server). When
+    ``train.py`` / ``eval.py`` are run as scripts (which is how ``accelerate
+    launch`` and the ``opentau-*`` console entry points invoke them), Python puts
+    ``opentau/scripts/`` on ``sys.path[0]``, so a bare ``import robocasa`` resolves
+    to that empty server package instead of the installed sim — leaving RoboCasa's
+    kitchen envs (e.g. ``CloseCabinet``) unregistered and every rollout raising
+    ``Environment ... not found``. We strip the shadowing path entry for the
+    duration of the import (and purge an already-imported shadow) so the real sim
+    package wins.
     """
+    import os
     import sys
 
-    if "robocasa" in sys.modules:
-        return
+    internal_pkg = os.path.realpath(os.path.join(os.path.dirname(__file__), os.pardir, "scripts", "robocasa"))
+
+    def _is_shadow(mod) -> bool:
+        mod_file = getattr(mod, "__file__", "") or ""
+        return os.path.realpath(os.path.dirname(mod_file)) == internal_pkg
+
+    existing = sys.modules.get("robocasa")
+    if existing is not None:
+        if not _is_shadow(existing):
+            return
+        # The internal server package got imported under the bare name first;
+        # purge it (and any submodules) so we can load the real sim package.
+        for name in [m for m in sys.modules if m == "robocasa" or m.startswith("robocasa.")]:
+            del sys.modules[name]
+
     import mujoco
     import numpy
 
     saved = (mujoco.__version__, numpy.__version__)
+    saved_path = list(sys.path)
+    # Drop the path entry that would resolve ``robocasa`` to the internal package.
+    sys.path[:] = [p for p in sys.path if os.path.realpath(os.path.join(p, "robocasa")) != internal_pkg]
     try:
         mujoco.__version__ = "3.3.1"
         numpy.__version__ = "2.2.5"
         import robocasa  # noqa: F401  (runs robocasa's version asserts once)
     finally:
         mujoco.__version__, numpy.__version__ = saved
+        sys.path[:] = saved_path
 
 
 def _resolve_tasks(task: str) -> tuple[list[str], str | None]:

--- a/src/opentau/envs/utils.py
+++ b/src/opentau/envs/utils.py
@@ -116,6 +116,24 @@ def are_all_envs_same_type(env: gym.vector.VectorEnv) -> bool:
     return all(t == first_type for t in types)
 
 
+def _env_attr_present(env: gym.vector.VectorEnv, attr: str) -> list[bool]:
+    r"""Return, per sub-env, whether wrapper attribute ``attr`` exists.
+
+    gymnasium ``>=1.0`` exposes ``Env.has_wrapper_attr`` for this, but the
+    RoboCasa / LIBERO stack caps gymnasium below ``1.0`` (via ``lerobot``), so
+    that method is unavailable here. Emulate it with ``get_wrapper_attr``, which
+    exists on ``0.29`` and raises ``AttributeError`` when the attribute is
+    absent — the same accessor ``add_envs_task`` already relies on.
+    """
+    if hasattr(env, "has_wrapper_attr"):
+        return list(env.call("has_wrapper_attr", attr))
+    try:
+        env.call("get_wrapper_attr", attr)
+        return [True] * env.num_envs
+    except AttributeError:
+        return [False] * env.num_envs
+
+
 def check_env_attributes_and_types(env: gym.vector.VectorEnv) -> None:
     r"""Checks if all environments in a vectorized environment have 'task_description' or 'task' attributes.
     A warning will be raised if any environment is missing these attributes.
@@ -133,8 +151,8 @@ def check_env_attributes_and_types(env: gym.vector.VectorEnv) -> None:
                 "Only gym.vector.SyncVectorEnv and gym.vector.AsyncVectorEnv are supported for now."
             )
 
-        task_desc_set = env.call("has_wrapper_attr", "task_description")
-        task_set = env.call("has_wrapper_attr", "task")
+        task_desc_set = _env_attr_present(env, "task_description")
+        task_set = _env_attr_present(env, "task")
         if not all(td or t for td, t in zip(task_desc_set, task_set, strict=True)):
             warnings.warn(
                 "At least 1 environment does not have 'task_description' or 'task'. Some policies require these features.",


### PR DESCRIPTION
## What this does

🐛 **Bug** — Fixes RoboCasa evaluation crashing before any success rate is logged to wandb.

Two independent bugs prevented the RoboCasa eval rollout from running at all, so `Success Rate` / `Success/{task}` never reached wandb during training:

1. **`import robocasa` resolved to the wrong package.** OpenTau ships an internal `opentau/scripts/robocasa` package (the inference WebSocket server). When `train.py` / `eval.py` run as scripts — which is how `accelerate launch` and the `opentau-*` console entry points invoke them — Python puts `opentau/scripts/` on `sys.path[0]`, so a bare `import robocasa` loaded that empty server package instead of the installed sim. RoboCasa's kitchen envs never registered and every rollout raised `Environment CloseCabinet not found ... among: Lift, Stack, ...`. `_import_robocasa_with_version_shim` now strips the shadowing path entry for the duration of the import and purges an already-imported shadow, so the real sim package wins. (It does not reproduce from a `python -c` at the repo root, only under the launcher — which is why it slipped through.)

2. **`has_wrapper_attr` is a gymnasium ≥1.0 API.** `check_env_attributes_and_types` called `env.call("has_wrapper_attr", ...)`, but the RoboCasa/LIBERO stack caps gymnasium below 1.0 (via `lerobot`), so the rollout raised `AttributeError: 'RoboCasaEnv' object has no attribute 'has_wrapper_attr'`. Added a small version-agnostic `_env_attr_present` helper that falls back to `get_wrapper_attr` (the accessor `add_envs_task` already uses) on gymnasium 0.29.

After both fixes the RoboCasa rollout completes and `Success Rate` (overall) + `Success/{task}` (per-task) are logged to wandb each eval.

## How it was tested

- `pre-commit run --all-files` (ruff lint+format, etc.) clean on the changed files.
- `pytest -m "not gpu" tests/envs/test_robocasa.py tests/envs/test_utils.py` — all RoboCasa tests and the `check_env_attributes_and_types` tests pass. (One pre-existing, unrelated failure remains: `test_utils.py::test_envs_different_types` uses gymnasium 1.x's `SyncVectorEnv(observation_mode=...)` kwarg, absent in the installed 0.29.1.)
- End-to-end smoke on a 2× RTX 3090 desktop (`MUJOCO_GL=osmesa`): fine-tuned pi0.5 (vision backbone + VLM frozen) on a RoboCasa dataset with a periodic `CloseCabinet` eval. Before: eval crashed at the two points above. After: the rollout runs to completion and wandb shows `Success Rate`, `Success/CloseCabinet`, `Evaluation Time`, and the eval vide

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/envs/test_robocasa.py

Reproduce the shadow fix directly (this is the bare-import bug the shim now guards against):

python - <<'PY'
import os, sys
sys.path.insert(0, os.path.abspath("src/opentau/scripts"))  # mimic running train.py as a script
from opentau.envs.robocasa import _import_robocasa_with_version_shim
_import_robocasa_with_version_shim()
import robocasa
from robosuite.environments.base import REGISTERED_ENVS
print("robocasa ->", robocasa.__file__)            # the real sim, not opentau/scripts/robocasa
print("CloseCabinet registered ->", "CloseCabinet" in REGISTERED_ENVS)  # True
PY

A full RoboCasa eval (needs the sim + assets + a GPU) logs Success Rate to wandb via:

opentau-train --config_path=<your pi05 robocasa eval config> --eval_freq=2 --steps=2

Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

Note: Before submitting this PR, please read the contributor guideline.


A few notes on choices I made:
- **Label: 🐛 Bug**, and I left **"policy-related changes" unchecked** — the fix is in `envs/` (eval infra so the GPU-pytest/regression requirement doesn't apply.
- I kept the checklist phrasing **verbatim** (the `check-pr-checklist.yml` CI grep-matches those exact strings).
- The "How to try" deliberately leads with the CPU test + a no-GPU repro of the core shadow bug, since a full RoboCasa rollout needs the sim, assets, and a GPU.
