### PR TITLE
Fix logging of success rate on robocasa eval

### DIFF
--- a/src/opentau/envs/robocasa.py
+++ b/src/opentau/envs/robocasa.py
@@ -30,11 +30,13 @@ this module (e.g. in the CPU test suite) never requires the sim to be installed.
 
 from __future__ import annotations
 
+import contextlib
 import importlib.util
 import json
 import os
 import shutil
 import socket
+import sys
 from collections import defaultdict
 from collections.abc import Callable, Sequence
 from functools import partial
@@ -134,6 +136,42 @@ def _resolve_robocasa_assets_root() -> Path:
     return HF_OPENTAU_HOME / "robocasa" / "assets"
 
 
+def _internal_robocasa_pkg_dir() -> str:
+    r"""Realpath of OpenTau's *internal* ``opentau/scripts/robocasa`` package.
+
+    That package (the inference WebSocket server) shares the bare name ``robocasa``
+    with the external sim. When ``train.py`` / ``eval.py`` run as scripts — which is
+    how ``accelerate launch`` and the ``opentau-*`` console entry points invoke them —
+    Python puts ``opentau/scripts/`` on ``sys.path[0]``, so ``import robocasa`` /
+    ``find_spec("robocasa")`` resolve to this empty package instead of the sim. The
+    helpers below use this path to skip the shadow.
+    """
+    return os.path.realpath(os.path.join(os.path.dirname(__file__), os.pardir, "scripts", "robocasa"))
+
+
+@contextlib.contextmanager
+def _robocasa_unshadowed():
+    r"""Temporarily drop the ``sys.path`` entry that shadows the external robocasa
+    package, and purge an already-imported shadow, so ``import robocasa`` /
+    ``find_spec("robocasa")`` resolve to the installed sim. Restores ``sys.path`` on exit.
+    """
+    internal = _internal_robocasa_pkg_dir()
+    # If the internal package was already imported under the bare name, evict it
+    # (and its submodules) so resolution can fall through to the real sim.
+    existing = sys.modules.get("robocasa")
+    if existing is not None:
+        mod_file = getattr(existing, "__file__", "") or ""
+        if os.path.realpath(os.path.dirname(mod_file)) == internal:
+            for name in [m for m in sys.modules if m == "robocasa" or m.startswith("robocasa.")]:
+                del sys.modules[name]
+    saved_path = list(sys.path)
+    sys.path[:] = [p for p in sys.path if os.path.realpath(os.path.join(p, "robocasa")) != internal]
+    try:
+        yield
+    finally:
+        sys.path[:] = saved_path
+
+
 def _robocasa_pkg_assets_dir() -> Path:
     r"""Locate ``<robocasa-pkg>/models/assets`` *without importing* robocasa.
 
@@ -143,7 +181,10 @@ def _robocasa_pkg_assets_dir() -> Path:
     *before* the first import — which means locating the package via its import spec, not
     via ``robocasa.__path__`` (that would require importing it).
     """
-    spec = importlib.util.find_spec("robocasa")
+    # Skip OpenTau's internal ``opentau/scripts/robocasa`` shadow, else ``find_spec``
+    # returns it and we look for assets in the wrong directory (see _internal_robocasa_pkg_dir).
+    with _robocasa_unshadowed():
+        spec = importlib.util.find_spec("robocasa")
     if spec is None or not spec.submodule_search_locations:
         raise ModuleNotFoundError("robocasa is not installed; cannot locate its assets dir.")
     return Path(next(iter(spec.submodule_search_locations))) / "models" / "assets"
@@ -255,11 +296,18 @@ def _import_robocasa_with_version_shim() -> None:
     only for the one-time package import, then restore them. A robocasa packaging
     fork that drops the asserts makes this shim unnecessary; until then it lets
     the integration run on a stock ``pip install robocasa``. No-op once imported.
-    """
-    import sys
 
-    if "robocasa" in sys.modules:
-        return
+    Also skips OpenTau's internal ``opentau/scripts/robocasa`` package, which would
+    otherwise shadow the sim under the script-launched entry points (see
+    :func:`_internal_robocasa_pkg_dir`).
+    """
+    # Already imported as the *real* sim -> nothing to do. (A shadow import is
+    # purged inside ``_robocasa_unshadowed`` so the real package can load.)
+    existing = sys.modules.get("robocasa")
+    if existing is not None:
+        mod_file = getattr(existing, "__file__", "") or ""
+        if os.path.realpath(os.path.dirname(mod_file)) != _internal_robocasa_pkg_dir():
+            return
     import mujoco
     import numpy
 
@@ -272,7 +320,8 @@ def _import_robocasa_with_version_shim() -> None:
         # the symlink must already be in place or the registry comes up empty (every object
         # category gets zero candidates -> "Probabilities contain NaN" at sampling time).
         _maybe_relink_robocasa_assets()
-        import robocasa  # noqa: F401  (runs robocasa's version asserts once)
+        with _robocasa_unshadowed():
+            import robocasa  # noqa: F401  (runs robocasa's version asserts once)
     finally:
         mujoco.__version__, numpy.__version__ = saved
 

--- a/src/opentau/envs/utils.py
+++ b/src/opentau/envs/utils.py
@@ -116,22 +116,61 @@ def are_all_envs_same_type(env: gym.vector.VectorEnv) -> bool:
     return all(t == first_type for t in types)
 
 
+def _single_env_attr_present(env: gym.Env, attr: str) -> bool:
+    r"""Whether a single (non-vector) env exposes wrapper attribute ``attr``.
+
+    Uses ``get_wrapper_attr`` (present on gymnasium ``0.29``), which searches the
+    wrapper stack and raises ``AttributeError`` when the attribute is absent.
+    Only call this on an in-process env — never across an ``AsyncVectorEnv``
+    pipe, where a raise tears the worker down (see :func:`_env_attr_present`).
+
+    Args:
+        env: A single (non-vector) Gym environment, e.g. a sub-env of a
+            ``SyncVectorEnv``.
+        attr: The wrapper attribute name to probe.
+
+    Returns:
+        ``True`` if ``attr`` is reachable on the env or any wrapper beneath it,
+        ``False`` otherwise.
+    """
+    try:
+        env.get_wrapper_attr(attr)
+        return True
+    except AttributeError:
+        return False
+
+
 def _env_attr_present(env: gym.vector.VectorEnv, attr: str) -> list[bool]:
     r"""Return, per sub-env, whether wrapper attribute ``attr`` exists.
 
-    gymnasium ``>=1.0`` exposes ``Env.has_wrapper_attr`` for this, but the
-    RoboCasa / LIBERO stack caps gymnasium below ``1.0`` (via ``lerobot``), so
-    that method is unavailable here. Emulate it with ``get_wrapper_attr``, which
-    exists on ``0.29`` and raises ``AttributeError`` when the attribute is
-    absent — the same accessor ``add_envs_task`` already relies on.
+    gymnasium ``>=1.0`` exposes ``Env.has_wrapper_attr`` — a non-raising,
+    async-safe presence check — and we use it directly when available. But the
+    RoboCasa / LIBERO stack caps gymnasium below ``1.0`` (via ``lerobot``),
+    where that method is absent. On ``0.29`` we must *not* emulate it by letting
+    ``env.call("get_wrapper_attr", attr)`` raise: on an ``AsyncVectorEnv`` (the
+    eval default, ``EnvConfig.use_async_envs``) the ``AttributeError`` propagates
+    inside gymnasium's worker to its ``finally: env.close()``, killing every
+    rollout sub-env before the rollout that reuses the same env runs. Instead:
+
+    * ``SyncVectorEnv`` — probe each sub-env directly via ``env.envs`` (in
+      process, never crosses a worker pipe), which also preserves the per-sub-env
+      granularity ``has_wrapper_attr`` would give.
+    * ``AsyncVectorEnv`` on gymnasium ``<1.0`` — there is no non-destructive
+      presence check across the pipe, so assume the attribute is present and skip
+      the (advisory-only) warning rather than risk tearing the rollout envs down.
+
+    Args:
+        env: A vectorized Gym environment (SyncVectorEnv or AsyncVectorEnv).
+        attr: The wrapper attribute name to probe on each sub-env.
+
+    Returns:
+        A length-``num_envs`` list of booleans, one per sub-env.
     """
     if hasattr(env, "has_wrapper_attr"):
         return list(env.call("has_wrapper_attr", attr))
-    try:
-        env.call("get_wrapper_attr", attr)
-        return [True] * env.num_envs
-    except AttributeError:
-        return [False] * env.num_envs
+    if isinstance(env, gym.vector.SyncVectorEnv):
+        return [_single_env_attr_present(sub_env, attr) for sub_env in env.envs]
+    return [True] * env.num_envs
 
 
 def check_env_attributes_and_types(env: gym.vector.VectorEnv) -> None:

--- a/src/opentau/envs/utils.py
+++ b/src/opentau/envs/utils.py
@@ -116,6 +116,24 @@ def are_all_envs_same_type(env: gym.vector.VectorEnv) -> bool:
     return all(t == first_type for t in types)
 
 
+def _env_attr_present(env: gym.vector.VectorEnv, attr: str) -> list[bool]:
+    r"""Return, per sub-env, whether wrapper attribute ``attr`` exists.
+
+    gymnasium ``>=1.0`` exposes ``Env.has_wrapper_attr`` for this, but the
+    RoboCasa / LIBERO stack caps gymnasium below ``1.0`` (via ``lerobot``), so
+    that method is unavailable here. Emulate it with ``get_wrapper_attr``, which
+    exists on ``0.29`` and raises ``AttributeError`` when the attribute is
+    absent — the same accessor ``add_envs_task`` already relies on.
+    """
+    if hasattr(env, "has_wrapper_attr"):
+        return list(env.call("has_wrapper_attr", attr))
+    try:
+        env.call("get_wrapper_attr", attr)
+        return [True] * env.num_envs
+    except AttributeError:
+        return [False] * env.num_envs
+
+
 def check_env_attributes_and_types(env: gym.vector.VectorEnv) -> None:
     r"""Checks if all environments in a vectorized environment have 'task_description' or 'task' attributes.
     A warning will be raised if any environment is missing these attributes.
@@ -133,8 +151,8 @@ def check_env_attributes_and_types(env: gym.vector.VectorEnv) -> None:
                 "Only gym.vector.SyncVectorEnv and gym.vector.AsyncVectorEnv are supported for now."
             )
 
-        task_desc_set = env.call("has_wrapper_attr", "task_description")
-        task_set = env.call("has_wrapper_attr", "task")
+        task_desc_set = _env_attr_present(env, "task_description")
+        task_set = _env_attr_present(env, "task")
         if not all(td or t for td, t in zip(task_desc_set, task_set, strict=True)):
             warnings.warn(
                 "At least 1 environment does not have 'task_description' or 'task'. Some policies require these features.",

--- a/tests/envs/test_robocasa.py
+++ b/tests/envs/test_robocasa.py
@@ -44,12 +44,14 @@ from opentau.envs.robocasa import (
     _direct_download_url,
     _ensure_robocasa_assets,
     _import_robocasa_with_version_shim,
+    _internal_robocasa_pkg_dir,
     _maybe_relink_robocasa_assets,
     _needed_asset_packs,
     _parse_camera_names,
     _resolve_robocasa_assets_root,
     _resolve_tasks,
     _robocasa_pkg_assets_dir,
+    _robocasa_unshadowed,
     _symlink_pkg_assets_to,
     convert_action,
     create_robocasa_envs,
@@ -185,6 +187,102 @@ class TestPureHelpers:
         sys.modules["robocasa"] = object()
         try:
             _import_robocasa_with_version_shim()  # must not raise / import anything
+        finally:
+            if had:
+                sys.modules["robocasa"] = saved
+            else:
+                sys.modules.pop("robocasa", None)
+
+
+class TestRobocasaUnshadow:
+    """The import-shadow guard.
+
+    OpenTau's internal ``opentau/scripts/robocasa`` package (the inference
+    WebSocket server) shares the bare name ``robocasa`` with the external sim.
+    Under the script-launched entry points (``accelerate launch`` / the
+    ``opentau-*`` console scripts) Python puts ``opentau/scripts`` on
+    ``sys.path[0]``, so ``import robocasa`` / ``find_spec("robocasa")`` resolve
+    to that empty package instead of the sim. These tests pin that
+    ``_robocasa_unshadowed`` drops the shadowing path entry and evicts an
+    already-imported shadow — without the real sim installed.
+    """
+
+    def test_internal_pkg_dir_resolves_to_scripts_robocasa(self):
+        internal = _internal_robocasa_pkg_dir()
+        assert os.path.isdir(internal)
+        assert internal.endswith(os.path.join("opentau", "scripts", "robocasa"))
+        # Already a realpath, so the comparisons inside the helper are stable.
+        assert internal == os.path.realpath(internal)
+
+    def test_unshadow_drops_shadowing_path_entry_and_restores(self):
+        import importlib.util
+        import sys
+
+        internal = _internal_robocasa_pkg_dir()
+        scripts_dir = os.path.dirname(internal)  # .../opentau/scripts
+
+        saved_path = list(sys.path)
+        sys.path.insert(0, scripts_dir)  # mimic train.py being launched as a script
+        try:
+            # The shadow is reachable before unshadowing...
+            spec = importlib.util.find_spec("robocasa")
+            assert spec is not None and spec.origin is not None
+            assert os.path.realpath(os.path.dirname(spec.origin)) == internal
+
+            before = list(sys.path)
+            with _robocasa_unshadowed():
+                # ...and no remaining sys.path entry resolves `robocasa` to it.
+                assert all(os.path.realpath(os.path.join(p, "robocasa")) != internal for p in sys.path)
+            # sys.path is restored verbatim on exit.
+            assert sys.path == before
+        finally:
+            sys.path[:] = saved_path
+
+    def test_unshadow_evicts_already_imported_shadow(self):
+        import sys
+        import types
+
+        internal = _internal_robocasa_pkg_dir()
+        had = "robocasa" in sys.modules
+        saved = sys.modules.get("robocasa")
+        saved_sub = sys.modules.get("robocasa.server")
+
+        # Fake a shadow import: a module whose file lives in the internal package,
+        # plus a submodule, exactly as importing the WebSocket server would leave them.
+        shadow = types.ModuleType("robocasa")
+        shadow.__file__ = os.path.join(internal, "__init__.py")
+        sys.modules["robocasa"] = shadow
+        sys.modules["robocasa.server"] = types.ModuleType("robocasa.server")
+        try:
+            with _robocasa_unshadowed():
+                # The shadow and its submodules are evicted so resolution falls
+                # through to the real sim.
+                assert "robocasa" not in sys.modules
+                assert "robocasa.server" not in sys.modules
+        finally:
+            sys.modules.pop("robocasa", None)
+            sys.modules.pop("robocasa.server", None)
+            if had:
+                sys.modules["robocasa"] = saved
+                if saved_sub is not None:
+                    sys.modules["robocasa.server"] = saved_sub
+
+    def test_unshadow_leaves_real_robocasa_import_untouched(self):
+        """A ``robocasa`` already imported as the *real* sim (file outside the
+        internal package) must not be evicted.
+        """
+        import sys
+        import types
+
+        had = "robocasa" in sys.modules
+        saved = sys.modules.get("robocasa")
+
+        real = types.ModuleType("robocasa")
+        real.__file__ = os.path.join(os.sep, "opt", "site-packages", "robocasa", "__init__.py")
+        sys.modules["robocasa"] = real
+        try:
+            with _robocasa_unshadowed():
+                assert sys.modules.get("robocasa") is real
         finally:
             if had:
                 sys.modules["robocasa"] = saved

--- a/tests/envs/test_utils.py
+++ b/tests/envs/test_utils.py
@@ -24,6 +24,7 @@ import torch
 
 from opentau.envs.configs import EnvMetadataConfig
 from opentau.envs.utils import (
+    _env_attr_present,
     add_eval_metadata,
     are_all_envs_same_type,
     check_env_attributes_and_types,
@@ -55,6 +56,12 @@ def make_no_attributes_env():
 def make_partial_attributes_env():
     env = make_no_attributes_env()
     env.task_description = "test task description"
+    return env
+
+
+def make_task_only_env():
+    env = make_no_attributes_env()
+    env.task = "test task"
     return env
 
 
@@ -199,6 +206,44 @@ class TestCheckEnvAttributesAndTypes:
 
             # Should not issue warning about missing attributes
             assert len(w) == 0
+
+
+class TestEnvAttrPresent:
+    """``_env_attr_present`` — the gymnasium-<1.0 emulation of ``has_wrapper_attr``.
+
+    Two properties are pinned here: per-sub-env granularity on ``SyncVectorEnv``
+    (heterogeneous sub-envs must not collapse to a uniform all-True/all-False
+    list), and async-safety — the probe must never let ``get_wrapper_attr``
+    raise across an ``AsyncVectorEnv`` worker pipe, which gymnasium 0.29 turns
+    into ``finally: env.close()`` and silently tears the rollout envs down.
+    """
+
+    def test_sync_per_sub_env_granularity(self):
+        """Heterogeneous sub-envs report individually, not as one collapsed bool."""
+        vector_env = gym.vector.SyncVectorEnv([make_task_only_env, make_no_attributes_env])
+        assert _env_attr_present(vector_env, "task") == [True, False]
+        assert _env_attr_present(vector_env, "task_description") == [False, False]
+
+    def test_sync_all_present_and_all_absent(self):
+        vector_env = gym.vector.SyncVectorEnv([make_type1_env for _ in range(3)])
+        assert _env_attr_present(vector_env, "task") == [True, True, True]
+        assert _env_attr_present(vector_env, "missing_attr") == [False, False, False]
+
+    def test_async_missing_attr_does_not_tear_down_envs(self):
+        """The blocking bug: on ``AsyncVectorEnv`` a missing attr must not raise
+        across the worker pipe (which would close the workers). The probe assumes
+        presence and the env stays usable for the rollout that reuses it.
+        """
+        vector_env = gym.vector.AsyncVectorEnv([make_no_attributes_env for _ in range(2)])
+        try:
+            # No raise, no worker teardown, even though neither attr exists.
+            assert _env_attr_present(vector_env, "task") == [True, True]
+            assert _env_attr_present(vector_env, "task_description") == [True, True]
+            # Env is still alive: a reset (which crosses the same pipe) succeeds.
+            obs, _info = vector_env.reset(seed=0)
+            assert len(obs) == 2
+        finally:
+            vector_env.close()
 
 
 def _make_obs(batch_size: int = 2, device: str = "cpu") -> dict:


### PR DESCRIPTION
 ## What this does

  🐛 **Bug** — Unblocks RoboCasa evaluation so `Success Rate` / `Success/{task}` (and eval videos) actually get logged to wandb during training.

  Two bugs caused RoboCasa eval to crash before logging anything:

  1. **OpenTau's internal `opentau/scripts/robocasa` package shadows the external `robocasa` sim.** When `train.py` / `eval.py` run as scripts — which is how `accelerate launch` and the `opentau-*` console entry points invoke them — Python puts `opentau/scripts/` on `sys.path[0]`, so the bare name `robocasa` resolves to OpenTau's WebSocket-server package instead of the installed sim. This surfaced two ways:
     - `_robocasa_pkg_assets_dir()` → `find_spec("robocasa")` returned the shadow, so asset setup looked under `…/opentau/scripts/robocasa/models/assets` and raised `FileNotFoundError: box_links_assets.json not found`.
     - `_import_robocasa_with_version_shim()` → `import robocasa` loaded the empty shadow, so RoboCasa's kitchen envs never registered and rollouts raised `Environment CloseCabinet not found ... among: Lift, Stack, ...`.

     Added `_internal_robocasa_pkg_dir()` and a `_robocasa_unshadowed()` context manager (drops the shadowing `sys.path` entry for the duration of the lookup and purges an already-imported shadow). Both the asset resolver and the import shim now go through it, so they always resolve to the real sim. (It doesn't reproduce from a `python -c` at the repo root — only under the launcher — which is why it slipped through.)

  2. **`has_wrapper_attr` is a gymnasium ≥1.0 API.** `check_env_attributes_and_types` called `env.call("has_wrapper_attr", ...)`, but the RoboCasa/LIBERO stack caps gymnasium below 1.0 (via `lerobot`), so the rollout raised `AttributeError: 'RoboCasaEnv' object has no attribute 'has_wrapper_attr'`. Added a version-agnostic `_env_attr_present` helper that falls back to `get_wrapper_attr` (the accessor `add_envs_task` already uses) on gymnasium 0.29.

  After both fixes the RoboCasa rollout runs to completion and `Success Rate`, `Success/{task}`, `Evaluation Time`, and the eval video are logged each eval step.

  ## How it was tested

  - `pre-commit run --files src/opentau/envs/robocasa.py src/opentau/envs/utils.py` — clean.
  - `pytest -m "not gpu" tests/envs/test_robocasa.py tests/envs/test_utils.py` — RoboCasa tests and the `check_env_attributes_and_types` tests pass. (One pre-existing, unrelated failure remains: `test_utils.py::test_envs_different_types` uses gymnasium 1.x's `SyncVectorEnv(observation_mode=...)`, absent in the installed 0.29.1.)
  - Isolation repro of the shadow: with `opentau/scripts` forced onto `sys.path[0]`, `find_spec("robocasa")` resolves to the internal package, but `_robocasa_pkg_assets_dir()` and `_import_robocasa_with_version_shim()` now resolve to the real sim and `CloseCabinet` registers.
  - End-to-end on a 2× RTX 3090 desktop (`MUJOCO_GL=osmesa`): fine-tuned pi0.5 (vision backbone + VLM frozen) on a RoboCasa dataset with a periodic `CloseCabinet` eval. Before: crashed at asset setup / env reset (errors above). After: rollout 
d Google-style docstrings to important functions and ensured function parameters are typed.
  - [ ] My PR includes policy-related changes.
    - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

  ### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).






```bash
pytest -sx tests/envs/test_robocasa.py

Reproduce the import-shadow fix directly (no GPU/sim rollout needed; the asset path is the bug the reverted code died on):

python - <<'PY'
import os, sys
sys.path.insert(0, os.path.abspath("src/opentau/scripts"))  # mimic train.py-as-script
import importlib.util
print("naive find_spec ->", importlib.util.find_spec("robocasa").origin)  # the internal shadow
from opentau.envs.robocasa import _robocasa_pkg_assets_dir, _import_robocasa_with_version_shim
print("assets dir ->", _robocasa_pkg_assets_dir())   # real <robocasa-pkg>/models/assets
_import_robocasa_with_version_shim()
import robocasa
from robosuite.environments.base import REGISTERED_ENVS
print("robocasa ->", robocasa.__file__, "| CloseCabinet registered ->", "CloseCabinet" in REGISTERED_ENVS)
PY

A full RoboCasa eval (needs the sim + assets + a GPU) logs Success Rate to wandb via:

opentau-train --config_path=<pi05 robocasa config> --eval_freq=2 --steps=2

Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

Note: Before submitting this PR, please read the contributor guideline.completes and wandb shows `Success Rate`, `Success/CloseCabinet`, `Evaluation Time`, and the eval video.

  ## How to checkout & try? (for the reviewer)

  ```bash
  pytest -sx tests/envs/test_robocasa.py

  Reproduce the import-shadow fix directly (no GPU/sim rollout needed; the asset path is the bug the reverted code died on):

  python - <<'PY'
  import os, sys
  sys.path.insert(0, os.path.abspath("src/opentau/scripts"))  # mimic train.py-as-script
  import importlib.util
  print("naive find_