### PR TITLE
feat(datasets): add read-only support for LeRobot v3.0 datasets

### DIFF
--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -141,9 +141,8 @@ from opentau.datasets.utils import (
     is_valid_version,
     load_advantages,
     load_episodes,
+    load_episodes_and_stats_v30,
     load_episodes_stats,
-    load_episodes_stats_v30,
-    load_episodes_v30,
     load_info,
     load_stats,
     load_tasks,
@@ -421,8 +420,8 @@ class LeRobotDatasetMetadata(DatasetMetadata):
             # carries the extra file-mapping columns the v3.0 path accessors and
             # video offset read; everything else downstream is unchanged.
             self.tasks, self.task_to_task_index = load_tasks_v30(self.root)
-            self.episodes = load_episodes_v30(self.root)
-            self.episodes_stats = load_episodes_stats_v30(self.root)
+            # Parse the episode-metadata shards once for both episodes + stats.
+            self.episodes, self.episodes_stats = load_episodes_and_stats_v30(self.root)
             self.stats = load_stats(self.root)
         else:
             self.tasks, self.task_to_task_index = load_tasks(self.root)
@@ -1939,17 +1938,23 @@ class LeRobotDataset(BaseDataset):
             raise FileNotFoundError(f"No parquet files for {self.repo_id} under {self.root}")
         hf_dataset = load_dataset("parquet", data_files=files, split="train")
 
-        # Subset load: a consolidated file may also hold unselected episodes, so
-        # drop their rows to keep the row layout aligned with episode_data_index.
-        # A whole-dataset load (`_episodes_were_specified` False -> self.episodes
-        # was backfilled to every episode and every file is loaded) keeps all
-        # rows and skips the episode_index column scan entirely.
-        if self._episodes_were_specified:
-            selected = np.asarray(sorted(self.episodes))
-            ep_col = np.asarray(hf_dataset.with_format("numpy")["episode_index"]).reshape(-1)
-            keep_mask = np.isin(ep_col, selected)
-            if not keep_mask.all():
-                hf_dataset = hf_dataset.select(np.nonzero(keep_mask)[0].tolist())
+        # episode_data_index (built from per-episode `length` cumsum) and the
+        # row-alignment invariant require the loaded rows to be ascending by
+        # episode_index: (chunk, file) file order == episode order, ascending
+        # within each file. Assert it so a malformed layout fails loudly here
+        # rather than silently desyncing per-dataset metrics (CLAUDE.md §5).
+        ep_col = np.asarray(hf_dataset.with_format("numpy")["episode_index"]).reshape(-1)
+        if ep_col.size and not np.all(ep_col[:-1] <= ep_col[1:]):
+            raise RuntimeError(
+                f"{self.repo_id}: v3.0 data rows are not ordered by ascending episode_index; "
+                "episode_data_index would desync. Check the consolidated data-file ordering."
+            )
+        # A consolidated file may also hold unselected episodes (subset load), so
+        # drop their rows to keep the row layout aligned with the selected-episode
+        # episode_data_index. Full loads keep every row.
+        keep_mask = np.isin(ep_col, np.asarray(sorted(self.episodes)))
+        if not keep_mask.all():
+            hf_dataset = hf_dataset.select(np.nonzero(keep_mask)[0].tolist())
 
         hf_dataset.set_transform(hf_transform_to_torch)
         return hf_dataset

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -142,9 +142,12 @@ from opentau.datasets.utils import (
     load_advantages,
     load_episodes,
     load_episodes_stats,
+    load_episodes_stats_v30,
+    load_episodes_v30,
     load_info,
     load_stats,
     load_tasks,
+    load_tasks_v30,
     validate_episode_buffer,
     validate_frame,
     write_episode,
@@ -410,15 +413,27 @@ class LeRobotDatasetMetadata(DatasetMetadata):
         assert self.repo_id is not None
         self.info = load_info(self.root)
         check_version_compatibility(self.repo_id, self._version, CODEBASE_VERSION)
-        self.tasks, self.task_to_task_index = load_tasks(self.root)
-        self.episodes = load_episodes(self.root)
-        if self._version < packaging.version.parse("v2.1"):
+        if self._is_v30:
+            # v3.0: parquet-based metadata (meta/tasks.parquet,
+            # meta/episodes/**/*.parquet) with aggregated stats kept in
+            # meta/stats.json. Per-episode stats are reconstructed from the
+            # episodes parquet's flattened stats/* columns. The episodes dict
+            # carries the extra file-mapping columns the v3.0 path accessors and
+            # video offset read; everything else downstream is unchanged.
+            self.tasks, self.task_to_task_index = load_tasks_v30(self.root)
+            self.episodes = load_episodes_v30(self.root)
+            self.episodes_stats = load_episodes_stats_v30(self.root)
             self.stats = load_stats(self.root)
-            assert self.stats is not None
-            self.episodes_stats = backward_compatible_episodes_stats(self.stats, self.episodes)
         else:
-            self.episodes_stats = load_episodes_stats(self.root)
-            self.stats = aggregate_stats(list(self.episodes_stats.values()))
+            self.tasks, self.task_to_task_index = load_tasks(self.root)
+            self.episodes = load_episodes(self.root)
+            if self._version < packaging.version.parse("v2.1"):
+                self.stats = load_stats(self.root)
+                assert self.stats is not None
+                self.episodes_stats = backward_compatible_episodes_stats(self.stats, self.episodes)
+            else:
+                self.episodes_stats = load_episodes_stats(self.root)
+                self.stats = aggregate_stats(list(self.episodes_stats.values()))
 
         self.advantages = load_advantages(self.root)
 
@@ -442,6 +457,16 @@ class LeRobotDatasetMetadata(DatasetMetadata):
         """Codebase version used to create this dataset."""
         return packaging.version.parse(self.info["codebase_version"])
 
+    @property
+    def _is_v30(self) -> bool:
+        """True when this dataset uses the v3.0 (file-consolidation) format.
+
+        In v3.0 many episodes are packed into one parquet / mp4, and the
+        per-episode file + row/timestamp mapping lives in the
+        ``meta/episodes/**/*.parquet`` rows (loaded into ``self.episodes``).
+        """
+        return self._version >= packaging.version.parse("v3.0")
+
     def get_data_file_path(self, ep_index: int) -> Path:
         """Get the file path for a specific episode's parquet data file.
 
@@ -451,6 +476,12 @@ class LeRobotDatasetMetadata(DatasetMetadata):
         Returns:
             Path to the parquet file for the episode.
         """
+        if self._is_v30:
+            ep = self.episodes[ep_index]
+            fpath = self.data_path.format(
+                chunk_index=int(ep["data/chunk_index"]), file_index=int(ep["data/file_index"])
+            )
+            return Path(fpath)
         ep_chunk = self.get_episode_chunk(ep_index)
         fpath = self.data_path.format(episode_chunk=ep_chunk, episode_index=ep_index)
         return Path(fpath)
@@ -465,8 +496,16 @@ class LeRobotDatasetMetadata(DatasetMetadata):
         Returns:
             Path to the video file for the episode.
         """
-        ep_chunk = self.get_episode_chunk(ep_index)
         assert self.video_path is not None
+        if self._is_v30:
+            ep = self.episodes[ep_index]
+            fpath = self.video_path.format(
+                video_key=vid_key,
+                chunk_index=int(ep[f"videos/{vid_key}/chunk_index"]),
+                file_index=int(ep[f"videos/{vid_key}/file_index"]),
+            )
+            return Path(fpath)
+        ep_chunk = self.get_episode_chunk(ep_index)
         fpath = self.video_path.format(episode_chunk=ep_chunk, video_key=vid_key, episode_index=ep_index)
         return Path(fpath)
 
@@ -1762,7 +1801,10 @@ class LeRobotDataset(BaseDataset):
         # trips the 3000 req / 5 min rate limit (429). Skip files already on
         # disk — when the selected episodes were pre-downloaded this is a
         # no-op that makes zero requests.
-        missing = [f for f in files if not (self.root / f).is_file()]
+        # Dedup: v3.0 maps many episodes to one consolidated file, so the
+        # per-episode path list repeats files; collapse before fetching to avoid
+        # racing concurrent downloads of the same path (v2.1 has no dups -> no-op).
+        missing = list(dict.fromkeys(f for f in files if not (self.root / f).is_file()))
         if not missing:
             return
         logging.info(
@@ -1864,10 +1906,51 @@ class LeRobotDataset(BaseDataset):
         list here: __init__ backfills it with the full episode list before this
         method is ever called.
         """
+        if self.meta._is_v30:
+            return self._load_hf_dataset_v30()
+
         files = [str(self.root / self.meta.get_data_file_path(ep_idx)) for ep_idx in self.episodes]
         if not files:
             raise FileNotFoundError(f"No parquet files for {self.repo_id} under {self.root}")
         hf_dataset = load_dataset("parquet", data_files=files, split="train")
+        hf_dataset.set_transform(hf_transform_to_torch)
+        return hf_dataset
+
+    def _load_hf_dataset_v30(self) -> datasets.Dataset:
+        """Load consolidated v3.0 data files and compact to the selected episodes.
+
+        v3.0 packs many episodes per parquet, so we load the deduped set of
+        consolidated files covering ``self.episodes`` (the same set
+        ``get_episodes_file_paths`` downloads) and then keep only the rows whose
+        ``episode_index`` is selected. Files are read in ascending
+        ``(chunk, file)`` order and episodes within a file are ascending, so the
+        kept rows come out in ascending-episode order == ``sorted(self.episodes)``
+        order. The existing ``get_episode_data_index`` (cumsum of per-episode
+        ``length``) and the row-layout invariant therefore hold exactly as for
+        v2.1 — no global-index bookkeeping is needed.
+
+        ``load_dataset("parquet", ...)`` is kept for its mmap behavior (see the
+        ``load_hf_dataset`` docstring); ``Dataset.select`` returns an
+        indices-mapped view over that same mmap-backed Arrow table, so RAM stays
+        bounded even when a consolidated file is only partially selected.
+        """
+        files = sorted({str(self.root / self.meta.get_data_file_path(ep_idx)) for ep_idx in self.episodes})
+        if not files:
+            raise FileNotFoundError(f"No parquet files for {self.repo_id} under {self.root}")
+        hf_dataset = load_dataset("parquet", data_files=files, split="train")
+
+        # Subset load: a consolidated file may also hold unselected episodes, so
+        # drop their rows to keep the row layout aligned with episode_data_index.
+        # A whole-dataset load (`_episodes_were_specified` False -> self.episodes
+        # was backfilled to every episode and every file is loaded) keeps all
+        # rows and skips the episode_index column scan entirely.
+        if self._episodes_were_specified:
+            selected = np.asarray(sorted(self.episodes))
+            ep_col = np.asarray(hf_dataset.with_format("numpy")["episode_index"]).reshape(-1)
+            keep_mask = np.isin(ep_col, selected)
+            if not keep_mask.all():
+                hf_dataset = hf_dataset.select(np.nonzero(keep_mask)[0].tolist())
+
         hf_dataset.set_transform(hf_transform_to_torch)
         return hf_dataset
 
@@ -2079,6 +2162,11 @@ class LeRobotDataset(BaseDataset):
         item = {}
         for vid_key, query_ts in query_timestamps.items():
             video_path = self._resolve_video_path(ep_idx, vid_key)
+            # v3.0 packs many episodes into one mp4; shift the episode-relative
+            # query timestamps by this episode's offset into the consolidated
+            # file. Absent (v2.1 per-episode mp4) the offset is 0.0 -> unchanged.
+            ts_offset = float(self.meta.episodes[ep_idx].get(f"videos/{vid_key}/from_timestamp", 0.0) or 0.0)
+            query_ts = np.asarray(query_ts, dtype=np.float64) + ts_offset
             frame_indices_soft = query_ts * self.fps
             if self.image_resample_strategy == "linear":
                 frame_indices_floor = np.floor(frame_indices_soft).astype(int)

--- a/src/opentau/datasets/utils.py
+++ b/src/opentau/datasets/utils.py
@@ -579,7 +579,7 @@ def _read_v30_episodes_table(local_dir: Path) -> pd.DataFrame:
     return pd.concat([pd.read_parquet(f) for f in files], ignore_index=True)
 
 
-def load_episodes_v30(local_dir: Path) -> dict[int, dict]:
+def load_episodes_v30(local_dir: Path, episodes_df: pd.DataFrame | None = None) -> dict[int, dict]:
     """Load episodes from the v3.0 ``meta/episodes/**/*.parquet`` shards.
 
     Emits the same ``{episode_index: {...}}`` shape as :func:`load_episodes`, so
@@ -587,8 +587,11 @@ def load_episodes_v30(local_dir: Path) -> dict[int, dict]:
     accessors are unchanged. Each value additionally carries the v3.0
     file-mapping columns. The flattened ``stats/*`` columns are dropped here and
     loaded separately by :func:`load_episodes_stats_v30`.
+
+    ``episodes_df`` lets a caller pass a pre-read table so the shards are parsed
+    once across episodes + stats (see :func:`load_episodes_and_stats_v30`).
     """
-    df = _read_v30_episodes_table(local_dir)
+    df = episodes_df if episodes_df is not None else _read_v30_episodes_table(local_dir)
     stat_cols = [c for c in df.columns if c.startswith("stats/")]
     df = df.drop(columns=stat_cols)
     episodes: dict[int, dict] = {}
@@ -626,13 +629,18 @@ def _deep_float_array(value) -> np.ndarray:
     return np.array(_deep(value), dtype=np.float64)
 
 
-def load_episodes_stats_v30(local_dir: Path) -> dict[int, dict[str, dict[str, np.ndarray]]]:
+def load_episodes_stats_v30(
+    local_dir: Path, episodes_df: pd.DataFrame | None = None
+) -> dict[int, dict[str, dict[str, np.ndarray]]]:
     """Reconstruct per-episode stats from the flattened ``stats/*`` columns of
     the v3.0 episodes parquet. Returns the same shape as
     :func:`load_episodes_stats` so ``aggregate_stats`` accepts v3.0 stats
     identically: ``count`` is ``(1,)`` int and image/video stats are ``(C, 1, 1)``.
+
+    ``episodes_df`` lets a caller pass a pre-read table so the shards are parsed
+    once across episodes + stats (see :func:`load_episodes_and_stats_v30`).
     """
-    df = _read_v30_episodes_table(local_dir)
+    df = episodes_df if episodes_df is not None else _read_v30_episodes_table(local_dir)
     stat_cols = [c for c in df.columns if c.startswith("stats/")]
     episodes_stats: dict[int, dict[str, dict[str, np.ndarray]]] = {}
     for record in df[["episode_index", *stat_cols]].to_dict(orient="records"):
@@ -651,6 +659,20 @@ def load_episodes_stats_v30(local_dir: Path) -> dict[int, dict[str, dict[str, np
             flat[col] = arr
         episodes_stats[ep_idx] = unflatten_dict(flat).get("stats", {})
     return dict(sorted(episodes_stats.items()))
+
+
+def load_episodes_and_stats_v30(
+    local_dir: Path,
+) -> tuple[dict[int, dict], dict[int, dict[str, dict[str, np.ndarray]]]]:
+    """Load v3.0 episodes and per-episode stats, parsing the metadata shards once.
+
+    The episodes parquet (incl. the wide flattened ``stats/*`` columns) is read a
+    single time and split into the :func:`load_episodes_v30` and
+    :func:`load_episodes_stats_v30` results, halving the metadata-load cost on
+    large datasets (e.g. DROID, whose episode metadata is ~600 MB).
+    """
+    df = _read_v30_episodes_table(local_dir)
+    return load_episodes_v30(local_dir, df), load_episodes_stats_v30(local_dir, df)
 
 
 def backward_compatible_episodes_stats(
@@ -861,7 +883,11 @@ def get_safe_version(
     # The requested version is absent and no same-major older format exists, but
     # the repo may carry a newer format the loader still reads (e.g. target v2.1,
     # repo published only as v3.0). Pick the newest such version up to the read
-    # ceiling rather than failing forward.
+    # ceiling rather than failing forward. In practice the only published formats
+    # in this window are v3.0 (read via the v3.0 path) and the v2.x minors (read
+    # via the v2.1-compatible path) — a hypothetical same-major newer minor like
+    # `v2.5` would resolve here and be read through the v2.1 path, consistent with
+    # how check_version_compatibility already treats all v2.x as v2.1-compatible.
     readable_newer = [v for v in hub_versions if target_version < v <= ceiling_version]
     if readable_newer:
         return f"v{max(readable_newer)}"

--- a/src/opentau/datasets/utils.py
+++ b/src/opentau/datasets/utils.py
@@ -88,6 +88,7 @@ import datasets
 import jsonlines
 import numpy as np
 import packaging.version
+import pandas as pd
 import torch
 from datasets.table import embed_table_storage
 from huggingface_hub import DatasetCard, DatasetCardData, HfApi
@@ -115,6 +116,26 @@ TASKS_PATH = "meta/tasks.jsonl"
 DEFAULT_VIDEO_PATH = "videos/chunk-{episode_chunk:03d}/{video_key}/episode_{episode_index:06d}.mp4"
 DEFAULT_PARQUET_PATH = "data/chunk-{episode_chunk:03d}/episode_{episode_index:06d}.parquet"
 DEFAULT_IMAGE_PATH = "images/{image_key}/episode_{episode_index:06d}/frame_{frame_index:06d}.png"
+
+# --- LeRobot v3.0 "file consolidation" format (read-only support) ------------
+# v3.0 packs many episodes into a single parquet / mp4 instead of one file per
+# episode. The data/video path templates below are read from each dataset's own
+# `meta/info.json` (`data_path`/`video_path`), exactly like v2.1; these
+# constants are used for the metadata glob and tests. The per-episode mapping
+# (which file + row/timestamp range an episode occupies) lives in the parquet
+# `meta/episodes/**/*.parquet`, and tasks moved to `meta/tasks.parquet`. See
+# `load_episodes_v30` / `load_tasks_v30`.
+V30_DATA_PATH = "data/chunk-{chunk_index:03d}/file-{file_index:03d}.parquet"
+V30_VIDEO_PATH = "videos/{video_key}/chunk-{chunk_index:03d}/file-{file_index:03d}.mp4"
+V30_EPISODES_DIR = "meta/episodes"
+V30_EPISODES_PATH = "meta/episodes/chunk-{chunk_index:03d}/file-{file_index:03d}.parquet"
+V30_TASKS_PATH = "meta/tasks.parquet"
+
+# Newest dataset format the loader can READ. The write path stays v2.1
+# (`CODEBASE_VERSION` in lerobot_dataset.py); this is the upper bound used when
+# resolving a Hub revision so a v3.0-only repo loads instead of raising
+# `ForwardCompatibilityError`.
+READ_CODEBASE_VERSION = "v3.0"
 
 DATASET_CARD_TEMPLATE = """
 ---
@@ -525,6 +546,113 @@ def load_episodes_stats(local_dir: Path) -> dict[int, dict[str, dict[str, np.nda
     }
 
 
+def load_tasks_v30(local_dir: Path) -> tuple[dict, dict]:
+    """Load tasks from the v3.0 ``meta/tasks.parquet`` file.
+
+    v3.0 replaces ``tasks.jsonl`` with a parquet indexed by the task string
+    (named ``task``) holding an integer ``task_index`` column. Returns the same
+    ``(tasks, task_to_task_index)`` contract as :func:`load_tasks`.
+    """
+    df = pd.read_parquet(local_dir / V30_TASKS_PATH).reset_index()
+    if "task" not in df.columns and "index" in df.columns:
+        # Unnamed index fallback: the task string surfaced as the generic "index".
+        df = df.rename(columns={"index": "task"})
+    tasks = {int(ti): str(t) for t, ti in zip(df["task"], df["task_index"], strict=True)}
+    tasks = dict(sorted(tasks.items()))
+    task_to_task_index = {task: task_index for task_index, task in tasks.items()}
+    return tasks, task_to_task_index
+
+
+def _read_v30_episodes_table(local_dir: Path) -> pd.DataFrame:
+    """Read and row-concat all v3.0 ``meta/episodes/**/*.parquet`` shards.
+
+    One row per episode, sorted by shard path so episodes stay in ascending
+    order. Columns carry the data/video file mapping
+    (``data/chunk_index``, ``data/file_index``, ``videos/{key}/...``),
+    ``dataset_from_index``/``dataset_to_index``, the legacy ``tasks``/``length``,
+    and flattened ``stats/{feature}/{stat}`` per-episode statistics.
+    """
+    episodes_dir = local_dir / V30_EPISODES_DIR
+    files = sorted(episodes_dir.glob("**/*.parquet"))
+    if not files:
+        raise FileNotFoundError(f"No v3.0 episode metadata parquet found under {episodes_dir}")
+    return pd.concat([pd.read_parquet(f) for f in files], ignore_index=True)
+
+
+def load_episodes_v30(local_dir: Path) -> dict[int, dict]:
+    """Load episodes from the v3.0 ``meta/episodes/**/*.parquet`` shards.
+
+    Emits the same ``{episode_index: {...}}`` shape as :func:`load_episodes`, so
+    ``get_episode_data_index``, the per-episode caches, and the file-path
+    accessors are unchanged. Each value additionally carries the v3.0
+    file-mapping columns. The flattened ``stats/*`` columns are dropped here and
+    loaded separately by :func:`load_episodes_stats_v30`.
+    """
+    df = _read_v30_episodes_table(local_dir)
+    stat_cols = [c for c in df.columns if c.startswith("stats/")]
+    df = df.drop(columns=stat_cols)
+    episodes: dict[int, dict] = {}
+    for record in df.to_dict(orient="records"):
+        ep_idx = int(record["episode_index"])
+        record["episode_index"] = ep_idx
+        record["length"] = int(record["length"])
+        if record.get("tasks") is not None:
+            # parquet list<string> reads back as an ndarray; normalize to list.
+            record["tasks"] = list(record["tasks"])
+        episodes[ep_idx] = record
+    return dict(sorted(episodes.items()))
+
+
+def _deep_float_array(value) -> np.ndarray:
+    """Recursively coerce a parquet stat cell into a clean float ndarray.
+
+    Image/video stats round-trip from parquet as deeply nested *object* arrays
+    (ndarrays whose elements are themselves object ndarrays, e.g. a ``(3,)``
+    object array of ``(1,)`` object arrays of ``(1,)`` float arrays). A single
+    ``ndarray.tolist()`` does not recurse through object dtype, leaving an
+    ``object``-dtype array that breaks numeric ops like ``np.isfinite`` in
+    ``aggregate_stats``. This walks every nested ndarray down to plain Python
+    floats so ``np.array`` rebuilds a clean float array with the stored shape.
+    Vector stats and ``count`` (already clean 1-D arrays) pass through unchanged.
+    """
+
+    def _deep(x):
+        if hasattr(x, "tolist"):
+            x = x.tolist()
+        if isinstance(x, (list, tuple)):
+            return [_deep(e) for e in x]
+        return float(x)
+
+    return np.array(_deep(value), dtype=np.float64)
+
+
+def load_episodes_stats_v30(local_dir: Path) -> dict[int, dict[str, dict[str, np.ndarray]]]:
+    """Reconstruct per-episode stats from the flattened ``stats/*`` columns of
+    the v3.0 episodes parquet. Returns the same shape as
+    :func:`load_episodes_stats` so ``aggregate_stats`` accepts v3.0 stats
+    identically: ``count`` is ``(1,)`` int and image/video stats are ``(C, 1, 1)``.
+    """
+    df = _read_v30_episodes_table(local_dir)
+    stat_cols = [c for c in df.columns if c.startswith("stats/")]
+    episodes_stats: dict[int, dict[str, dict[str, np.ndarray]]] = {}
+    for record in df[["episode_index", *stat_cols]].to_dict(orient="records"):
+        ep_idx = int(record["episode_index"])
+        flat: dict[str, np.ndarray] = {}
+        for col in stat_cols:
+            # col == "stats/{feature}/{stat}"; feature names use dots, not slashes.
+            _, feature, stat = col.split("/", 2)
+            arr = _deep_float_array(record[col])
+            if stat == "count":
+                arr = arr.astype(np.int64)
+            elif "image" in feature:
+                # A parquet round-trip can drop/add trailing singleton dims;
+                # normalize to (C, 1, 1) like compute_stats._assert_type_and_shape.
+                arr = arr.reshape(-1, 1, 1)
+            flat[col] = arr
+        episodes_stats[ep_idx] = unflatten_dict(flat).get("stats", {})
+    return dict(sorted(episodes_stats.items()))
+
+
 def backward_compatible_episodes_stats(
     stats: dict[str, dict[str, np.ndarray]], episodes: Iterable[int]
 ) -> dict[int, dict[str, dict[str, np.ndarray]]]:
@@ -659,7 +787,11 @@ def check_version_compatibility(
     )
     if v_check.major < v_current.major and enforce_breaking_major:
         raise BackwardCompatibilityError(repo_id, v_check)
-    elif v_check.minor < v_current.minor:
+    elif v_check.major == v_current.major and v_check.minor < v_current.minor:
+        # Only the v2.0 -> v2.1 gap (same major, lower minor) needs the
+        # global-stats upgrade warning. Guarding on the major keeps a newer
+        # readable format (e.g. v3.0, which has its own per-episode stats) from
+        # tripping this v2.0-specific message.
         _warn_v21_global_stats(repo_id, v_check)
 
 
@@ -676,13 +808,28 @@ def get_repo_versions(repo_id: str) -> list[packaging.version.Version]:
     return repo_versions
 
 
-def get_safe_version(repo_id: str, version: str | packaging.version.Version) -> str:
+def get_safe_version(
+    repo_id: str,
+    version: str | packaging.version.Version,
+    read_ceiling: str | packaging.version.Version = READ_CODEBASE_VERSION,
+) -> str:
     """
     Returns the version if available on repo or the latest compatible one.
     Otherwise, will throw a `CompatibilityError`.
+
+    ``read_ceiling`` is the newest format the loader can read (default
+    ``READ_CODEBASE_VERSION``). When the requested ``version`` is unavailable but
+    the repo only carries a newer-yet-still-readable format (e.g. a v3.0-only
+    dataset while the default target is v2.1), the newest such version up to the
+    ceiling is selected instead of raising ``ForwardCompatibilityError``.
     """
     target_version = (
         packaging.version.parse(version) if not isinstance(version, packaging.version.Version) else version
+    )
+    ceiling_version = (
+        packaging.version.parse(read_ceiling)
+        if not isinstance(read_ceiling, packaging.version.Version)
+        else read_ceiling
     )
     hub_versions = get_repo_versions(repo_id)
 
@@ -710,6 +857,14 @@ def get_safe_version(repo_id: str, version: str | packaging.version.Version) -> 
         if return_version < target_version:
             logging.warning(f"Revision {version} for {repo_id} not found, using version v{return_version}")
         return f"v{return_version}"
+
+    # The requested version is absent and no same-major older format exists, but
+    # the repo may carry a newer format the loader still reads (e.g. target v2.1,
+    # repo published only as v3.0). Pick the newest such version up to the read
+    # ceiling rather than failing forward.
+    readable_newer = [v for v in hub_versions if target_version < v <= ceiling_version]
+    if readable_newer:
+        return f"v{max(readable_newer)}"
 
     lower_major = [v for v in hub_versions if v.major < target_version.major]
     if lower_major:

--- a/tests/datasets/test_datasets_v30.py
+++ b/tests/datasets/test_datasets_v30.py
@@ -1,0 +1,510 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Read-only support for LeRobot v3.0 ("file consolidation") datasets.
+
+v3.0 packs many episodes into a single parquet / mp4 instead of one file per
+episode; the per-episode file + row/timestamp mapping lives in
+``meta/episodes/**/*.parquet`` and tasks move to ``meta/tasks.parquet``. These
+tests synthesize a tiny real on-disk v3.0 dataset (no Hub, no GPU, no real
+codec) and check that metadata loads, ``episode_data_index`` stays aligned for
+full and subset loads, ``__getitem__`` returns the right rows, and consolidated
+video frames are queried at the correct (offset) timestamps.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import packaging.version
+import pandas as pd
+import pytest
+import torch
+
+import opentau.datasets.lerobot_dataset as lerobot_dataset_mod
+from opentau.datasets.lerobot_dataset import LeRobotDataset, LeRobotDatasetMetadata
+from opentau.datasets.utils import (
+    DEFAULT_FEATURES,
+    V30_DATA_PATH,
+    V30_EPISODES_PATH,
+    V30_TASKS_PATH,
+    V30_VIDEO_PATH,
+    check_version_compatibility,
+    flatten_dict,
+    get_safe_version,
+    load_episodes_stats_v30,
+    load_episodes_v30,
+    load_tasks_v30,
+    write_json,
+)
+
+FPS = 10
+STATE_DIM = 4
+ACTION_DIM = 2
+VIDEO_KEY = "observation.images.camera0"
+DEFAULT_LENGTHS = (4, 3, 5)  # ep0+ep1 -> file-000, ep2 -> file-001
+
+
+def _features(use_videos: bool) -> dict:
+    features = {
+        "observation.state": {"dtype": "float32", "shape": (STATE_DIM,), "names": None},
+        "action": {"dtype": "float32", "shape": (ACTION_DIM,), "names": None},
+    }
+    if use_videos:
+        features[VIDEO_KEY] = {
+            "dtype": "video",
+            "shape": (3, 16, 16),
+            "names": ["channels", "height", "width"],
+            "video_info": {"video.fps": float(FPS), "video.codec": "h264"},
+        }
+    features.update({k: dict(v) for k, v in DEFAULT_FEATURES.items()})
+    return features
+
+
+# Features that get per-episode statistics. Kept to the 1-D vector modalities so
+# the synthetic stats round-trip through parquet without nested-shape fuss; the
+# loader path under test (unflatten + cast_stats_to_numpy + aggregate_stats) is
+# identical regardless of how many features are present.
+_STAT_FEATURES = {"observation.state": STATE_DIM, "action": ACTION_DIM}
+
+
+def _episode_stats(length: int, use_videos: bool) -> dict:
+    """Per-episode stats dict shaped like ``load_episodes_stats`` output."""
+    stats = {}
+    for feat, dim in _STAT_FEATURES.items():
+        stats[feat] = {
+            "min": np.zeros(dim, dtype=np.float32),
+            "max": np.ones(dim, dtype=np.float32),
+            "mean": np.full(dim, 0.5, dtype=np.float32),
+            "std": np.full(dim, 0.25, dtype=np.float32),
+            "count": np.array([length], dtype=np.int64),
+        }
+    if use_videos:
+        # Image/video stats are (C,1,1). After a parquet round-trip they surface
+        # as a (3,) object array of nested per-channel arrays, which must be
+        # restored to (3,1,1) for aggregate_stats — the exact shape DROID hit.
+        stats[VIDEO_KEY] = {
+            "min": np.zeros((3, 1, 1), dtype=np.float32),
+            "max": np.ones((3, 1, 1), dtype=np.float32),
+            "mean": np.full((3, 1, 1), 0.5, dtype=np.float32),
+            "std": np.full((3, 1, 1), 0.25, dtype=np.float32),
+            "count": np.array([length], dtype=np.int64),
+        }
+    return stats
+
+
+def _state_row(ep: int, frame: int) -> list[float]:
+    # state[0] encodes (episode, frame) so any row mix-up is unambiguous.
+    return [float(ep * 1000 + frame), 0.0, 0.0, 0.0]
+
+
+def _action_row(ep: int, frame: int) -> list[float]:
+    return [float(ep * 100 + frame), 0.0]
+
+
+def _write_v30_dataset(
+    root: Path,
+    *,
+    lengths=DEFAULT_LENGTHS,
+    use_videos: bool = True,
+    multi_task: bool = False,
+    data_file_of_ep=None,
+) -> None:
+    """Write a complete, loadable v3.0 dataset under ``root``.
+
+    ``data_file_of_ep`` maps episode_index -> (chunk_index, file_index) for the
+    consolidated data parquet; default packs ep0,ep1 into file-000 and ep2 into
+    file-001 to exercise the multi-file + subset paths. All episodes share one
+    consolidated mp4 per camera (chunk-000/file-000).
+    """
+    root = Path(root)
+    n_eps = len(lengths)
+    if data_file_of_ep is None:
+        data_file_of_ep = {ep: (0, 0 if ep < 2 else 1) for ep in range(n_eps)}
+
+    features = _features(use_videos)
+    tasks = ["Perform action 0.", "Perform action 1."] if multi_task else ["Perform action 0."]
+
+    # --- per-frame data rows, grouped by their consolidated data file ----------
+    files_rows: dict[tuple[int, int], list[dict]] = {}
+    ep_meta_rows = []
+    global_index = 0
+    video_cursor = 0.0
+    for ep in range(n_eps):
+        length = lengths[ep]
+        task_index = ep % len(tasks)
+        dataset_from = global_index
+        for frame in range(length):
+            files_rows.setdefault(data_file_of_ep[ep], []).append(
+                {
+                    "observation.state": _state_row(ep, frame),
+                    "action": _action_row(ep, frame),
+                    "timestamp": np.float32(frame / FPS),
+                    "frame_index": np.int64(frame),
+                    "episode_index": np.int64(ep),
+                    "index": np.int64(global_index),
+                    "task_index": np.int64(task_index),
+                }
+            )
+            global_index += 1
+        dataset_to = global_index
+
+        ep_chunk, ep_file = data_file_of_ep[ep]
+        row = {
+            "episode_index": np.int64(ep),
+            "tasks": [tasks[task_index]],
+            "length": np.int64(length),
+            "data/chunk_index": np.int64(ep_chunk),
+            "data/file_index": np.int64(ep_file),
+            "dataset_from_index": np.int64(dataset_from),
+            "dataset_to_index": np.int64(dataset_to),
+        }
+        if use_videos:
+            ep_dur = length / FPS
+            row.update(
+                {
+                    f"videos/{VIDEO_KEY}/chunk_index": np.int64(0),
+                    f"videos/{VIDEO_KEY}/file_index": np.int64(0),
+                    f"videos/{VIDEO_KEY}/from_timestamp": np.float64(video_cursor),
+                    f"videos/{VIDEO_KEY}/to_timestamp": np.float64(video_cursor + ep_dur),
+                }
+            )
+            video_cursor += ep_dur
+        # flatten per-episode stats into stats/{feature}/{stat} columns, as
+        # (possibly nested) Python lists so pandas/pyarrow stores them as list
+        # columns — mirroring the real v3.0 converter (HF datasets), including
+        # the nested (C,1,1) image stats that a parquet round-trip flattens.
+        stat_flat = flatten_dict({"stats": _episode_stats(length, use_videos)})
+        row.update({k: (v.tolist() if hasattr(v, "tolist") else v) for k, v in stat_flat.items()})
+        ep_meta_rows.append(row)
+
+    # --- write consolidated data parquet shards --------------------------------
+    for (chunk_idx, file_idx), rows in files_rows.items():
+        fpath = root / V30_DATA_PATH.format(chunk_index=chunk_idx, file_index=file_idx)
+        fpath.parent.mkdir(parents=True, exist_ok=True)
+        pd.DataFrame(rows).to_parquet(fpath, index=False)
+
+    # --- meta/episodes/chunk-000/file-000.parquet ------------------------------
+    ep_path = root / V30_EPISODES_PATH.format(chunk_index=0, file_index=0)
+    ep_path.parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(ep_meta_rows).to_parquet(ep_path, index=False)
+
+    # --- meta/tasks.parquet (indexed by the task string, like upstream) --------
+    tasks_path = root / V30_TASKS_PATH
+    tasks_path.parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(
+        {"task_index": list(range(len(tasks)))},
+        index=pd.Index(tasks, name="task"),
+    ).to_parquet(tasks_path)
+
+    # --- meta/stats.json (aggregate; all episodes identical here) --------------
+    agg = _episode_stats(sum(lengths), use_videos)
+    write_json({k: {s: v.tolist() for s, v in fv.items()} for k, fv in agg.items()}, root / "meta/stats.json")
+
+    # --- meta/info.json (v3.0; omits total_chunks/total_videos like upstream) --
+    info = {
+        "codebase_version": "v3.0",
+        "robot_type": "dummy",
+        "total_episodes": n_eps,
+        "total_frames": sum(lengths),
+        "total_tasks": len(tasks),
+        "chunks_size": 1000,
+        "data_files_size_in_mb": 100,
+        "video_files_size_in_mb": 200,
+        "fps": FPS,
+        "splits": {"train": f"0:{n_eps}"},
+        "data_path": V30_DATA_PATH,
+        "video_path": V30_VIDEO_PATH if use_videos else None,
+        "features": features,
+    }
+    write_json(info, root / "meta/info.json")
+
+    # Touch the consolidated mp4 so the on-disk file-existence assert passes;
+    # actual decoding is monkeypatched in the video test.
+    if use_videos:
+        vpath = root / V30_VIDEO_PATH.format(video_key=VIDEO_KEY, chunk_index=0, file_index=0)
+        vpath.parent.mkdir(parents=True, exist_ok=True)
+        vpath.touch()
+
+
+def _make_cfg(root: Path, repo_id: str, episodes):
+    """Minimal TrainPipelineConfig, mirroring tests/fixtures/dataset_factories."""
+    from dataclasses import dataclass
+
+    from opentau.configs.default import DatasetConfig, DatasetMixtureConfig
+    from opentau.configs.policies import PreTrainedConfig
+    from opentau.configs.train import TrainPipelineConfig
+
+    @dataclass
+    class DummyPolicyConfig(PreTrainedConfig):
+        @property
+        def observation_delta_indices(self):
+            return None
+
+        @property
+        def action_delta_indices(self):
+            return None
+
+        @property
+        def reward_delta_indices(self):
+            return None
+
+        def get_optimizer_preset(self):
+            return None
+
+        def get_scheduler_preset(self):
+            return None
+
+        def validate_features(self):
+            pass
+
+    dataset_cfg = DatasetConfig(repo_id=repo_id, root=str(root), episodes=episodes)
+    mixture_cfg = DatasetMixtureConfig(
+        datasets=[dataset_cfg],
+        weights=[1.0],
+        history_state_drop_prob=0.0,
+        subgoal_drop_prob=0.0,
+        subgoal_end_of_segment_prob=0.0,
+        response_drop_prob=0.0,
+        metadata_drop_all_prob=0.0,
+        metadata_drop_each_prob=0.0,
+    )
+    return TrainPipelineConfig(dataset_mixture=mixture_cfg, policy=DummyPolicyConfig(), batch_size=8)
+
+
+def _make_dataset(root: Path, *, episodes=None, repo_id="dummy/v30", **kwargs) -> LeRobotDataset:
+    cfg = _make_cfg(root, repo_id, episodes)
+    return LeRobotDataset(
+        cfg=cfg,
+        repo_id=repo_id,
+        root=root,
+        episodes=episodes,
+        standardize=False,
+        **kwargs,
+    )
+
+
+def _episode_index_column(dataset: LeRobotDataset) -> np.ndarray:
+    """Compacted (indices-map-respecting) episode_index column of the loaded rows.
+
+    NOTE: do not use ``hf_dataset.data.table`` here — for a v3.0 subset load the
+    rows are an ``.select()`` index-map over the full table, so the raw table is
+    not physically compacted. Column access goes through the index map.
+    """
+    return np.asarray(dataset.hf_dataset.with_format("numpy")["episode_index"]).reshape(-1)
+
+
+def _assert_row_alignment(dataset: LeRobotDataset) -> None:
+    ep_col = _episode_index_column(dataset)
+    for ep in dataset.episodes:
+        pos = dataset.epi2idx[ep]
+        start = int(dataset.episode_data_index["from"][pos])
+        end = int(dataset.episode_data_index["to"][pos])
+        assert end > start
+        assert all(int(e) == ep for e in ep_col[start:end]), (
+            f"episode {ep} rows [{start}:{end}] carry mismatched episode_index"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Metadata loaders + version gating
+# --------------------------------------------------------------------------- #
+def test_v30_metadata_loads(tmp_path):
+    root = tmp_path / "ds"
+    _write_v30_dataset(root)
+    meta = LeRobotDatasetMetadata(repo_id="dummy/v30", root=root)
+
+    assert meta._is_v30
+    assert meta.total_episodes == 3
+    assert meta.total_frames == sum(DEFAULT_LENGTHS)
+    assert set(meta.episodes) == {0, 1, 2}
+    assert meta.episodes[1]["length"] == DEFAULT_LENGTHS[1]
+    assert meta.tasks[0] == "Perform action 0."
+    # per-episode stats reconstructed from the flattened stats/* columns
+    assert meta.episodes_stats[0]["observation.state"]["mean"].shape == (STATE_DIM,)
+    np.testing.assert_allclose(meta.episodes_stats[2]["action"]["max"], np.ones(ACTION_DIM))
+    # image/video stats must round-trip from parquet as (3,1,1) (not flattened to
+    # (3,)) so aggregate_stats/_assert_type_and_shape accept them — the DROID bug.
+    assert meta.episodes_stats[0][VIDEO_KEY]["min"].shape == (3, 1, 1)
+    assert meta.episodes_stats[0][VIDEO_KEY]["count"].shape == (1,)
+    # aggregated stats from meta/stats.json
+    assert meta.stats["observation.state"]["mean"].shape == (STATE_DIM,)
+
+
+def test_v30_path_accessors_use_consolidated_files(tmp_path):
+    root = tmp_path / "ds"
+    _write_v30_dataset(root)
+    meta = LeRobotDatasetMetadata(repo_id="dummy/v30", root=root)
+
+    # ep0 and ep1 share file-000; ep2 is in file-001.
+    assert meta.get_data_file_path(0) == Path("data/chunk-000/file-000.parquet")
+    assert meta.get_data_file_path(1) == Path("data/chunk-000/file-000.parquet")
+    assert meta.get_data_file_path(2) == Path("data/chunk-000/file-001.parquet")
+    # all episodes share one consolidated mp4
+    assert meta.get_video_file_path(2, VIDEO_KEY) == Path(f"videos/{VIDEO_KEY}/chunk-000/file-000.mp4")
+
+
+def test_v30_loaders_standalone(tmp_path):
+    root = tmp_path / "ds"
+    _write_v30_dataset(root, multi_task=True)
+    tasks, task_to_idx = load_tasks_v30(root)
+    assert tasks == {0: "Perform action 0.", 1: "Perform action 1."}
+    assert task_to_idx["Perform action 1."] == 1
+
+    episodes = load_episodes_v30(root)
+    assert episodes[0]["dataset_from_index"] == 0
+    assert episodes[0]["dataset_to_index"] == DEFAULT_LENGTHS[0]
+    assert episodes[2]["data/file_index"] == 1
+
+    stats = load_episodes_stats_v30(root)
+    assert set(stats) == {0, 1, 2}
+    assert stats[1]["observation.state"]["std"].shape == (STATE_DIM,)
+
+
+def test_deep_float_array_coerces_object_nested_image_stat():
+    # Reproduce the exact structure a real v3.0 image stat round-trips to from
+    # parquet: a (3,) object array of (1,) object arrays of (1,) float arrays
+    # (DROID). A single .tolist() leaves object dtype, breaking np.isfinite in
+    # aggregate_stats; _deep_float_array must walk it down to clean float.
+    from opentau.datasets.utils import _deep_float_array
+
+    def _channel(v):
+        return np.array([np.array([v], dtype=np.float64)], dtype=object)
+
+    val = np.array([_channel(0.1), _channel(0.2), _channel(0.3)], dtype=object)
+    out = _deep_float_array(val)
+    assert out.dtype == np.float64
+    assert np.isfinite(out).all()
+    np.testing.assert_allclose(out.reshape(-1), [0.1, 0.2, 0.3])
+
+
+def test_check_version_compatibility_does_not_warn_on_v30(caplog):
+    # The v2.0 global-stats warning must not fire for a v3.0 (different major)
+    # dataset; v3.0 carries its own per-episode stats.
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        check_version_compatibility("dummy/v30", "v3.0", "v2.1")
+    assert "global stats" not in caplog.text.lower()
+
+
+def test_get_safe_version_resolves_v30_only_repo(monkeypatch):
+    # A repo published only as v3.0 must resolve (not ForwardCompatibilityError)
+    # under the default v2.1 target, thanks to the read ceiling.
+    import opentau.datasets.utils as utils_mod
+
+    monkeypatch.setattr(utils_mod, "get_repo_versions", lambda repo_id: [packaging.version.parse("v3.0")])
+    assert get_safe_version("dummy/v30", "v2.1") == "v3.0"
+
+
+def test_get_safe_version_v21_repo_unchanged(monkeypatch):
+    import opentau.datasets.utils as utils_mod
+
+    monkeypatch.setattr(utils_mod, "get_repo_versions", lambda repo_id: [packaging.version.parse("v2.1")])
+    assert get_safe_version("dummy/v21", "v2.1") == "v2.1"
+
+
+# --------------------------------------------------------------------------- #
+# Full LeRobotDataset: alignment + __getitem__ + video offset
+# --------------------------------------------------------------------------- #
+def test_v30_full_load_alignment(tmp_path):
+    root = tmp_path / "ds"
+    _write_v30_dataset(root, use_videos=False)
+    dataset = _make_dataset(root)
+
+    assert dataset.episodes == [0, 1, 2]
+    assert len(dataset) == sum(DEFAULT_LENGTHS)
+    # episode_data_index matches the authored dataset_from/to (== length cumsum)
+    assert dataset.episode_data_index["from"].tolist() == [0, 4, 7]
+    assert dataset.episode_data_index["to"].tolist() == [4, 7, 12]
+    _assert_row_alignment(dataset)
+
+
+def test_v30_getitem_returns_aligned_rows(tmp_path):
+    root = tmp_path / "ds"
+    _write_v30_dataset(root, use_videos=False)
+    dataset = _make_dataset(root)
+
+    # global row 7 is episode 2, frame 0  -> state[0] == 2*1000 + 0
+    item = dataset[7]
+    assert int(item["episode_index"].item()) == 2
+    assert float(item["observation.state"][0].item()) == pytest.approx(2000.0)
+    # last row of episode 1 (global row 6): frame 2 of ep1 -> 1*1000 + 2
+    item = dataset[6]
+    assert int(item["episode_index"].item()) == 1
+    assert float(item["observation.state"][0].item()) == pytest.approx(1002.0)
+
+
+def test_v30_subset_load_alignment(tmp_path):
+    root = tmp_path / "ds"
+    _write_v30_dataset(root, use_videos=False)
+    # episodes 0 and 2 share files with the unselected episode 1 (subset path).
+    dataset = _make_dataset(root, episodes=[0, 2])
+
+    assert dataset.episodes == [0, 2]
+    assert len(dataset) == DEFAULT_LENGTHS[0] + DEFAULT_LENGTHS[2]
+    # compacted: ep0 -> [0,4), ep2 -> [4,9)
+    assert dataset.episode_data_index["from"].tolist() == [0, 4]
+    assert dataset.episode_data_index["to"].tolist() == [4, 9]
+    assert set(_episode_index_column(dataset).tolist()) == {0, 2}
+    _assert_row_alignment(dataset)
+
+    # compacted row 4 == episode 2, frame 0
+    item = dataset[4]
+    assert int(item["episode_index"].item()) == 2
+    assert float(item["observation.state"][0].item()) == pytest.approx(2000.0)
+
+
+def test_v30_video_query_uses_from_timestamp_offset(tmp_path, monkeypatch):
+    root = tmp_path / "ds"
+    _write_v30_dataset(root, use_videos=True)
+
+    captured = []
+
+    def _fake_decode(video_path, timestamps, tolerance_s, backend):
+        captured.append((str(video_path), list(np.asarray(timestamps, dtype=np.float64))))
+        return torch.zeros((len(timestamps), 3, 16, 16))
+
+    monkeypatch.setattr(lerobot_dataset_mod, "decode_video_frames", _fake_decode)
+
+    dataset = _make_dataset(root)  # nearest resample (default) -> one decode call
+
+    # episode 0, frame 0: offset 0.0 -> queried at t=0.0
+    captured.clear()
+    dataset[0]
+    assert captured[-1][0].endswith(f"videos/{VIDEO_KEY}/chunk-000/file-000.mp4")
+    assert captured[-1][1] == pytest.approx([0.0])
+
+    # episode 2, frame 0 (global row 7): cumulative offset 0.7s -> queried at 0.7
+    captured.clear()
+    dataset[7]
+    assert captured[-1][1] == pytest.approx([0.7])
+
+
+def test_v30_no_video_dataset_loads(tmp_path):
+    root = tmp_path / "ds"
+    _write_v30_dataset(root, use_videos=False)
+    dataset = _make_dataset(root)
+    assert dataset.meta.video_keys == []
+    item = dataset[0]
+    assert VIDEO_KEY not in item
+    assert int(item["episode_index"].item()) == 0
+
+
+def test_v30_multi_task_scalar_task_lookup(tmp_path):
+    root = tmp_path / "ds"
+    _write_v30_dataset(root, use_videos=False, multi_task=True)
+    dataset = _make_dataset(root)
+    # episode 1 -> task_index 1 -> "Perform action 1."
+    item = dataset[4]  # global row 4 == episode 1, frame 0
+    assert int(item["episode_index"].item()) == 1
+    assert item["task"] == "Perform action 1."

--- a/tests/datasets/test_datasets_v30.py
+++ b/tests/datasets/test_datasets_v30.py
@@ -30,7 +30,6 @@ import pandas as pd
 import pytest
 import torch
 
-import opentau.datasets.lerobot_dataset as lerobot_dataset_mod
 from opentau.datasets.lerobot_dataset import LeRobotDataset, LeRobotDatasetMetadata
 from opentau.datasets.utils import (
     DEFAULT_FEATURES,
@@ -400,16 +399,16 @@ def test_check_version_compatibility_does_not_warn_on_v30(caplog):
 def test_get_safe_version_resolves_v30_only_repo(monkeypatch):
     # A repo published only as v3.0 must resolve (not ForwardCompatibilityError)
     # under the default v2.1 target, thanks to the read ceiling.
-    import opentau.datasets.utils as utils_mod
-
-    monkeypatch.setattr(utils_mod, "get_repo_versions", lambda repo_id: [packaging.version.parse("v3.0")])
+    monkeypatch.setattr(
+        "opentau.datasets.utils.get_repo_versions", lambda repo_id: [packaging.version.parse("v3.0")]
+    )
     assert get_safe_version("dummy/v30", "v2.1") == "v3.0"
 
 
 def test_get_safe_version_v21_repo_unchanged(monkeypatch):
-    import opentau.datasets.utils as utils_mod
-
-    monkeypatch.setattr(utils_mod, "get_repo_versions", lambda repo_id: [packaging.version.parse("v2.1")])
+    monkeypatch.setattr(
+        "opentau.datasets.utils.get_repo_versions", lambda repo_id: [packaging.version.parse("v2.1")]
+    )
     assert get_safe_version("dummy/v21", "v2.1") == "v2.1"
 
 
@@ -474,19 +473,19 @@ def test_v30_video_query_uses_from_timestamp_offset(tmp_path, monkeypatch):
         captured.append((str(video_path), list(np.asarray(timestamps, dtype=np.float64))))
         return torch.zeros((len(timestamps), 3, 16, 16))
 
-    monkeypatch.setattr(lerobot_dataset_mod, "decode_video_frames", _fake_decode)
+    monkeypatch.setattr("opentau.datasets.lerobot_dataset.decode_video_frames", _fake_decode)
 
     dataset = _make_dataset(root)  # nearest resample (default) -> one decode call
 
     # episode 0, frame 0: offset 0.0 -> queried at t=0.0
     captured.clear()
-    dataset[0]
+    _ = dataset[0]
     assert captured[-1][0].endswith(f"videos/{VIDEO_KEY}/chunk-000/file-000.mp4")
     assert captured[-1][1] == pytest.approx([0.0])
 
     # episode 2, frame 0 (global row 7): cumulative offset 0.7s -> queried at 0.7
     captured.clear()
-    dataset[7]
+    _ = dataset[7]
     assert captured[-1][1] == pytest.approx([0.7])
 
 


### PR DESCRIPTION
## What this does

Adds native **read-only** support for **LeRobot v3.0** ("file-consolidation") datasets, which OpenTau could not load before (`CODEBASE_VERSION = "v2.1"`; `get_safe_version` raised `ForwardCompatibilityError` on a v3.0-only repo). v3.0 packs many episodes into a single consolidated parquet/mp4 and moves metadata to parquet (`meta/episodes/**/*.parquet`, `meta/tasks.parquet`) instead of one file per episode.

The change is deliberately isolated: v3.0 metadata is loaded into the **same in-memory shapes** the v2.1 path already produces (`meta.episodes`, `meta.tasks`, `meta.episodes_stats`), so everything downstream (sampler, mixture, `episode_data_index`, normalization) is unchanged. Only these surfaces branch on the new format:

- **Version gating** — a `READ_CODEBASE_VERSION = "v3.0"` read ceiling in `get_safe_version` (additive; v2.x/v1.x resolution unchanged) plus a same-major guard so the v2.0 global-stats warning doesn't mis-fire on v3.0.
- **Metadata loaders** (`datasets/utils.py`) — `load_tasks_v30` / `load_episodes_v30` / `load_episodes_stats_v30`, reading the parquet metadata and reconstructing per-episode stats from the flattened `stats/*` columns.
- **Path accessors** — `get_data_file_path` / `get_video_file_path` resolve the consolidated file from each episode's `data/chunk_index`/`data/file_index` and `videos/{key}/...`.
- **Loading** — `load_hf_dataset` reads the deduped consolidated data files and, for an episode subset, compacts via an `episode_index` mask + `Dataset.select` (memory-mapping preserved), reusing the existing `episode_data_index`.
- **Video** — a per-episode `from_timestamp` offset so frames decode correctly from the consolidated mp4 (0.0 for v2.1, so that path is byte-for-byte unchanged).

The **write path is unchanged** — `CODEBASE_VERSION` stays `v2.1`; creating/saving datasets in the v3.0 layout is out of scope.

Label: 🗃️ Feature

## How it was tested

- Added `tests/datasets/test_datasets_v30.py` (13 CPU tests) over a synthetic on-disk v3.0 dataset: metadata loading, full- and subset-load `episode_data_index` alignment, `__getitem__` row correctness, the consolidated-mp4 timestamp offset, no-video and multi-task variants, version gating, and per-episode image-stat `(3,1,1)` reconstruction.
- Full `pytest -m "not gpu" tests/datasets/` → **526 passed, 7 skipped** (no v2.x regression).
- `pre-commit run --all-files` clean.
- Loaded real v3.0 Hub datasets end-to-end on a GPU dev box:
  - `lerobot/pusht_keypoints` (`revision="v3.0"`, no video) — metadata + data + subset compaction (`episodes=[0,1,2]` → aligned `episode_data_index`).
  - `lerobot/droid_1.0.1` (`revision="v3.0"`, ~412 GB, 95,658 episodes, 3 cameras) — a single episode (`episodes=[1]`) pulled only its consolidated chunk (~2.2 GB / 4 files, not the full 412 GB), decoded all three camera videos, and queried the consolidated mp4 at the correct per-episode `from_timestamp` offset (11.133 s). This also surfaced a real bug — per-episode image/video stats round-trip from the parquet as deeply-nested object arrays, breaking `aggregate_stats` — now fixed (`_deep_float_array`) with a dedicated regression test.

Determinism (CLAUDE.md rule 3): not triggered — no changes to the training loop / modeling / optim / sampler, and the v2.x load path is unchanged (covered by the 526 passing dataset tests).

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/datasets/test_datasets_v30.py
```

```python
# Load any v3.0 dataset directly. Request revision="v3.0" explicitly when the
# repo also has a v2.1 tag (the default target resolves to v2.1 when present).
from opentau.datasets.lerobot_dataset import LeRobotDatasetMetadata

meta = LeRobotDatasetMetadata("lerobot/pusht_keypoints", revision="v3.0")
print(meta._is_v30, meta.total_episodes)  # True 206
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.
