### PR TITLE
perf(train): free the CUDA allocator cache before in-training eval

### DIFF
--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -14,6 +14,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import gc
 import inspect
 import json
 import logging
@@ -1086,7 +1087,13 @@ def train(cfg: TrainPipelineConfig):
             accelerator.wait_for_everyone()
 
         if is_eval_step and eval_envs:
+            # Return the allocator's cached-but-unused blocks (freed training
+            # activations) to the CUDA driver before eval, so eval runs at a lower
+            # peak and any non-PyTorch GPU consumer (e.g. an EGL render context for
+            # sim eval) has room. Training re-grows the cache on the next step.
+            gc.collect()
             if torch.cuda.is_available():
+                torch.cuda.empty_cache()
                 pre_eval_alloc_gib = torch.cuda.memory_allocated() / 1024**3
                 pre_eval_resv_gib = torch.cuda.memory_reserved() / 1024**3
                 torch.cuda.reset_peak_memory_stats()


### PR DESCRIPTION
## What this does

⚡️ **Performance / memory** — frees the CUDA caching-allocator's unused blocks before each in-training evaluation, lowering eval-time peak GPU memory and making room for non-PyTorch GPU consumers.

During in-training eval (`scripts/train.py`, the `if is_eval_step and eval_envs:` branch) the loop runs under `torch.no_grad()` between training steps. The previous step's training activations are already dereferenced, but PyTorch's caching allocator keeps that memory as cached *free* blocks rather than returning it to the driver — so `nvidia-smi` still shows the GPU as ~full during eval, and anything that allocates GPU memory *outside* PyTorch (e.g. a MuJoCo EGL render context for sim eval) has no room.

This adds `gc.collect()` + `torch.cuda.empty_cache()` at the top of the eval branch, returning those cached blocks to the driver for the duration of eval. Training transparently re-grows the cache on the next step. The branch already records `memory_allocated` vs `memory_reserved` (logged as `pre`/`peak`/`post`), so the amount freed is visible in the eval metrics.

7-line change: `import gc`, plus `gc.collect()` and a `torch.cuda.is_available()`-guarded `torch.cuda.empty_cache()`.

## How it was tested

- `pre-commit run --files src/opentau/scripts/train.py` — clean (ruff, ruff-format, pyupgrade, bandit, …).
- `pytest -m "not gpu" tests/scripts/test_train.py tests/scripts/test_outlier_logging.py` — **29 passed** (the CPU suite `cpu_test.yml` gates on).
- The change is **non-numerical and CPU-guarded**: `gc.collect()` and `torch.cuda.empty_cache()` are pure memory-management calls (they only return *unused* cached memory to the driver), `empty_cache()` is behind `torch.cuda.is_available()`, and both run only during `no_grad` eval between training steps. They cannot affect training loss, gradients, optimizer steps, eval results, or determinism — the change is correctness-preserving by construction.
- I left the **policy-related** box unchecked for that reason: although the diff touches `scripts/train.py`, it is memory hygiene with no model-math / optimizer / sampler / numerics impact (and `train.py` has no `gpu`-marked unit tests). Happy to add a GPU eval-smoke if a reviewer prefers — just flag it.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/scripts/test_train.py
```

The change is exercised on any run that does in-training eval (`eval_freq > 0` with an env). At eval start the eval metrics now show the allocator cache released — `pre_resv` drops toward `pre_alloc` (cache returned to the driver) instead of sitting at the full training high-water mark.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
