### PR TITLE
fix(ci): install robocasa extra in nightly GPU job for RoboCasa test

### DIFF
--- a/.github/workflows/gpu_test.yml
+++ b/.github/workflows/gpu_test.yml
@@ -49,7 +49,9 @@ jobs:
     name: Run Pytest on GPU
     needs: start-runner
     runs-on: [g6.2xlarge]
-    timeout-minutes: 30
+    # 45 (not 30): the RoboCasa GPU test cold-downloads ~4.4G of kitchen asset packs onto
+    # the ephemeral runner before building a real scene; the rest of the suite is ~15 min.
+    timeout-minutes: 45
 
     container:
       image: nvidia/cuda:12.2.0-devel-ubuntu22.04
@@ -72,7 +74,11 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv sync --extra dev --extra libero
+          # --extra robocasa installs the RoboCasa sim (shuheng-liu/robocasa fork) so the
+          # @pytest.mark.gpu RoboCasa env test in tests/envs/test_robocasa.py can run instead
+          # of erroring with "robocasa is not installed"; it co-resolves with libero on the
+          # shared robosuite-master stack, so the resolved env for the other tests is unchanged.
+          uv sync --extra dev --extra libero --extra robocasa
 
       - name: Check GPU
         run: nvidia-smi


### PR DESCRIPTION
## What this does

Fixes #394 (🐛 Bug).

The nightly GPU test `tests/envs/test_robocasa.py::test_robocasa_autodownload_and_rollout_from_relocated_root` (added in #387) failed every night with:

```
ModuleNotFoundError: robocasa is not installed; cannot locate its assets dir.
```

Root cause: the test is `@pytest.mark.gpu`, so it runs in the nightly GPU job — but `.github/workflows/gpu_test.yml` synced only `--extra dev --extra libero`, so the `robocasa` sim package was never installed on the runner and `_robocasa_pkg_assets_dir()` raised before the test could do anything. (The LIBERO real-sim GPU test passes because the same job already syncs `--extra libero`; robocasa just needed the same treatment.)

This PR:

- Adds `--extra robocasa` to the GPU job's `uv sync`, mirroring how `--extra libero` gates the LIBERO real-sim GPU test. It co-resolves with `libero` on the shared robosuite-master stack, so the resolved env for the other GPU tests is unchanged.
- Bumps the job `timeout-minutes` 30 → 45 to cover the test's ~4.4G cold-cache kitchen-asset download on the ephemeral runner (the rest of the suite is ~15 min).

CI-config only — no policy / model / training code is touched.

## How it was tested

Manually dispatched the **Nightly GPU Tests** workflow on this branch (`workflow_dispatch`); it passed end-to-end ([run 26971334215](https://github.com/TensorAuto/OpenTau/actions/runs/26971334215)):

- `tests/envs/test_robocasa.py::test_robocasa_autodownload_and_rollout_from_relocated_root PASSED`
- `=== 154 passed, 10 skipped, 1653 deselected, 6 warnings in 567.08s ===` — i.e. **154 passed, 0 failed**, versus the issue's failing run (`1 failed, 153 passed`).
- The `Install dependencies` step (`uv sync --extra dev --extra libero --extra robocasa`) resolved cleanly on the CUDA runner, and the test ran for real (cold-cache asset download → `models/assets` relocation symlink → real `CloseFridge` reset/step under EGL). Total job 16m17s, comfortably within the timeout.

`pre-commit run --files .github/workflows/gpu_test.yml` is clean (check-yaml, zizmor, end-of-file/trailing-whitespace/typos).

## How to checkout & try? (for the reviewer)

Re-run the workflow on this branch from the Actions tab (**Nightly GPU Tests → Run workflow**), or via the CLI:

```bash
gh workflow run gpu_test.yml --ref claude/trusting-lehmann-050333
```

It auto-downloads ~4.4G of RoboCasa assets onto the runner, then builds a real `CloseFridge` scene and runs a reset/step under EGL; the previously-failing `test_robocasa_autodownload_and_rollout_from_relocated_root` now passes.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
