### PR TITLE
fix(train): broadcast output_dir so all ranks share one checkpoint tree

### DIFF
--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -56,6 +56,7 @@ from opentau.utils.accelerate_utils import set_proc_accelerator
 from opentau.utils.logging_utils import AverageMeter, MetricsTracker
 from opentau.utils.random_utils import set_seed
 from opentau.utils.train_utils import (
+    find_missing_rng_state_ranks,
     get_step_checkpoint_dir,
     get_step_identifier,
     load_training_state,
@@ -889,20 +890,19 @@ def train(cfg: TrainPipelineConfig):
             accelerator.wait_for_everyone()
 
             # Defense-in-depth tripwire for the partial-save / output_dir-divergence failure
-            # mode: accelerate writes exactly one ``random_states_<process_index>.pkl`` per
-            # process on every backend, so after the barrier the count must equal
-            # ``world_size``. Fewer means a rank saved into a different directory or not at
-            # all, leaving an unresumable checkpoint -- surface it loudly here instead of
-            # discovering it at resume/consolidation time.
+            # mode: accelerate writes one ``random_states_<process_index>.pkl`` per process on
+            # every backend, so a complete checkpoint has one per rank. Surface a missing rank
+            # loudly here (the hard failure otherwise only appears at resume/consolidation time).
             if accelerator.is_main_process:
-                n_rng = len(list(Path(checkpoint_dir).glob("random_states_*.pkl")))
-                if n_rng != accelerator.num_processes:
+                missing_ranks = find_missing_rng_state_ranks(checkpoint_dir, accelerator.num_processes)
+                if missing_ranks:
                     logging.error(
-                        "Checkpoint %s is incomplete: found %d/%d per-rank RNG-state files. A "
-                        "rank likely wrote to a different output_dir or failed to save; this "
-                        "checkpoint may not be resumable.",
+                        "CHECKPOINT INCOMPLETE: %s is missing per-rank RNG state for rank(s) %s "
+                        "(have %d/%d). A rank likely wrote to a different output_dir or failed to "
+                        "save; this checkpoint is not resumable.",
                         checkpoint_dir,
-                        n_rng,
+                        missing_ranks,
+                        accelerator.num_processes - len(missing_ranks),
                         accelerator.num_processes,
                     )
 

--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -32,7 +32,7 @@ import torch
 import wandb
 from accelerate.optimizer import AcceleratedOptimizer
 from accelerate.scheduler import AcceleratedScheduler
-from accelerate.utils import DistributedDataParallelKwargs, gather_object
+from accelerate.utils import DistributedDataParallelKwargs, broadcast_object_list, gather_object
 from termcolor import colored
 
 from opentau.configs import parser
@@ -504,6 +504,18 @@ def train(cfg: TrainPipelineConfig):
         accelerator_kwargs["log_with"] = "wandb"
 
     accelerator = accelerate.Accelerator(**accelerator_kwargs)
+    # ``cfg.output_dir`` embeds a per-process wall-clock timestamp (assigned in
+    # ``TrainPipelineConfig`` as ``f"{now:%Y-%m-%d}/{now:%H-%M-%S}_{job_name}"``) and every
+    # rank parses the config independently, so a launch whose startup straddles a one-second
+    # tick leaves ranks disagreeing on ``output_dir`` (e.g. one rank lands on ``HH-MM-49``
+    # while the rest use ``HH-MM-50``). Each rank then writes its checkpoint shard / RNG state
+    # into a *sibling* directory, silently yielding a checkpoint with fewer than ``world_size``
+    # shards that cannot be consolidated or resumed. Broadcast rank 0's value so all ranks
+    # share one output tree before ``output_dir`` is first used (the Accelerator does not
+    # consume ``output_dir``, so doing this immediately after construction is safe).
+    _output_dir = [str(cfg.output_dir)]
+    broadcast_object_list(_output_dir, from_process=0)
+    cfg.output_dir = Path(_output_dir[0])
     init_logging(accelerator, level=logging.DEBUG if cfg.debug else logging.INFO)
     # Register accelerator globally for use in other modules, (e.g., detect current rank, etc.)
     set_proc_accelerator(accelerator)
@@ -875,6 +887,24 @@ def train(cfg: TrainPipelineConfig):
                     prune_old_checkpoints(checkpoint_dir)
 
             accelerator.wait_for_everyone()
+
+            # Defense-in-depth tripwire for the partial-save / output_dir-divergence failure
+            # mode: accelerate writes exactly one ``random_states_<process_index>.pkl`` per
+            # process on every backend, so after the barrier the count must equal
+            # ``world_size``. Fewer means a rank saved into a different directory or not at
+            # all, leaving an unresumable checkpoint -- surface it loudly here instead of
+            # discovering it at resume/consolidation time.
+            if accelerator.is_main_process:
+                n_rng = len(list(Path(checkpoint_dir).glob("random_states_*.pkl")))
+                if n_rng != accelerator.num_processes:
+                    logging.error(
+                        "Checkpoint %s is incomplete: found %d/%d per-rank RNG-state files. A "
+                        "rank likely wrote to a different output_dir or failed to save; this "
+                        "checkpoint may not be resumable.",
+                        checkpoint_dir,
+                        n_rng,
+                        accelerator.num_processes,
+                    )
 
         if is_val_step and val_dataloader is not None:
             policy.eval()

--- a/src/opentau/utils/train_utils.py
+++ b/src/opentau/utils/train_utils.py
@@ -130,6 +130,29 @@ def save_checkpoint(
     save_rng_state(checkpoint_dir)
 
 
+def find_missing_rng_state_ranks(checkpoint_dir: Path, world_size: int) -> list[int]:
+    """Return the process indices whose ``random_states_<i>.pkl`` is absent from a checkpoint.
+
+    Accelerate writes exactly one ``random_states_<process_index>.pkl`` per process on
+    every backend, so a complete checkpoint contains ``world_size`` of them. A non-empty
+    result means some rank saved into a different directory or not at all (e.g. a divergent
+    ``output_dir`` across ranks), leaving the checkpoint unresumable.
+
+    Args:
+        checkpoint_dir: Directory accelerate saved the per-rank RNG files into.
+        world_size: Expected number of processes (``accelerator.num_processes``).
+
+    Returns:
+        Sorted list of missing process indices; empty when the checkpoint is complete.
+    """
+    present: set[int] = set()
+    for path in Path(checkpoint_dir).glob("random_states_*.pkl"):
+        index = path.name[len("random_states_") : -len(".pkl")]
+        if index.isdigit():
+            present.add(int(index))
+    return sorted(set(range(world_size)) - present)
+
+
 def reseed_new_ranks_on_resume(
     checkpoint_dir: Path,
     accelerator: "accelerate.Accelerator",

--- a/tests/utils/test_train_utils.py
+++ b/tests/utils/test_train_utils.py
@@ -21,6 +21,7 @@ from opentau.constants import (
     TRAINING_STEP,
 )
 from opentau.utils.train_utils import (
+    find_missing_rng_state_ranks,
     get_step_checkpoint_dir,
     get_step_identifier,
     load_training_step,
@@ -35,6 +36,24 @@ def test_get_step_identifier():
     assert get_step_identifier(5, 1000) == "000005"
     assert get_step_identifier(123, 100_000) == "000123"
     assert get_step_identifier(456789, 1_000_000) == "0456789"
+
+
+def test_find_missing_rng_state_ranks(tmp_path):
+    """find_missing_rng_state_ranks flags ranks whose per-rank RNG file is absent."""
+    # Complete checkpoint: one random_states_<i>.pkl per rank -> nothing missing.
+    for i in range(8):
+        (tmp_path / f"random_states_{i}.pkl").touch()
+    assert find_missing_rng_state_ranks(tmp_path, 8) == []
+
+    # The output_dir-divergence failure mode: rank 6 wrote to a sibling dir, so its
+    # per-rank file is absent here.
+    (tmp_path / "random_states_6.pkl").unlink()
+    assert find_missing_rng_state_ranks(tmp_path, 8) == [6]
+
+    # Unrelated files are ignored, and a non-existent directory reports every rank.
+    (tmp_path / "bf16_zero_pp_rank_0_mp_rank_00_optim_states.pt").touch()
+    assert find_missing_rng_state_ranks(tmp_path, 8) == [6]
+    assert find_missing_rng_state_ranks(tmp_path / "does_not_exist", 3) == [0, 1, 2]
 
 
 def test_get_step_checkpoint_dir():


### PR DESCRIPTION
## What this does

🐛 **Bug fix** — makes `output_dir` rank-consistent so every rank of a multi-rank run writes its checkpoint shard into the **same** tree.

**Symptom.** A DeepSpeed ZeRO-2 run on 8 GPUs produced checkpoints that were silently missing one rank's optimizer shard (`bf16_zero_pp_rank_<r>_mp_rank_00_optim_states.pt`) **and** that rank's `random_states_<r>.pkl` — every save, the same rank. `zero_to_fp32` then refused to consolidate (`Expected 8 of '*_optim_states.pt' ... but found 7`), and the checkpoint could not be resumed. There was no error and no hang at save time; the run trained normally.

**Root cause.** `TrainPipelineConfig.validate()` assigns the default `output_dir` from a per-process wall-clock timestamp:

```python
now = dt.datetime.now()
self.output_dir = Path("outputs/train") / f"{now:%Y-%m-%d}/{now:%H-%M-%S}_{job_name}"
```

`validate()` runs independently in every rank (each process parses the config), so a launch whose process startup straddles a one-second boundary leaves ranks disagreeing on `output_dir` — e.g. one rank computes `…-49` while the other seven compute `…-50`. Each rank then writes its optimizer shard and RNG state into its **own sibling directory**. The NCCL collectives inside DeepSpeed's `save_checkpoint` are path-independent, so nothing errors or hangs; the per-rank files are simply split across two trees, and each tree looks like it is missing a rank. (Confirmed in practice: the two sibling trees were exactly complementary — 7 ranks in one, the 8th in the other — so no data was ever lost, only split.)

**Fix.** Broadcast rank 0's `output_dir` to all ranks immediately after the `Accelerator` is constructed (it does not consume `output_dir`, so doing it there is safe) and before `output_dir` is first used, so every rank shares one output tree. Also adds a cheap, backend-agnostic post-save tripwire: rank 0 verifies that the number of `random_states_*.pkl` files equals `world_size` and logs a loud error otherwise — so any future partial save surfaces immediately instead of silently at resume/consolidation time.

## How it was tested

- `pre-commit run --files src/opentau/scripts/train.py` — clean (ruff, ruff-format, pyupgrade, bandit, …).
- `pytest -m "not gpu" -n auto tests/scripts/test_train.py tests/scripts/test_outlier_logging.py` — **29 passed** (the CPU suite `cpu_test.yml` gates on).
- **8-GPU ZeRO-2 forced-divergence smoke** (reproducing the exact failure mode): with a temporary patch that forced each rank's `output_dir` to diverge **before** the broadcast (`…_ODTEST0` … `…_ODTEST7`), all 8 ranks converged to rank 0's directory **after** the broadcast, exactly one output tree was created, and its checkpoint contained **all 8** optimizer shards + **all 8** RNG-state files; the new integrity tripwire stayed silent. A control run without the forced divergence likewise produced a complete 8-shard checkpoint.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/scripts/test_train.py
```

The fix is exercised by any multi-rank run — every rank now resolves and writes to the same `output_dir`. To observe the failure it prevents, temporarily force divergence right before the broadcast in `train()`:

```python
cfg.output_dir = Path(f"{cfg.output_dir}_{accelerator.process_index}")  # simulate the timestamp race
```

Without the fix this yields `world_size` sibling directories each holding one shard; with the fix all ranks collapse onto rank 0's directory and the checkpoint is complete.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

> Note: `train.py` is touched, but the change is checkpoint-path coordination plus a logging tripwire — no model math / optimizer / sampler / numerics impact, so the policy box is left unchecked (determinism is unaffected). An 8-GPU ZeRO-2 smoke was nonetheless run to verify the fix end-to-end (see *How it was tested*).

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
