### PR TITLE
feat(datasets): default to main/master when no codebase-version tag

### DIFF
--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -388,7 +388,9 @@ class LeRobotDatasetMetadata(DatasetMetadata):
             self.load_metadata()
         except (FileNotFoundError, NotADirectoryError):
             if is_valid_version(self.revision):
-                self.revision = get_safe_version(self.repo_id, self.revision)
+                self.revision = get_safe_version(
+                    self.repo_id, self.revision, allow_branch_fallback=not revision
+                )
 
             # In distributed training, only rank 0 downloads to avoid race conditions
             # where other ranks read metadata before the download has finished.
@@ -1597,7 +1599,9 @@ class LeRobotDataset(BaseDataset):
             self.hf_dataset = self.load_hf_dataset()
         except (AssertionError, FileNotFoundError, NotADirectoryError):
             if is_valid_version(self.revision):
-                self.revision = get_safe_version(self.repo_id, self.revision)
+                self.revision = get_safe_version(
+                    self.repo_id, self.revision, allow_branch_fallback=not revision
+                )
             self.download_episodes(download_videos)
             self.hf_dataset = self.load_hf_dataset()
 

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -1502,9 +1502,12 @@ class LeRobotDataset(BaseDataset):
 
         self.root.mkdir(exist_ok=True, parents=True)
 
-        # Load metadata
+        # Load metadata. Forward the *original* `revision` (may be None), not the
+        # `CODEBASE_VERSION`-coerced `self.revision`: the metadata constructor
+        # applies the default itself and must see an unset revision to enable its
+        # main/master branch fallback for untagged repos.
         self.meta = LeRobotDatasetMetadata(
-            self.repo_id, self.root, self.revision, force_cache_sync=force_cache_sync
+            self.repo_id, self.root, revision, force_cache_sync=force_cache_sync
         )
 
         # Overlay setup: when info.json declares a `videos.source_repo`, all video

--- a/src/opentau/datasets/utils.py
+++ b/src/opentau/datasets/utils.py
@@ -817,6 +817,24 @@ def check_version_compatibility(
         _warn_v21_global_stats(repo_id, v_check)
 
 
+DEFAULT_BRANCHES = ("main", "master")
+
+
+def get_repo_branches(repo_id: str) -> list[str]:
+    """Return the branch names of a dataset repo on the Hub.
+
+    Args:
+        repo_id: Repository ID of the dataset on the Hugging Face Hub.
+
+    Returns:
+        The names of every branch ref on the repo (e.g. ``["main"]``); tags are
+        not included.
+    """
+    api = HfApi()
+    refs = api.list_repo_refs(repo_id, repo_type="dataset")
+    return [b.name for b in refs.branches]
+
+
 def get_repo_versions(repo_id: str) -> list[packaging.version.Version]:
     """Returns available valid versions (branches and tags) on given repo."""
     api = HfApi()
@@ -834,16 +852,42 @@ def get_safe_version(
     repo_id: str,
     version: str | packaging.version.Version,
     read_ceiling: str | packaging.version.Version = READ_CODEBASE_VERSION,
+    allow_branch_fallback: bool = False,
 ) -> str:
-    """
-    Returns the version if available on repo or the latest compatible one.
-    Otherwise, will throw a `CompatibilityError`.
+    """Resolve ``version`` to a concrete revision available on the repo.
 
-    ``read_ceiling`` is the newest format the loader can read (default
-    ``READ_CODEBASE_VERSION``). When the requested ``version`` is unavailable but
-    the repo only carries a newer-yet-still-readable format (e.g. a v3.0-only
-    dataset while the default target is v2.1), the newest such version up to the
-    ceiling is selected instead of raising ``ForwardCompatibilityError``.
+    Returns the requested version if the repo carries it, otherwise the latest
+    compatible one. ``read_ceiling`` is the newest format the loader can read
+    (default ``READ_CODEBASE_VERSION``): when the requested ``version`` is
+    unavailable but the repo only carries a newer-yet-still-readable format (e.g.
+    a v3.0-only dataset while the default target is v2.1), the newest such
+    version up to the ceiling is selected instead of raising
+    ``ForwardCompatibilityError``.
+
+    When the repo carries no codebase-version tag at all and
+    ``allow_branch_fallback`` is set, the repo's default branch (``main``, then
+    ``master``) is returned instead of raising ``RevisionNotFoundError`` — this
+    lets untagged Hub datasets load when the caller did not pin a revision.
+
+    Args:
+        repo_id: Repository ID of the dataset on the Hugging Face Hub.
+        version: Desired codebase version (e.g. ``"v2.1"``).
+        read_ceiling: Newest format the loader can read. Defaults to
+            ``READ_CODEBASE_VERSION``.
+        allow_branch_fallback: When True and the repo carries no version tags,
+            fall back to the ``main``/``master`` branch instead of raising. Set
+            by callers only when no explicit revision was requested.
+
+    Returns:
+        A revision usable as a Hub ``revision``: either ``f"v{version}"`` for a
+        resolved version, or a branch name (``"main"``/``"master"``) on fallback.
+
+    Raises:
+        RevisionNotFoundError: The repo has no version tags and either
+            ``allow_branch_fallback`` is False or it has no ``main``/``master``
+            branch.
+        BackwardCompatibilityError: Only older, incompatible major versions exist.
+        ForwardCompatibilityError: Only newer versions beyond the ceiling exist.
     """
     target_version = (
         packaging.version.parse(version) if not isinstance(version, packaging.version.Version) else version
@@ -856,6 +900,18 @@ def get_safe_version(
     hub_versions = get_repo_versions(repo_id)
 
     if not hub_versions:
+        # An untagged repo carries no codebase-version ref to resolve against.
+        # When the caller did not pin a revision, fall back to the repo's default
+        # branch (main, then master) so such datasets still load instead of
+        # hard-failing; an explicitly requested revision keeps the strict error.
+        if allow_branch_fallback:
+            branches = get_repo_branches(repo_id)
+            for candidate in DEFAULT_BRANCHES:
+                if candidate in branches:
+                    logging.warning(
+                        f"{repo_id} has no codebase-version tag; defaulting to the '{candidate}' branch."
+                    )
+                    return candidate
         raise RevisionNotFoundError(
             f"""Your dataset must be tagged with a codebase version.
             Assuming _version_ is the codebase_version value in the info.json, you can run this:

--- a/tests/datasets/test_datasets_v30.py
+++ b/tests/datasets/test_datasets_v30.py
@@ -480,6 +480,27 @@ def test_metadata_untagged_repo_explicit_revision_still_raises(tmp_path, monkeyp
         LeRobotDatasetMetadata(repo_id="dummy/untagged", root=root, revision="v2.1")
 
 
+def test_dataset_untagged_repo_loads_via_branch_fallback(tmp_path, monkeypatch):
+    # Full LeRobotDataset path (the primary use case): an untagged repo with no
+    # local cache must load by falling back to the default branch, not raise at
+    # metadata construction. Regression test for forwarding the *original*
+    # (uncoerced) revision from LeRobotDataset to its metadata constructor — with
+    # the coerced `self.revision` the fallback was dead and this raised.
+    root = tmp_path / "ds"
+    monkeypatch.setattr("opentau.datasets.lerobot_dataset.get_proc_accelerator", lambda: None)
+    monkeypatch.setattr("opentau.datasets.utils.get_repo_versions", lambda repo_id: [])
+    monkeypatch.setattr("opentau.datasets.utils.get_repo_branches", lambda repo_id: ["main"])
+
+    def _fake_pull(self, allow_patterns=None, ignore_patterns=None):
+        _write_v30_dataset(root, use_videos=False)
+
+    monkeypatch.setattr(LeRobotDatasetMetadata, "pull_from_repo", _fake_pull)
+    dataset = _make_dataset(root)  # repo_id="dummy/v30", revision unset
+    assert dataset.meta.revision == "main"
+    assert dataset.episodes == [0, 1, 2]
+    assert len(dataset) == sum(DEFAULT_LENGTHS)
+
+
 # --------------------------------------------------------------------------- #
 # Full LeRobotDataset: alignment + __getitem__ + video offset
 # --------------------------------------------------------------------------- #

--- a/tests/datasets/test_datasets_v30.py
+++ b/tests/datasets/test_datasets_v30.py
@@ -29,6 +29,7 @@ import packaging.version
 import pandas as pd
 import pytest
 import torch
+from huggingface_hub.errors import RevisionNotFoundError
 
 from opentau.datasets.lerobot_dataset import LeRobotDataset, LeRobotDatasetMetadata
 from opentau.datasets.utils import (
@@ -410,6 +411,73 @@ def test_get_safe_version_v21_repo_unchanged(monkeypatch):
         "opentau.datasets.utils.get_repo_versions", lambda repo_id: [packaging.version.parse("v2.1")]
     )
     assert get_safe_version("dummy/v21", "v2.1") == "v2.1"
+
+
+def test_get_safe_version_untagged_repo_falls_back_to_main(monkeypatch):
+    # An untagged repo (no version refs) resolves to the default branch when the
+    # caller did not pin a revision, instead of raising RevisionNotFoundError.
+    monkeypatch.setattr("opentau.datasets.utils.get_repo_versions", lambda repo_id: [])
+    monkeypatch.setattr("opentau.datasets.utils.get_repo_branches", lambda repo_id: ["main", "parquet"])
+    assert get_safe_version("dummy/untagged", "v2.1", allow_branch_fallback=True) == "main"
+
+
+def test_get_safe_version_untagged_repo_falls_back_to_master(monkeypatch):
+    # With no `main`, the next default branch (`master`) is used.
+    monkeypatch.setattr("opentau.datasets.utils.get_repo_versions", lambda repo_id: [])
+    monkeypatch.setattr("opentau.datasets.utils.get_repo_branches", lambda repo_id: ["master"])
+    assert get_safe_version("dummy/untagged", "v2.1", allow_branch_fallback=True) == "master"
+
+
+def test_get_safe_version_prefers_main_over_master(monkeypatch):
+    # Order matters: `main` wins even when `master` is listed first.
+    monkeypatch.setattr("opentau.datasets.utils.get_repo_versions", lambda repo_id: [])
+    monkeypatch.setattr("opentau.datasets.utils.get_repo_branches", lambda repo_id: ["master", "main"])
+    assert get_safe_version("dummy/untagged", "v2.1", allow_branch_fallback=True) == "main"
+
+
+def test_get_safe_version_untagged_repo_raises_without_fallback(monkeypatch):
+    # Default behaviour (an explicitly requested revision): still hard-fails.
+    monkeypatch.setattr("opentau.datasets.utils.get_repo_versions", lambda repo_id: [])
+    monkeypatch.setattr("opentau.datasets.utils.get_repo_branches", lambda repo_id: ["main"])
+    with pytest.raises(RevisionNotFoundError):
+        get_safe_version("dummy/untagged", "v2.1")
+
+
+def test_get_safe_version_raises_when_no_default_branch(monkeypatch):
+    # Fallback allowed but neither `main` nor `master` exists -> still raises.
+    monkeypatch.setattr("opentau.datasets.utils.get_repo_versions", lambda repo_id: [])
+    monkeypatch.setattr("opentau.datasets.utils.get_repo_branches", lambda repo_id: ["dev"])
+    with pytest.raises(RevisionNotFoundError):
+        get_safe_version("dummy/untagged", "v2.1", allow_branch_fallback=True)
+
+
+def test_metadata_untagged_repo_defaults_to_main(tmp_path, monkeypatch):
+    # End-to-end: an untagged repo with no local cache resolves its revision to
+    # the default branch (revision unset) and loads, rather than hitting the
+    # strict get_safe_version error path. pull_from_repo is faked to materialize
+    # the metadata the second load reads.
+    root = tmp_path / "ds"
+    monkeypatch.setattr("opentau.datasets.lerobot_dataset.get_proc_accelerator", lambda: None)
+    monkeypatch.setattr("opentau.datasets.utils.get_repo_versions", lambda repo_id: [])
+    monkeypatch.setattr("opentau.datasets.utils.get_repo_branches", lambda repo_id: ["main"])
+
+    def _fake_pull(self, allow_patterns=None, ignore_patterns=None):
+        _write_v30_dataset(root)
+
+    monkeypatch.setattr(LeRobotDatasetMetadata, "pull_from_repo", _fake_pull)
+    meta = LeRobotDatasetMetadata(repo_id="dummy/untagged", root=root)  # revision unset
+    assert meta.revision == "main"
+    assert meta._is_v30
+
+
+def test_metadata_untagged_repo_explicit_revision_still_raises(tmp_path, monkeypatch):
+    # An explicitly pinned revision keeps the strict behaviour (no branch fallback).
+    root = tmp_path / "ds"
+    monkeypatch.setattr("opentau.datasets.lerobot_dataset.get_proc_accelerator", lambda: None)
+    monkeypatch.setattr("opentau.datasets.utils.get_repo_versions", lambda repo_id: [])
+    monkeypatch.setattr("opentau.datasets.utils.get_repo_branches", lambda repo_id: ["main"])
+    with pytest.raises(RevisionNotFoundError):
+        LeRobotDatasetMetadata(repo_id="dummy/untagged", root=root, revision="v2.1")
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/fixtures/dataset_factories.py
+++ b/tests/fixtures/dataset_factories.py
@@ -432,7 +432,7 @@ def lerobot_dataset_metadata_factory(
             patch("opentau.datasets.lerobot_dataset.get_safe_version") as mock_get_safe_version_patch,
             patch("opentau.datasets.lerobot_dataset.snapshot_download") as mock_snapshot_download_patch,
         ):
-            mock_get_safe_version_patch.side_effect = lambda repo_id, version: version
+            mock_get_safe_version_patch.side_effect = lambda repo_id, version, **kwargs: version
             mock_snapshot_download_patch.side_effect = mock_snapshot_download
 
             return LeRobotDatasetMetadata(repo_id=repo_id, root=root)
@@ -519,7 +519,7 @@ def lerobot_dataset_factory(
             patch("opentau.datasets.lerobot_dataset.hf_hub_download") as mock_hf_hub_download_patch,
         ):
             mock_metadata_patch.return_value = mock_metadata
-            mock_get_safe_version_patch.side_effect = lambda repo_id, version: version
+            mock_get_safe_version_patch.side_effect = lambda repo_id, version, **kwargs: version
             mock_snapshot_download_patch.side_effect = mock_snapshot_download
             mock_hf_hub_download_patch.side_effect = mock_hf_hub_download
 


### PR DESCRIPTION
## What this does
`get_safe_version` resolves a dataset's Hub revision from its codebase-version tags. For a repo that carries **no version tags at all** (only a `main` branch — common for community LeRobot / RoboCasa conversions), it raised `RevisionNotFoundError`, so the dataset could not be loaded directly from the Hub.

This PR makes the resolver **fall back to the repo's default branch — `main`, then `master`, in that order — when no `revision` is explicitly requested and the repo has no codebase-version tag available**. An explicitly pinned `revision` keeps the strict behaviour (still raises), so nothing silently changes for callers that pass a revision.

Details:
- New `allow_branch_fallback` flag on `get_safe_version` (default `False`), set to `True` by the two read-path call sites *only when `revision` is unset* (`LeRobotDatasetMetadata.__init__` and `LeRobotDataset.__init__`).
- New `get_repo_branches(repo_id)` helper to look up the repo's branch refs; the first of `("main", "master")` present is returned.
- When fallback is allowed but neither branch exists (and there are no version tags), the original `RevisionNotFoundError` is still raised.

🗃️ Feature

## How it was tested
- Added 7 tests in `tests/datasets/test_datasets_v30.py`:
  - Unit (`get_safe_version`): falls back to `main`; falls back to `master` when `main` is absent; prefers `main` over `master`; raises without `allow_branch_fallback` (explicit revision); raises when neither default branch exists.
  - End-to-end (`LeRobotDatasetMetadata`): an untagged repo with no local cache resolves its revision to `main` when no revision is pinned, and still raises for an explicitly pinned revision.
- `uv run pytest -m "not gpu" tests/datasets/test_datasets_v30.py` → 20 passed.
- `pre-commit run --files ...` clean (ruff, ruff-format, pyupgrade, bandit, …).
- Not a policy change (touches `datasets/` only), so the GPU/regression suites were not required.

## How to checkout & try? (for the reviewer)
```bash
pytest -sx tests/datasets/test_datasets_v30.py -k "untagged or main_over_master or no_default_branch"
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
