### PR TITLE
feat(envs): render all cameras in eval rollout videos

### DIFF
--- a/src/opentau/envs/libero.py
+++ b/src/opentau/envs/libero.py
@@ -24,6 +24,7 @@ from functools import partial
 from pathlib import Path
 from typing import Any
 
+import einops
 import gymnasium as gym
 import numpy as np
 import torch
@@ -225,13 +226,15 @@ class LiberoEnv(gym.Env):
         )
 
     def render(self) -> np.ndarray:
-        r"""Render the environment and return a numpy array representing the RGB camera.
-        If `self.render_cam` is set, use that camera; otherwise, use the first camera."""
+        r"""Render an RGB array for video recording. If ``self.render_cam`` is set,
+        use that single camera; otherwise concatenate all configured cameras
+        side-by-side so eval rollout videos show every camera the policy sees."""
         raw_obs = self._env.env._get_observations()
         cams: dict[str, np.ndarray] = self._format_raw_obs(raw_obs)["pixels"]
-        # if `self.render_cam` is not set, use the first camera
-        render_cam = self.render_cam or next(iter(cams))
-        return cams[render_cam]
+        if self.render_cam:
+            return cams[self.render_cam]
+        frames = list(cams.values())  # each (H, W, 3), camera_name order
+        return einops.rearrange(np.stack(frames), "n h w c -> h (n w) c")
 
     def _make_envs_task(self, task_suite: Any, task_id: int = 0):
         task = task_suite.get_task(task_id)

--- a/src/opentau/envs/robocasa.py
+++ b/src/opentau/envs/robocasa.py
@@ -45,6 +45,7 @@ from typing import Any
 from urllib.request import urlretrieve
 from zipfile import BadZipFile, ZipFile
 
+import einops
 import gymnasium as gym
 import numpy as np
 from gymnasium import spaces
@@ -537,6 +538,9 @@ class RoboCasaEnv(gym.Env):
         # subprocess to avoid inheriting a stale GPU/EGL context across fork().
         self._env: Any = None
         self.task_description = ""
+        # Latest per-camera frames ({camera0,camera1,...}), cached by
+        # _format_raw_obs so render() can composite all cameras for eval videos.
+        self._render_pixels: dict[str, np.ndarray] | None = None
 
         images = {}
         for cam in self.camera_name:
@@ -609,6 +613,10 @@ class RoboCasaEnv(gym.Env):
             for mapped_cam in self.camera_name_mapping[cam]:
                 images[mapped_cam] = frame
 
+        # Cache for render(): the underlying RoboCasaGymEnv.render() is single-cam,
+        # so we composite these frames ourselves to show every camera in eval videos.
+        self._render_pixels = images
+
         if self.obs_type == "pixels":
             return {"pixels": images}
 
@@ -627,9 +635,15 @@ class RoboCasaEnv(gym.Env):
         return {"pixels": images, "agent_pos": agent_pos}
 
     def render(self) -> np.ndarray:
-        r"""Render the environment and return an RGB array for video recording."""
+        r"""Render an RGB array for video recording: all configured cameras
+        concatenated side-by-side (left→right in ``camera_name`` order), so eval
+        rollout videos show every camera the policy sees rather than just one."""
         self._ensure_env()
         assert self._env is not None
+        if self._render_pixels:
+            frames = list(self._render_pixels.values())  # each (H, W, 3), camera_name order
+            return einops.rearrange(np.stack(frames), "n h w c -> h (n w) c")
+        # No observation cached yet (render before the first reset/step).
         return self._env.render()
 
     def reset(self, seed=None, **kwargs) -> tuple[dict[str, Any], dict[str, Any]]:

--- a/src/opentau/scripts/eval.py
+++ b/src/opentau/scripts/eval.py
@@ -535,7 +535,11 @@ def create_grid_summary_video(
         if not Path(video_path).exists():
             logging.warning(f"Video file not found: {video_path}")
             continue
-        video = imageio.mimread(video_path)
+        # memtest=False disables imageio.mimread's 256 MB read cap — a full
+        # multi-camera episode video (e.g. 3 cams × 256 px × ~500 steps ≈ 280 MB)
+        # exceeds the default. The grid builder already holds every loaded video
+        # in memory, so the cap was the only blocker.
+        video = imageio.mimread(video_path, memtest=False)
         videos.append(video)
         max_frames = max(max_frames, len(video))
 

--- a/tests/envs/test_robocasa.py
+++ b/tests/envs/test_robocasa.py
@@ -647,6 +647,51 @@ class TestCreateRoboCasaEnvsAssets:
         ensure.assert_called_once()  # but the asset/barrier step still ran
 
 
+class TestRenderMultiCamera:
+    """``render()`` composites every configured camera side-by-side for eval videos.
+
+    CPU-only: the gym env is built without the sim (``_ensure_env`` returns early
+    once ``_env`` is set), and the per-camera frames ``render`` reads are stubbed
+    directly via ``_render_pixels``.
+    """
+
+    @staticmethod
+    def _env_with_pixels(pixels: dict | None):
+        from opentau.envs.robocasa import RoboCasaEnv as RoboCasaGymEnv
+
+        env = RoboCasaGymEnv(task="CloseFridge")
+        env._env = Mock()  # non-None so _ensure_env() is a no-op (no sim build)
+        env._render_pixels = pixels
+        return env
+
+    def test_concatenates_all_cameras_left_to_right(self):
+        env = self._env_with_pixels(
+            {
+                "camera0": np.full((4, 5, 3), 1, np.uint8),
+                "camera1": np.full((4, 5, 3), 2, np.uint8),
+                "camera2": np.full((4, 5, 3), 3, np.uint8),
+            }
+        )
+        frame = env.render()
+        # 3 cameras (5 px wide each) tiled along width, in camera_name order.
+        assert frame.shape == (4, 15, 3)
+        assert (frame[:, 0:5] == 1).all()
+        assert (frame[:, 5:10] == 2).all()
+        assert (frame[:, 10:15] == 3).all()
+
+    def test_single_camera_is_not_widened(self):
+        env = self._env_with_pixels({"camera0": np.full((4, 5, 3), 7, np.uint8)})
+        frame = env.render()
+        assert frame.shape == (4, 5, 3)
+        assert (frame == 7).all()
+
+    def test_falls_back_to_env_render_before_first_observation(self):
+        env = self._env_with_pixels(None)  # no frames cached yet
+        sentinel = np.zeros((2, 2, 3), np.uint8)
+        env._env.render.return_value = sentinel
+        assert env.render() is sentinel
+
+
 @pytest.mark.gpu
 @pytest.mark.slow
 def test_robocasa_autodownload_and_rollout_from_relocated_root(monkeypatch):


### PR DESCRIPTION
## What this does

Eval rollout videos (and the `grid_summary.mp4`) showed only a single camera, even though the policy is fed multiple cameras. The sole video frame source is `env.render()`, which returned one camera. This makes both sim envs' `render()` return **all configured cameras concatenated side-by-side**, so per-episode rollout videos — and the grid summary and `wandb.Video` built from them — show every camera the policy sees, making rollouts actually debuggable.

- `RoboCasaEnv.render()` / `LiberoEnv.render()` now concatenate every `camera_name` view (left→right in config order) via `einops.rearrange("n h w c -> h (n w) c")`. LIBERO keeps its `render_cam` override as a single-camera escape hatch; RoboCasa caches the per-camera frames in `_format_raw_obs` since its underlying `render()` is single-view.
- `create_grid_summary_video` now loads episode clips with `imageio.mimread(..., memtest=False)`: the wider multi-camera frames exceed imageio's default 256 MB per-read cap, which otherwise aborts grid creation.

No change to the rollout/record path in `eval.py`, the grid tiler's layout, or the wandb logging — they read frame dimensions dynamically and adapt to the wider frames.

🗃️ Feature

## How it was tested

- pre-commit (ruff lint + format, pyupgrade, bandit, …) passes on the changed files; `pytest -m "not gpu" tests/scripts/test_eval.py` green (3 passed).
- Ran a RoboCasa **CloseFridge** sim eval on a GPU dev box with the change: per-episode rollout mp4s are now `(256, 768, 3)` — 3 cameras × 256 px wide — vs `(256, 256, 3)` before, and `grid_summary.mp4` renders each episode row with all three camera views. The eval completed normally; rendering is visualization-only and does not touch the rollout, policy, or RNG, so success rates are unaffected.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/scripts/test_eval.py
```

Then any sim eval with rendering enabled records all cameras — an eval config with `env.type=robocasa` (or `libero`) and `eval.max_episodes_rendered>0` produces rollout videos whose width is `n_cameras × per_camera_width` (set `env.render_cam` on LIBERO to keep a single camera).

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.
