### PR TITLE
perf(eval): stream grid summary video to bound memory

### DIFF
--- a/src/opentau/scripts/eval.py
+++ b/src/opentau/scripts/eval.py
@@ -528,84 +528,89 @@ def create_grid_summary_video(
             f"Too many videos ({len(video_paths)}) for grid size {grid_size} (max {expected_videos})"
         )
 
-    # Load all videos
-    videos = []
-    max_frames = 0
-    for video_path in video_paths:
-        if not Path(video_path).exists():
+    # Stream the tiling instead of pre-loading every clip. Each episode video is
+    # advanced one frame at a time and written straight to the output, so peak
+    # memory is one frame per clip plus the grid — not every decoded clip at once.
+    # With multi-camera (wide) frames and high episode counts the old load-all
+    # approach scaled as episodes × n_cams × width × frames and could OOM rank-0.
+    valid_paths: list[str] = []
+    valid_successes: list[bool] = []
+    for video_path, success in zip(video_paths, success_statuses, strict=True):
+        if Path(video_path).exists():
+            valid_paths.append(video_path)
+            valid_successes.append(success)
+        else:
             logging.warning(f"Video file not found: {video_path}")
-            continue
-        # memtest=False disables imageio.mimread's 256 MB read cap — a full
-        # multi-camera episode video (e.g. 3 cams × 256 px × ~500 steps ≈ 280 MB)
-        # exceeds the default. The grid builder already holds every loaded video
-        # in memory, so the cap was the only blocker.
-        video = imageio.mimread(video_path, memtest=False)
-        videos.append(video)
-        max_frames = max(max_frames, len(video))
 
-    if not videos:
+    if not valid_paths:
         logging.error("No valid videos found to create grid summary")
         return
 
-    # Get dimensions from first video
-    frame_height, frame_width = videos[0][0].shape[:2]
+    # Tile dimensions from the first clip's first frame (one-frame decode).
+    probe = imageio.get_reader(valid_paths[0])
+    try:
+        frame_height, frame_width = probe.get_data(0).shape[:2]
+    finally:
+        probe.close()
     grid_width = frame_width * grid_cols
     grid_height = frame_height * grid_rows
 
-    # Create grid frames
-    grid_frames = []
+    def _place(grid: np.ndarray, idx: int, frame) -> None:
+        # Frames may be RGBA or grayscale on rare backends; only tile RGB.
+        if frame is None or frame.ndim != 3 or frame.shape[2] != 3:
+            return
+        row, col = idx // grid_cols, idx % grid_cols
+        y, x = row * frame_height, col * frame_width
+        grid[y : y + frame_height, x : x + frame_width] = frame
 
-    for frame_idx in range(max_frames):
-        # Create empty grid frame
-        grid_frame = np.zeros((grid_height, grid_width, 3), dtype=np.uint8)
+    readers = [imageio.get_reader(p) for p in valid_paths]
+    frame_streams = [reader.iter_data() for reader in readers]
+    # Hold each clip's last frame so a clip that ends early keeps showing its
+    # final state (matches the previous behaviour) rather than going blank.
+    last_frames: list = [None] * len(readers)
+    exhausted = [False] * len(readers)
+    writer = imageio.get_writer(output_path, fps=fps)
+    end = object()  # sentinel: next(stream, end) avoids the inf-length list() pitfall
+    last_grid = None
+    try:
+        # One iteration per output frame; stop once every clip is exhausted.
+        while True:
+            advanced = False
+            for i, stream in enumerate(frame_streams):
+                if exhausted[i]:
+                    continue
+                frame = next(stream, end)
+                if frame is end:
+                    exhausted[i] = True
+                else:
+                    last_frames[i] = frame
+                    advanced = True
+            if not advanced:
+                break
+            grid_frame = np.zeros((grid_height, grid_width, 3), dtype=np.uint8)
+            for i, frame in enumerate(last_frames):
+                _place(grid_frame, i, frame)
+            writer.append_data(grid_frame)
+            last_grid = grid_frame
 
-        # Fill grid with video frames
-        for i, video in enumerate(videos):
-            row = i // grid_cols
-            col = i % grid_cols
+        # Hold the final frame with a green/red success border per tile.
+        if last_grid is not None:
+            highlighted_frame = last_grid.copy()
+            for i, success in enumerate(valid_successes):
+                row, col = i // grid_cols, i % grid_cols
+                y, x = row * frame_height, col * frame_width
+                color = np.array([0, 255, 0]) if success else np.array([255, 0, 0])  # green / red
+                overlay = np.full((frame_height, frame_width, 3), color, dtype=np.uint8)
+                highlighted_frame[y : y + frame_height, x : x + frame_width] = (
+                    0.5 * highlighted_frame[y : y + frame_height, x : x + frame_width] + 0.5 * overlay
+                ).astype(np.uint8)
+            for _ in range(int(highlight_duration * fps)):
+                writer.append_data(highlighted_frame)
+    finally:
+        writer.close()
+        for reader in readers:
+            reader.close()
 
-            # Use last frame if video is shorter
-            frame_to_use = min(frame_idx, len(video) - 1)
-            frame = video[frame_to_use]
-
-            # Ensure frame is RGB
-            if len(frame.shape) == 3 and frame.shape[2] == 3:
-                y_start = row * frame_height
-                y_end = y_start + frame_height
-                x_start = col * frame_width
-                x_end = x_start + frame_width
-                grid_frame[y_start:y_end, x_start:x_end] = frame
-
-        grid_frames.append(grid_frame)
-
-    # Add highlighting frames at the end
-    highlight_frames = int(highlight_duration * fps)
-    for _ in range(highlight_frames):
-        # Create highlighted version of the last frame
-        highlighted_frame = grid_frame.copy()
-
-        for i, success in enumerate(success_statuses):
-            row = i // grid_cols
-            col = i % grid_cols
-
-            y_start = row * frame_height
-            y_end = y_start + frame_height
-            x_start = col * frame_width
-            x_end = x_start + frame_width
-
-            # Create colored overlay
-            color = np.array([0, 255, 0]) if success else np.array([255, 0, 0])  # Green or Red
-            overlay = np.full((frame_height, frame_width, 3), color, dtype=np.uint8)
-
-            # Blend with original frame (50% opacity)
-            highlighted_frame[y_start:y_end, x_start:x_end] = (
-                0.5 * highlighted_frame[y_start:y_end, x_start:x_end] + 0.5 * overlay
-            ).astype(np.uint8)
-
-        grid_frames.append(highlighted_frame)
-
-    # Save the grid video
-    imageio.mimsave(output_path, grid_frames, fps=fps)
     logging.info(f"Grid summary video saved to: {output_path}")
 
 

--- a/src/opentau/scripts/eval.py
+++ b/src/opentau/scripts/eval.py
@@ -563,16 +563,21 @@ def create_grid_summary_video(
         y, x = row * frame_height, col * frame_width
         grid[y : y + frame_height, x : x + frame_width] = frame
 
-    readers = [imageio.get_reader(p) for p in valid_paths]
-    frame_streams = [reader.iter_data() for reader in readers]
-    # Hold each clip's last frame so a clip that ends early keeps showing its
-    # final state (matches the previous behaviour) rather than going blank.
-    last_frames: list = [None] * len(readers)
-    exhausted = [False] * len(readers)
-    writer = imageio.get_writer(output_path, fps=fps)
+    # Open readers/writer inside the try so a mid-way get_reader failure still
+    # closes whatever was already opened (no leaked file handles).
+    readers: list = []
+    writer = None
     end = object()  # sentinel: next(stream, end) avoids the inf-length list() pitfall
     last_grid = None
     try:
+        for path in valid_paths:
+            readers.append(imageio.get_reader(path))
+        frame_streams = [reader.iter_data() for reader in readers]
+        # Hold each clip's last frame so a clip that ends early keeps showing its
+        # final state (matches the previous behaviour) rather than going blank.
+        last_frames: list = [None] * len(readers)
+        exhausted = [False] * len(readers)
+        writer = imageio.get_writer(output_path, fps=fps)
         # One iteration per output frame; stop once every clip is exhausted.
         while True:
             advanced = False
@@ -607,7 +612,8 @@ def create_grid_summary_video(
             for _ in range(int(highlight_duration * fps)):
                 writer.append_data(highlighted_frame)
     finally:
-        writer.close()
+        if writer is not None:
+            writer.close()
         for reader in readers:
             reader.close()
 

--- a/tests/scripts/test_eval.py
+++ b/tests/scripts/test_eval.py
@@ -15,10 +15,12 @@
 from pathlib import Path
 from unittest.mock import Mock
 
+import imageio.v2 as imageio
+import numpy as np
 import pytest
 
 from opentau.envs.configs import RoboCasaEnv
-from opentau.scripts.eval import collect_grid_summary_videos, eval_policy_all
+from opentau.scripts.eval import collect_grid_summary_videos, create_grid_summary_video, eval_policy_all
 
 
 def _touch(p: Path):
@@ -51,3 +53,38 @@ def test_eval_policy_all_rejects_recording_root_for_non_libero_env():
 
     with pytest.raises(NotImplementedError, match="recording_root"):
         eval_policy_all({}, policy=Mock(), n_episodes=1, cfg=cfg)
+
+
+def test_create_grid_summary_video_streams_into_expected_grid(tmp_path):
+    """The grid builder streams each clip frame-by-frame (bounded memory) and tiles
+    them into a (grid_rows*H, grid_cols*W, 3) video, holding a clip's last frame
+    once it ends. Two clips of different lengths exercise both paths."""
+    h, w = 16, 16
+    paths = []
+    for k, n_frames in enumerate((3, 5)):  # different lengths -> hold-last-frame path
+        clip = tmp_path / f"clip_{k}.mp4"
+        frames = [np.full((h, w, 3), 40 * (k + 1), np.uint8) for _ in range(n_frames)]
+        imageio.mimsave(str(clip), frames, fps=10)
+        paths.append(str(clip))
+
+    out = tmp_path / "grid_summary.mp4"
+    create_grid_summary_video(paths, [False, True], str(out), fps=10, highlight_duration=0.2)
+
+    assert out.exists()
+    reader = imageio.get_reader(str(out))
+    try:
+        first_frame = reader.get_data(0)
+        n_out = reader.count_frames()
+    finally:
+        reader.close()
+    # 2 clips -> auto grid rows=ceil(sqrt(2))=2, cols=1 -> tiles stacked vertically.
+    assert first_frame.shape == (2 * h, 1 * w, 3)
+    # at least the longest clip's frames (5); + highlight frames (int(0.2*10)=2).
+    assert n_out >= 5
+
+
+def test_create_grid_summary_video_no_valid_videos_is_noop(tmp_path):
+    """Missing input clips are skipped; with none left it writes nothing."""
+    out = tmp_path / "grid_summary.mp4"
+    create_grid_summary_video([str(tmp_path / "missing.mp4")], [True], str(out), fps=10)
+    assert not out.exists()


### PR DESCRIPTION
## What this does

`create_grid_summary_video` loaded **every** episode clip fully into memory before tiling (`videos = [imageio.mimread(p, memtest=False) for p in video_paths]`). After the multi-camera eval videos change (#398) each clip is ~3× wider, so aggregate rank-0 RSS scaled as `episodes × n_cams × per_cam_width × frames` — for high render counts (some configs render 64–96 episodes) × 3 cameras that reaches tens of GB and can OOM.

This streams the tiling instead: one `imageio.get_reader` per clip, advanced one frame at a time in lockstep and written straight to an `imageio.get_writer`, so peak memory is **one frame per clip plus the grid**, regardless of episode count or clip length.

Behaviour is preserved: auto grid sizing, a clip that ends early keeps showing its last frame (not blank), the green/red per-tile success border, and the same output path / fps. It uses `iter_data()` + `next(stream, sentinel)` rather than `list(reader)` — the ffmpeg reader reports `nframes=inf`, so `list()` preallocates and `MemoryError`s.

⚡️ Performance

## How it was tested

- `pytest -m "not gpu" tests/scripts/test_eval.py` green (5 passed), including two new CPU tests: one builds a grid from tiny synthetic mp4s of differing lengths and asserts the `(grid_rows·H, grid_cols·W, 3)` output shape; one checks the all-missing-inputs no-op.
- Regenerated a real multi-camera grid from two 768-px-wide × 472-frame RoboCasa CloseFridge clips on a GPU dev box: identical `(512, 768, 3)` output to the previous load-all builder, with the per-clip video memory now flat rather than growing with episode count.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/scripts/test_eval.py::test_create_grid_summary_video_streams_into_expected_grid
```

The grid summary written at the end of any rendered eval (`eval.max_episodes_rendered > 0`) is produced this way; it now stays memory-flat as the rendered-episode count grows.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.
