### PR TITLE
fix(ci): use HF_TOKEN env var instead of flaky hf auth login step

### DIFF
--- a/.github/workflows/cpu_test.yml
+++ b/.github/workflows/cpu_test.yml
@@ -140,13 +140,6 @@ jobs:
       - name: Verify ffmpeg
         run: ffmpeg -version
 
-      - name: Set up HuggingFace authentication
-        env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
-        run: |
-          source .venv/bin/activate
-          hf auth login --token $HF_TOKEN
-
       - name: Configure wandb
         run: |
           source .venv/bin/activate
@@ -156,6 +149,16 @@ jobs:
         run: df -h /dev/shm
 
       - name: Run CPU tests with coverage
+        # Authenticate to the HF Hub via env vars instead of `hf auth login`.
+        # The CLI login does an eager whoami() network call to validate the token;
+        # that call gets rate-limited (429) and fails the whole job at setup before
+        # any test runs. huggingface_hub reads HF_TOKEN / HUGGINGFACE_HUB_TOKEN with
+        # no network call. A handful of tests still need the token: test_hub.py
+        # pushes to the Hub, and the dataset tests get a higher (authenticated)
+        # rate limit on public-repo downloads.
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HUGGINGFACE_HUB_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           source .venv/bin/activate
           mkdir -p /tmp/libero-assets/libero/libero

--- a/.github/workflows/gpu_test.yml
+++ b/.github/workflows/gpu_test.yml
@@ -83,16 +83,15 @@ jobs:
       - name: Check GPU
         run: nvidia-smi
 
-      - name: Set up HuggingFace authentication
-        shell: bash
-        env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
-        run: |
-          source .venv/bin/activate
-          hf auth login --token $HF_TOKEN
-
       - name: Run Tests
         shell: bash
+        # Authenticate via env vars instead of `hf auth login`: the CLI login does
+        # an eager whoami() call that can be rate-limited (429) and fail the job at
+        # setup. huggingface_hub reads HF_TOKEN / HUGGINGFACE_HUB_TOKEN with no
+        # network call, and the GPU tests need it (gated model weights, datasets).
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HUGGINGFACE_HUB_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           source .venv/bin/activate
           # Point LIBERO at the assets bundled inside the installed package (the

--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -52,6 +52,14 @@ jobs:
     needs: start-runner
     runs-on: [g6.12xlarge]
     timeout-minutes: 30
+    # Authenticate to the HF Hub via env vars instead of `hf auth login` (which
+    # does an eager, rate-limit-prone whoami() at setup and can 429 the whole job).
+    # Set at job level because several steps below hit the Hub: Run Training (base
+    # weights), Check State Keys (--source=hf), and Run Inference. huggingface_hub
+    # reads HF_TOKEN / HUGGINGFACE_HUB_TOKEN directly, with no network call.
+    env:
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      HUGGINGFACE_HUB_TOKEN: ${{ secrets.HF_TOKEN }}
 
     container:
       image: nvidia/cuda:12.2.0-devel-ubuntu22.04
@@ -79,14 +87,6 @@ jobs:
 
       - name: Check GPU
         run: nvidia-smi
-
-      - name: Set up HuggingFace authentication
-        shell: bash
-        env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
-        run: |
-          source .venv/bin/activate
-          huggingface-cli login --token $HF_TOKEN
 
       - name: Set up Wandb authentication
         shell: bash

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,11 +79,15 @@ def patch_builtins_input(monkeypatch):
 
 @pytest.fixture(scope="session")
 def get_huggingface_api():
+    # Deliberately no whoami() call: its result (the username) is unused by the
+    # only consumer (test_save_pretrained discards api/username, uses hf_token).
+    # whoami() hits the same rate-limit-prone endpoint that has flaked CI at
+    # setup, so we skip it; the token is validated implicitly when the push test
+    # actually writes to the Hub. The middle tuple element stays for arity.
     hf_token = os.getenv("HUGGINGFACE_HUB_TOKEN")
     api = HfApi(token=hf_token)
-    username = api.whoami(token=hf_token)["name"]
 
-    return api, username, hf_token
+    return api, None, hf_token
 
 
 @pytest.fixture(scope="session", autouse=True)


### PR DESCRIPTION
## What this does

The CPU Tests job fails intermittently in the **`Set up HuggingFace authentication`** step — not in any test:

```
hf auth login --token $HF_TOKEN
→ HfHubHTTPError: 429 Client Error: Too Many Requests for url: https://huggingface.co/api/whoami-v2
```

`hf auth login --token` makes an eager `whoami()` network call to validate the token before saving it. When that call is rate-limited (429), the step exits non-zero under `bash -e` and fails the whole job **before any test runs**. It is purely transient infra flakiness.

This replaces the login step with plain `HF_TOKEN` / `HUGGINGFACE_HUB_TOKEN` environment variables. `huggingface_hub` (0.36.1, pinned in `uv.lock`) resolves credentials via `get_token()`, which reads those env vars with **no network call**, so every Hub call stays authenticated without the flaky validation. We keep the token because a few CPU tests genuinely need it — `tests/utils/test_hub.py::test_save_pretrained` pushes to the Hub, and the public-dataset download tests get a higher *authenticated* rate limit (dropping auth would make them *more* 429-prone) — we only drop the network round-trip.

Applied to all three test workflows:
- `cpu_test.yml`, `gpu_test.yml` — env on the single test step.
- `regression_test.yml` — env at **job level**, since several of its steps hit the Hub (training pulls base weights, `Check State Keys --source=hf`, inference).

Also removes the now-redundant `whoami()` call in the `get_huggingface_api` fixture (`tests/conftest.py`): its result (the username) was never used by the only consumer, yet it hit the same 429-prone endpoint at every test-setup.

Failing run for reference: https://github.com/TensorAuto/OpenTau/actions/runs/26979795710/job/79615895101?pr=399

## How it was tested

- `uv run --extra dev pre-commit run --files .github/workflows/cpu_test.yml .github/workflows/gpu_test.yml .github/workflows/regression_test.yml tests/conftest.py` — all hooks pass (incl. `check yaml`, `zizmor`, `ruff`).
- `uv run pytest -m "not gpu" tests/utils/test_hub.py` — 4/4 pass. The Hub-push parametrization was deselected locally only to avoid creating a real repo; it is exercised in CI via the new env-var token, and the fixture change is what makes the other cases pass without a setup-time `whoami()`.
- The real proof is CI re-running green on this PR without the `hf auth login` step.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/utils/test_hub.py
```

The workflow change is reviewable directly in the diff: each `Set up HuggingFace authentication` step is gone, replaced by `HF_TOKEN` + `HUGGINGFACE_HUB_TOKEN` in the relevant `env:` block. CI on this PR runs the updated `cpu_test.yml` end-to-end.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
