### PR TITLE
fix(eval): honor max_episodes_rendered and grid_size from EvalConfig

### DIFF
--- a/src/opentau/scripts/eval.py
+++ b/src/opentau/scripts/eval.py
@@ -686,7 +686,8 @@ def eval_main(cfg: TrainPipelineConfig):
             policy=policy,
             n_episodes=cfg.eval.n_episodes,
             cfg=cfg,
-            max_episodes_rendered=10,
+            max_episodes_rendered=cfg.eval.max_episodes_rendered,
+            grid_size=cfg.eval.grid_size,
             videos_dir=eval_output_dir / "videos",
             start_seed=cfg.seed,
             max_parallel_tasks=cfg.env.max_parallel_tasks,
@@ -735,6 +736,7 @@ def eval_one(
     videos_dir: Path | None,
     return_episode_data: bool,
     start_seed: int | None,
+    grid_size: tuple[int, int] | None = None,
     subgoal_generator: SubgoalImageGenerator | None = None,
 ) -> tuple[TaskMetrics, dict]:
     """Evaluates one task_id of one suite using the provided vec env."""
@@ -750,6 +752,7 @@ def eval_one(
         videos_dir=task_videos_dir,
         return_episode_data=return_episode_data,
         start_seed=start_seed,
+        grid_size=grid_size,
         subgoal_generator=subgoal_generator,
     )
 
@@ -774,6 +777,7 @@ def run_one(
     videos_dir: Path | None,
     return_episode_data: bool,
     start_seed: int | None,
+    grid_size: tuple[int, int] | None = None,
     subgoal_generator: SubgoalImageGenerator | None = None,
 ) -> tuple[str, int, TaskMetrics, dict]:
     """
@@ -800,6 +804,7 @@ def run_one(
         videos_dir=task_videos_dir,
         return_episode_data=return_episode_data,
         start_seed=start_seed,
+        grid_size=grid_size,
         subgoal_generator=subgoal_generator,
     )
     # ensure we always provide video_paths key to simplify accumulation
@@ -826,6 +831,7 @@ def eval_policy_all(
     videos_dir: Path | None = None,
     return_episode_data: bool = False,
     start_seed: int | None = None,
+    grid_size: tuple[int, int] | None = None,
     max_parallel_tasks: int = 1,
     subgoal_generator: SubgoalImageGenerator | None = None,
 ) -> dict:
@@ -835,6 +841,10 @@ def eval_policy_all(
     accumulates per-group and overall statistics, and returns the same aggregate metrics
     schema as the single-env evaluator (avg_sum_reward / avg_max_reward / pc_success / timings)
     plus per-task infos.
+
+    ``max_episodes_rendered`` (how many rollouts to render into each task's grid
+    summary) and ``grid_size`` (its ``(rows, cols)`` layout, ``None`` = auto square)
+    are forwarded unchanged to ``eval_policy`` for every task.
     """
     start_t = time.time()
 
@@ -891,6 +901,7 @@ def eval_policy_all(
         videos_dir=videos_dir,
         return_episode_data=return_episode_data,
         start_seed=start_seed,
+        grid_size=grid_size,
         subgoal_generator=subgoal_generator,
     )
 

--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -1142,6 +1142,7 @@ def train(cfg: TrainPipelineConfig):
                     cfg,
                     videos_dir=cfg.output_dir / "eval" / f"videos_step_{step_id}",
                     max_episodes_rendered=cfg.eval.max_episodes_rendered,
+                    grid_size=cfg.eval.grid_size,
                     start_seed=cfg.seed,
                     max_parallel_tasks=cfg.env.max_parallel_tasks,
                     subgoal_generator=eval_subgoal_generator,

--- a/tests/scripts/test_eval.py
+++ b/tests/scripts/test_eval.py
@@ -61,8 +61,6 @@ def test_eval_policy_all_forwards_render_cap_and_grid_size_to_eval_policy(monkey
     eval_policy_all -> run_one -> eval_one -> eval_policy. Regression guard: eval_main
     used to hardcode the render cap (10) and never threaded grid_size, so both
     EvalConfig fields were silently ignored and grids only ever tiled 10 rollouts."""
-    import opentau.scripts.eval as eval_mod
-
     captured: dict = {}
 
     def fake_eval_policy(**kwargs):
@@ -71,12 +69,14 @@ def test_eval_policy_all_forwards_render_cap_and_grid_size_to_eval_policy(monkey
         captured.update(kwargs)
         return {"per_episode": []}
 
-    monkeypatch.setattr(eval_mod, "eval_policy", fake_eval_policy)
+    # Patch the module global by dotted path so eval_one's call-time lookup of
+    # `eval_policy` resolves to the stub (keeps a single `from`-import style).
+    monkeypatch.setattr("opentau.scripts.eval.eval_policy", fake_eval_policy)
 
     cfg = Mock()
     cfg.eval.recording_root = None  # skip the LIBERO-only recorder guard + block
 
-    eval_mod.eval_policy_all(
+    eval_policy_all(
         {"group": {0: object()}},  # one fake task; the env is never touched (eval_policy is stubbed)
         policy=Mock(),
         n_episodes=1,

--- a/tests/scripts/test_eval.py
+++ b/tests/scripts/test_eval.py
@@ -55,6 +55,42 @@ def test_eval_policy_all_rejects_recording_root_for_non_libero_env():
         eval_policy_all({}, policy=Mock(), n_episodes=1, cfg=cfg)
 
 
+def test_eval_policy_all_forwards_render_cap_and_grid_size_to_eval_policy(monkeypatch):
+    """The grid-summary controls must reach the leaf evaluator. eval_main exposes
+    `cfg.eval.max_episodes_rendered` / `cfg.eval.grid_size` by forwarding them through
+    eval_policy_all -> run_one -> eval_one -> eval_policy. Regression guard: eval_main
+    used to hardcode the render cap (10) and never threaded grid_size, so both
+    EvalConfig fields were silently ignored and grids only ever tiled 10 rollouts."""
+    import opentau.scripts.eval as eval_mod
+
+    captured: dict = {}
+
+    def fake_eval_policy(**kwargs):
+        # Stub the real rollout: capture the render controls and return an empty
+        # per-episode result so the (real) run_one/eval_one wrappers still run.
+        captured.update(kwargs)
+        return {"per_episode": []}
+
+    monkeypatch.setattr(eval_mod, "eval_policy", fake_eval_policy)
+
+    cfg = Mock()
+    cfg.eval.recording_root = None  # skip the LIBERO-only recorder guard + block
+
+    eval_mod.eval_policy_all(
+        {"group": {0: object()}},  # one fake task; the env is never touched (eval_policy is stubbed)
+        policy=Mock(),
+        n_episodes=1,
+        cfg=cfg,
+        max_episodes_rendered=7,
+        grid_size=(2, 3),
+        videos_dir=None,
+        max_parallel_tasks=1,
+    )
+
+    assert captured["max_episodes_rendered"] == 7
+    assert captured["grid_size"] == (2, 3)
+
+
 def test_create_grid_summary_video_streams_into_expected_grid(tmp_path):
     """The grid builder streams each clip frame-by-frame (bounded memory) and tiles
     them into a (grid_rows*H, grid_cols*W, 3) video, holding a clip's last frame


### PR DESCRIPTION
## What this does

`eval_main` hardcoded `max_episodes_rendered=10` and never passed `grid_size`, so two `EvalConfig` fields were silently ignored on the eval path:

- **`cfg.eval.max_episodes_rendered`** — the per-task `grid_summary.mp4` only ever tiled the **first 10 rollouts** of an N-episode eval, regardless of config. A 30-episode run still produced a 10-tile grid.
- **`cfg.eval.grid_size`** — the grid layout was always auto-computed; setting the field had no effect.

This wires both fields through:

- `eval_main` now reads `cfg.eval.max_episodes_rendered` and `cfg.eval.grid_size` instead of hardcoding `10` / `None`.
- `grid_size` is threaded `eval_policy_all → run_one → eval_one` (the leaf `eval_policy` and `create_grid_summary_video` already accept it). `max_episodes_rendered` already threaded through the chain — only the top-level value in `eval_main` was hardcoded.
- The in-training validation eval in `train.py` already passed `max_episodes_rendered` from config but also omitted `grid_size`; it now passes it too, so **every** `eval_policy_all` call site honors the field.

Both new params default to the prior behavior (`grid_size=None` = auto square grid), so configs that don't set them are unchanged. The one behavior change: the default render count now follows `EvalConfig.max_episodes_rendered` (16) rather than the old hardcoded 10.

> The `train.py` hunk is a visualization-only kwarg on the validation eval (which runs under `no_grad` and never feeds back into training) — no model math, training loop, loss, optimizer, sampler, or RNG is touched, so determinism is unaffected and the policy/GPU boxes are left unchecked. (ruff also reordered a pre-existing `import wandb` when the file was touched.)

🐛 Bug

## How it was tested

- Added `test_eval_policy_all_forwards_render_cap_and_grid_size_to_eval_policy` in `tests/scripts/test_eval.py`: it stubs the leaf `eval_policy` and asserts `eval_policy_all` forwards both `max_episodes_rendered` and `grid_size` down through the real `run_one` / `eval_one` wrappers — guarding exactly the regression (the controls never reaching the renderer). Full `tests/scripts/test_eval.py` passes (6/6); pre-commit clean.
- End-to-end: a 30-episode RoboCasa `CloseFridge` sim eval that previously rendered a 10-tile `grid_summary.mp4` now renders all 30 rollouts into the grid (success rate unchanged — this is render/visualization only), confirming `--eval.max_episodes_rendered` now takes effect.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/scripts/test_eval.py::test_eval_policy_all_forwards_render_cap_and_grid_size_to_eval_policy
```

Any sim eval now tiles all rendered rollouts into the grid; raise the (previously ignored) render cap to match the episode count:

```bash
opentau-eval --accelerate-config <yaml> --config_path=<eval_config.json> \
    --eval.n_episodes=30 --eval.max_episodes_rendered=30
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
