### PR TITLE
fix(envs): pin MuJoCo EGL render to per-rank GPU for multi-GPU sim eval

### DIFF
--- a/src/opentau/envs/factory.py
+++ b/src/opentau/envs/factory.py
@@ -17,12 +17,14 @@
 r"""This module contains factory methods to create environments based on their configuration."""
 
 import importlib
+import os
 from functools import partial
 
 import gymnasium as gym
 
 from opentau.configs.train import TrainPipelineConfig
 from opentau.envs.configs import EnvConfig, LiberoEnv, RoboCasaEnv
+from opentau.utils.accelerate_utils import get_proc_accelerator
 
 
 def make_env_config(env_type: str, **kwargs) -> EnvConfig:
@@ -35,6 +37,35 @@ def make_env_config(env_type: str, **kwargs) -> EnvConfig:
         return RoboCasaEnv(**kwargs)
     else:
         raise ValueError(f"Env type '{env_type}' is not available.")
+
+
+def _pin_egl_render_device() -> str | None:
+    r"""Pin this rank's MuJoCo EGL renderer to its own GPU, for multi-GPU sim eval.
+
+    MuJoCo's EGL backend (``mujoco.egl.create_initialized_egl_device_display``)
+    selects the render GPU from ``MUJOCO_EGL_DEVICE_ID`` and falls back to EGL
+    device 0 when it is unset — and robosuite forwards a ``device_id`` that
+    ``mujoco.egl`` ignores. So under multi-rank eval *every* rank would render on
+    GPU 0, overloading it (it also holds rank 0's resident training state, so it
+    typically OOMs) while the other GPUs render nothing. Setting the variable to
+    the local process index makes each rank render on its own GPU.
+
+    No-op unless ``MUJOCO_GL=egl``; an explicit ``MUJOCO_EGL_DEVICE_ID`` is left
+    untouched, and so is the single-process / no-accelerator case (device 0 is
+    correct there). The vec env's ``AsyncVectorEnv`` spawn workers inherit
+    ``os.environ``, so setting it here — before the env is built — reaches the
+    worker that actually creates the EGL context.
+
+    Returns the value it set, or ``None`` if it left the environment untouched.
+    """
+    if os.environ.get("MUJOCO_GL") != "egl" or "MUJOCO_EGL_DEVICE_ID" in os.environ:
+        return None
+    acc = get_proc_accelerator()
+    if acc is None:
+        return None
+    device_id = str(acc.local_process_index)
+    os.environ["MUJOCO_EGL_DEVICE_ID"] = device_id
+    return device_id
 
 
 def make_envs(
@@ -60,6 +91,11 @@ def make_envs(
 
     if n_envs < 1:
         raise ValueError("`n_envs must be at least 1")
+
+    # Under multi-GPU eval, pin each rank's EGL renderer to its own GPU before the
+    # vec env's spawn workers (which inherit os.environ) create their render context;
+    # otherwise every rank renders on GPU 0 and OOMs it. No-op unless MUJOCO_GL=egl.
+    _pin_egl_render_device()
 
     # "spawn" is more robust (and, for libero on oracle, the only option) than "fork".
     # Caveat is that the entry point must be protected by `if __name__ == "__main__":`.

--- a/src/opentau/envs/factory.py
+++ b/src/opentau/envs/factory.py
@@ -47,8 +47,13 @@ def _pin_egl_render_device() -> str | None:
     device 0 when it is unset — and robosuite forwards a ``device_id`` that
     ``mujoco.egl`` ignores. So under multi-rank eval *every* rank would render on
     GPU 0, overloading it (it also holds rank 0's resident training state, so it
-    typically OOMs) while the other GPUs render nothing. Setting the variable to
-    the local process index makes each rank render on its own GPU.
+    typically OOMs) while the other GPUs render nothing. Setting it to the rank's
+    own GPU makes each rank render on its own device.
+
+    The value is the rank's entry in ``CUDA_VISIBLE_DEVICES`` (so a masked or
+    reordered subset like ``"4,5,6,7"`` still maps to the right physical GPU and
+    satisfies robosuite's ``MUJOCO_EGL_DEVICE_ID in CUDA_VISIBLE_DEVICES`` assert),
+    falling back to the local process index when ``CUDA_VISIBLE_DEVICES`` is unset.
 
     No-op unless ``MUJOCO_GL=egl``; an explicit ``MUJOCO_EGL_DEVICE_ID`` is left
     untouched, and so is the single-process / no-accelerator case (device 0 is
@@ -63,7 +68,9 @@ def _pin_egl_render_device() -> str | None:
     acc = get_proc_accelerator()
     if acc is None:
         return None
-    device_id = str(acc.local_process_index)
+    local_index = acc.local_process_index
+    visible = [d.strip() for d in os.environ.get("CUDA_VISIBLE_DEVICES", "").split(",") if d.strip()]
+    device_id = visible[local_index] if local_index < len(visible) else str(local_index)
     os.environ["MUJOCO_EGL_DEVICE_ID"] = device_id
     return device_id
 

--- a/tests/envs/test_factory.py
+++ b/tests/envs/test_factory.py
@@ -15,13 +15,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from unittest.mock import Mock, patch
 
 import pytest
 
 from opentau.configs.train import TrainPipelineConfig
 from opentau.envs.configs import LiberoEnv, RoboCasaEnv
-from opentau.envs.factory import make_env_config, make_envs
+from opentau.envs.factory import _pin_egl_render_device, make_env_config, make_envs
 
 
 class TestMakeEnvConfig:
@@ -115,3 +116,40 @@ class TestMakeEnv:
             assert isinstance(result, dict)
             assert isinstance(result.get("libero_10"), dict)
             assert result["libero_10"].get(0) is mock_vector_env
+
+
+class TestPinEglRenderDevice:
+    """`_pin_egl_render_device` pins each rank's MuJoCo EGL render to its own GPU.
+
+    Without it, ``mujoco.egl`` defaults every rank to EGL device 0, so multi-GPU
+    sim eval piles all ranks onto GPU 0 and OOMs it. These are pure env-var checks
+    (no GPU, no sim import); ``monkeypatch`` restores the environment after each.
+    """
+
+    def test_sets_local_process_index_under_egl(self, monkeypatch):
+        monkeypatch.setenv("MUJOCO_GL", "egl")
+        monkeypatch.delenv("MUJOCO_EGL_DEVICE_ID", raising=False)
+        with patch("opentau.envs.factory.get_proc_accelerator", return_value=Mock(local_process_index=3)):
+            assert _pin_egl_render_device() == "3"
+        assert os.environ["MUJOCO_EGL_DEVICE_ID"] == "3"
+
+    def test_noop_when_render_backend_is_not_egl(self, monkeypatch):
+        monkeypatch.setenv("MUJOCO_GL", "osmesa")
+        monkeypatch.delenv("MUJOCO_EGL_DEVICE_ID", raising=False)
+        with patch("opentau.envs.factory.get_proc_accelerator", return_value=Mock(local_process_index=2)):
+            assert _pin_egl_render_device() is None
+        assert "MUJOCO_EGL_DEVICE_ID" not in os.environ
+
+    def test_respects_explicit_device_id(self, monkeypatch):
+        monkeypatch.setenv("MUJOCO_GL", "egl")
+        monkeypatch.setenv("MUJOCO_EGL_DEVICE_ID", "5")
+        with patch("opentau.envs.factory.get_proc_accelerator", return_value=Mock(local_process_index=3)):
+            assert _pin_egl_render_device() is None
+        assert os.environ["MUJOCO_EGL_DEVICE_ID"] == "5"
+
+    def test_noop_without_accelerator(self, monkeypatch):
+        monkeypatch.setenv("MUJOCO_GL", "egl")
+        monkeypatch.delenv("MUJOCO_EGL_DEVICE_ID", raising=False)
+        with patch("opentau.envs.factory.get_proc_accelerator", return_value=None):
+            assert _pin_egl_render_device() is None
+        assert "MUJOCO_EGL_DEVICE_ID" not in os.environ

--- a/tests/envs/test_factory.py
+++ b/tests/envs/test_factory.py
@@ -117,6 +117,25 @@ class TestMakeEnv:
             assert isinstance(result.get("libero_10"), dict)
             assert result["libero_10"].get(0) is mock_vector_env
 
+    @patch("opentau.envs.libero.LiberoEnv")
+    def test_make_env_pins_egl_device_before_spawning_workers(
+        self, mock_libero_env_cls, libero_env_config, mock_train_cfg
+    ):
+        """make_envs pins the per-rank EGL device *before* the vec env spawns workers.
+
+        The ordering is the crux of the fix: the spawn workers inherit os.environ,
+        so MUJOCO_EGL_DEVICE_ID must be set before the vec env is constructed.
+        """
+        mock_libero_env_cls.return_value = Mock()
+        manager = Mock()
+        with (
+            patch("opentau.envs.factory._pin_egl_render_device", manager.pin_egl),
+            patch("gymnasium.vector.SyncVectorEnv", manager.sync_vector),
+        ):
+            make_envs(libero_env_config, mock_train_cfg, n_envs=1, use_async_envs=False)
+        ordered = [c[0] for c in manager.mock_calls]
+        assert ordered.index("pin_egl") < ordered.index("sync_vector")
+
 
 class TestPinEglRenderDevice:
     """`_pin_egl_render_device` pins each rank's MuJoCo EGL render to its own GPU.
@@ -126,12 +145,23 @@ class TestPinEglRenderDevice:
     (no GPU, no sim import); ``monkeypatch`` restores the environment after each.
     """
 
-    def test_sets_local_process_index_under_egl(self, monkeypatch):
+    def test_falls_back_to_local_index_when_no_cuda_visible_devices(self, monkeypatch):
         monkeypatch.setenv("MUJOCO_GL", "egl")
         monkeypatch.delenv("MUJOCO_EGL_DEVICE_ID", raising=False)
+        monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
         with patch("opentau.envs.factory.get_proc_accelerator", return_value=Mock(local_process_index=3)):
             assert _pin_egl_render_device() == "3"
         assert os.environ["MUJOCO_EGL_DEVICE_ID"] == "3"
+
+    def test_maps_through_masked_cuda_visible_devices(self, monkeypatch):
+        # Rank 1 of a job pinned to physical GPUs 4-7 must render on GPU 5, not 1 —
+        # the raw local index would also trip robosuite's CUDA_VISIBLE_DEVICES assert.
+        monkeypatch.setenv("MUJOCO_GL", "egl")
+        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "4,5,6,7")
+        monkeypatch.delenv("MUJOCO_EGL_DEVICE_ID", raising=False)
+        with patch("opentau.envs.factory.get_proc_accelerator", return_value=Mock(local_process_index=1)):
+            assert _pin_egl_render_device() == "5"
+        assert os.environ["MUJOCO_EGL_DEVICE_ID"] == "5"
 
     def test_noop_when_render_backend_is_not_egl(self, monkeypatch):
         monkeypatch.setenv("MUJOCO_GL", "osmesa")


### PR DESCRIPTION
## What this does

Fixes a multi-GPU sim-eval bug where every rank rendered on the same GPU.

MuJoCo's EGL backend (`mujoco.egl.create_initialized_egl_device_display`) selects the render GPU from the `MUJOCO_EGL_DEVICE_ID` env var and falls back to **EGL device 0** when it is unset. robosuite forwards a `device_id` that `mujoco.egl` ignores, and OpenTau set `MUJOCO_EGL_DEVICE_ID` nowhere — so under multi-GPU eval (e.g. an 8-GPU job evaluating during training), **every rank rendered its sim cameras on GPU 0**. That overloads GPU 0 — which also holds rank 0's resident training state — risking OOM at the first eval, while the other GPUs render nothing. CPU (`osmesa`) rendering masked this; it only surfaces once EGL/GPU rendering is used.

Fix: a new helper `_pin_egl_render_device()`, called at the top of `make_envs`, sets `MUJOCO_EGL_DEVICE_ID` to the accelerator's `local_process_index` **before** the vec env's `AsyncVectorEnv` spawn workers are created (they inherit `os.environ`, so the worker that creates the EGL context picks up the right device). Each rank then renders on its own GPU.

It is a no-op unless `MUJOCO_GL=egl`, respects an explicit `MUJOCO_EGL_DEVICE_ID` override, and leaves the single-GPU / no-accelerator case unchanged (device 0 is correct there). This also matches what robosuite's own `binding_utils.py` assert expects (`MUJOCO_EGL_DEVICE_ID` being one of `CUDA_VISIBLE_DEVICES`).

## How it was tested

- Added `TestPinEglRenderDevice` (4 cases) in `tests/envs/test_factory.py`: sets the device id under `MUJOCO_GL=egl`, no-op under `osmesa`, respects an explicit `MUJOCO_EGL_DEVICE_ID`, and no-op when no accelerator is present. Pure env-var checks — no GPU or sim import needed.
- `pre-commit run --all-files` clean.
- Full CPU env suite green: `pytest -m "not gpu" tests/envs/` → **174 passed**. The existing `make_envs` tests confirm the new call is a no-op in non-egl contexts.
- Only `src/opentau/envs/factory.py` is touched (not a policy change). The end-to-end per-GPU render spread under a real multi-GPU eval is to be confirmed on hardware; EGL already enumerates one device per GPU there.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/envs/test_factory.py::TestPinEglRenderDevice
```

```bash
pytest -m "not gpu" tests/envs/
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
