### PR TITLE
fix(envs): register nvidia EGL ICD so RoboCasa sim eval renders on GPU

### DIFF
--- a/src/opentau/envs/factory.py
+++ b/src/opentau/envs/factory.py
@@ -76,19 +76,28 @@ def _ensure_nvidia_egl_icd() -> str | None:
     for vendor_dir in ("/usr/share/glvnd/egl_vendor.d", "/etc/glvnd/egl_vendor.d"):
         if glob.glob(os.path.join(vendor_dir, "*nvidia*.json")):
             return None
-    libs = sorted(glob.glob("/usr/lib/x86_64-linux-gnu/libEGL_nvidia.so.*")) or sorted(
-        glob.glob("/usr/lib/*/libEGL_nvidia.so.*")
+    # Prefer the version-stable soname symlink (``libEGL_nvidia.so.0``) over a
+    # specific versioned file, so the choice doesn't depend on lexicographic-vs-
+    # numeric ordering of multiple injected libs.
+    libs = (
+        glob.glob("/usr/lib/x86_64-linux-gnu/libEGL_nvidia.so.0")
+        or glob.glob("/usr/lib/*/libEGL_nvidia.so.0")
+        or sorted(glob.glob("/usr/lib/x86_64-linux-gnu/libEGL_nvidia.so.*"))
+        or sorted(glob.glob("/usr/lib/*/libEGL_nvidia.so.*"))
     )
     if not libs:
         return None
-    icd_dir = os.path.join(tempfile.gettempdir(), "opentau_egl")
+    # Namespace the descriptor dir by uid: on a shared multi-tenant node a second
+    # user must not hit ``PermissionError`` writing into the first user's dir (which
+    # would crash ``make_envs``). Same-user ranks share it; the write below is atomic
+    # (mkstemp + ``os.replace``) so a partial file is never visible to a spawn worker.
+    uid = getattr(os, "getuid", os.getpid)()
+    icd_dir = os.path.join(tempfile.gettempdir(), f"opentau_egl_{uid}")
     os.makedirs(icd_dir, exist_ok=True)
     icd_path = os.path.join(icd_dir, "10_nvidia.json")
-    # Atomic write: ranks share /tmp on a node, so a partial file must never be
-    # visible to a spawn worker reading the descriptor.
     fd, tmp_path = tempfile.mkstemp(dir=icd_dir, suffix=".json")
     with os.fdopen(fd, "w") as f:
-        json.dump({"file_format_version": "1.0.0", "ICD": {"library_path": libs[-1]}}, f)
+        json.dump({"file_format_version": "1.0.0", "ICD": {"library_path": libs[0]}}, f)
     os.replace(tmp_path, icd_path)
     os.environ["__EGL_VENDOR_LIBRARY_FILENAMES"] = icd_path
     return icd_path

--- a/src/opentau/envs/factory.py
+++ b/src/opentau/envs/factory.py
@@ -87,18 +87,14 @@ def _ensure_nvidia_egl_icd() -> str | None:
     )
     if not libs:
         return None
-    # Namespace the descriptor dir by uid: on a shared multi-tenant node a second
-    # user must not hit ``PermissionError`` writing into the first user's dir (which
-    # would crash ``make_envs``). Same-user ranks share it; the write below is atomic
-    # (mkstemp + ``os.replace``) so a partial file is never visible to a spawn worker.
-    uid = getattr(os, "getuid", os.getpid)()
-    icd_dir = os.path.join(tempfile.gettempdir(), f"opentau_egl_{uid}")
-    os.makedirs(icd_dir, exist_ok=True)
+    # Write the descriptor into a fresh private (0700) tmp dir: mkdtemp returns a
+    # unique, unpredictable path owned by this process, so there is no cross-user
+    # collision and no fixed path a co-tenant could pre-squat to break the write.
+    # Each rank makes its own; the spawn workers inherit __EGL_VENDOR_LIBRARY_FILENAMES.
+    icd_dir = tempfile.mkdtemp(prefix="opentau_egl_")
     icd_path = os.path.join(icd_dir, "10_nvidia.json")
-    fd, tmp_path = tempfile.mkstemp(dir=icd_dir, suffix=".json")
-    with os.fdopen(fd, "w") as f:
+    with open(icd_path, "w") as f:
         json.dump({"file_format_version": "1.0.0", "ICD": {"library_path": libs[0]}}, f)
-    os.replace(tmp_path, icd_path)
     os.environ["__EGL_VENDOR_LIBRARY_FILENAMES"] = icd_path
     return icd_path
 

--- a/src/opentau/envs/factory.py
+++ b/src/opentau/envs/factory.py
@@ -16,8 +16,11 @@
 # limitations under the License.
 r"""This module contains factory methods to create environments based on their configuration."""
 
+import glob
 import importlib
+import json
 import os
+import tempfile
 from functools import partial
 
 import gymnasium as gym
@@ -37,6 +40,58 @@ def make_env_config(env_type: str, **kwargs) -> EnvConfig:
         return RoboCasaEnv(**kwargs)
     else:
         raise ValueError(f"Env type '{env_type}' is not available.")
+
+
+def _ensure_nvidia_egl_icd() -> str | None:
+    r"""Register the nvidia EGL ICD when a container ships only Mesa's, so GPU rendering works.
+
+    Some container images (e.g. the training enroot image) inject
+    ``libEGL_nvidia.so`` via ``NVIDIA_DRIVER_CAPABILITIES`` *graphics* but ship only
+    Mesa's glvnd ICD descriptor (``egl_vendor.d/50_mesa.json``) and no nvidia one.
+    glvnd then loads Mesa, whose GPU path needs ``/dev/dri`` render nodes the
+    container typically does not expose — so ``eglQueryDevicesEXT`` enumerates
+    unusable Mesa devices and robosuite's per-device EGL context (it indexes that
+    list by ``MUJOCO_EGL_DEVICE_ID``) fails to initialize a headless display, while
+    MuJoCo's own backend silently falls back to the llvmpipe *software* device.
+
+    When ``MUJOCO_GL=egl`` and no nvidia ICD is registered, write a minimal glvnd
+    descriptor pointing at the injected ``libEGL_nvidia.so`` and point
+    ``__EGL_VENDOR_LIBRARY_FILENAMES`` at it, so glvnd uses only nvidia EGL and
+    ``eglQueryDevicesEXT`` returns the GPUs. The vec env's ``AsyncVectorEnv`` spawn
+    workers inherit ``os.environ``, so setting it here — before the env is built —
+    reaches the worker that creates the EGL context (paired with
+    ``_pin_egl_render_device``, which selects which GPU that worker uses).
+
+    No-op unless ``MUJOCO_GL=egl``; if ``__EGL_VENDOR_LIBRARY_*`` is already set, an
+    nvidia ICD descriptor already exists, or no ``libEGL_nvidia.so`` is present (so
+    there is nothing to point at), the environment is left untouched.
+
+    Returns the descriptor path it wrote, or ``None`` if it left the environment alone.
+    """
+    if os.environ.get("MUJOCO_GL") != "egl":
+        return None
+    if os.environ.get("__EGL_VENDOR_LIBRARY_FILENAMES") or os.environ.get("__EGL_VENDOR_LIBRARY_DIRS"):
+        return None
+    # An nvidia ICD already registered with glvnd -> let it be.
+    for vendor_dir in ("/usr/share/glvnd/egl_vendor.d", "/etc/glvnd/egl_vendor.d"):
+        if glob.glob(os.path.join(vendor_dir, "*nvidia*.json")):
+            return None
+    libs = sorted(glob.glob("/usr/lib/x86_64-linux-gnu/libEGL_nvidia.so.*")) or sorted(
+        glob.glob("/usr/lib/*/libEGL_nvidia.so.*")
+    )
+    if not libs:
+        return None
+    icd_dir = os.path.join(tempfile.gettempdir(), "opentau_egl")
+    os.makedirs(icd_dir, exist_ok=True)
+    icd_path = os.path.join(icd_dir, "10_nvidia.json")
+    # Atomic write: ranks share /tmp on a node, so a partial file must never be
+    # visible to a spawn worker reading the descriptor.
+    fd, tmp_path = tempfile.mkstemp(dir=icd_dir, suffix=".json")
+    with os.fdopen(fd, "w") as f:
+        json.dump({"file_format_version": "1.0.0", "ICD": {"library_path": libs[-1]}}, f)
+    os.replace(tmp_path, icd_path)
+    os.environ["__EGL_VENDOR_LIBRARY_FILENAMES"] = icd_path
+    return icd_path
 
 
 def _pin_egl_render_device() -> str | None:
@@ -99,9 +154,12 @@ def make_envs(
     if n_envs < 1:
         raise ValueError("`n_envs must be at least 1")
 
-    # Under multi-GPU eval, pin each rank's EGL renderer to its own GPU before the
-    # vec env's spawn workers (which inherit os.environ) create their render context;
-    # otherwise every rank renders on GPU 0 and OOMs it. No-op unless MUJOCO_GL=egl.
+    # Make GPU EGL rendering work before the vec env's spawn workers (which inherit
+    # os.environ) create their render context. Both are no-ops unless MUJOCO_GL=egl:
+    # (1) register the nvidia EGL ICD if the container ships only Mesa's (else robosuite
+    # cannot init a headless GPU display); (2) pin each rank's renderer to its own GPU
+    # (else every rank renders on GPU 0 and OOMs it).
+    _ensure_nvidia_egl_icd()
     _pin_egl_render_device()
 
     # "spawn" is more robust (and, for libero on oracle, the only option) than "fork".

--- a/tests/envs/test_factory.py
+++ b/tests/envs/test_factory.py
@@ -243,7 +243,13 @@ class TestEnsureNvidiaEglIcd:
             return []
 
         monkeypatch.setattr("opentau.envs.factory.glob.glob", fake_glob)
-        monkeypatch.setattr("opentau.envs.factory.tempfile.gettempdir", lambda: str(tmp_path))
+
+        def fake_mkdtemp(prefix="", **kwargs):
+            d = tmp_path / "egl_icd"
+            d.mkdir(exist_ok=True)
+            return str(d)
+
+        monkeypatch.setattr("opentau.envs.factory.tempfile.mkdtemp", fake_mkdtemp)
         icd = _ensure_nvidia_egl_icd()
         assert icd is not None and os.path.exists(icd)
         with open(icd) as f:

--- a/tests/envs/test_factory.py
+++ b/tests/envs/test_factory.py
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import os
 from unittest.mock import Mock, patch
 
@@ -22,7 +23,12 @@ import pytest
 
 from opentau.configs.train import TrainPipelineConfig
 from opentau.envs.configs import LiberoEnv, RoboCasaEnv
-from opentau.envs.factory import _pin_egl_render_device, make_env_config, make_envs
+from opentau.envs.factory import (
+    _ensure_nvidia_egl_icd,
+    _pin_egl_render_device,
+    make_env_config,
+    make_envs,
+)
 
 
 class TestMakeEnvConfig:
@@ -183,3 +189,66 @@ class TestPinEglRenderDevice:
         with patch("opentau.envs.factory.get_proc_accelerator", return_value=None):
             assert _pin_egl_render_device() is None
         assert "MUJOCO_EGL_DEVICE_ID" not in os.environ
+
+
+class TestEnsureNvidiaEglIcd:
+    """`_ensure_nvidia_egl_icd` registers the nvidia EGL ICD when only Mesa's ships.
+
+    Without it, glvnd loads Mesa (which needs ``/dev/dri``) and robosuite cannot init
+    a headless GPU display. Pure env-var/filesystem checks (no GPU, no sim import);
+    ``monkeypatch`` restores the environment and ``tmp_path`` isolates the descriptor.
+    """
+
+    def test_noop_when_render_backend_is_not_egl(self, monkeypatch):
+        monkeypatch.setenv("MUJOCO_GL", "osmesa")
+        monkeypatch.delenv("__EGL_VENDOR_LIBRARY_FILENAMES", raising=False)
+        assert _ensure_nvidia_egl_icd() is None
+        assert "__EGL_VENDOR_LIBRARY_FILENAMES" not in os.environ
+
+    def test_noop_when_vendor_already_set(self, monkeypatch):
+        monkeypatch.setenv("MUJOCO_GL", "egl")
+        monkeypatch.setenv("__EGL_VENDOR_LIBRARY_FILENAMES", "/somewhere/10_nvidia.json")
+        assert _ensure_nvidia_egl_icd() is None
+
+    def test_noop_when_nvidia_icd_already_registered(self, monkeypatch):
+        monkeypatch.setenv("MUJOCO_GL", "egl")
+        monkeypatch.delenv("__EGL_VENDOR_LIBRARY_FILENAMES", raising=False)
+        monkeypatch.delenv("__EGL_VENDOR_LIBRARY_DIRS", raising=False)
+        monkeypatch.setattr(
+            "opentau.envs.factory.glob.glob",
+            lambda p: (["/usr/share/glvnd/egl_vendor.d/10_nvidia.json"] if "egl_vendor.d" in p else []),
+        )
+        assert _ensure_nvidia_egl_icd() is None
+        assert "__EGL_VENDOR_LIBRARY_FILENAMES" not in os.environ
+
+    def test_noop_when_no_nvidia_lib(self, monkeypatch):
+        monkeypatch.setenv("MUJOCO_GL", "egl")
+        monkeypatch.delenv("__EGL_VENDOR_LIBRARY_FILENAMES", raising=False)
+        monkeypatch.setattr("opentau.envs.factory.glob.glob", lambda p: [])
+        assert _ensure_nvidia_egl_icd() is None
+        assert "__EGL_VENDOR_LIBRARY_FILENAMES" not in os.environ
+
+    def test_synthesizes_descriptor_and_sets_vendor(self, monkeypatch, tmp_path):
+        # Container has libEGL_nvidia.so but only Mesa's glvnd descriptor -> synthesize one.
+        monkeypatch.setenv("MUJOCO_GL", "egl")
+        monkeypatch.delenv("__EGL_VENDOR_LIBRARY_FILENAMES", raising=False)
+        monkeypatch.delenv("__EGL_VENDOR_LIBRARY_DIRS", raising=False)
+        fake_lib = "/usr/lib/x86_64-linux-gnu/libEGL_nvidia.so.999.0"
+
+        def fake_glob(pattern):
+            if "egl_vendor.d" in pattern:
+                return []  # no nvidia ICD registered
+            if "libEGL_nvidia.so" in pattern:
+                return [fake_lib]
+            return []
+
+        monkeypatch.setattr("opentau.envs.factory.glob.glob", fake_glob)
+        monkeypatch.setattr("opentau.envs.factory.tempfile.gettempdir", lambda: str(tmp_path))
+        icd = _ensure_nvidia_egl_icd()
+        assert icd is not None and os.path.exists(icd)
+        with open(icd) as f:
+            descriptor = json.load(f)
+        assert descriptor["ICD"]["library_path"] == fake_lib
+        assert os.environ["__EGL_VENDOR_LIBRARY_FILENAMES"] == icd
+        # Idempotent: with the vendor var now set, a second call leaves it alone.
+        assert _ensure_nvidia_egl_icd() is None


### PR DESCRIPTION
## What this does

🐛 **Bug fix** — makes RoboCasa sim eval render on **GPU** (egl) in the training container, instead of failing to create a headless display (or silently falling back to CPU software rendering).

**Symptom.** Multi-GPU RoboCasa sim eval under `MUJOCO_GL=egl` crashed in the `AsyncVectorEnv` spawn workers with `robosuite/.../egl_context.py: ImportError: Cannot initialize a EGL device display ... PLATFORM_DEVICE extension`. (MuJoCo's own renderer didn't crash earlier because it silently used the Mesa **llvmpipe software** device — eval "ran" but never touched the GPU.)

**Root cause.** The training container image injects `libEGL_nvidia.so` (via `NVIDIA_DRIVER_CAPABILITIES` *graphics*) but ships only Mesa's glvnd ICD descriptor (`/usr/share/glvnd/egl_vendor.d/50_mesa.json`) — there is **no nvidia ICD descriptor**. glvnd therefore loads Mesa, whose GPU path needs `/dev/dri` render nodes the container doesn't expose (`/dev/dri/* Permission denied`). So `eglQueryDevicesEXT()` enumerates only unusable Mesa/software devices, and robosuite's per-device EGL context — which indexes that list by `MUJOCO_EGL_DEVICE_ID` (set per-rank by #402) — fails to initialize a display.

**Fix.** `_ensure_nvidia_egl_icd()`, called in `make_envs` alongside #402's `_pin_egl_render_device` before the spawn workers build their render context: when `MUJOCO_GL=egl` and no nvidia ICD is registered, synthesize a minimal glvnd descriptor pointing at the injected `libEGL_nvidia.so` and set `__EGL_VENDOR_LIBRARY_FILENAMES` so glvnd uses only nvidia EGL. `eglQueryDevicesEXT()` then returns the GPUs, and each rank renders on its own. No-op unless `MUJOCO_GL=egl` **and** the descriptor is genuinely missing — so a host with a normal nvidia EGL install (its own `*nvidia*.json`) is untouched.

## How it was tested

- `pre-commit run --files src/opentau/envs/factory.py tests/envs/test_factory.py` — clean.
- `pytest -m "not gpu" tests/envs/test_factory.py` — the new `TestEnsureNvidiaEglIcd` (5 cases: not-egl, vendor-already-set, nvidia-ICD-already-registered, no-nvidia-lib, synthesize + idempotent) and the existing `_pin_egl` tests pass. The 3 `TestMakeEnv` cases require the `libero` extra (they pass on CI `cpu_test.yml`; they fail only in a `--extra dev`-only local env — confirmed identical on `main`).
- **8-GPU in-training RoboCasa CloseFridge eval** under `MUJOCO_GL=egl` + graphics caps: with this fix all 8 ranks create **GPU** EGL contexts (`eglQueryDevicesEXT` returns the 8 GPUs), the eval renders and reports per-task success, and the run exits cleanly. Without it, the spawn workers fail with "Cannot initialize a EGL device display." Also verified the isolated robosuite `EGLGLContext` succeeds per device (0–7) under the synthesized ICD.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/envs/test_factory.py -k Egl
```

On a GPU node running the container with `MUJOCO_GL=egl` and `NVIDIA_DRIVER_CAPABILITIES=all` (graphics), any RoboCasa eval now auto-registers the nvidia EGL ICD inside `make_envs`, so robosuite renders on the GPU instead of failing or falling back to llvmpipe.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

> Note: `envs/factory.py` is environment / render plumbing — no model math, optimizer, sampler, or numerics — so the policy box is left unchecked. GPU sim eval was nonetheless validated end-to-end (see *How it was tested*).

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
