### PR TITLE
feat(config): add wandb option to skip eval video logging

### DIFF
--- a/src/opentau/configs/default.py
+++ b/src/opentau/configs/default.py
@@ -433,6 +433,8 @@ class WandBConfig:
             `run_id` is provided. Defaults to True.
         disable_artifact: Set to True to disable saving an artifact despite
             `training.save_checkpoint=True`. Defaults to False.
+        disable_video: Set to True to skip logging eval grid-summary videos to
+            wandb. Defaults to False (videos are logged).
     """
 
     enable: bool = False  # Enable Weights & Biases logging.
@@ -450,6 +452,8 @@ class WandBConfig:
     allow_resume: bool | None = True  # If True, resume the run from the last checkpoint.
     # Set to true to disable saving an artifact despite training.save_checkpoint=True
     disable_artifact: bool = False
+    # Set to true to skip logging eval grid-summary videos to wandb.
+    disable_video: bool = False
 
     def __post_init__(self):
         """Prompt user for wandb notes if enabled and notes are not provided."""
@@ -472,7 +476,7 @@ class WandBConfig:
             Dictionary of keyword arguments suitable for passing to wandb.init().
         """
         kwargs = encode_dataclass(self)
-        excluded_keys = ["enable", "disable_artifact", "project"]
+        excluded_keys = ["enable", "disable_artifact", "disable_video", "project"]
         for ek in excluded_keys:
             kwargs.pop(ek)
 

--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -1195,7 +1195,7 @@ def train(cfg: TrainPipelineConfig):
                 # assumes every rank wrote to a filesystem the main process can
                 # read (true for the single-node multi-GPU setup; non-rank-0
                 # videos on a multi-node run without a shared FS won't be seen).
-                if cfg.wandb.enable and cfg.eval.max_episodes_rendered > 0:
+                if cfg.wandb.enable and not cfg.wandb.disable_video and cfg.eval.max_episodes_rendered > 0:
                     grid_videos = {
                         f"Eval Videos/{task_name}": wandb.Video(grid_path, format="mp4")
                         for task_name, grid_path in collect_grid_summary_videos(videos_dir)

--- a/tests/artifacts/configs/train_config.json
+++ b/tests/artifacts/configs/train_config.json
@@ -94,6 +94,7 @@
     "wandb": {
         "enable": false,
         "disable_artifact": false,
+        "disable_video": false,
         "project": "lerobot",
         "entity": null,
         "notes": null,

--- a/tests/configs/test_default.py
+++ b/tests/configs/test_default.py
@@ -19,7 +19,7 @@ from pathlib import Path
 import draccus
 import pytest
 
-from opentau.configs.default import DatasetConfig, DatasetMixtureConfig
+from opentau.configs.default import DatasetConfig, DatasetMixtureConfig, WandBConfig
 from opentau.datasets.standard_data_format_mapping import DATA_FEATURES_NAME_MAPPING
 
 
@@ -226,6 +226,23 @@ def test_invalid_negative_bare_dataset_tolerance_raises():
         match=r"`DatasetConfig\.tolerance_s` must be >= 0 \(or None to inherit\), got -1\.0 for foo/bar",
     ):
         DatasetConfig(repo_id="foo/bar", tolerance_s=-1.0)
+
+
+class TestWandBConfig:
+    """Cover the optional ``disable_video`` flag on ``WandBConfig``."""
+
+    def test_disable_video_defaults_to_false(self):
+        """Videos are logged by default — the flag is opt-in (like
+        ``disable_artifact``), so existing runs keep logging eval videos."""
+        assert WandBConfig().disable_video is False
+
+    def test_disable_video_excluded_from_wandb_init_kwargs(self):
+        """``disable_video`` is an OpenTau-side switch, not a ``wandb.init()``
+        argument, so ``to_wandb_kwargs`` must drop it (mirroring
+        ``disable_artifact``); leaking it would make ``wandb.init()`` reject an
+        unknown keyword."""
+        cfg = WandBConfig(disable_video=True)
+        assert "disable_video" not in cfg.to_wandb_kwargs()
 
 
 class TestDatasetConfigDataMapping:


### PR DESCRIPTION
## What this does
Adds an optional `wandb.disable_video` flag to `WandBConfig` that skips logging the eval grid-summary videos to Weights & Biases. It defaults to `False`, so the default behavior is unchanged — videos are still logged whenever wandb is enabled and rendering is on.

This is useful for runs that don't need the eval videos in wandb, or that bump into wandb media-storage limits, without having to disable wandb or rendering entirely.

The implementation mirrors the existing `disable_artifact` flag:
- New field `disable_video: bool = False` on `WandBConfig` (`src/opentau/configs/default.py`), with a Google-style docstring entry.
- Added to `excluded_keys` in `to_wandb_kwargs`, so it never reaches `wandb.init()` as an unknown kwarg.
- Gates the `wandb.Video` log in the eval block of `src/opentau/scripts/train.py`:
  `if cfg.wandb.enable and not cfg.wandb.disable_video and cfg.eval.max_episodes_rendered > 0`.

Label: 🗃️ Feature

## How it was tested
- `pre-commit run --files <changed files>` — clean (ruff lint + format, pyupgrade, etc.).
- `pytest -m "not gpu" tests/configs/test_refs.py tests/configs/test_train.py tests/configs/test_utils_policies.py` — 54 passed. This includes `test_train_config_round_trip_matches_baseline`, which re-serializes the `wandb` block, so the new field round-trips cleanly.
- Direct check: `WandBConfig().disable_video` is `False` by default, and `to_wandb_kwargs()` does not contain `disable_video` (so it is never passed to `wandb.init()`).
- Not a policy change — no model / training-loop / optimizer / sampler math is touched, only the wandb video-logging gate in the eval block — so the GPU pytests and regression tests are not applicable here.

## How to checkout & try? (for the reviewer)
```bash
pytest -sx tests/configs/test_refs.py::test_train_config_round_trip_matches_baseline
```
```python
from opentau.configs.default import WandBConfig

# Default: videos are still logged.
assert WandBConfig().disable_video is False

# Opt out, and confirm the flag never reaches wandb.init().
cfg = WandBConfig(enable=True, notes="x", disable_video=True)
assert "disable_video" not in cfg.to_wandb_kwargs()
```
To skip eval video logging on a real run, set the flag on the CLI:
```bash
opentau-train --config_path=configs/examples/pi05_training_config.json --wandb.enable=true --wandb.disable_video=true
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
