### PR TITLE
fix(policies): single-head norm fallback for older checkpoints

### DIFF
--- a/src/opentau/policies/pretrained.py
+++ b/src/opentau/policies/pretrained.py
@@ -377,6 +377,20 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
         # rather than CPU so subsequent `index_select` runs on the right side.
         return 0, self._model_device()
 
+    def _single_head_fallback_index(self, batch: dict[str, Tensor]) -> Tensor | None:
+        """Row 0 for a single-norm-head policy, else ``None``.
+
+        Checkpoints predating per-(robot_type, control_mode) normalization carry a
+        single norm head and no name maps, so an eval batch tagged with an
+        identifier can't be looked up — but with one head there is nothing to
+        resolve, so route every sample to row 0. Returns ``None`` for a multi-head
+        policy, which is genuinely unresolvable without a map and must raise.
+        """
+        if self._stacked_num_datasets() <= 1:
+            batch_size, device = self._infer_batch_size_and_device(batch)
+            return torch.zeros(batch_size or 1, dtype=torch.long, device=device)
+        return None
+
     def _resolve_dataset_index(self, batch: dict[str, Tensor]) -> Tensor:
         """Resolve per-sample norm-head row indices from a training or inference batch.
 
@@ -402,7 +416,9 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
            ``self._norm_key_to_index``. Checked before ``dataset_repo_id``
            so the "precedence when both are present" invariant documented
            on ``EvalConfig`` / ``ServerConfig`` holds even for callers
-           that bypass the eval / gRPC scripts.
+           that bypass the eval / gRPC scripts. A legacy *single-head*
+           checkpoint (no ``dataset_names``, hence no norm-key map) has
+           nothing to resolve and falls back to row 0 rather than raising.
 
         3. **Inference by repo id.** ``batch["dataset_repo_id"]`` (a
            single ``str`` or ``list[str]`` of length B) is mapped through
@@ -423,8 +439,8 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
             ValueError: an identifier was supplied that doesn't match any
                 row on the policy.
             RuntimeError: ``dataset_repo_id`` or ``(robot_type, control_mode)``
-                supplied but the policy has no name maps (legacy
-                pre-multi-dataset checkpoint).
+                supplied to a *multi-head* policy that has no name maps
+                (a single-head legacy checkpoint falls back to row 0 instead).
         """
         if "dataset_index" in batch:
             idx = batch["dataset_index"]
@@ -442,6 +458,9 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
 
         if "robot_type" in batch and "control_mode" in batch:
             if self._norm_key_to_index is None:
+                single = self._single_head_fallback_index(batch)
+                if single is not None:
+                    return single
                 raise RuntimeError(
                     "Policy was loaded without `dataset_names`; cannot resolve "
                     "`(robot_type, control_mode)` to a norm head. Pass "
@@ -480,6 +499,11 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
 
         if "dataset_repo_id" in batch:
             if self._dataset_to_norm_index is None:
+                # Single-head legacy checkpoint: see the (robot_type, control_mode)
+                # branch above — one norm head means row 0; multi-head still raises.
+                single = self._single_head_fallback_index(batch)
+                if single is not None:
+                    return single
                 raise RuntimeError(
                     "Policy was loaded without `dataset_names`; cannot resolve "
                     "`dataset_repo_id` strings. Either pass `batch['dataset_index']` "

--- a/tests/policies/test_normalize_per_dataset.py
+++ b/tests/policies/test_normalize_per_dataset.py
@@ -251,7 +251,7 @@ def _make_policy_with_normalize(dataset_names, dataset_to_norm_index, *, num_row
             raise NotImplementedError
 
     cfg = _DummyConfig()
-    cfg.dataset_names = list(dataset_names)
+    cfg.dataset_names = list(dataset_names) if dataset_names is not None else None
     cfg.dataset_to_norm_index = dict(dataset_to_norm_index) if dataset_to_norm_index is not None else None
     return _DummyPolicy(cfg)
 
@@ -360,6 +360,44 @@ class TestResolveDatasetIndex:
         )
         with pytest.raises(KeyError, match="requires one of"):
             policy._resolve_dataset_index({"observation.state": torch.zeros(1, 2)})
+
+    def test_single_head_legacy_no_maps_robot_type_routes_to_row0(self):
+        """Backward-compat: a checkpoint predating per-(robot_type, control_mode)
+        normalization has one norm head and no name maps (`dataset_names=None`). An
+        eval batch tagged with (robot_type, control_mode) must route to row 0 rather
+        than raising "loaded without dataset_names" — one head, nothing to resolve."""
+        policy = _make_policy_with_normalize(None, None, num_rows=1)
+        assert policy._norm_key_to_index is None  # genuinely the legacy single-head case
+        idx = policy._resolve_dataset_index(
+            {
+                "robot_type": ["PandaOmron"],
+                "control_mode": ["ee"],
+                "observation.state": torch.zeros(1, 2),
+            }
+        )
+        assert torch.equal(idx.cpu(), torch.tensor([0], dtype=torch.long))
+
+    def test_single_head_legacy_no_maps_repo_id_routes_to_row0(self):
+        """Same single-head fallback on the `dataset_repo_id` route."""
+        policy = _make_policy_with_normalize(None, None, num_rows=1)
+        idx = policy._resolve_dataset_index(
+            {"dataset_repo_id": ["whatever/repo"], "observation.state": torch.zeros(1, 2)}
+        )
+        assert torch.equal(idx.cpu(), torch.tensor([0], dtype=torch.long))
+
+    def test_multihead_no_maps_robot_type_still_raises(self):
+        """The fallback must NOT swallow a genuinely-unresolvable case: a *multi-head*
+        policy with no name map can't be routed from (robot_type, control_mode)."""
+        policy = _make_policy_with_normalize(None, None, num_rows=2)
+        assert policy._norm_key_to_index is None
+        with pytest.raises(RuntimeError, match="without `dataset_names`"):
+            policy._resolve_dataset_index(
+                {
+                    "robot_type": ["franka"],
+                    "control_mode": ["joint"],
+                    "observation.state": torch.zeros(1, 2),
+                }
+            )
 
 
 # -- zero-variance guard ----------------------------------------------------


### PR DESCRIPTION
## What this does

Lets checkpoints predating per-`(robot_type, control_mode)` normalization be sim-evaluated again.

Such checkpoints carry a **single norm head** and no `dataset_names`. But eval tags each batch with `(robot_type, control_mode)` (or `dataset_repo_id`), so `PreTrainedPolicy._resolve_dataset_index` hit its legacy-no-name-map guard and raised:

```
RuntimeError: Policy was loaded without `dataset_names`; cannot resolve
`(robot_type, control_mode)` to a norm head.
```

— so those policies couldn't run sim eval at all, even though with one head there's nothing to resolve.

Fix: a new `_single_head_fallback_index(batch)` helper returns row 0 when the policy has a single norm head (`_stacked_num_datasets() <= 1`). It's called in the two legacy-no-name-map branches (the `(robot_type, control_mode)` and `dataset_repo_id` routes) **before** they raise. Multi-head policies with no map still raise (genuinely unresolvable).

Scoped deliberately to the single-norm-head case: per-group-projection policies have their name maps populated, so they take the normal resolution path and are unaffected — the resolved index also drives per-group projection, so short-circuiting them to row 0 would be wrong.

## How it was tested

- Added 3 unit tests in `tests/policies/test_normalize_per_dataset.py`:
  - single-head legacy policy (`dataset_names=None`) → row 0 via `(robot_type, control_mode)`;
  - same via `dataset_repo_id`;
  - guard: a **multi-head** no-map policy still raises (the fallback must not swallow it).
- `pre-commit run --all-files` clean.
- `pytest -m "not gpu" tests/policies/` → **490 passed, 2 skipped** — including the per-group-projection `train == eval` head-consistency test, confirming multi-group policies are unaffected.
- Not a policy / model-math change (base-class norm-head index selection in `pretrained.py`, no GPU-specific behavior), so CPU-tested only.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/policies/test_normalize_per_dataset.py::TestResolveDatasetIndex
```

```bash
pytest -m "not gpu" tests/policies/
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
