### PR TITLE
chore: bump version to 0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ huggingface = "https://huggingface.co/TensorAuto"
 
 [project]
 name = "opentau"
-version = "0.5.0"
+version = "0.6.0"
 description = "OpenTau: Tensor's VLA Training Infrastructure for Real-World Robotics in Pytorch"
 authors = [
     { name = "Shuheng Liu", email = "wish1104@icloud.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -2157,7 +2157,7 @@ wheels = [
 
 [[package]]
 name = "opentau"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
## What this does
Bumps the package version from `0.5.0` to `0.6.0` in `pyproject.toml`, and re-runs `uv lock` to update the `opentau` entry in `uv.lock` accordingly. (📝 Documentation / chore)

## How it was tested
No functional changes — version-string-only bump. `uv lock` resolved cleanly (274 packages) and updated the `opentau` editable entry to `0.6.0`. The pre-commit hooks that run automatically on `git commit` passed for the two changed files.

## How to checkout & try? (for the reviewer)
```bash
git checkout chore/bump-version-0.6.0
python -c "import opentau; print(opentau.__version__)"  # 0.6.0 once installed
grep '^version' pyproject.toml
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).