### PR TITLE
fix(train,pi07): stabilize multi-rank in-training sim eval (OOM + desync)

### DIFF
--- a/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
@@ -1472,6 +1472,7 @@ class PI07LowLevelFlowMatching(nn.Module):
         subgoal_images: list[Tensor] | None = None,
         subgoal_img_masks: list[Tensor] | None = None,
         group_index: Tensor | None = None,
+        sync_across_ranks: bool = True,
     ) -> tuple[Tensor, Tensor, Tensor]:
         """Embed all prefix modalities and build the 1-D attention pattern.
 
@@ -1586,7 +1587,7 @@ class PI07LowLevelFlowMatching(nn.Module):
             any_locals=(has_response_local, has_subgoal_local, has_metadata_local),
             field_names=("response", "subgoal", "metadata"),
             device=device,
-            sync_across_ranks=self.training,
+            sync_across_ranks=sync_across_ranks,
         )
         has_any_optional = bool(has_response or has_subgoal or has_metadata)
 
@@ -2188,6 +2189,9 @@ class PI07LowLevelFlowMatching(nn.Module):
             subgoal_img_masks=subgoal_img_masks,
             obs_history_is_pad=obs_history_is_pad,
             group_index=group_index,
+            # Independent per-rank rollout (sim eval): skip the cross-rank branch
+            # all-reduce so variable-length rollouts don't desync at NCCL.
+            sync_across_ranks=False,
         )
         prefix_att_2d_masks = make_att_2d_masks(prefix_pad_masks, prefix_att_masks)
         prefix_position_ids = torch.cumsum(prefix_pad_masks, dim=1) - 1

--- a/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
@@ -119,9 +119,10 @@ def _global_or_branch_decisions(
         device: Device to allocate the all-reduce buffer on; must match the
             distributed backend (typically the policy's CUDA device).
         sync_across_ranks: When ``True`` (training default), OR-reduce the
-            decisions across ranks. When ``False`` (eval/inference, passed from
-            ``self.training``), skip the all-reduce and return the local
-            decision — required because per-rank-independent eval rollouts call
+            decisions across ranks. When ``False`` (threaded explicitly from the
+            independent sim-eval rollout path — ``sample_actions``), skip the
+            all-reduce and return the local decision — required because the
+            per-rank-independent eval rollouts call
             the forward a different number of times, so a per-step collective
             here would desync at NCCL (one rank's ALLREDUCE vs another's later
             post-eval ALLGATHER). Safe under replicated params (DDP / ZeRO-1/2),

--- a/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
@@ -77,6 +77,7 @@ def _global_or_branch_decisions(
     any_locals: tuple[bool, ...],
     field_names: tuple[str, ...],
     device: torch.device,
+    sync_across_ranks: bool = True,
 ) -> tuple[bool, ...]:
     """Synchronize ``embed_prefix`` branch decisions across distributed ranks.
 
@@ -117,6 +118,15 @@ def _global_or_branch_decisions(
             (used in the divergence error message).
         device: Device to allocate the all-reduce buffer on; must match the
             distributed backend (typically the policy's CUDA device).
+        sync_across_ranks: When ``True`` (training default), OR-reduce the
+            decisions across ranks. When ``False`` (eval/inference, passed from
+            ``self.training``), skip the all-reduce and return the local
+            decision — required because per-rank-independent eval rollouts call
+            the forward a different number of times, so a per-step collective
+            here would desync at NCCL (one rank's ALLREDUCE vs another's later
+            post-eval ALLGATHER). Safe under replicated params (DDP / ZeRO-1/2),
+            where the eval forward fires no other cross-rank collective; not
+            safe under ZeRO-3 / FSDP sharded-param eval (guarded in train.py).
 
     Returns:
         A tuple of OR-reduced ``has_*`` booleans, one per ``any_locals`` entry,
@@ -133,7 +143,7 @@ def _global_or_branch_decisions(
             f"must have the same length, got "
             f"{len(presence_locals)}/{n}/{len(field_names)}."
         )
-    if not (torch.distributed.is_available() and torch.distributed.is_initialized()):
+    if not sync_across_ranks or not (torch.distributed.is_available() and torch.distributed.is_initialized()):
         return tuple(bool(a) for a in any_locals)
     # One SUM all-reduce over [presence | any]: SUM lets us derive both the
     # OR (sum > 0) for the any flags and the cross-rank-agreement check
@@ -1576,6 +1586,7 @@ class PI07LowLevelFlowMatching(nn.Module):
             any_locals=(has_response_local, has_subgoal_local, has_metadata_local),
             field_names=("response", "subgoal", "metadata"),
             device=device,
+            sync_across_ranks=self.training,
         )
         has_any_optional = bool(has_response or has_subgoal or has_metadata)
 

--- a/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
@@ -1873,7 +1873,7 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
         """
         return self.video_encoder(video, obs_history_is_pad=obs_history_is_pad)
 
-    def _global_run_image_tower(self, items: list[ContextItem]) -> bool:
+    def _global_run_image_tower(self, items: list[ContextItem], sync_across_ranks: bool = True) -> bool:
         """Decide once, across all ranks, whether the subgoal image tower runs.
 
         :meth:`embed_prefix` calls this exactly once per forward — before the
@@ -1914,7 +1914,7 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
             any_locals=(subgoal_any_local,),
             field_names=("subgoal_image",),
             device=items[0].data.device,
-            sync_across_ranks=self.training,
+            sync_across_ranks=sync_across_ranks,
         )
         return run_image_tower
 
@@ -2066,7 +2066,7 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
         raise ValueError(f"Unknown attention mode: {mode!r}")
 
     def embed_prefix(
-        self, items: list[ContextItem], group_index: Tensor | None = None
+        self, items: list[ContextItem], group_index: Tensor | None = None, sync_across_ranks: bool = True
     ) -> tuple[Tensor, Tensor, Tensor, int]:
         """Embed a layout-agnostic list of ``ContextItem``s into the prefix.
 
@@ -2095,7 +2095,7 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
         # rank, before the loop) and threaded into each item — see
         # _global_run_image_tower for why the collective must not live inside
         # the per-item ``image`` branch.
-        run_image_tower = self._global_run_image_tower(items)
+        run_image_tower = self._global_run_image_tower(items, sync_across_ranks=sync_across_ranks)
 
         cross_att_running = 0
         cross_att_locked = False
@@ -2383,7 +2383,11 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
             The sampled action tensor.
         """
         prefix_embs, prefix_pad_masks, prefix_att_masks, num_cross_att_tokens = self.embed_prefix(
-            prefix_items, group_index=group_index
+            # Independent per-rank rollout (sim eval): skip the cross-rank branch
+            # all-reduce so variable-length rollouts don't desync at NCCL.
+            prefix_items,
+            group_index=group_index,
+            sync_across_ranks=False,
         )
         bsize = prefix_embs.shape[0]
         device = prefix_embs.device

--- a/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
@@ -1914,6 +1914,7 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
             any_locals=(subgoal_any_local,),
             field_names=("subgoal_image",),
             device=items[0].data.device,
+            sync_across_ranks=self.training,
         )
         return run_image_tower
 

--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -73,6 +73,50 @@ from opentau.utils.utils import (
 )
 
 
+def _eval_with_fresh_envs(
+    cfg: TrainPipelineConfig,
+    policy: PreTrainedPolicy,
+    accelerator: accelerate.Accelerator,
+    eval_subgoal_generator,
+    step_id: str,
+) -> dict:
+    r"""Build the in-training eval envs, run one ``eval_policy_all``, and ALWAYS tear them down.
+
+    The eval envs are created per-eval and closed in a ``finally`` so the sim
+    renderer's GPU memory is released before training resumes. RoboCasa's
+    ``AsyncVectorEnv`` spawn workers hold their EGL render contexts as
+    *non-PyTorch* device memory (~GiB per env) that ``torch.cuda.empty_cache``
+    cannot reclaim; left open across an eval it stacks with the regrown training
+    footprint and OOMs the next backward. Mirrors the standalone eval lifecycle
+    in ``eval.py`` (build -> eval -> ``close_envs``).
+
+    Returns this rank's local ``eval_info`` (the caller gathers across ranks).
+    """
+    eval_envs = make_envs(cfg.env, cfg, n_envs=cfg.eval.batch_size, use_async_envs=cfg.eval.use_async_envs)
+    try:
+        with (
+            torch.no_grad(),
+            torch.autocast(device_type=accelerator.device.type) if cfg.policy.use_amp else nullcontext(),
+        ):
+            return eval_policy_all(
+                eval_envs,
+                policy,
+                cfg.eval.n_episodes,
+                cfg,
+                videos_dir=cfg.output_dir / "eval" / f"videos_step_{step_id}",
+                max_episodes_rendered=cfg.eval.max_episodes_rendered,
+                grid_size=cfg.eval.grid_size,
+                start_seed=cfg.seed,
+                max_parallel_tasks=cfg.env.max_parallel_tasks,
+                subgoal_generator=eval_subgoal_generator,
+            )
+    finally:
+        close_envs(eval_envs)
+        gc.collect()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
+
 def update_policy(
     train_config: TrainPipelineConfig,
     train_metrics: MetricsTracker,
@@ -600,15 +644,31 @@ def train(cfg: TrainPipelineConfig):
     else:
         train_dataset = make_dataset_mixture(cfg)
 
-    # Create environment used for evaluating checkpoints during training on simulation data.
-    # On real-world data, no need to create an environment as evaluations are done outside train.py,
-    eval_envs = None
+    # Eval envs for in-training sim eval are built *per eval* (inside the eval branch,
+    # via _eval_with_fresh_envs) and torn down immediately after, so the sim renderer's
+    # non-PyTorch GPU memory doesn't persist into training steps and OOM the next backward.
+    # On real-world data, no env is needed (eval runs outside train.py).
     eval_subgoal_generator = None
     if cfg.eval_freq > 0 and cfg.env is not None:
-        logging.info("Creating env")
-        eval_envs = make_envs(
-            cfg.env, cfg, n_envs=cfg.eval.batch_size, use_async_envs=cfg.eval.use_async_envs
-        )
+        # Per-rank-independent eval rollouts require the eval forward to fire no
+        # cross-rank collective (``_global_or_branch_decisions`` is gated off in eval).
+        # Under parameter sharding the forward still all-gathers params per layer,
+        # which WOULD desync across the independent rollouts and hang at NCCL — fail
+        # fast instead of hanging hours into a run.
+        sharded_params = accelerator.distributed_type == accelerate.DistributedType.FSDP
+        if accelerator.distributed_type == accelerate.DistributedType.DEEPSPEED:
+            zero_stage = accelerator.deepspeed_plugin.hf_ds_config.config.get("zero_optimization", {}).get(
+                "stage", 0
+            )
+            sharded_params = zero_stage >= 3
+        if sharded_params:
+            raise ValueError(
+                "In-training simulation eval (eval_freq > 0 with a sim env) is not "
+                "supported under parameter sharding (DeepSpeed ZeRO-3 or FSDP): each "
+                "rank rolls out independently, so the sharded-param all-gathers in the "
+                "eval forward desync across ranks and hang at NCCL. Use ZeRO-1/2 (params "
+                "replicated), or run eval out-of-process on saved checkpoints."
+            )
         eval_subgoal_generator = make_subgoal_generator(cfg)
 
     logging.info("Creating policy")
@@ -1116,11 +1176,11 @@ def train(cfg: TrainPipelineConfig):
             # other processes wait for the main process to finish saving
             accelerator.wait_for_everyone()
 
-        if is_eval_step and eval_envs:
+        if is_eval_step and cfg.env is not None:
             # Return the allocator's cached-but-unused blocks (freed training
             # activations) to the CUDA driver before eval, so eval runs at a lower
-            # peak and any non-PyTorch GPU consumer (e.g. an EGL render context for
-            # sim eval) has room. Training re-grows the cache on the next step.
+            # peak and the sim's non-PyTorch EGL render context has room. Training
+            # re-grows the cache on the next step.
             gc.collect()
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()
@@ -1131,22 +1191,9 @@ def train(cfg: TrainPipelineConfig):
                 pre_eval_alloc_gib = pre_eval_resv_gib = 0.0
             step_id = get_step_identifier(step, cfg.steps)
             logging.info(f"Eval policy at step {step}")
-            with (
-                torch.no_grad(),
-                torch.autocast(device_type=accelerator.device.type) if cfg.policy.use_amp else nullcontext(),
-            ):
-                eval_info = eval_policy_all(
-                    eval_envs,
-                    policy,
-                    cfg.eval.n_episodes,
-                    cfg,
-                    videos_dir=cfg.output_dir / "eval" / f"videos_step_{step_id}",
-                    max_episodes_rendered=cfg.eval.max_episodes_rendered,
-                    grid_size=cfg.eval.grid_size,
-                    start_seed=cfg.seed,
-                    max_parallel_tasks=cfg.env.max_parallel_tasks,
-                    subgoal_generator=eval_subgoal_generator,
-                )
+            # Build eval envs, run eval, then tear them down so the sim renderer's
+            # GPU memory is freed before training resumes (see _eval_with_fresh_envs).
+            eval_info = _eval_with_fresh_envs(cfg, policy, accelerator, eval_subgoal_generator, step_id)
 
             eval_info = gather_object([eval_info])  # gather across all accelerator processes
             if accelerator.is_main_process:
@@ -1239,11 +1286,10 @@ def train(cfg: TrainPipelineConfig):
         # conditions that gate the logging blocks above, so we only commit on
         # steps that actually logged, and only on main where the trackers live.
         # See issue #353.
-        if accelerator.is_main_process and (is_log_step or is_val_step or (is_eval_step and eval_envs)):
+        if accelerator.is_main_process and (
+            is_log_step or is_val_step or (is_eval_step and cfg.env is not None)
+        ):
             _commit_wandb_step(accelerator, step)
-
-    if cfg.eval_freq > 0 and eval_envs:
-        close_envs(eval_envs)
 
     accelerator.end_training()
     if accelerator.is_main_process:

--- a/tests/policies/test_pi07_cpu.py
+++ b/tests/policies/test_pi07_cpu.py
@@ -778,6 +778,9 @@ def _make_fake_flow_matching(*, hidden: int = 4, n_video_tokens: int = 3):
         embed_video=_embed_video,
         config=types.SimpleNamespace(discrete_action_max_length=2),
         _apply_proj=PI07LowLevelFlowMatching._apply_proj,
+        # embed_prefix reads self.training to gate the cross-rank branch all-reduce
+        # (sync_across_ranks); single-process here, so the value only needs to exist.
+        training=True,
     )
     return fake
 

--- a/tests/policies/test_pi07_cpu.py
+++ b/tests/policies/test_pi07_cpu.py
@@ -778,9 +778,6 @@ def _make_fake_flow_matching(*, hidden: int = 4, n_video_tokens: int = 3):
         embed_video=_embed_video,
         config=types.SimpleNamespace(discrete_action_max_length=2),
         _apply_proj=PI07LowLevelFlowMatching._apply_proj,
-        # embed_prefix reads self.training to gate the cross-rank branch all-reduce
-        # (sync_across_ranks); single-process here, so the value only needs to exist.
-        training=True,
     )
     return fake
 

--- a/tests/policies/test_pi07_low_level.py
+++ b/tests/policies/test_pi07_low_level.py
@@ -23,6 +23,7 @@ from opentau.policies.pi07.low_level.configuration_pi07_low_level import (
 from opentau.policies.pi07.low_level.modeling_pi07_low_level import (
     PI07LowLevelFlowMatching,
     PI07LowLevelPolicy,
+    _global_or_branch_decisions,
     make_att_2d_masks,
 )
 
@@ -1030,3 +1031,38 @@ class TestPI07LowLevelExecutionHorizon:
         a_next = PI07LowLevelPolicy.select_action(policy, batch)
         assert calls["n"] == 2
         assert a_next[0, 0].item() == 2000.0
+
+
+class TestGlobalOrBranchDecisionsSyncGuard:
+    """``_global_or_branch_decisions(sync_across_ranks=...)`` gates the cross-rank all-reduce.
+
+    During eval/inference each rank rolls out independently, so the branch
+    all-reduce must be skipped (``sync_across_ranks=False``, wired from
+    ``self.training`` at both call sites) — otherwise ranks call the forward a
+    different number of times and the mismatched collectives deadlock at NCCL.
+    """
+
+    def test_sync_across_ranks_false_skips_collective_returns_local(self, monkeypatch):
+        called = {"n": 0}
+        monkeypatch.setattr(torch.distributed, "is_available", lambda: True)
+        monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+        monkeypatch.setattr(
+            torch.distributed,
+            "all_reduce",
+            lambda *a, **k: called.__setitem__("n", called["n"] + 1),
+        )
+        out = _global_or_branch_decisions(
+            presence_locals=(True, True, False),
+            any_locals=(True, False, False),
+            field_names=("response", "subgoal", "metadata"),
+            device=torch.device("cpu"),
+            sync_across_ranks=False,
+        )
+        assert out == (True, False, False)  # local any_locals, returned un-reduced
+        assert called["n"] == 0  # no collective fired in eval/inference
+
+    def test_default_sync_across_ranks_is_true(self):
+        import inspect
+
+        sig = inspect.signature(_global_or_branch_decisions)
+        assert sig.parameters["sync_across_ranks"].default is True

--- a/tests/policies/test_pi07_low_level.py
+++ b/tests/policies/test_pi07_low_level.py
@@ -1037,8 +1037,8 @@ class TestGlobalOrBranchDecisionsSyncGuard:
     """``_global_or_branch_decisions(sync_across_ranks=...)`` gates the cross-rank all-reduce.
 
     During eval/inference each rank rolls out independently, so the branch
-    all-reduce must be skipped (``sync_across_ranks=False``, wired from
-    ``self.training`` at both call sites) — otherwise ranks call the forward a
+    all-reduce must be skipped (``sync_across_ranks=False``, threaded explicitly
+    from the sim-eval rollout entry point) — otherwise ranks call the forward a
     different number of times and the mismatched collectives deadlock at NCCL.
     """
 

--- a/tests/policies/test_pi07_low_level.py
+++ b/tests/policies/test_pi07_low_level.py
@@ -1066,3 +1066,11 @@ class TestGlobalOrBranchDecisionsSyncGuard:
 
         sig = inspect.signature(_global_or_branch_decisions)
         assert sig.parameters["sync_across_ranks"].default is True
+
+    def test_embed_prefix_defaults_to_sync_on(self):
+        """embed_prefix defaults sync_across_ranks=True, so training + (lockstep) validation
+        keep the cross-rank OR-reduce; only the independent sim-eval rollout passes False."""
+        import inspect
+
+        sig = inspect.signature(PI07LowLevelFlowMatching.embed_prefix)
+        assert sig.parameters["sync_across_ranks"].default is True

--- a/tests/policies/test_pi07_paligemma_low_level.py
+++ b/tests/policies/test_pi07_paligemma_low_level.py
@@ -700,6 +700,10 @@ class TestPI07PaligemmaLowLevelStateEmbedding:
         drive ``embed_prefix`` on CPU with non-zero state embeddings."""
         h = hidden_size
         model = object.__new__(PI07PaligemmaLowLevelFlowMatching)
+        # Fabricated via object.__new__ (no nn.Module.__init__), so mirror a real
+        # module's default train mode: embed_prefix / _global_run_image_tower read
+        # self.training to gate the cross-rank branch all-reduce (sync_across_ranks).
+        model.training = True
 
         # num_image_tokens mirrors embed_image's 4-token output below, so the
         # image-tower skip path (zeros of that width) matches the run path.
@@ -1274,6 +1278,10 @@ class TestPI07PaligemmaLowLevelResponseEmbedding:
     def _make_mock_model(cls, hidden_size: int = 8):
         h = hidden_size
         model = object.__new__(PI07PaligemmaLowLevelFlowMatching)
+        # Fabricated via object.__new__ (no nn.Module.__init__), so mirror a real
+        # module's default train mode: embed_prefix / _global_run_image_tower read
+        # self.training to gate the cross-rank branch all-reduce (sync_across_ranks).
+        model.training = True
 
         # num_image_tokens mirrors embed_image's 4-token output below, so the
         # image-tower skip path (zeros of that width) matches the run path.
@@ -2417,6 +2425,41 @@ class TestPI07PaligemmaLowLevelSubgoalEmbedding:
         assert not model._global_run_image_tower([text, _img(torch.zeros(bsz, dtype=torch.bool))])
         # No image item at all → skip (and no crash deriving the device).
         assert not model._global_run_image_tower([text])
+
+    def test_global_run_image_tower_eval_mode_skips_collective(self, monkeypatch):
+        """In eval mode the hoisted collective is gated off (``sync_across_ranks=self.training``),
+        so each rank uses its LOCAL decision and fires NO all-reduce — even with a process
+        group "initialized". This is what lets independent per-rank eval rollouts not desync."""
+        bsz, h = 2, 8
+        model = TestPI07PaligemmaLowLevelResponseEmbedding._make_mock_model(hidden_size=h)
+        model.training = False  # eval mode (the fabricated mock has no nn.Module .eval() machinery)
+
+        n_all_reduce = {"n": 0}
+        monkeypatch.setattr(torch.distributed, "is_available", lambda: True)
+        monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+        monkeypatch.setattr(
+            torch.distributed,
+            "all_reduce",
+            lambda *a, **k: n_all_reduce.__setitem__("n", n_all_reduce["n"] + 1),
+        )
+
+        def _img(mask):
+            return ContextItem(
+                data=torch.zeros(bsz, 3, 224, 224), item_type="image", pad_mask=mask, attention="continue"
+            )
+
+        text = ContextItem(
+            data=torch.zeros(bsz, 3, dtype=torch.long),
+            item_type="text",
+            pad_mask=torch.ones(bsz, 3, dtype=torch.bool),
+            attention="continue",
+        )
+        # Local OR over image items, with NO cross-rank collective fired.
+        assert model._global_run_image_tower(
+            [text, _img(torch.zeros(bsz, dtype=torch.bool)), _img(torch.tensor([False, True]))]
+        )
+        assert not model._global_run_image_tower([text, _img(torch.zeros(bsz, dtype=torch.bool))])
+        assert n_all_reduce["n"] == 0
 
     # ------------------------------------------------------------------ #
     # DDP lockstep: the hoisted ``_global_run_image_tower`` collective must make

--- a/tests/policies/test_pi07_paligemma_low_level.py
+++ b/tests/policies/test_pi07_paligemma_low_level.py
@@ -700,10 +700,6 @@ class TestPI07PaligemmaLowLevelStateEmbedding:
         drive ``embed_prefix`` on CPU with non-zero state embeddings."""
         h = hidden_size
         model = object.__new__(PI07PaligemmaLowLevelFlowMatching)
-        # Fabricated via object.__new__ (no nn.Module.__init__), so mirror a real
-        # module's default train mode: embed_prefix / _global_run_image_tower read
-        # self.training to gate the cross-rank branch all-reduce (sync_across_ranks).
-        model.training = True
 
         # num_image_tokens mirrors embed_image's 4-token output below, so the
         # image-tower skip path (zeros of that width) matches the run path.
@@ -1278,10 +1274,6 @@ class TestPI07PaligemmaLowLevelResponseEmbedding:
     def _make_mock_model(cls, hidden_size: int = 8):
         h = hidden_size
         model = object.__new__(PI07PaligemmaLowLevelFlowMatching)
-        # Fabricated via object.__new__ (no nn.Module.__init__), so mirror a real
-        # module's default train mode: embed_prefix / _global_run_image_tower read
-        # self.training to gate the cross-rank branch all-reduce (sync_across_ranks).
-        model.training = True
 
         # num_image_tokens mirrors embed_image's 4-token output below, so the
         # image-tower skip path (zeros of that width) matches the run path.
@@ -2426,13 +2418,13 @@ class TestPI07PaligemmaLowLevelSubgoalEmbedding:
         # No image item at all → skip (and no crash deriving the device).
         assert not model._global_run_image_tower([text])
 
-    def test_global_run_image_tower_eval_mode_skips_collective(self, monkeypatch):
-        """In eval mode the hoisted collective is gated off (``sync_across_ranks=self.training``),
-        so each rank uses its LOCAL decision and fires NO all-reduce — even with a process
-        group "initialized". This is what lets independent per-rank eval rollouts not desync."""
+    def test_global_run_image_tower_sync_across_ranks_false_skips_collective(self, monkeypatch):
+        """``sync_across_ranks=False`` (set on the independent sim-eval rollout path) gates the
+        hoisted collective off, so each rank uses its LOCAL decision and fires NO all-reduce —
+        even with a process group "initialized". This is what lets variable-length per-rank eval
+        rollouts not desync. (The default ``True`` keeps training + validation in lockstep.)"""
         bsz, h = 2, 8
         model = TestPI07PaligemmaLowLevelResponseEmbedding._make_mock_model(hidden_size=h)
-        model.training = False  # eval mode (the fabricated mock has no nn.Module .eval() machinery)
 
         n_all_reduce = {"n": 0}
         monkeypatch.setattr(torch.distributed, "is_available", lambda: True)
@@ -2456,10 +2448,28 @@ class TestPI07PaligemmaLowLevelSubgoalEmbedding:
         )
         # Local OR over image items, with NO cross-rank collective fired.
         assert model._global_run_image_tower(
-            [text, _img(torch.zeros(bsz, dtype=torch.bool)), _img(torch.tensor([False, True]))]
+            [text, _img(torch.zeros(bsz, dtype=torch.bool)), _img(torch.tensor([False, True]))],
+            sync_across_ranks=False,
         )
-        assert not model._global_run_image_tower([text, _img(torch.zeros(bsz, dtype=torch.bool))])
+        assert not model._global_run_image_tower(
+            [text, _img(torch.zeros(bsz, dtype=torch.bool))], sync_across_ranks=False
+        )
         assert n_all_reduce["n"] == 0
+
+    def test_global_run_image_tower_default_syncs_across_ranks(self):
+        """The flag defaults to ``True`` so training + (lockstep) validation keep the
+        cross-rank OR-reduce — guards against silently disabling it for those paths."""
+        import inspect
+
+        from opentau.policies.pi07_paligemma.low_level.modeling_pi07_low_level import (
+            PI07PaligemmaLowLevelFlowMatching,
+        )
+
+        for fn in (
+            PI07PaligemmaLowLevelFlowMatching._global_run_image_tower,
+            PI07PaligemmaLowLevelFlowMatching.embed_prefix,
+        ):
+            assert inspect.signature(fn).parameters["sync_across_ranks"].default is True
 
     # ------------------------------------------------------------------ #
     # DDP lockstep: the hoisted ``_global_run_image_tower`` collective must make

--- a/tests/scripts/test_train.py
+++ b/tests/scripts/test_train.py
@@ -34,6 +34,7 @@ import torch
 from opentau.scripts.train import (
     _bucket_per_sample,
     _commit_wandb_step,
+    _eval_with_fresh_envs,
     _find_unused_params_from_env,
     _mixture_weighted_aggregate,
     _sync_deepspeed_gradient_accumulation_steps,
@@ -356,21 +357,19 @@ class TestEvalWithFreshEnvs:
         )
 
     def test_builds_and_closes_each_call(self, monkeypatch):
-        import opentau.scripts.train as train_mod
-
         envs1 = {"robocasa": {0: object()}}
         envs2 = {"robocasa": {0: object()}}
         make = Mock(side_effect=[envs1, envs2])
         close = Mock()
         ep_all = Mock(return_value={"overall": {}})
-        monkeypatch.setattr(train_mod, "make_envs", make)
-        monkeypatch.setattr(train_mod, "close_envs", close)
-        monkeypatch.setattr(train_mod, "eval_policy_all", ep_all)
+        monkeypatch.setattr("opentau.scripts.train.make_envs", make)
+        monkeypatch.setattr("opentau.scripts.train.close_envs", close)
+        monkeypatch.setattr("opentau.scripts.train.eval_policy_all", ep_all)
 
         acc = SimpleNamespace(device=SimpleNamespace(type="cpu"))
         cfg = self._cfg()
-        out1 = train_mod._eval_with_fresh_envs(cfg, Mock(), acc, None, "000010")
-        out2 = train_mod._eval_with_fresh_envs(cfg, Mock(), acc, None, "000020")
+        out1 = _eval_with_fresh_envs(cfg, Mock(), acc, None, "000010")
+        out2 = _eval_with_fresh_envs(cfg, Mock(), acc, None, "000020")
 
         assert make.call_count == 2
         assert close.call_count == 2
@@ -380,19 +379,17 @@ class TestEvalWithFreshEnvs:
         assert out2 is ep_all.return_value
 
     def test_closes_even_when_eval_raises(self, monkeypatch):
-        import opentau.scripts.train as train_mod
-
         envs = {"robocasa": {0: object()}}
         make = Mock(return_value=envs)
         close = Mock()
         boom = Mock(side_effect=RuntimeError("eval blew up"))
-        monkeypatch.setattr(train_mod, "make_envs", make)
-        monkeypatch.setattr(train_mod, "close_envs", close)
-        monkeypatch.setattr(train_mod, "eval_policy_all", boom)
+        monkeypatch.setattr("opentau.scripts.train.make_envs", make)
+        monkeypatch.setattr("opentau.scripts.train.close_envs", close)
+        monkeypatch.setattr("opentau.scripts.train.eval_policy_all", boom)
 
         acc = SimpleNamespace(device=SimpleNamespace(type="cpu"))
         with pytest.raises(RuntimeError, match="eval blew up"):
-            train_mod._eval_with_fresh_envs(self._cfg(), Mock(), acc, None, "000010")
+            _eval_with_fresh_envs(self._cfg(), Mock(), acc, None, "000010")
         close.assert_called_once_with(envs)
 
 

--- a/tests/scripts/test_train.py
+++ b/tests/scripts/test_train.py
@@ -23,7 +23,9 @@ isolated coverage.
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import accelerate
 import pytest
@@ -326,6 +328,72 @@ class TestCommitWandbStep:
         _commit_wandb_step(accelerator, 1234)
 
         assert calls == [({}, 1234, {"wandb": {"commit": True}})]
+
+
+class TestEvalWithFreshEnvs:
+    """``_eval_with_fresh_envs`` builds eval envs, runs eval, and ALWAYS closes them.
+
+    Per-eval teardown frees the sim renderer's non-PyTorch GPU memory before
+    training resumes (otherwise it stacks with the regrown training footprint
+    and OOMs the next backward). The ``finally`` must close the envs even when
+    the eval itself raises.
+    """
+
+    @staticmethod
+    def _cfg():
+        return SimpleNamespace(
+            env=SimpleNamespace(max_parallel_tasks=1),
+            eval=SimpleNamespace(
+                batch_size=2,
+                use_async_envs=True,
+                n_episodes=2,
+                max_episodes_rendered=0,
+                grid_size=None,
+            ),
+            policy=SimpleNamespace(use_amp=False),
+            output_dir=Path("/tmp/opentau_eval_test"),
+            seed=0,
+        )
+
+    def test_builds_and_closes_each_call(self, monkeypatch):
+        import opentau.scripts.train as train_mod
+
+        envs1 = {"robocasa": {0: object()}}
+        envs2 = {"robocasa": {0: object()}}
+        make = Mock(side_effect=[envs1, envs2])
+        close = Mock()
+        ep_all = Mock(return_value={"overall": {}})
+        monkeypatch.setattr(train_mod, "make_envs", make)
+        monkeypatch.setattr(train_mod, "close_envs", close)
+        monkeypatch.setattr(train_mod, "eval_policy_all", ep_all)
+
+        acc = SimpleNamespace(device=SimpleNamespace(type="cpu"))
+        cfg = self._cfg()
+        out1 = train_mod._eval_with_fresh_envs(cfg, Mock(), acc, None, "000010")
+        out2 = train_mod._eval_with_fresh_envs(cfg, Mock(), acc, None, "000020")
+
+        assert make.call_count == 2
+        assert close.call_count == 2
+        # The exact env dict built each call is the one handed to close (lifecycle pairing).
+        assert [c.args[0] for c in close.call_args_list] == [envs1, envs2]
+        assert out1 is ep_all.return_value
+        assert out2 is ep_all.return_value
+
+    def test_closes_even_when_eval_raises(self, monkeypatch):
+        import opentau.scripts.train as train_mod
+
+        envs = {"robocasa": {0: object()}}
+        make = Mock(return_value=envs)
+        close = Mock()
+        boom = Mock(side_effect=RuntimeError("eval blew up"))
+        monkeypatch.setattr(train_mod, "make_envs", make)
+        monkeypatch.setattr(train_mod, "close_envs", close)
+        monkeypatch.setattr(train_mod, "eval_policy_all", boom)
+
+        acc = SimpleNamespace(device=SimpleNamespace(type="cpu"))
+        with pytest.raises(RuntimeError, match="eval blew up"):
+            train_mod._eval_with_fresh_envs(self._cfg(), Mock(), acc, None, "000010")
+        close.assert_called_once_with(envs)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What this does

Multi-rank **in-training simulation eval** (e.g. RoboCasa under DeepSpeed ZeRO-2 with `MUJOCO_GL=egl`) crashed at *every* eval boundary. Two independent root causes, both fixed here (🐛 Bug):

**1. CUDA OOM right after eval.** Eval envs were built once and reused, so the sim's `AsyncVectorEnv` EGL render contexts (~GiB per env — *non-PyTorch* device memory the caching allocator can't reclaim) persisted into training and OOM'd the first post-eval backward. Eval envs are now built **per eval** and closed in a `finally` (`_eval_with_fresh_envs` in `scripts/train.py`), so that memory is released before training resumes. `close_envs` runs even if the eval raises.

**2. Cross-rank collective deadlock (and pathologically slow evals).** Each rank rolls out independent, variable-length episodes, but the policy forward fired a per-step cross-rank all-reduce — `_global_or_branch_decisions` (the branch-decision OR-reduce in `pi07` / `pi07_paligemma`). When the fastest rank finished its rollout and reached the post-eval `gather` while slower ranks were still mid-rollout, the mismatched collectives (ALLREDUCE vs ALLGATHER at the same sequence number) deadlocked at NCCL. The all-reduce is now gated by an explicit `sync_across_ranks` flag threaded from the **independent-rollout entry point** (`sample_actions`), defaulting `True`: only the sim-eval rollout passes `False`, while **training *and* lockstep in-training validation keep the collective** (so the FSDP/ZeRO-3 param-all-gather desync protection of CLAUDE.md rule 5 is preserved). The training forward stays byte-identical.

**3. Fail-fast guard.** In-training sim eval under parameter sharding (DeepSpeed ZeRO-3 / FSDP) now raises a clear error at startup instead of hanging — the eval forward's param all-gathers would desync across the independent rollouts regardless of (2). Use ZeRO-1/2, or run eval out-of-process.

## How it was tested

- `pre-commit` clean; CPU suite (`pytest -m "not gpu"`): `tests/policies/` (693 passed) + `tests/scripts/` (198 passed). New coverage: the `sync_across_ranks` guard truth table + default-`True` tripwires (both `pi07` and `pi07_paligemma`), and `_eval_with_fresh_envs` env-lifecycle pairing (build↔close each eval, incl. `close_envs` still called when the eval raises).
- **Targeted GPU pytests** (`pytest -m "gpu"` for the two changed policy files) on A100: **5 passed, 4 skipped** (the skips are pre-existing memory-gated tests).
- **Determinism** (CLAUDE.md rule 3): two same-seed 8×A100 ZeRO-2 runs produced **bit-identical** per-step training losses (total / MSE / CE) across all pre-eval steps — the fix leaves the training forward byte-identical.
- **End-to-end 8×A100 multi-eval run** (cold start, `eval_freq=10`, `steps=50` → **5 consecutive** in-training RoboCasa CloseFridge evals, ZeRO-2, `MUJOCO_GL=egl`, 8 envs/GPU = the OOM-trigger config): **all 5 evals completed, training resumed past every eval to step 50 — zero OOM, zero NCCL-watchdog deadlock, zero requeue.** `eval_per_gpu_s` is now a consistent **~104–110 s** (vs. **597 s → 1481 s** plus a crash pre-fix). This directly reproduces, then resolves, the conditions that crashed the prior run at every eval boundary.
- The nightly `gpu_test.yml` / `regression_test.yml` provide the full GPU + regression coverage.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/policies/test_pi07_low_level.py::TestGlobalOrBranchDecisionsSyncGuard
pytest -sx tests/scripts/test_train.py::TestEvalWithFreshEnvs
pytest -m "not gpu" tests/policies/ tests/scripts/
```

Or exercise the path directly: run training with `eval_freq > 0` on a RoboCasa config under DeepSpeed ZeRO-2 (`MUJOCO_GL=egl`); consecutive in-training evals no longer OOM the next step or deadlock at NCCL.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [x] My PR includes policy-related changes.
  - [x] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.
