### PR TITLE
test(ci): quarantine live-Hub tests off the gating CPU run

### DIFF
--- a/.github/workflows/cpu_test.yml
+++ b/.github/workflows/cpu_test.yml
@@ -167,7 +167,7 @@ jobs:
           python3 -c "import sys; print(sys.path)"
           python3 -c "import libero.libero" && echo "LIBERO config set successfully."
           echo "Running cpu based pytest and generating coverage report..."
-          pytest -m "not gpu" -n auto -v --cov=lerobot/ --cov-report=xml:cpu_test/cpu_test.xml --ignore=tests/planner/test_planner.py --ignore tests/utils/test_libero_utils.py --deselect=tests/envs/test_factory.py::TestMakeEnv::test_make_env_async_vector_env --deselect=tests/envs/test_factory.py::TestMakeEnv::test_make_env_sync_vector_env tests/
+          pytest -m "not gpu and not network" -n auto -v --cov=lerobot/ --cov-report=xml:cpu_test/cpu_test.xml --ignore=tests/planner/test_planner.py --ignore tests/utils/test_libero_utils.py --deselect=tests/envs/test_factory.py::TestMakeEnv::test_make_env_async_vector_env --deselect=tests/envs/test_factory.py::TestMakeEnv::test_make_env_sync_vector_env tests/
           echo "Pytest execution and coverage report generation completed."
 
       - name: Upload coverage reports

--- a/.github/workflows/network_test.yml
+++ b/.github/workflows/network_test.yml
@@ -42,7 +42,9 @@ jobs:
   network-tests:
     name: Network Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # ~57 tests run serially (-n 0) here, including a ~3.5-min mixture test and
+    # @retry_on_hf_flakiness reruns; give the non-gating job comfortable headroom.
+    timeout-minutes: 45
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/network_test.yml
+++ b/.github/workflows/network_test.yml
@@ -1,0 +1,94 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Network Tests
+
+# Tests that reach the live Hugging Face Hub (dataset / tokenizer downloads,
+# Hub push and pull) are marked `@pytest.mark.network` and EXCLUDED from the
+# gating CPU suite (cpu_test.yml runs `-m "not gpu and not network"`), so a
+# transient Hub rate-limit or outage can never block a PR or push. This
+# workflow runs that quarantined subset on a nightly schedule purely for
+# signal. It is intentionally NOT wired into branch-protection required checks.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Nightly at 10:00 UTC, alongside the gpu / regression nightlies.
+    - cron: "0 10 * * *"
+
+permissions:
+  contents: read
+
+env:
+  GIT_LFS_SKIP_SMUDGE: "1"
+  GIT_CLEAN_FLAGS: "-ffdx -e .venv/"
+  PYTORCH_CUDA_ALLOC_CONF: "expandable_segments:True"
+  UV_LINK_MODE: "copy"
+  MUJOCO_GL: "egl"
+  PYOPENGL_PLATFORM: "egl"
+
+jobs:
+  network-tests:
+    name: Network Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          lfs: false
+
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg libegl1 libegl-mesa0 libgl1 libglx-mesa0 libgles2 mesa-utils
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+
+      - name: Install dependencies
+        run: |
+          uv sync --extra dev --extra libero
+
+      - name: Configure wandb
+        run: |
+          source .venv/bin/activate
+          wandb offline
+
+      - name: Run network tests
+        # The gated google/gemma-3 and google/paligemma tokenizers and the
+        # lerobot/* datasets need an authenticated token. Run serially (-n 0):
+        # parallel xdist workers fetching the same gated repos is what trips the
+        # 429 rate-limit storms this quarantine exists to avoid.
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HUGGINGFACE_HUB_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          source .venv/bin/activate
+          mkdir -p /tmp/libero-assets/libero/libero
+          export LIBERO_CONFIG_PATH="$(pwd)/.github/assets/libero"
+          echo "LIBERO_CONFIG_PATH is $LIBERO_CONFIG_PATH"
+          echo "Running network-marked pytest subset..."
+          pytest -m "network" -n 0 -v --ignore=tests/planner/test_planner.py --ignore tests/utils/test_libero_utils.py tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -247,5 +247,6 @@ build-backend = "setuptools.build_meta"
 [tool.pytest.ini_options]
 markers = [
     "slow: marks tests as slow (runtime > 1s).",
-    "gpu: marks tests as gpu (uses gpu)."
+    "gpu: marks tests as gpu (uses gpu).",
+    "network: marks tests that require live Hugging Face Hub access (excluded from the gating CPU run; run nightly in network_test.yml).",
 ]

--- a/tests/configs/test_utils_policies.py
+++ b/tests/configs/test_utils_policies.py
@@ -19,6 +19,7 @@ from unittest.mock import patch
 import pytest
 from draccus.utils import ParsingError
 from huggingface_hub.constants import CONFIG_NAME
+from huggingface_hub.errors import RepositoryNotFoundError
 
 from opentau.configs.policies import (
     PreTrainedConfig,
@@ -144,7 +145,18 @@ def test_from_pretrained_path_does_not_exits():
     """
     Tests if from_pretrained raises FIleNotFpund Error when invalid repo id is passed
     """
-    with pytest.raises(FileNotFoundError):
+    # Mock the Hub lookup so this stays on the gating CPU run instead of
+    # reaching the live Hub: from_pretrained must translate a Hub "repo not
+    # found" error into FileNotFoundError. Hitting the real Hub here flakes on
+    # connectivity -- a raw OSError is not an HfHubHTTPError, so it would escape
+    # the pytest.raises(FileNotFoundError) below and red the gate.
+    with (
+        patch(
+            "opentau.configs.policies.hf_hub_download",
+            side_effect=RepositoryNotFoundError("bert123 does not exist"),
+        ),
+        pytest.raises(FileNotFoundError),
+    ):
         PreTrainedConfig.from_pretrained(pretrained_name_or_path="bert123")
 
 

--- a/tests/datasets/test_dataset_mixture.py
+++ b/tests/datasets/test_dataset_mixture.py
@@ -436,6 +436,7 @@ class TestWeightedDatasetMixtureIntegration:
         assert dataloader.num_workers == train_pipeline_config.num_workers
 
     @pytest.mark.slow  # ~3.5 min
+    @pytest.mark.network
     @retry_on_hf_flakiness()
     def test_integration_basic_functionality_with_same_fps_as_dataset(self, train_pipeline_config):
         """Test that the mixture with same fps as datasets actually uses the samples from the datasets."""

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -693,6 +693,7 @@ def check_standard_data_format(item, delta_timestamps_params, dataset, train_pip
     ],
 )
 @retry_on_hf_flakiness()
+@pytest.mark.network
 def test_lerobot_dataset_factory(dataset_config, train_pipeline_config, repo_id):
     """
     Tests that:
@@ -721,6 +722,7 @@ def test_lerobot_dataset_factory(dataset_config, train_pipeline_config, repo_id)
     ],
 )
 @retry_on_hf_flakiness()
+@pytest.mark.network
 def test_do_not_use_imagenet_stats(dataset_config, train_pipeline_config, repo_id):
     """
     Tests that:

--- a/tests/datasets/test_loc_tokens_gemma3.py
+++ b/tests/datasets/test_loc_tokens_gemma3.py
@@ -35,6 +35,11 @@ from transformers import AutoTokenizer
 from opentau.datasets.grounding.loc_codec import xyxy_to_loc_tokens
 from opentau.datasets.grounding.tokenizer_utils import LOC_TOKENS, ensure_loc_tokens
 
+# Every test in this module fetches a tokenizer from the live HF Hub
+# (gated google/gemma-3-4b-pt), so quarantine the whole file off the gating
+# CPU run; it runs in the nightly network_test.yml instead.
+pytestmark = pytest.mark.network
+
 
 def _fresh_gemma3_tokenizer():
     """Always return a freshly loaded tokenizer so tests don't share state."""

--- a/tests/datasets/test_loc_tokens_paligemma.py
+++ b/tests/datasets/test_loc_tokens_paligemma.py
@@ -35,6 +35,11 @@ from transformers import AutoTokenizer
 from opentau.datasets.grounding.loc_codec import xyxy_to_loc_tokens
 from opentau.datasets.grounding.tokenizer_utils import LOC_TOKENS, ensure_loc_tokens
 
+# Every test in this module fetches a tokenizer from the live HF Hub
+# (gated google/paligemma-3b-pt-224), so quarantine the whole file off the
+# gating CPU run; it runs in the nightly network_test.yml instead.
+pytestmark = pytest.mark.network
+
 
 @pytest.fixture(scope="module")
 def paligemma_tokenizer():

--- a/tests/policies/test_pi07_paligemma_low_level.py
+++ b/tests/policies/test_pi07_paligemma_low_level.py
@@ -1209,6 +1209,7 @@ class TestPI07EmbedPrefixInvariants:
         )
 
 
+@pytest.mark.network
 class TestPI07PaligemmaLowLevelResponseEmbedding:
     """CPU-only tests verifying response token masking in ``embed_prefix``.
 
@@ -1505,6 +1506,7 @@ class TestPI07PaligemmaLowLevelResponseEmbedding:
         )
 
 
+@pytest.mark.network
 class TestPI07PaligemmaLowLevelMetadataEmbedding:
     """CPU-only tests for metadata pad masks in ``embed_prefix``.
 
@@ -1873,6 +1875,7 @@ def _ddp_image_skip_worker(rank: int, world_size: int, port: int, scenario: str)
         torch.distributed.destroy_process_group()
 
 
+@pytest.mark.network
 class TestPI07PaligemmaLowLevelSubgoalEmbedding:
     """CPU-only tests for subgoal block pad masks in ``embed_prefix``.
 

--- a/tests/scripts/test_attach_metadata.py
+++ b/tests/scripts/test_attach_metadata.py
@@ -284,6 +284,7 @@ def _synthesize_annotations(episodes: dict[int, dict]) -> list[dict]:
 
 
 @pytest.mark.slow
+@pytest.mark.network
 @retry_on_hf_flakiness()
 def test_attach_metadata_end_to_end_droid_100(tmp_path, dataset_config, train_pipeline_config):
     """Real-network integration test against lerobot/droid_100@v2.1.

--- a/tests/utils/test_hub.py
+++ b/tests/utils/test_hub.py
@@ -20,6 +20,10 @@ import pytest
 from opentau.utils.hub import HubMixin
 from tests.fixtures.utils import DummyHubMixin
 
+# Both tests here push to / pull from the live HF Hub, so quarantine the file
+# off the gating CPU run; it runs in the nightly network_test.yml instead.
+pytestmark = pytest.mark.network
+
 
 @pytest.mark.parametrize(
     "create_hubmixin_instance",


### PR DESCRIPTION
## What this does

The gating CPU test suite (`cpu_test.yml`) goes red constantly on transient Hugging Face Hub failures rather than real bugs. Across the latest 20 failed `cpu_test` runs, ~11 were **pure** Hub rate-limit / connectivity errors (`429 Too Many Requests`, `OSError: couldn't connect to huggingface.co`, `404` on gated repos), and the most recent run was **43 failed + 6 errors, 100% `huggingface.co` connectivity** — zero real failures. This reds the required `CPU Tests Status` check for reasons unrelated to the PR, and worse, buries any genuine regression under ~40 flake-reds every run.

Root cause: a handful of integration tests download from the live Hub on every run while sitting on the **gating** path. This PR quarantines them instead of deleting them:

- Adds a `network` pytest marker (`pyproject.toml`).
- Tags the live-Hub tests (~57) `@pytest.mark.network` across 7 files — module-level on the loc-token and `test_hub` files, class-level on the 3 PaliGemma embedding test classes, per-test on the `lerobot/*` dataset integration tests.
- Excludes them from the gating run: `-m "not gpu"` → `-m "not gpu and not network"` (`cpu_test.yml`).
- Adds a **non-gating** nightly `network_test.yml` that runs `pytest -m "network" -n 0` (serial, so parallel workers don't trigger 429 storms) — the tests still execute regularly, they just can't block PRs.

No assertions are removed; dataset-path logic stays covered on the gate via the existing fixture-mocked tests (which patch `snapshot_download` / `hf_hub_download`). Only test decorators, the marker registration, and CI workflows change — no policy or modeling code.

Label: `test`.

## How it was tested

- `pytest --markers` shows the registered `network` marker.
- Collection partition verified: `-m network` selects exactly 57 tests across the 7 files; `-m "not gpu and not network"` drops all 57 (whole-file-marked files → 0 on the gate; `test_datasets.py` keeps 62 local tests, the PaliGemma file keeps 25). Confirmed no live-Hub test is left on the CPU gate — the only other Hub-loading test, `test_pi06.py::test_pi06_loc_tokens_extend_vocab_and_resize_embeddings`, is already `@pytest.mark.gpu`.
- `pre-commit run --files <changed>` clean (ruff, ruff-format, zizmor, bandit, secret scan, license header).
- Ran the kept-on-gate local tests in the four mixed-content files I edited: **167 passed**, 50 network/slow deselected, fully offline.

## How to checkout & try? (for the reviewer)

```bash
# the quarantined set (now runs nightly, off the gate):
pytest -m "network" --collect-only -q
```
```bash
# the new gating expression — no live-Hub tests, stays green offline:
pytest -m "not gpu and not network" --collect-only -q
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
