### PR TITLE
fix(envs): silence per-worker robosuite import banner in sim-eval logs

### DIFF
--- a/src/opentau/envs/robocasa.py
+++ b/src/opentau/envs/robocasa.py
@@ -52,6 +52,7 @@ from gymnasium import spaces
 
 from opentau.constants import HF_OPENTAU_HOME
 from opentau.utils.accelerate_utils import acc_print, get_proc_accelerator
+from opentau.utils.io_utils import silence_output_unless_error
 
 # Flat action/state vector dimensions for the PandaOmron mobile manipulator
 # (RoboCasa365's default robot).
@@ -585,21 +586,27 @@ class RoboCasaEnv(gym.Env):
         """
         if self._env is not None:
             return
-        _import_robocasa_with_version_shim()
-        from robocasa.wrappers.gym_wrapper import RoboCasaGymEnv
+        # Mute the noisy one-per-worker robosuite/robocasa import + construction
+        # banner (private-macro / mink / mimicgen / controller-config lines): with
+        # AsyncVectorEnv there is one copy per spawn worker, i.e. n_envs * world_size
+        # duplicates flooding the log on every eval. Captured output is replayed to
+        # stderr only if construction raises, so a real failure stays debuggable.
+        with silence_output_unless_error(label=f"task={self.task} idx={self.episode_index}"):
+            _import_robocasa_with_version_shim()
+            from robocasa.wrappers.gym_wrapper import RoboCasaGymEnv
 
-        # RoboCasaGymEnv defaults split="test", which create_env rejects (only
-        # None/"all"/"pretrain"/"target" are valid). Always pass a valid value.
-        self._env = RoboCasaGymEnv(
-            env_name=self.task,
-            camera_widths=self.observation_width,
-            camera_heights=self.observation_height,
-            split=self.split if self.split is not None else "all",
-            obj_registries=self.obj_registries,
-        )
+            # RoboCasaGymEnv defaults split="test", which create_env rejects (only
+            # None/"all"/"pretrain"/"target" are valid). Always pass a valid value.
+            self._env = RoboCasaGymEnv(
+                env_name=self.task,
+                camera_widths=self.observation_width,
+                camera_heights=self.observation_height,
+                split=self.split if self.split is not None else "all",
+                obj_registries=self.obj_registries,
+            )
 
-        ep_meta = self._env.env.get_ep_meta()
-        self.task_description = ep_meta.get("lang", self.task)
+            ep_meta = self._env.env.get_ep_meta()
+            self.task_description = ep_meta.get("lang", self.task)
 
     def _format_raw_obs(self, raw_obs: dict[str, Any]) -> dict[str, Any]:
         r"""Convert a ``RoboCasaGymEnv`` observation dict to OpenTau format."""

--- a/src/opentau/utils/io_utils.py
+++ b/src/opentau/utils/io_utils.py
@@ -17,11 +17,18 @@
 """Utilities for file I/O operations.
 
 This module provides functions for reading and writing JSON files, saving videos,
-and deserializing JSON data into structured objects with type checking.
+and deserializing JSON data into structured objects with type checking. It also
+provides :func:`silence_output_unless_error` for muting noisy subprocess output
+(captured and replayed only if the wrapped block raises).
 """
 
+import contextlib
 import json
+import os
+import sys
+import tempfile
 import warnings
+from collections.abc import Iterator
 from pathlib import Path
 from typing import TypeVar
 
@@ -29,6 +36,65 @@ import imageio
 
 JsonLike = str | int | float | bool | None | list["JsonLike"] | dict[str, "JsonLike"] | tuple["JsonLike", ...]
 T = TypeVar("T", bound=JsonLike)
+
+
+@contextlib.contextmanager
+def silence_output_unless_error(label: str = "") -> Iterator[None]:
+    r"""Mute this process's stdout/stderr for the block, replaying it only on error.
+
+    Redirection happens at the **file-descriptor** level (``os.dup2`` on fds 1 and
+    2), not by swapping ``sys.stdout`` / ``sys.stderr``. That is what lets it capture
+    output a Python-level :func:`contextlib.redirect_stdout` would miss: writes from
+    C extensions (mujoco / EGL) and ``logging`` handlers that grabbed a reference to
+    the original stream at import time (e.g. robosuite's logger).
+
+    The motivating use is muting the noisy one-per-worker robosuite/robocasa
+    import-and-construction banner emitted inside ``gym.vector.AsyncVectorEnv`` spawn
+    workers during sim eval — ``n_envs * world_size`` duplicate copies of the
+    private-macro / mink / mimicgen / controller-config lines on every eval. On
+    success the captured output is discarded; if the wrapped block raises, the
+    captured bytes are written to the real stderr first (prefixed with ``label``) so
+    the failing worker stays debuggable, then the exception propagates unchanged.
+
+    Args:
+        label: Optional identifier (e.g. ``"task=CloseFridge idx=3"``) prepended to
+            the replayed output so a failing worker can be attributed.
+
+    Yields:
+        None. Wrap the code whose output should be muted in the ``with`` block.
+    """
+    sys.stdout.flush()
+    sys.stderr.flush()
+    saved_stdout_fd = os.dup(1)
+    saved_stderr_fd = os.dup(2)
+    failed = False
+    try:
+        with tempfile.TemporaryFile(mode="w+b") as buffer:
+            os.dup2(buffer.fileno(), 1)
+            os.dup2(buffer.fileno(), 2)
+            try:
+                yield
+            except BaseException:
+                failed = True
+                raise
+            finally:
+                # Restore the real stdout/stderr fds whether or not the block raised,
+                # then (on failure only) replay the captured bytes so they are not lost.
+                sys.stdout.flush()
+                sys.stderr.flush()
+                os.dup2(saved_stdout_fd, 1)
+                os.dup2(saved_stderr_fd, 2)
+                if failed:
+                    buffer.seek(0)
+                    captured = buffer.read()
+                    if captured:
+                        prefix = f"[silenced output — {label}]\n" if label else "[silenced output]\n"
+                        payload = prefix.encode(errors="replace") + captured
+                        while payload:
+                            payload = payload[os.write(saved_stderr_fd, payload) :]
+    finally:
+        os.close(saved_stdout_fd)
+        os.close(saved_stderr_fd)
 
 
 def write_video(video_path: str | Path, stacked_frames: list, fps: float) -> None:

--- a/src/opentau/utils/io_utils.py
+++ b/src/opentau/utils/io_utils.py
@@ -70,9 +70,11 @@ def silence_output_unless_error(label: str = "") -> Iterator[None]:
     failed = False
     try:
         with tempfile.TemporaryFile(mode="w+b") as buffer:
-            os.dup2(buffer.fileno(), 1)
-            os.dup2(buffer.fileno(), 2)
             try:
+                # Inside the try so a failure of the second dup2 (fd 1 already
+                # redirected) still hits the finally and restores both fds.
+                os.dup2(buffer.fileno(), 1)
+                os.dup2(buffer.fileno(), 2)
                 yield
             except BaseException:
                 failed = True

--- a/tests/utils/test_io_utils.py
+++ b/tests/utils/test_io_utils.py
@@ -19,7 +19,11 @@ from typing import Any
 
 import pytest
 
-from opentau.utils.io_utils import deserialize_json_into_object, write_video
+from opentau.utils.io_utils import (
+    deserialize_json_into_object,
+    silence_output_unless_error,
+    write_video,
+)
 
 
 def create_temp_json(tmp_path: Path, data: Any) -> Path:
@@ -162,3 +166,47 @@ def test_success_on_int_float(value, tmp_path):
     source = deserialize_json_into_object(fpath, template_obj)
 
     assert source == json_data
+
+
+# These exercise the file-descriptor-level redirect — the robosuite-logger / mujoco-C
+# case the helper exists for — via os.write(1/2, ...). Note: pytest swaps
+# sys.stdout/sys.stderr for objects NOT backed by fds 1/2, so a plain print() bypasses
+# the fd redirect under pytest and is not a valid probe here; write to the fds directly.
+def test_silence_output_unless_error_mutes_on_success(capfd):
+    """On the success path, fd-level stdout and stderr writes are discarded."""
+    with silence_output_unless_error():
+        os.write(1, b"stdout banner noise\n")
+        os.write(2, b"stderr banner noise\n")
+
+    out, err = capfd.readouterr()
+    assert "stdout banner noise" not in out
+    assert "stderr banner noise" not in err
+
+
+def test_silence_output_unless_error_replays_on_failure(capfd):
+    """If the block raises, the captured fd output is replayed to stderr with the label."""
+    with (
+        pytest.raises(ValueError, match="boom"),
+        silence_output_unless_error(label="task=CloseFridge idx=3"),
+    ):
+        os.write(1, b"stdout before crash\n")
+        os.write(2, b"stderr before crash\n")
+        raise ValueError("boom")
+
+    out, err = capfd.readouterr()
+    # The exception still propagates (asserted above) and the otherwise-muted output
+    # is replayed on stderr, tagged with the label, so the failure stays debuggable.
+    assert "task=CloseFridge idx=3" in err
+    assert "stdout before crash" in err
+    assert "stderr before crash" in err
+
+
+def test_silence_output_unless_error_restores_streams(capfd):
+    """fd-level stdout/stderr resume working after the block exits."""
+    with silence_output_unless_error():
+        os.write(1, b"hidden\n")
+    os.write(1, b"visible again\n")
+
+    out, err = capfd.readouterr()
+    assert "hidden" not in out
+    assert "visible again" in out

--- a/tests/utils/test_io_utils.py
+++ b/tests/utils/test_io_utils.py
@@ -185,22 +185,25 @@ def test_silence_output_unless_error_mutes_on_success(capfd):
 
 def test_silence_output_unless_error_replays_on_failure(capfd):
     """If the block raises, the captured fd output is replayed to stderr with the label."""
-    # Explicit try/except (rather than `pytest.raises`) so the exception propagation
-    # is modelled plainly and the assertions afterwards are unambiguously reachable.
-    raised = False
-    try:
-        with silence_output_unless_error(label="task=CloseFridge idx=3"):
-            os.write(1, b"stdout before crash\n")
-            os.write(2, b"stderr before crash\n")
-            raise ValueError("boom")
-    except ValueError as exc:
-        raised = True
-        assert str(exc) == "boom"
-    assert raised, "the exception must propagate through the context manager"
+
+    def _emit_then_raise():
+        # Factored into a helper so the failing action is a call rather than a literal
+        # raise as the block's last statement, which keeps static analyzers from
+        # wrongly treating the post-block assertions as unreachable code.
+        os.write(1, b"stdout before crash\n")
+        os.write(2, b"stderr before crash\n")
+        raise ValueError("boom")
+
+    with (
+        pytest.raises(ValueError, match="boom"),
+        silence_output_unless_error(label="task=CloseFridge idx=3"),
+    ):
+        _emit_then_raise()
 
     out, err = capfd.readouterr()
-    # The otherwise-muted output is replayed on stderr, tagged with the label, so a
-    # failing worker stays debuggable.
+    # The exception still propagates (asserted by pytest.raises) and the otherwise-muted
+    # output is replayed on stderr, tagged with the label, so a failing worker stays
+    # debuggable.
     assert "task=CloseFridge idx=3" in err
     assert "stdout before crash" in err
     assert "stderr before crash" in err

--- a/tests/utils/test_io_utils.py
+++ b/tests/utils/test_io_utils.py
@@ -185,17 +185,22 @@ def test_silence_output_unless_error_mutes_on_success(capfd):
 
 def test_silence_output_unless_error_replays_on_failure(capfd):
     """If the block raises, the captured fd output is replayed to stderr with the label."""
-    with (
-        pytest.raises(ValueError, match="boom"),
-        silence_output_unless_error(label="task=CloseFridge idx=3"),
-    ):
-        os.write(1, b"stdout before crash\n")
-        os.write(2, b"stderr before crash\n")
-        raise ValueError("boom")
+    # Explicit try/except (rather than `pytest.raises`) so the exception propagation
+    # is modelled plainly and the assertions afterwards are unambiguously reachable.
+    raised = False
+    try:
+        with silence_output_unless_error(label="task=CloseFridge idx=3"):
+            os.write(1, b"stdout before crash\n")
+            os.write(2, b"stderr before crash\n")
+            raise ValueError("boom")
+    except ValueError as exc:
+        raised = True
+        assert str(exc) == "boom"
+    assert raised, "the exception must propagate through the context manager"
 
     out, err = capfd.readouterr()
-    # The exception still propagates (asserted above) and the otherwise-muted output
-    # is replayed on stderr, tagged with the label, so the failure stays debuggable.
+    # The otherwise-muted output is replayed on stderr, tagged with the label, so a
+    # failing worker stays debuggable.
     assert "task=CloseFridge idx=3" in err
     assert "stdout before crash" in err
     assert "stderr before crash" in err


### PR DESCRIPTION
## What this does

Multi-rank RoboCasa **sim eval** floods the training log at every eval boundary (🐛 Bug). The eval builds one `gym.vector.AsyncVectorEnv` worker per env (`n_envs × world_size`), and each worker re-imports robosuite/robocasa on spawn — re-emitting the same import + construction banner (private-macro / mink whole-body-IK / `mimicgen` not installed / `robosuite_models` / controller-config / `Creating <task>` lines). On a typical 8-rank × 8-env eval that is **~610 duplicate noise lines per eval**, drowning the ~40 lines of actual signal (step losses, eval success, HBM probes) and repeating on every eval.

Fix: wrap `RoboCasaEnv._ensure_env` (the lazy robosuite/robocasa import + `RoboCasaGymEnv` construction) in a new `io_utils.silence_output_unless_error`:

- **File-descriptor-level redirect.** It saves and `os.dup2`-redirects fds 1 and 2 (not just `sys.stdout` / `sys.stderr`), so it captures output a Python-level `contextlib.redirect_stdout` would miss — robosuite's `logging` handler (bound to the original stream at import time) and mujoco's C-level writes.
- **Replay only on failure.** On the success path the captured banner is discarded. If construction raises, the captured bytes are written to the real stderr first — prefixed with the worker's `task=… idx=…` — then the exception propagates unchanged, so a genuinely failing worker stays fully debuggable.

The eval rollout, env semantics, determinism, and all non-construction output are untouched; only the once-per-worker construction banner is muted.

LIBERO has the same pattern but imports robosuite at module top, so quieting it needs a separate import-seam change — left as a follow-up.

## How it was tested

- `pre-commit` clean; `pytest -m "not gpu"` for the affected dirs green: `tests/utils/` + `tests/envs/test_robocasa.py` (**296 passed**). New coverage in `tests/utils/test_io_utils.py`: `silence_output_unless_error` mutes fd-level stdout/stderr on success, replays the captured bytes (with the label) to stderr on failure while re-raising, and restores the streams afterward (verified via pytest's `capfd`).
- The LIBERO-dependent test modules (`test_libero_utils.py`, `test_libero_control_freq.py`, and the `libero`-importing cases in `test_factory.py`) require the `libero` extra and are exercised by the CPU CI workflow (`cpu_test.yml`, which syncs `--extra libero`); they are unrelated to this diff.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/utils/test_io_utils.py -k silence_output_unless_error
```

Or run any RoboCasa config with `eval_freq > 0` (`MUJOCO_GL=egl`): the per-worker robosuite/robocasa banner no longer repeats `n_envs × world_size` times per eval; if an env fails to construct, that worker's output is replayed to stderr tagged with its `task` / `idx`.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.
