### PR TITLE
perf(datasets): read v3.0 columns via arrow formatter, not row-wise numpy

### DIFF
--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -1632,7 +1632,9 @@ class LeRobotDataset(BaseDataset):
                     self.repo_id,
                 )
         else:
-            no_transform_ds = self.hf_dataset.with_transform(None).with_format("numpy")
+            # "arrow" (columnar), not "numpy": with_format("numpy")[col] row-formats
+            # the whole table (O(rows) Python) -- very slow on large v3.0 datasets.
+            no_transform_ds = self.hf_dataset.with_transform(None).with_format("arrow")
             logging.info("Checking timestamps synchronization...")
             timestamps = np.asarray(no_transform_ds["timestamp"], dtype=np.float32)
             episode_indices = np.asarray(no_transform_ds["episode_index"], dtype=np.int64)
@@ -1950,7 +1952,12 @@ class LeRobotDataset(BaseDataset):
         # episode_index: (chunk, file) file order == episode order, ascending
         # within each file. Assert it so a malformed layout fails loudly here
         # rather than silently desyncing per-dataset metrics (CLAUDE.md §5).
-        ep_col = np.asarray(hf_dataset.with_format("numpy")["episode_index"]).reshape(-1)
+        # Read `episode_index` via the columnar "arrow" formatter, NOT
+        # `with_format("numpy")[col]`: the latter row-formats/decodes the entire
+        # table (O(rows) Python), which is pathologically slow on large
+        # consolidated v3.0 splits -- tens of minutes for a ~29M-row file set vs.
+        # milliseconds here. `np.asarray` converts the Arrow column in one shot.
+        ep_col = np.asarray(hf_dataset.with_format("arrow")["episode_index"]).reshape(-1)
         if ep_col.size and not np.all(ep_col[:-1] <= ep_col[1:]):
             raise RuntimeError(
                 f"{self.repo_id}: v3.0 data rows are not ordered by ascending episode_index; "


### PR DESCRIPTION
## What this does

Speeds up LeRobot **v3.0** dataset loading by reading single columns through the
columnar `arrow` formatter instead of the per-row `numpy` formatter.

`hf_dataset.with_format("numpy")[col]` row-formats and decodes the **entire**
table in Python (`format_row` → `decode_example` → `recursive_tensorize`, plus a
per-row numpy-version parse) just to pull one column. That is `O(rows)` Python —
fine for small datasets, but pathological on large consolidated v3.0 splits: a
~29M-row file set spends *tens of minutes* here, on every process and every
run/resume, with the GPUs idle the whole time.

Two reads in `LeRobotDataset` are switched to `with_format("arrow")[col]`, which
returns the column directly:

- `_load_hf_dataset_v30` — the `episode_index` extraction used for the
  ascending-order assert and the subset keep-mask.
- the timestamp-sync check (the `skip_timestamp_check=False` branch).

The extracted values are identical; only the access path changes.

⚡️ Performance / optimization.

## How it was tested

- **Equivalence**, on a real LeRobot v3.0 dataset (~155k rows): the
  `episode_index` and `timestamp` arrays produced by the old `numpy`-formatter
  path and the new `arrow` path are bit-identical (`np.array_equal` → `True`,
  same dtypes). The surrounding logic — the ascending-`episode_index` assert, the
  `np.isin` keep-mask + `.select(...)`, and `check_timestamps_sync` — is unchanged
  and consumes those identical arrays.
- **Speed**, same dataset: ~**20000×** faster for the column read (11.7s → 0.6ms);
  the gap widens with row count.
- `pre-commit run --all-files` clean (ruff, ruff-format, …).
- The v3.0 load path is exercised by `tests/datasets/test_datasets_v30.py` in the
  CPU suite (`cpu_test.yml`).

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/datasets/test_datasets_v30.py -m "not gpu"
```

Or confirm the equivalence + speedup directly on any v3.0 data split:

```python
import numpy as np
from datasets import load_dataset
hf = load_dataset("parquet", data_files=files, split="train")  # a v3.0 data split
old = np.asarray(hf.with_format("numpy")["episode_index"]).reshape(-1)
new = np.asarray(hf.with_format("arrow")["episode_index"]).reshape(-1)
assert np.array_equal(old, new)  # identical values; `new` is orders of magnitude faster
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
