### PR TITLE
fix(datasets): drop non-tensorizable columns in hf_transform_to_torch

### DIFF
--- a/src/opentau/datasets/utils.py
+++ b/src/opentau/datasets/utils.py
@@ -738,6 +738,25 @@ def _warn_dropped_nontensor_column_once(key: str) -> None:
         )
 
 
+def _is_dict_like(value) -> bool:
+    """Return True if a column value is a dict or a list/tuple of dicts.
+
+    Such values come from struct / list-of-struct parquet columns (e.g.
+    chat-style ``language_persistent`` annotations) and cannot be converted to
+    tensors. Plain numeric scalars/sequences (and string columns) are not
+    dict-like, so a genuinely malformed model-input column still raises loudly at
+    ``torch.tensor`` instead of being silently dropped.
+
+    Args:
+        value: A single column value taken from one dataset row.
+    """
+    if isinstance(value, dict):
+        return True
+    if isinstance(value, (list, tuple)) and value:
+        return _is_dict_like(value[0])
+    return False
+
+
 def hf_transform_to_torch(items_dict: dict[str, list]):
     """Get a transform function that convert items from Hugging Face dataset (pyarrow)
     to torch tensors. Importantly, images are converted from PIL, which corresponds to
@@ -756,16 +775,17 @@ def hf_transform_to_torch(items_dict: dict[str, list]):
             items_dict[key] = [to_tensor(img) for img in items_dict[key]]
         elif first_item is None:
             pass
+        elif _is_dict_like(first_item):
+            # Struct / list-of-struct annotation columns (e.g. chat-style
+            # language annotations such as `language_persistent`) are not model
+            # inputs and cannot be converted to tensors. Drop them so the
+            # dataloader/collate does not choke. Narrowed to dict-like values so
+            # a genuinely malformed model-input column (e.g. a ragged `action`)
+            # still raises loudly at `torch.tensor` below instead of being
+            # silently dropped here.
+            drop_keys.append(key)
         else:
-            try:
-                items_dict[key] = [x if isinstance(x, str) else torch.tensor(x) for x in items_dict[key]]
-            except (TypeError, ValueError, RuntimeError):
-                # Auxiliary struct/dict columns (e.g. chat-style language
-                # annotations such as `language_persistent`) are not model
-                # inputs and torch.tensor() cannot infer their dtype. Drop them
-                # so the dataloader/collate does not choke, instead of crashing
-                # the whole run on the first batch.
-                drop_keys.append(key)
+            items_dict[key] = [x if isinstance(x, str) else torch.tensor(x) for x in items_dict[key]]
     for key in drop_keys:
         _warn_dropped_nontensor_column_once(key)
         del items_dict[key]

--- a/src/opentau/datasets/utils.py
+++ b/src/opentau/datasets/utils.py
@@ -718,12 +718,37 @@ def load_image_as_numpy(
     return img_array
 
 
+_DROPPED_NONTENSOR_COLUMNS_WARNED: set[str] = set()
+
+
+def _warn_dropped_nontensor_column_once(key: str) -> None:
+    """Warn once per column that a non-tensorizable field was dropped.
+
+    Args:
+        key: Name of the column dropped from the sample dict.
+    """
+    if key not in _DROPPED_NONTENSOR_COLUMNS_WARNED:
+        _DROPPED_NONTENSOR_COLUMNS_WARNED.add(key)
+        logging.warning(
+            "hf_transform_to_torch: dropping column %r whose values are not "
+            "convertible to tensors (e.g. a dict/struct annotation column such "
+            "as `language_persistent`). It is not a model input; this is "
+            "expected for datasets carrying auxiliary annotation fields.",
+            key,
+        )
+
+
 def hf_transform_to_torch(items_dict: dict[str, list]):
     """Get a transform function that convert items from Hugging Face dataset (pyarrow)
     to torch tensors. Importantly, images are converted from PIL, which corresponds to
     a channel last representation (h w c) of uint8 type, to a torch image representation
     with channel first (c h w) of float32 type in range [0,1].
+
+    Columns whose values cannot be converted to tensors (e.g. dict/struct
+    annotation columns such as ``language_persistent``) are not model inputs and
+    are dropped from the returned dict rather than crashing the dataloader.
     """
+    drop_keys: list[str] = []
     for key in items_dict:
         first_item = items_dict[key][0]
         if isinstance(first_item, PILImage.Image):
@@ -732,7 +757,18 @@ def hf_transform_to_torch(items_dict: dict[str, list]):
         elif first_item is None:
             pass
         else:
-            items_dict[key] = [x if isinstance(x, str) else torch.tensor(x) for x in items_dict[key]]
+            try:
+                items_dict[key] = [x if isinstance(x, str) else torch.tensor(x) for x in items_dict[key]]
+            except (TypeError, ValueError, RuntimeError):
+                # Auxiliary struct/dict columns (e.g. chat-style language
+                # annotations such as `language_persistent`) are not model
+                # inputs and torch.tensor() cannot infer their dtype. Drop them
+                # so the dataloader/collate does not choke, instead of crashing
+                # the whole run on the first batch.
+                drop_keys.append(key)
+    for key in drop_keys:
+        _warn_dropped_nontensor_column_once(key)
+        del items_dict[key]
     return items_dict
 
 

--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -137,3 +137,10 @@ def test_hf_transform_drops_nontensorizable_columns(caplog, reset_dropped_column
         r for r in caplog.records if r.levelno == logging.WARNING and "language_persistent" in r.getMessage()
     ]
     assert not repeat, "dropped-column warning should be emitted only once per column"
+
+
+def test_hf_transform_raises_on_malformed_model_input():
+    """A malformed (non-dict-like) numeric column still raises loudly rather than
+    being silently dropped, so genuine data/shape bugs surface at their source."""
+    with pytest.raises((ValueError, RuntimeError, TypeError)):
+        hf_transform_to_torch({"observation.state": [[[1.0, 2.0], [1.0, 2.0, 3.0]]]})

--- a/tests/datasets/test_utils.py
+++ b/tests/datasets/test_utils.py
@@ -95,3 +95,45 @@ def test_v21_warning_dedup(caplog, reset_v21_warning_state):
         assert repo_id in msg
         assert "convert_dataset_v20_to_v21.py" in msg
         assert "discord.com/invite" not in msg
+
+
+@pytest.fixture
+def reset_dropped_column_warning_state():
+    """Reset the warn-once dedup set for dropped non-tensorizable columns so the
+    warning assertion is deterministic regardless of test ordering."""
+    datasets_utils._DROPPED_NONTENSOR_COLUMNS_WARNED.clear()
+    yield
+    datasets_utils._DROPPED_NONTENSOR_COLUMNS_WARNED.clear()
+
+
+def test_hf_transform_drops_nontensorizable_columns(caplog, reset_dropped_column_warning_state):
+    """`hf_transform_to_torch` drops dict/struct columns it can't tensorize
+    (e.g. chat-style `language_persistent` annotations) and warns once, while
+    leaving numeric / string / empty-list columns intact."""
+    items_dict = {
+        "observation.state": [[1.0, 2.0, 3.0]],
+        "task": ["close the fridge"],
+        "language_events": [[]],  # null/empty list -> torch.tensor([]) -> kept
+        "language_persistent": [[{"role": "user", "content": "hi"}]],  # struct -> dropped
+    }
+    with caplog.at_level(logging.WARNING):
+        out = hf_transform_to_torch(items_dict)
+
+    # The struct column is dropped; model-relevant columns survive unchanged.
+    assert "language_persistent" not in out
+    assert torch.equal(out["observation.state"][0], torch.tensor([1.0, 2.0, 3.0]))
+    assert out["task"][0] == "close the fridge"
+    assert isinstance(out["language_events"][0], torch.Tensor)
+    assert out["language_events"][0].numel() == 0
+
+    warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("language_persistent" in m for m in warnings), warnings
+
+    # Warn-once: a second call with the same column does not re-warn.
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        hf_transform_to_torch({"language_persistent": [[{"a": 1}]], "observation.state": [[1.0]]})
+    repeat = [
+        r for r in caplog.records if r.levelno == logging.WARNING and "language_persistent" in r.getMessage()
+    ]
+    assert not repeat, "dropped-column warning should be emitted only once per column"


### PR DESCRIPTION
## What this does

Makes `hf_transform_to_torch` robust to dataset columns that aren't model inputs
and can't be converted to tensors.

A LeRobot dataset can carry auxiliary columns — e.g. chat-style language
annotations stored as a `list<struct<role, content, …>>` (`language_persistent`).
`hf_transform_to_torch` ran `torch.tensor()` on **every** column, so such a
column raised `RuntimeError: Could not infer dtype of dict` and **crashed the
dataloader on the very first training batch** (every sample from that dataset
failed to load).

This wraps the per-column tensorization in a `try/except`: on failure the column
is **dropped** from the sample (with a one-time warning naming it) instead of
crashing the run. Real numeric / string / empty-list columns are unaffected, and
since the dropped columns aren't model inputs, training is unchanged.

🐛 Bug fix.

## How it was tested

- Added `test_hf_transform_drops_nontensorizable_columns` in
  `tests/datasets/test_utils.py`: a `list<struct>` column is dropped, the
  numeric / string / empty-list columns survive unchanged, and the warning is
  emitted exactly once per column.
- Ran `tests/datasets/test_utils.py` (the new test plus the existing
  `hf_transform_to_torch` / version-warning tests) — all green.
- Validated on a real LeRobot **v3.0** dataset whose data carries a
  `language_persistent` `list<struct>` column: before this change the dataloader
  raised `Could not infer dtype of dict` on the first batch; after it, the column
  is skipped and a valid batch is produced (numeric `observation.state` / `action`
  still tensorized).
- `pre-commit run --all-files` clean.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/datasets/test_utils.py -k drops_nontensorizable
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
