### PR TITLE
fix(datasets): val-split RAM + v3.0 video frame-index clamp + load retry

### DIFF
--- a/src/opentau/datasets/factory.py
+++ b/src/opentau/datasets/factory.py
@@ -169,6 +169,33 @@ def resolve_delta_timestamps(
     return dt_mean, {}, {}, {}
 
 
+def _subset_meta(meta: LeRobotDatasetMetadata) -> LeRobotDatasetMetadata:
+    """Per-subset metadata copy that shares read-only per-episode structures.
+
+    Returns a shallow copy of ``meta`` that shares ``episodes`` /
+    ``episodes_stats`` (and every other attribute) by reference, deep-copying
+    only the small aggregated ``stats`` dict so the train/val halves can hold
+    independent normalization stats without cross-contamination.
+
+    ``random_split`` divides a dataset by frame index, so the per-episode
+    ``episodes`` / ``episodes_stats`` are identical across the two subsets and
+    are read-only on the training path (only the dataset-*creation*
+    ``save_episode`` / stats-conversion paths write them). A blanket
+    ``deepcopy(meta)`` cloned them per subset: for a large per-episode-stats
+    dataset listed under many mixture configs that is tens of GB of needless
+    copies per rank, and — worse — copy-on-write surface that blows up host RAM
+    once forked across dataloader workers (every worker touches the clones).
+    Sharing them by reference removes both costs. Mirrors the share-by-reference
+    contract of :meth:`BaseDataset.shallow_copy_with_dropout`.
+
+    Args:
+        meta: The source dataset metadata to copy for a train/val subset.
+    """
+    subset_meta = copy.copy(meta)
+    subset_meta.stats = copy.deepcopy(meta.stats)
+    return subset_meta
+
+
 def make_dataset(
     cfg: DatasetConfig,
     train_cfg: TrainPipelineConfig,
@@ -278,8 +305,14 @@ def make_dataset(
         val_size = int(len(dataset) * effective_val_split)
         train_size = len(dataset) - val_size
         train_dataset, val_dataset = torch.utils.data.random_split(dataset, [train_size, val_size])
-        train_dataset.meta = copy.deepcopy(dataset.meta)  # type: ignore[assignment]
-        val_dataset.meta = copy.deepcopy(dataset.meta)  # type: ignore[assignment]
+        # Share the large, read-only per-episode metadata (`episodes`,
+        # `episodes_stats`) across the two halves; deep-copy only the small
+        # aggregated `stats`. A blanket `deepcopy(meta)` here is tens of GB of
+        # needless per-rank copies for a large per-episode-stats dataset and
+        # becomes copy-on-write surface that OOMs the host across dataloader
+        # workers. See `_subset_meta`.
+        train_dataset.meta = _subset_meta(dataset.meta)  # type: ignore[assignment]
+        val_dataset.meta = _subset_meta(dataset.meta)  # type: ignore[assignment]
 
         # Subset wraps the same underlying dataset by reference, so the
         # training and validation halves would share every instance attribute

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -168,6 +168,17 @@ from opentau.policies.value.reward import (
 from opentau.utils.accelerate_utils import get_proc_accelerator
 from opentau.utils.utils import on_accelerate_main_proc
 
+# Default number of random-index retries for ``retry_random_on_failure`` when a
+# dataset item fails to load. Until now ``_total_rand_attempts`` was read with a
+# ``getattr(..., 0)`` fallback and never set anywhere, so the retry feature was
+# inert (exactly one attempt) and a single unrecoverable item killed the whole
+# run. Transient per-item failures are real on large mixtures — most commonly a
+# consolidated video encoded with marginally fewer frames than its metadata
+# implies, whose trailing-frame decode raises — so a handful of retries lets the
+# loader skip that item and resample instead of aborting training. Subclasses may
+# still override ``self._total_rand_attempts`` to tune or disable it.
+DEFAULT_RAND_RETRY_ATTEMPTS = 8
+
 
 def retry_random_on_failure(f):
     """Decorator to retry dataset item retrieval with random indices on failure.
@@ -185,7 +196,7 @@ def retry_random_on_failure(f):
     @functools.wraps(f)
     def wrapped(self, idx):
         g = getattr(self, "_rr_rng", None)
-        total_attempts = getattr(self, "_total_rand_attempts", 0)
+        total_attempts = getattr(self, "_total_rand_attempts", DEFAULT_RAND_RETRY_ATTEMPTS)
         if g is None:
             g = torch.Generator()
             g.manual_seed(torch.initial_seed())  # different seed per DataLoader worker

--- a/src/opentau/datasets/video_utils.py
+++ b/src/opentau/datasets/video_utils.py
@@ -376,9 +376,21 @@ def decode_video_frames_torchcodec(
     # get metadata for frame information
     metadata = decoder.metadata
     average_fps = metadata.average_fps
+    num_frames = metadata.num_frames
 
     # convert timestamps to frame indices
     frame_indices = [round(ts * average_fps) for ts in timestamps]
+    # Clamp to the decodable range [0, num_frames - 1]. A query timestamp can map
+    # past the final frame when a consolidated video was encoded with marginally
+    # fewer frames than its metadata implies, or when ``average_fps`` rounds up
+    # near the end of a long video. ``torchcodec``'s ``get_frames_at`` raises a
+    # hard ``IndexError`` on an out-of-range index, whereas the pyav path returns
+    # the nearest decoded frame; clamping reproduces that nearest-frame behavior.
+    # The tolerance check below still rejects a frame that is genuinely too far
+    # from its query timestamp (and ``retry_random_on_failure`` then skips that
+    # item), so this only rescues the off-by-rounding boundary case.
+    if num_frames:
+        frame_indices = [min(max(int(fi), 0), num_frames - 1) for fi in frame_indices]
 
     # retrieve frames based on indices
     frames_batch = decoder.get_frames_at(indices=frame_indices)

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -961,6 +961,40 @@ def test_make_dataset_per_dataset_val_split_ratio_zero_opts_out(train_pipeline_c
         cleanup()
 
 
+def test_subset_meta_shares_episode_metadata_but_isolates_stats():
+    """`_subset_meta` shares the large read-only per-episode metadata by reference
+    while giving each subset an independent aggregated `stats`.
+
+    This is the host-RAM-blowup fix: a blanket `deepcopy(meta)` per train/val
+    subset cloned the per-episode `episodes` / `episodes_stats` (tens of GB for a
+    large per-episode-stats dataset, and copy-on-write surface that OOMs across
+    dataloader workers). They are identical between the split halves and read-only
+    during training, so they must be SHARED; only the small aggregated `stats`
+    may diverge and is deep-copied.
+    """
+    from types import SimpleNamespace
+
+    from opentau.datasets.factory import _subset_meta
+
+    episodes = {0: {"length": 3}, 1: {"length": 5}}
+    episodes_stats = {0: {"action": {"mean": np.zeros(4)}}, 1: {"action": {"mean": np.ones(4)}}}
+    stats = {"action": {"mean": np.zeros(4)}}
+    meta = SimpleNamespace(episodes=episodes, episodes_stats=episodes_stats, stats=stats, info={}, tasks={})
+
+    sub = _subset_meta(meta)
+
+    # Large per-episode structures are shared by reference (no per-subset clone).
+    assert sub.episodes is meta.episodes
+    assert sub.episodes_stats is meta.episodes_stats
+    # The small aggregated stats is an independent deep copy.
+    assert sub.stats is not meta.stats
+    assert sub.stats.keys() == meta.stats.keys()
+    assert np.array_equal(sub.stats["action"]["mean"], meta.stats["action"]["mean"])
+    # Mutating the subset's stats must not bleed into the source's.
+    sub.stats["action"]["mean"][:] = 7.0
+    assert np.array_equal(meta.stats["action"]["mean"], np.zeros(4))
+
+
 # TODO(aliberts): Move to more appropriate location
 def test_flatten_unflatten_dict():
     d = {

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -1546,3 +1546,50 @@ def test_robot_type_and_control_mode_in_meta_info(tmp_path, lerobot_dataset_fact
     )
     assert ds_without.meta.info["robot_type"] is None
     assert "control_mode" not in ds_without.meta.info
+
+
+def test_retry_random_on_failure_uses_default_attempts():
+    """``retry_random_on_failure`` retries ``DEFAULT_RAND_RETRY_ATTEMPTS`` times.
+
+    Regression for the dead-retry bug: ``_total_rand_attempts`` was never set, so
+    the fallback was 0 -> exactly one attempt -> a single unrecoverable item
+    (e.g. a short consolidated video) aborted the whole run. The default must now
+    drive multiple retries.
+    """
+    from opentau.datasets.lerobot_dataset import DEFAULT_RAND_RETRY_ATTEMPTS, retry_random_on_failure
+
+    assert DEFAULT_RAND_RETRY_ATTEMPTS > 0
+    calls = {"n": 0}
+
+    class _AlwaysFails:
+        def __len__(self):
+            return 16
+
+        @retry_random_on_failure
+        def __getitem__(self, idx):
+            calls["n"] += 1
+            raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match=rf"after {DEFAULT_RAND_RETRY_ATTEMPTS + 1} attempt"):
+        _AlwaysFails()[0]
+    # one initial attempt + DEFAULT_RAND_RETRY_ATTEMPTS retries.
+    assert calls["n"] == DEFAULT_RAND_RETRY_ATTEMPTS + 1
+
+
+def test_retry_random_on_failure_recovers_from_transient_failure():
+    """A transient per-item failure is skipped: the wrapper resamples a different
+    index and returns successfully instead of raising."""
+    from opentau.datasets.lerobot_dataset import retry_random_on_failure
+
+    class _FailsOnce:
+        def __len__(self):
+            return 16
+
+        @retry_random_on_failure
+        def __getitem__(self, idx):
+            if idx == 0:  # the originally-requested (bad) index
+                raise RuntimeError("bad video frame")
+            return idx
+
+    out = _FailsOnce()[0]
+    assert out != 0  # recovered on a resampled index

--- a/tests/datasets/test_video_utils.py
+++ b/tests/datasets/test_video_utils.py
@@ -127,3 +127,40 @@ def test_explicit_torchcodec_falls_back_to_pyav_with_single_warning(tmp_path, ca
     assert len(fallback_warnings) == 1, (
         f"expected exactly one explicit-fallback warning across 3 calls, got {len(fallback_warnings)}"
     )
+
+
+def test_torchcodec_clamps_out_of_range_frame_index(monkeypatch):
+    """A query timestamp mapping past the last frame is clamped to ``num_frames-1``.
+
+    Consolidated v3.0 videos are occasionally encoded with marginally fewer frames
+    than their metadata implies, so ``round(ts * average_fps)`` can land at/just
+    past ``num_frames``. ``torchcodec.get_frames_at`` raises a hard ``IndexError``
+    on such an index; the loader must instead clamp to the nearest decodable frame
+    (matching the pyav path), letting the tolerance check decide acceptance.
+    """
+    import torch
+
+    captured = {}
+    num_frames, avg_fps = 100, 20.0
+
+    class _FakeBatch:
+        def __init__(self, indices):
+            self.data = [torch.zeros(3, 4, 4, dtype=torch.uint8) for _ in indices]
+            self.pts_seconds = [torch.tensor(i / avg_fps) for i in indices]
+
+    class _FakeDecoder:
+        def __init__(self, *a, **k):
+            self.metadata = type("M", (), {"num_frames": num_frames, "average_fps": avg_fps})()
+
+        def get_frames_at(self, indices):
+            captured["indices"] = list(indices)
+            return _FakeBatch(indices)
+
+    monkeypatch.setattr(video_utils, "_load_torchcodec_videodecoder", lambda: (_FakeDecoder, None))
+
+    # ts = num_frames / avg_fps -> round() == num_frames (out of range by one).
+    ts = num_frames / avg_fps
+    frames = video_utils.decode_video_frames_torchcodec("fake.mp4", [ts], tolerance_s=0.5)
+
+    assert captured["indices"] == [num_frames - 1], f"index not clamped: {captured['indices']}"
+    assert frames.shape[0] == 1


### PR DESCRIPTION
## What this does

Three robustness fixes that surfaced co-training a large mixture of **v3.0**
(file-consolidated) robot datasets, each independent:

**1. Bound host RAM on the train/val split (`_subset_meta`).**
`make_dataset` did `copy.deepcopy(dataset.meta)` for *each* of the train and val
subsets when `val_freq > 0`. For a dataset with **per-episode** stats this clones
the large read-only `episodes` / `episodes_stats` dicts; when the same big repo
is listed under many mixture configs that is tens of GB of duplicated metadata
**per rank**, and — worse — copy-on-write surface that explodes host RAM once the
DataLoader forks its workers (it OOM-killed an 8-rank run). The split is by frame
index, so those dicts are identical between halves and read-only during training;
share them by reference and deep-copy only the small aggregated `stats`.

**2. Clamp the v3.0 video frame index (torchcodec).**
`decode_video_frames_torchcodec` passed `round(ts * average_fps)` straight to
`get_frames_at` with no bounds check. A query timestamp can land at/just past a
consolidated video's final frame (a minority of videos are encoded with
marginally fewer frames than their metadata implies, or `average_fps` rounds up
near the end of a long video). torchcodec raises a hard `IndexError` there —
unlike the pyav path, which returns the nearest decoded frame. Clamp the indices
to `[0, num_frames-1]` so the two backends behave the same; the existing
tolerance check still rejects a frame genuinely too far from its query.

**3. Enable the load-retry fallback (`DEFAULT_RAND_RETRY_ATTEMPTS`).**
`retry_random_on_failure` read `_total_rand_attempts` via `getattr(..., 0)`, and
the attribute was never set anywhere — so the documented retry-on-load-failure
feature was inert (exactly one attempt), and a single unrecoverable item aborted
the whole run. Add a default of 8 so a transient per-item failure (e.g. a video
whose decode raises despite the clamp) is skipped and resampled instead of fatal.

⚡️ Performance / 🐛 Bug.

## How it was tested

- **New unit tests** (CPU):
  - `test_subset_meta_shares_episode_metadata_but_isolates_stats` — train/val
    subsets share `episodes`/`episodes_stats` by reference, each gets an
    independent `stats`.
  - `test_torchcodec_clamps_out_of_range_frame_index` — a past-the-end query is
    clamped to `num_frames-1` (mocked decoder) instead of raising.
  - `test_retry_random_on_failure_uses_default_attempts` /
    `..._recovers_from_transient_failure` — the retry default drives N retries and
    recovers from a transient failure.
  - Existing val-split (`test_make_dataset_*_val_split_ratio_*`) and v3.0/mixture
    suites still pass.
- **Validated against real data**: the clamp was exercised in-environment on a
  real consolidated video (a one-frame-past query returns the last frame; a
  far-past query raises a tolerance error that the retry then skips).
- **End-to-end**: an 8-GPU run of the mixture trained cleanly through the
  step-1000 checkpoint. Host RAM stayed bounded (~0.2-0.3 TB; the prior baseline
  was ~0.9 TB and climbed to an OOM kill), the load-retry recovered transient
  bad-video samples without aborting, total loss fell from ~13.7 (step 50) to
  ~2.0 (step 1000) with MSE ~10.5 -> ~1.2, and per-task sim-eval success rose
  from 0 to non-zero by step 750 — i.e. the fixes produce sane, converging
  training rather than masking a problem.
- `pre-commit run --all-files` clean.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/datasets/test_video_utils.py::test_torchcodec_clamps_out_of_range_frame_index
pytest -sx tests/datasets/test_datasets.py -k "subset_meta_shares or retry_random_on_failure or val_split_ratio"
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
