### PR TITLE
fix(train): reset policy after in-training eval to free eval-batch buffers

### DIFF
--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -91,7 +91,9 @@ def _eval_with_fresh_envs(
     *non-PyTorch* device memory (~GiB per env) that ``torch.cuda.empty_cache``
     cannot reclaim; left open across an eval it stacks with the regrown training
     footprint and OOMs the next backward. Mirrors the standalone eval lifecycle
-    in ``eval.py`` (build -> eval -> ``close_envs``).
+    in ``eval.py`` (build -> eval -> ``close_envs``). The ``finally`` also
+    ``reset()``s the policy so its per-eval observation buffers (sized to
+    ``eval.batch_size``) do not persist into the resumed training step.
 
     Returns this rank's local ``eval_info`` (the caller gathers across ranks).
     """
@@ -115,6 +117,15 @@ def _eval_with_fresh_envs(
             )
     finally:
         close_envs(eval_envs)
+        # Drop the policy's per-eval observation history before training resumes.
+        # ``select_action`` accumulates ``_obs_buffers`` / ``_state_buffer`` /
+        # ``_action_queue`` sized to ``eval.batch_size``; ``reset()`` runs at each
+        # rollout *start* but never after the eval, so those eval-batch tensors stay
+        # *referenced* into the next training step. ``empty_cache`` cannot reclaim
+        # referenced memory, so without this they surface as a positive
+        # ``retained_alloc`` in the HBM probe and OOM the next backward at larger
+        # eval batch sizes (e.g. +1.36 GiB at batch 16 on an already-tight run).
+        accelerator.unwrap_model(policy).reset()
         gc.collect()
         if torch.cuda.is_available():
             torch.cuda.empty_cache()

--- a/tests/scripts/test_train.py
+++ b/tests/scripts/test_train.py
@@ -332,12 +332,14 @@ class TestCommitWandbStep:
 
 
 class TestEvalWithFreshEnvs:
-    """``_eval_with_fresh_envs`` builds eval envs, runs eval, and ALWAYS closes them.
+    """``_eval_with_fresh_envs`` builds eval envs, runs eval, and ALWAYS tears them down.
 
     Per-eval teardown frees the sim renderer's non-PyTorch GPU memory before
     training resumes (otherwise it stacks with the regrown training footprint
-    and OOMs the next backward). The ``finally`` must close the envs even when
-    the eval itself raises.
+    and OOMs the next backward). Even when the eval itself raises, the ``finally``
+    must (1) close the envs and (2) ``reset()`` the policy so its per-eval
+    observation buffers (sized to ``eval.batch_size``) do not persist into the
+    next training step (the ``retained_alloc`` leak).
     """
 
     @staticmethod
@@ -356,6 +358,12 @@ class TestEvalWithFreshEnvs:
             seed=0,
         )
 
+    @staticmethod
+    def _acc():
+        # ``unwrap_model`` returns the underlying module so the helper can call
+        # ``reset()`` on it (mirrors ``accelerate.Accelerator.unwrap_model``).
+        return SimpleNamespace(device=SimpleNamespace(type="cpu"), unwrap_model=lambda p: p)
+
     def test_builds_and_closes_each_call(self, monkeypatch):
         envs1 = {"robocasa": {0: object()}}
         envs2 = {"robocasa": {0: object()}}
@@ -366,7 +374,7 @@ class TestEvalWithFreshEnvs:
         monkeypatch.setattr("opentau.scripts.train.close_envs", close)
         monkeypatch.setattr("opentau.scripts.train.eval_policy_all", ep_all)
 
-        acc = SimpleNamespace(device=SimpleNamespace(type="cpu"))
+        acc = self._acc()
         cfg = self._cfg()
         out1 = _eval_with_fresh_envs(cfg, Mock(), acc, None, "000010")
         out2 = _eval_with_fresh_envs(cfg, Mock(), acc, None, "000020")
@@ -387,10 +395,37 @@ class TestEvalWithFreshEnvs:
         monkeypatch.setattr("opentau.scripts.train.close_envs", close)
         monkeypatch.setattr("opentau.scripts.train.eval_policy_all", boom)
 
-        acc = SimpleNamespace(device=SimpleNamespace(type="cpu"))
         with pytest.raises(RuntimeError, match="eval blew up"):
-            _eval_with_fresh_envs(self._cfg(), Mock(), acc, None, "000010")
+            _eval_with_fresh_envs(self._cfg(), Mock(), self._acc(), None, "000010")
         close.assert_called_once_with(envs)
+
+    def test_resets_policy_after_successful_eval(self, monkeypatch):
+        # The policy accumulates eval-batch-sized observation history in its internal
+        # buffers; reset() must run after the eval so referenced GPU memory (which
+        # empty_cache cannot reclaim) does not persist into the resumed training step.
+        make = Mock(return_value={"robocasa": {0: object()}})
+        ep_all = Mock(return_value={"overall": {}})
+        monkeypatch.setattr("opentau.scripts.train.make_envs", make)
+        monkeypatch.setattr("opentau.scripts.train.close_envs", Mock())
+        monkeypatch.setattr("opentau.scripts.train.eval_policy_all", ep_all)
+
+        policy = Mock()
+        _eval_with_fresh_envs(self._cfg(), policy, self._acc(), None, "000010")
+        policy.reset.assert_called_once_with()
+
+    def test_resets_policy_even_when_eval_raises(self, monkeypatch):
+        # reset() shares the ``finally`` with ``close_envs``: a failed eval must not
+        # leak the policy's eval-batch observation buffers into the next training step.
+        make = Mock(return_value={"robocasa": {0: object()}})
+        boom = Mock(side_effect=RuntimeError("eval blew up"))
+        monkeypatch.setattr("opentau.scripts.train.make_envs", make)
+        monkeypatch.setattr("opentau.scripts.train.close_envs", Mock())
+        monkeypatch.setattr("opentau.scripts.train.eval_policy_all", boom)
+
+        policy = Mock()
+        with pytest.raises(RuntimeError, match="eval blew up"):
+            _eval_with_fresh_envs(self._cfg(), policy, self._acc(), None, "000010")
+        policy.reset.assert_called_once_with()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What this does

🐛 Bug. Fixes a GPU-memory leak across in-training RoboCasa eval that OOMs the run at larger eval batch sizes.

`_eval_with_fresh_envs` (`src/opentau/scripts/train.py`) tears down the eval sim envs (`close_envs` + `gc.collect()` + `torch.cuda.empty_cache()`) but never resets the policy. The policy accumulates per-eval observation history in `self._obs_buffers` (per-camera `(B, C, H, W)` deques), `self._state_buffer`, and `self._action_queue`, sized to `eval.batch_size`. `policy.reset()` clears those, but the eval rollout only calls it at each rollout **start** (`src/opentau/scripts/eval.py`), never after the eval — so the eval-batch observation history stays **referenced** into the resumed training step. `empty_cache()` cannot reclaim *referenced* memory, so it surfaces as a positive `retained_alloc` in the eval HBM probe and OOMs the next backward at larger eval sizes.

Observed on a memory-tight run (training peak near the card's capacity): the eval HBM probe's `retained_alloc` is positive and grows with `eval.batch_size` — **+0.68 GiB at batch 8** (stays under the OOM threshold, training continues) and **+1.36 GiB at batch 16** (OOMs the next backward). It is referenced GPU memory held in the policy's eval-batch observation buffers, so it scales with the eval batch.

Fix: call `accelerator.unwrap_model(policy).reset()` in the `finally`, alongside the existing env teardown. It applies to every policy (the base `PreTrainedPolicy.reset()` plus all subclasses), and only touches eval cleanup — not the training forward/backward path — so loss determinism is unchanged.

## How it was tested

- Extended `tests/scripts/test_train.py::TestEvalWithFreshEnvs` with `test_resets_policy_after_successful_eval` and `test_resets_policy_even_when_eval_raises` (assert the policy is `reset()` in the `finally`, including when the eval raises); gave the mock accelerator an `unwrap_model`.
- `pytest -m "not gpu and not network" tests/scripts/` → **199 passed**. `pre-commit run --all-files` clean.
- Real-world confirmation from in-training eval HBM probes: `retained_alloc` was **+0.68 GiB at `eval.batch_size=8`** (training resumed without OOM) and **+1.36 GiB at 16** (OOM'd the next backward). With this patch, `reset()` clears the eval-batch buffers, so `retained_alloc` should return to ~0 at any eval size — worth confirming on a multi-GPU RoboCasa eval.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/scripts/test_train.py::TestEvalWithFreshEnvs
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).