### PR TITLE
feat(train): fork the wandb run on resume by default

### DIFF
--- a/configs/benchmarks/pi05.json
+++ b/configs/benchmarks/pi05.json
@@ -81,7 +81,7 @@
         "group": null,
         "job_type": null,
         "mode": null,
-        "allow_resume": false,
+        "on_resume": "fork",
         "disable_artifact": true
     }
 }

--- a/configs/benchmarks/pi05_mem.json
+++ b/configs/benchmarks/pi05_mem.json
@@ -84,7 +84,7 @@
         "group": null,
         "job_type": null,
         "mode": null,
-        "allow_resume": false,
+        "on_resume": "fork",
         "disable_artifact": true
     }
 }

--- a/configs/benchmarks/pi07_high_level.json
+++ b/configs/benchmarks/pi07_high_level.json
@@ -79,7 +79,7 @@
         "group": null,
         "job_type": null,
         "mode": null,
-        "allow_resume": false,
+        "on_resume": "fork",
         "disable_artifact": true
     }
 }

--- a/configs/benchmarks/pi07_low_level.json
+++ b/configs/benchmarks/pi07_low_level.json
@@ -87,7 +87,7 @@
         "group": null,
         "job_type": null,
         "mode": null,
-        "allow_resume": false,
+        "on_resume": "fork",
         "disable_artifact": true
     }
 }

--- a/configs/benchmarks/pi07_paligemma_high_level.json
+++ b/configs/benchmarks/pi07_paligemma_high_level.json
@@ -78,7 +78,7 @@
         "group": null,
         "job_type": null,
         "mode": null,
-        "allow_resume": false,
+        "on_resume": "fork",
         "disable_artifact": true
     }
 }

--- a/configs/benchmarks/pi07_paligemma_low_level.json
+++ b/configs/benchmarks/pi07_paligemma_low_level.json
@@ -86,7 +86,7 @@
         "group": null,
         "job_type": null,
         "mode": null,
-        "allow_resume": false,
+        "on_resume": "fork",
         "disable_artifact": true
     }
 }

--- a/configs/dev/ci_config.json
+++ b/configs/dev/ci_config.json
@@ -88,7 +88,7 @@
         "group": null,
         "job_type": null,
         "mode": null,
-        "allow_resume": true,
+        "on_resume": "fork",
         "disable_artifact": false
     }
 }

--- a/configs/dev/dev_config.json
+++ b/configs/dev/dev_config.json
@@ -92,7 +92,7 @@
         "group": null,
         "job_type": null,
         "mode": null,
-        "allow_resume": true,
+        "on_resume": "fork",
         "disable_artifact": false
     }
 }

--- a/configs/examples/pi05_continuous_state_training_config.json
+++ b/configs/examples/pi05_continuous_state_training_config.json
@@ -97,7 +97,7 @@
         "group": null,
         "job_type": null,
         "mode": null,
-        "allow_resume": true,
+        "on_resume": "fork",
         "disable_artifact": false
     }
 }

--- a/configs/examples/pi05_inference_config.json
+++ b/configs/examples/pi05_inference_config.json
@@ -132,7 +132,7 @@
         "group": null,
         "job_type": null,
         "mode": null,
-        "allow_resume": true,
+        "on_resume": "fork",
         "disable_artifact": false
     }
 }

--- a/configs/examples/pi05_libero_eval_config.json
+++ b/configs/examples/pi05_libero_eval_config.json
@@ -153,7 +153,7 @@
         "group": null,
         "job_type": null,
         "mode": null,
-        "allow_resume": true,
+        "on_resume": "fork",
         "disable_artifact": false
     }
 }

--- a/configs/examples/pi05_mem_training_config.json
+++ b/configs/examples/pi05_mem_training_config.json
@@ -99,7 +99,7 @@
         "group": null,
         "job_type": null,
         "mode": null,
-        "allow_resume": true,
+        "on_resume": "fork",
         "disable_artifact": false
     },
     "env": {

--- a/configs/examples/pi05_robocasa_eval_config.json
+++ b/configs/examples/pi05_robocasa_eval_config.json
@@ -168,7 +168,7 @@
         "group": null,
         "job_type": null,
         "mode": null,
-        "allow_resume": true,
+        "on_resume": "fork",
         "disable_artifact": false
     }
 }

--- a/configs/examples/pi05_training_config.json
+++ b/configs/examples/pi05_training_config.json
@@ -97,7 +97,7 @@
         "group": null,
         "job_type": null,
         "mode": null,
-        "allow_resume": true,
+        "on_resume": "fork",
         "disable_artifact": false
     }
 }

--- a/configs/examples/pi06_training_config.json
+++ b/configs/examples/pi06_training_config.json
@@ -98,7 +98,7 @@
         "group": null,
         "job_type": null,
         "mode": null,
-        "allow_resume": true,
+        "on_resume": "fork",
         "disable_artifact": false
     }
 }

--- a/configs/examples/pi07_libero.json
+++ b/configs/examples/pi07_libero.json
@@ -98,7 +98,7 @@
         "group": null,
         "job_type": null,
         "mode": null,
-        "allow_resume": true,
+        "on_resume": "fork",
         "disable_artifact": false
     },
     "env": {

--- a/configs/examples/pi07_low_level_libero.json
+++ b/configs/examples/pi07_low_level_libero.json
@@ -92,7 +92,7 @@
         "group": null,
         "job_type": null,
         "mode": null,
-        "allow_resume": true,
+        "on_resume": "fork",
         "disable_artifact": false
     }
 }

--- a/configs/examples/pi_config.json
+++ b/configs/examples/pi_config.json
@@ -103,7 +103,7 @@
         "group": null,
         "job_type": null,
         "mode": null,
-        "allow_resume": true,
+        "on_resume": "fork",
         "disable_artifact": false
     },
     "env": {

--- a/configs/examples/value_config.json
+++ b/configs/examples/value_config.json
@@ -81,7 +81,7 @@
         "group": null,
         "job_type": null,
         "mode": null,
-        "allow_resume": true,
+        "on_resume": "fork",
         "disable_artifact": false
     }
 }

--- a/configs/libero/reproduce_pi05_libero.json
+++ b/configs/libero/reproduce_pi05_libero.json
@@ -95,7 +95,7 @@
         "group": null,
         "job_type": null,
         "mode": null,
-        "allow_resume": true,
+        "on_resume": "fork",
         "disable_artifact": false
     },
     "env": {

--- a/src/opentau/configs/default.py
+++ b/src/opentau/configs/default.py
@@ -479,6 +479,11 @@ class WandBConfig:
             )
             # True historically meant "resume the run in place" -> 'continue'.
             mapped = "continue" if self.allow_resume else "fork"
+            # Known limitation: because "fork" is also the default, we cannot tell an explicit
+            # `on_resume="fork"` apart from the default, so a deprecated `allow_resume=True` paired
+            # with an explicit `on_resume="fork"` silently lets the alias win (-> "continue"). The
+            # conflict warning below only fires for the unambiguous case (alias maps to "fork" while
+            # `on_resume` is "continue"). Both inputs together are a deprecated-config edge case.
             if self.on_resume == "fork":
                 # `on_resume` left at its default -> let the deprecated alias drive behavior.
                 self.on_resume = mapped

--- a/src/opentau/configs/default.py
+++ b/src/opentau/configs/default.py
@@ -22,7 +22,9 @@ This module provides default configuration classes for:
 - Evaluation settings and parameters
 """
 
+import warnings
 from dataclasses import dataclass, field
+from typing import Literal
 
 import draccus
 import numpy as np
@@ -429,8 +431,16 @@ class WandBConfig:
             Defaults to None.
         mode: Allowed values: 'online', 'offline', 'disabled'. Defaults to None
             (which uses 'online').
-        allow_resume: If True, resume the run from the last checkpoint when
-            `run_id` is provided. Defaults to True.
+        on_resume: What to do when resuming a run that has a `run_id` and a
+            training `step` (i.e. resuming from a checkpoint). Allowed values:
+            'fork' (default) creates a NEW run that branches from the parent at
+            the resume step via wandb's `fork_from`; 'continue' resumes the same
+            run in place (`resume='allow'`). Forking keeps the parent run
+            immutable and records server-side lineage; the cost is that a job
+            preempted/requeued N times produces a chain of N linked runs.
+        allow_resume: DEPRECATED, use `on_resume` instead. If set, it is mapped
+            to `on_resume` for backward compatibility (True -> 'continue',
+            False -> 'fork') and a `FutureWarning` is emitted. Defaults to None.
         disable_artifact: Set to True to disable saving an artifact despite
             `training.save_checkpoint=True`. Defaults to False.
         disable_video: Set to True to skip logging eval grid-summary videos to
@@ -449,14 +459,43 @@ class WandBConfig:
     group: str | None = None  # Used to group runs in the UI, e.g. "experiment_1", "experiment_2"
     job_type: str | None = None  # Used to group runs in the UI, e.g. "train", "eval", "test"
     mode: str | None = None  # Allowed values: 'online', 'offline' 'disabled'. Defaults to 'online'
-    allow_resume: bool | None = True  # If True, resume the run from the last checkpoint.
+    # On checkpoint resume: 'fork' a new branched run (default) or 'continue' the same run in place.
+    on_resume: Literal["fork", "continue"] = "fork"
+    # DEPRECATED, use `on_resume`. Mapped to `on_resume` for back-compat (True->continue, False->fork).
+    allow_resume: bool | None = None
     # Set to true to disable saving an artifact despite training.save_checkpoint=True
     disable_artifact: bool = False
     # Set to true to skip logging eval grid-summary videos to wandb.
     disable_video: bool = False
 
     def __post_init__(self):
-        """Prompt user for wandb notes if enabled and notes are not provided."""
+        """Map the deprecated `allow_resume` alias, validate, and prompt for notes."""
+        # Back-compat: `allow_resume` is deprecated in favor of `on_resume`.
+        if self.allow_resume is not None:
+            warnings.warn(
+                "`wandb.allow_resume` is deprecated; use `wandb.on_resume='fork'|'continue'`.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            # True historically meant "resume the run in place" -> 'continue'.
+            mapped = "continue" if self.allow_resume else "fork"
+            if self.on_resume == "fork":
+                # `on_resume` left at its default -> let the deprecated alias drive behavior.
+                self.on_resume = mapped
+            elif self.on_resume != mapped:
+                warnings.warn(
+                    f"Both `allow_resume`={self.allow_resume} and `on_resume`='{self.on_resume}' "
+                    "are set; using `on_resume`.",
+                    FutureWarning,
+                    stacklevel=2,
+                )
+            # Normalize so a re-saved checkpoint config does not re-trigger this warning forever.
+            self.allow_resume = None
+
+        if self.on_resume not in ("fork", "continue"):
+            raise ValueError(f"`on_resume` must be 'fork' or 'continue', got {self.on_resume!r}.")
+
+        # Prompt user for wandb notes if enabled and notes are not provided.
         if not self.enable or self.notes is not None:
             return
 
@@ -476,24 +515,40 @@ class WandBConfig:
             Dictionary of keyword arguments suitable for passing to wandb.init().
         """
         kwargs = encode_dataclass(self)
-        excluded_keys = ["enable", "disable_artifact", "disable_video", "project"]
+        # OpenTau-side switches that are not valid `wandb.init()` arguments.
+        excluded_keys = [
+            "enable",
+            "disable_artifact",
+            "disable_video",
+            "project",
+            "on_resume",
+            "allow_resume",
+        ]
         for ek in excluded_keys:
-            kwargs.pop(ek)
+            kwargs.pop(ek, None)
 
-        allow_resume = kwargs.pop("allow_resume")
         run_id = kwargs.pop("run_id", None)
 
-        # If both `run_id` and `step` are provided, we handle the resuming or forking logic.
+        # If both `run_id` and `step` are provided, we are resuming from a checkpoint and
+        # handle the resuming or forking logic. Use `step is not None` (not truthiness) so a
+        # resume from a step-0 checkpoint still forks at `?_step=0`.
         if run_id is not None and step is not None:
-            if allow_resume:
-                # if `allow_resume`, we resume from the `run_id` if provided.
+            offline = self.mode in ("offline", "disabled")
+            if self.on_resume == "continue":
+                # Resume the same run in place.
                 kwargs["id"] = run_id
                 kwargs["resume"] = "allow"
+            elif not offline:
+                # Fork a new run that branches from the parent at `step`. Server-side lineage
+                # requires an online run, hence the offline guard below.
+                kwargs["fork_from"] = f"{run_id}?_step={step}"
+                note = f"Forked from run {run_id} at step {step}."
+                kwargs["notes"] = note if kwargs.get("notes") is None else f"{kwargs['notes']}\n{note}"
             else:
-                # Without `allow_resume`, we create a new run,
-                # and add information about the forked run in the notes.
-                # TODO request `kwargs[fork_from]=f"{run_id}?_step={step}"` feature from wandb
-                kwargs["notes"] += f"\nForked from run {run_id} at step {step}."
+                # Offline/disabled: lineage cannot be resolved, so start a fresh run and only
+                # record the intended fork in the notes.
+                note = f"(offline) would fork from run {run_id} at step {step}."
+                kwargs["notes"] = note if kwargs.get("notes") is None else f"{kwargs['notes']}\n{note}"
 
         return kwargs
 

--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -372,6 +372,61 @@ def _commit_wandb_step(accelerator: accelerate.Accelerator, step: int) -> None:
     accelerator.log({}, step=step, log_kwargs={"wandb": {"commit": True}})
 
 
+def _init_wandb_trackers(
+    accelerator: accelerate.Accelerator,
+    cfg: TrainPipelineConfig,
+    tracker_config: dict,
+    step: int | None,
+) -> object:
+    """Initialize the wandb tracker, forking on resume when configured.
+
+    Wraps ``accelerator.init_trackers`` so that a fork failure does not crash a
+    resume. Forking (``wandb.on_resume="fork"``) needs a paid wandb tier and a
+    resolvable parent run; wandb raises a ``wandb.Error`` (``CommError``) if
+    either is missing (e.g. a free tier, or a stale / deleted parent id). In that
+    case we drop ``fork_from`` and retry as an in-place resume of the parent run
+    so the run still starts. Non-wandb exceptions (and wandb errors on a
+    non-fork init) propagate unchanged.
+
+    Args:
+        accelerator: The active accelerate ``Accelerator`` (caller must already
+            be on the main process, where the trackers live).
+        cfg: The training config; ``cfg.wandb`` drives the init kwargs and holds
+            the parent ``run_id`` used by the fork fallback.
+        tracker_config: The config dict logged to wandb (passed through verbatim).
+        step: The resume step (``None`` for a fresh run), forwarded to
+            ``WandBConfig.to_wandb_kwargs``.
+
+    Returns:
+        The unwrapped wandb run object.
+    """
+    wandb_kwargs = cfg.wandb.to_wandb_kwargs(step=step)
+    try:
+        accelerator.init_trackers(
+            cfg.wandb.project, config=tracker_config, init_kwargs={"wandb": wandb_kwargs}
+        )
+    except wandb.Error as e:
+        # Only the fork path has a meaningful fallback; a non-fork wandb failure is a real error.
+        if "fork_from" not in wandb_kwargs:
+            raise
+        logging.warning(
+            f"wandb fork_from={wandb_kwargs['fork_from']!r} failed ({e}); falling back to resuming "
+            "the run in place. Forking requires a paid wandb tier and a resolvable parent run."
+        )
+        # Build a fresh dict for the retry (do not mutate the kwargs already handed to the failed
+        # call). Drop `fork_from`, drop the now-inaccurate "Forked from ..." note that
+        # `to_wandb_kwargs` added (restore the user's original notes), and resume in place.
+        retry_kwargs = {k: v for k, v in wandb_kwargs.items() if k != "fork_from"}
+        retry_kwargs["notes"] = cfg.wandb.notes
+        if cfg.wandb.run_id is not None:
+            retry_kwargs["id"] = cfg.wandb.run_id
+            retry_kwargs["resume"] = "allow"
+        accelerator.init_trackers(
+            cfg.wandb.project, config=tracker_config, init_kwargs={"wandb": retry_kwargs}
+        )
+    return accelerator.get_tracker("wandb", unwrap=True)
+
+
 def _mixture_weighted_aggregate(
     per_dataset_trackers: dict[str, MetricsTracker],
     name_to_weight: dict[str, float],
@@ -633,30 +688,7 @@ def train(cfg: TrainPipelineConfig):
             step = load_training_step(cfg.checkpoint_path) if cfg.resume else None
             slurm_dict = {k: v for k, v in os.environ.items() if k.startswith("SLURM_")}
             tracker_config = {**cfg.to_dict(), "accelerator": accelerator_config, "slurm": slurm_dict}
-            wandb_kwargs = cfg.wandb.to_wandb_kwargs(step=step)
-            try:
-                accelerator.init_trackers(
-                    cfg.wandb.project, config=tracker_config, init_kwargs={"wandb": wandb_kwargs}
-                )
-            except Exception as e:
-                # Forking (`on_resume="fork"`) needs a paid wandb tier and a resolvable parent
-                # run; wandb raises CommError if either is missing (e.g. free tier, or a stale /
-                # deleted parent id). Fall back to resuming the parent run in place so a resume
-                # never hard-crashes at init. Re-raise anything unrelated to forking.
-                if "fork_from" not in wandb_kwargs:
-                    raise
-                logging.warning(
-                    f"wandb fork_from={wandb_kwargs['fork_from']!r} failed ({e}); falling back to "
-                    "resuming the run in place. Forking requires a paid wandb tier."
-                )
-                wandb_kwargs.pop("fork_from", None)
-                if cfg.wandb.run_id is not None:
-                    wandb_kwargs["id"] = cfg.wandb.run_id
-                    wandb_kwargs["resume"] = "allow"
-                accelerator.init_trackers(
-                    cfg.wandb.project, config=tracker_config, init_kwargs={"wandb": wandb_kwargs}
-                )
-            tracker = accelerator.get_tracker("wandb", unwrap=True)
+            tracker = _init_wandb_trackers(accelerator, cfg, tracker_config, step)
             cfg.wandb.run_id = tracker.id
             logging.info(f"tracker initialized with wandb job id: {tracker.id}")
 

--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -632,11 +632,30 @@ def train(cfg: TrainPipelineConfig):
         if cfg.wandb.enable:
             step = load_training_step(cfg.checkpoint_path) if cfg.resume else None
             slurm_dict = {k: v for k, v in os.environ.items() if k.startswith("SLURM_")}
-            accelerator.init_trackers(
-                cfg.wandb.project,
-                config={**cfg.to_dict(), "accelerator": accelerator_config, "slurm": slurm_dict},
-                init_kwargs={"wandb": cfg.wandb.to_wandb_kwargs(step=step)},
-            )
+            tracker_config = {**cfg.to_dict(), "accelerator": accelerator_config, "slurm": slurm_dict}
+            wandb_kwargs = cfg.wandb.to_wandb_kwargs(step=step)
+            try:
+                accelerator.init_trackers(
+                    cfg.wandb.project, config=tracker_config, init_kwargs={"wandb": wandb_kwargs}
+                )
+            except Exception as e:
+                # Forking (`on_resume="fork"`) needs a paid wandb tier and a resolvable parent
+                # run; wandb raises CommError if either is missing (e.g. free tier, or a stale /
+                # deleted parent id). Fall back to resuming the parent run in place so a resume
+                # never hard-crashes at init. Re-raise anything unrelated to forking.
+                if "fork_from" not in wandb_kwargs:
+                    raise
+                logging.warning(
+                    f"wandb fork_from={wandb_kwargs['fork_from']!r} failed ({e}); falling back to "
+                    "resuming the run in place. Forking requires a paid wandb tier."
+                )
+                wandb_kwargs.pop("fork_from", None)
+                if cfg.wandb.run_id is not None:
+                    wandb_kwargs["id"] = cfg.wandb.run_id
+                    wandb_kwargs["resume"] = "allow"
+                accelerator.init_trackers(
+                    cfg.wandb.project, config=tracker_config, init_kwargs={"wandb": wandb_kwargs}
+                )
             tracker = accelerator.get_tracker("wandb", unwrap=True)
             cfg.wandb.run_id = tracker.id
             logging.info(f"tracker initialized with wandb job id: {tracker.id}")

--- a/tests/configs/test_default.py
+++ b/tests/configs/test_default.py
@@ -229,7 +229,12 @@ def test_invalid_negative_bare_dataset_tolerance_raises():
 
 
 class TestWandBConfig:
-    """Cover the optional ``disable_video`` flag on ``WandBConfig``."""
+    """Cover the ``disable_video`` flag and the ``on_resume`` fork/continue behavior.
+
+    All cases use ``enable=False`` (the default) so ``__post_init__`` never hits
+    the interactive ``input()`` notes prompt (the patching fixture is opt-in, not
+    autouse, so an enabled config without ``notes`` would block on stdin).
+    """
 
     def test_disable_video_defaults_to_false(self):
         """Videos are logged by default — the flag is opt-in (like
@@ -243,6 +248,82 @@ class TestWandBConfig:
         unknown keyword."""
         cfg = WandBConfig(disable_video=True)
         assert "disable_video" not in cfg.to_wandb_kwargs()
+
+    # --- on_resume: fork (default) vs continue ---------------------------------
+
+    def test_on_resume_defaults_to_fork(self):
+        """Resuming forks a new branched run by default."""
+        assert WandBConfig().on_resume == "fork"
+
+    def test_fork_path_sets_fork_from_and_not_resume(self):
+        """With ``on_resume='fork'`` (default), a resume (run_id + step) emits
+        ``fork_from`` and must NOT set ``id``/``resume`` (which would instead
+        continue the parent run in place)."""
+        kwargs = WandBConfig(run_id="abc", notes="n").to_wandb_kwargs(step=100)
+        assert kwargs["fork_from"] == "abc?_step=100"
+        assert "id" not in kwargs
+        assert "resume" not in kwargs
+
+    def test_continue_path_sets_resume_and_not_fork(self):
+        """``on_resume='continue'`` resumes the same run in place."""
+        kwargs = WandBConfig(on_resume="continue", run_id="abc").to_wandb_kwargs(step=100)
+        assert kwargs["id"] == "abc"
+        assert kwargs["resume"] == "allow"
+        assert "fork_from" not in kwargs
+
+    def test_no_run_id_or_step_is_a_fresh_run(self):
+        """Without both a run_id and a step there is nothing to fork/resume from,
+        so neither ``fork_from`` nor ``id`` is emitted."""
+        # No run_id, step given.
+        assert "fork_from" not in WandBConfig().to_wandb_kwargs(step=100)
+        # run_id given but step is None (e.g. not actually resuming).
+        kwargs = WandBConfig(run_id="abc").to_wandb_kwargs(step=None)
+        assert "fork_from" not in kwargs and "id" not in kwargs
+
+    def test_fork_at_step_zero(self):
+        """``step=0`` must still fork (guards against a truthiness check)."""
+        kwargs = WandBConfig(run_id="abc", notes="n").to_wandb_kwargs(step=0)
+        assert kwargs["fork_from"] == "abc?_step=0"
+
+    def test_fork_with_none_notes_does_not_crash(self):
+        """``notes`` defaults to None and the fork path now runs on every resume,
+        so the annotation must be built without ``None + str``."""
+        kwargs = WandBConfig(run_id="abc").to_wandb_kwargs(step=7)
+        assert kwargs["fork_from"] == "abc?_step=7"
+        assert "Forked from run abc at step 7" in kwargs["notes"]
+
+    def test_offline_mode_skips_fork_from(self):
+        """Server-side lineage cannot be resolved offline, so ``fork_from`` is
+        dropped (a fresh run is started) and the intent is left in the notes."""
+        kwargs = WandBConfig(mode="offline", run_id="abc").to_wandb_kwargs(step=5)
+        assert "fork_from" not in kwargs
+        assert "would fork from run abc at step 5" in kwargs["notes"]
+
+    def test_on_resume_and_allow_resume_excluded_from_init_kwargs(self):
+        """Both are OpenTau-side switches; neither is a valid ``wandb.init()``
+        keyword."""
+        kwargs = WandBConfig().to_wandb_kwargs()
+        assert "on_resume" not in kwargs
+        assert "allow_resume" not in kwargs
+
+    def test_invalid_on_resume_raises(self):
+        with pytest.raises(ValueError, match="on_resume"):
+            WandBConfig(on_resume="bogus")
+
+    # --- deprecated allow_resume alias -----------------------------------------
+
+    def test_allow_resume_true_maps_to_continue_with_warning(self):
+        with pytest.warns(FutureWarning, match="allow_resume"):
+            cfg = WandBConfig(allow_resume=True)
+        assert cfg.on_resume == "continue"
+        # Normalized so a re-saved checkpoint config does not re-warn forever.
+        assert cfg.allow_resume is None
+
+    def test_allow_resume_false_maps_to_fork_with_warning(self):
+        with pytest.warns(FutureWarning, match="allow_resume"):
+            cfg = WandBConfig(allow_resume=False)
+        assert cfg.on_resume == "fork"
+        assert cfg.allow_resume is None
 
 
 class TestDatasetConfigDataMapping:

--- a/tests/scripts/test_train.py
+++ b/tests/scripts/test_train.py
@@ -30,12 +30,14 @@ from unittest.mock import Mock
 import accelerate
 import pytest
 import torch
+import wandb
 
 from opentau.scripts.train import (
     _bucket_per_sample,
     _commit_wandb_step,
     _eval_with_fresh_envs,
     _find_unused_params_from_env,
+    _init_wandb_trackers,
     _mixture_weighted_aggregate,
     _sync_deepspeed_gradient_accumulation_steps,
 )
@@ -329,6 +331,62 @@ class TestCommitWandbStep:
         _commit_wandb_step(accelerator, 1234)
 
         assert calls == [({}, 1234, {"wandb": {"commit": True}})]
+
+
+class TestInitWandbTrackers:
+    """``_init_wandb_trackers`` forks on resume and degrades safely on a fork failure."""
+
+    @staticmethod
+    def _cfg(**wandb_kwargs):
+        from opentau.configs.default import WandBConfig
+
+        return SimpleNamespace(wandb=WandBConfig(enable=False, project="proj", **wandb_kwargs))
+
+    def test_fork_passes_fork_from_in_single_init(self):
+        """A successful resume-fork issues exactly one init carrying ``fork_from``
+        and returns the new tracker."""
+        cfg = self._cfg(run_id="parent", notes="user notes")
+        init = Mock()
+        accelerator = SimpleNamespace(
+            init_trackers=init, get_tracker=lambda name, unwrap: SimpleNamespace(id="forked")
+        )
+
+        run = _init_wandb_trackers(accelerator, cfg, {"cfg": 1}, step=50)
+
+        assert run.id == "forked"
+        assert init.call_count == 1
+        assert init.call_args.kwargs["init_kwargs"]["wandb"]["fork_from"] == "parent?_step=50"
+
+    def test_fork_failure_falls_back_to_in_place_resume(self):
+        """A ``wandb.Error`` on the fork init drops ``fork_from``, restores the user's
+        notes (no stale "Forked from ..." annotation), and retries as an in-place
+        resume (``id`` + ``resume='allow'``)."""
+        cfg = self._cfg(run_id="parent", notes="user notes")
+        init = Mock(side_effect=[wandb.errors.CommError("run not found"), None])
+        accelerator = SimpleNamespace(
+            init_trackers=init, get_tracker=lambda name, unwrap: SimpleNamespace(id="resumed")
+        )
+
+        run = _init_wandb_trackers(accelerator, cfg, {"cfg": 1}, step=50)
+
+        assert run.id == "resumed"
+        assert init.call_count == 2
+        first = init.call_args_list[0].kwargs["init_kwargs"]["wandb"]
+        assert first["fork_from"] == "parent?_step=50"
+        retry = init.call_args_list[1].kwargs["init_kwargs"]["wandb"]
+        assert "fork_from" not in retry
+        assert retry["id"] == "parent" and retry["resume"] == "allow"
+        assert retry["notes"] == "user notes"
+
+    def test_non_fork_wandb_error_propagates(self):
+        """A ``wandb.Error`` on a non-fork init (no ``run_id`` -> no ``fork_from``) is a
+        real failure and must not be swallowed by the fork fallback."""
+        cfg = self._cfg()  # no run_id -> to_wandb_kwargs emits no fork_from
+        init = Mock(side_effect=wandb.errors.CommError("boom"))
+        accelerator = SimpleNamespace(init_trackers=init, get_tracker=lambda name, unwrap: None)
+
+        with pytest.raises(wandb.errors.CommError):
+            _init_wandb_trackers(accelerator, cfg, {"cfg": 1}, step=None)
 
 
 class TestEvalWithFreshEnvs:


### PR DESCRIPTION
## What this does

Makes wandb's `fork_from` the automatic default when a training run resumes from a checkpoint (🗃️ Feature). On resume, OpenTau now creates a **new wandb run that branches from the parent at the resume step** (`wandb.init(fork_from="<run_id>?_step=<step>")`) instead of continuing the same run or only annotating `notes`. The parent run stays immutable and the branch lineage is recorded server-side, which is cleaner when a resume is an intentional experiment branch.

This finishes the existing `# TODO request kwargs[fork_from]=...` in `WandBConfig.to_wandb_kwargs` — the scaffolding (`run_id` persisted into the checkpoint config, `step` from `load_training_step`) was already in place.

**Changes**
- New `WandBConfig.on_resume: Literal["fork", "continue"]`, defaulting to `"fork"`. `"continue"` keeps the old single-run behavior per run.
- `allow_resume` kept as a **deprecated alias** (`True -> continue`, `False -> fork`), mapped in `__post_init__` with a `FutureWarning` and normalized to `None` so a re-saved checkpoint config never re-warns. It is intentionally **not removed** — draccus rejects unknown keys, so old checkpoints must still decode it.
- `to_wandb_kwargs` now emits real `fork_from`, with a None-safe `notes` annotation and an offline/disabled guard (server-side lineage needs an online run).
- `train.py` wraps `init_trackers`: if a fork fails (free wandb tier, or a stale/deleted parent id — wandb surfaces this as `CommError`) it logs a warning and falls back to resuming the run in place, so a resume never hard-crashes at init.
- All 20 checked-in configs migrated from `allow_resume` to `"on_resume": "fork"`.

**Trade-off:** a job that is preempted/requeued N times now produces a chain of N linked runs rather than one continuous run. That is the accepted behavior; set `wandb.on_resume="continue"` to opt out.

**Not a policy change.** The `train.py` edit is confined to the rank-0 `if cfg.wandb.enable:` init block; it touches no loss / optimizer / dataloader / RNG / sampler path, so training determinism is unaffected by construction (no same-seed double-run needed, and no GPU/regression suite is meaningful for it).

## How it was tested

- Added 13 cases to `TestWandBConfig` in `tests/configs/test_default.py` covering: default `on_resume == "fork"`; the fork path emits `fork_from` and not `id`/`resume`; the continue path emits `id`/`resume` and not `fork_from`; fresh-run cases (no `run_id`, or `step is None`); `step=0` still forks (guards a truthiness bug); None-`notes` does not crash; the offline guard drops `fork_from`; both `on_resume`/`allow_resume` are excluded from `wandb.init` kwargs; the deprecated `allow_resume` alias maps + emits `FutureWarning` + normalizes to `None`; and invalid `on_resume` raises.
- `pytest -m "not gpu and not network" tests/configs/test_default.py tests/configs/test_refs.py` → **61 passed**, including a `-W error::FutureWarning` run proving no non-asserting path trips the deprecation. `tests/scripts/test_train.py -k "wandb or commit or tracker"` → **3 passed**.
- Verified all checked-in training configs still decode and none carry a stray `allow_resume`.
- End-to-end against the **real init path** on a paid-tier wandb team: drove `WandBConfig.to_wandb_kwargs` → the exact `accelerator.init_trackers(init_kwargs={"wandb": ...})` call `train.py` uses → confirmed the forked run's server-side `branchPoint = {run: <parent>, step: <fork step>}`.
- `pre-commit run --all-files` on the changed files: clean.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/configs/test_default.py::TestWandBConfig
```
```bash
pytest -sx tests/configs/test_refs.py
```
Inspect the resulting `wandb.init` kwargs directly:
```bash
python -c "from opentau.configs.default import WandBConfig as W; \
print(W(run_id='abc', notes='n').to_wandb_kwargs(step=100)); \
print(W(on_resume='continue', run_id='abc').to_wandb_kwargs(step=100))"
# -> {... 'fork_from': 'abc?_step=100'}   and   {... 'id': 'abc', 'resume': 'allow'}
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
