### PR TITLE
Adding async high level planner and vla code to server.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,6 +205,8 @@ where = ["src"]
 # Ship the custom flash-attention CUDA source so the kernel can be JIT-compiled
 # from an installed wheel (not just an editable/source checkout).
 "opentau.policies.flash_attn_cuda" = ["_csrc/*.cu", "_csrc/*.cuh", "_csrc/*.cpp", "_csrc/*.h"]
+# Ship the planner prompt library so installed (non-editable) wheels can load it.
+"opentau.planner" = ["prompts.yaml"]
 
 [tool.ruff]
 line-length = 110

--- a/src/opentau/configs/deployment.py
+++ b/src/opentau/configs/deployment.py
@@ -96,3 +96,67 @@ class ServerConfig:
             Maximum receive message length in bytes.
         """
         return self.max_receive_message_length_mb * 1024 * 1024
+
+
+@dataclass
+class PlannerConfig:
+    """Configuration for the high-level planner of the gRPC inference server.
+
+    When ``enabled`` is False (the default), the inference server runs the VLA
+    policy only. When enabled, a Gemini Robotics-ER planner runs
+    asynchronously alongside the policy: it
+    consumes the latest observation (images, state) plus the request prompt
+    (treated as the overall task) and a memory-as-language string, and produces
+    the subtask the VLA policy is conditioned on.
+
+    Args:
+        enabled: Whether to spin up the high-level planner. Defaults to False.
+        model: Gemini model ID used for planning. Defaults to
+            ``gemini-robotics-er-1.5-preview``.
+        api_key_env: Environment variable holding the Gemini API key
+            (``GOOGLE_API_KEY`` is also tried as a fallback). Defaults to
+            ``GEMINI_API_KEY``.
+        interval_s: Wall-clock seconds between planner calls. The planner runs
+            on its own free-running background loop, decoupled from request
+            arrival; the VLA path never blocks on replanning and reads
+            whatever subtask is currently available. The loop skips a cycle
+            when no new observation arrived since the last plan. Defaults
+            to 5.0.
+        first_plan_timeout_s: Maximum seconds a request blocks at the start of
+            inference for a task (no subtask available yet) waiting for the
+            initial subtask. On timeout the request falls back to the raw
+            task prompt. Defaults to 30.0.
+        max_output_tokens: Generation cap for the planner response.
+            Defaults to 512.
+        temperature: Sampling temperature for the planner. Defaults to 0.0.
+        include_state: Whether to include the robot proprioceptive state in
+            the planner prompt. Defaults to True.
+        system_prompt_key: Key into ``planner/prompts.yaml`` for the system
+            prompt template.
+        user_prompt_key: Key into ``planner/prompts.yaml`` for the user
+            prompt template.
+
+    Raises:
+        ValueError: If ``interval_s``, ``first_plan_timeout_s`` or
+            ``max_output_tokens`` are out of range.
+    """
+
+    enabled: bool = False
+    model: str = "gemini-robotics-er-1.5-preview"
+    api_key_env: str = "GEMINI_API_KEY"
+    interval_s: float = 5.0
+    first_plan_timeout_s: float = 30.0
+    max_output_tokens: int = 512
+    temperature: float = 0.0
+    include_state: bool = True
+    system_prompt_key: str = "gemini_er_planner_system"
+    user_prompt_key: str = "gemini_er_planner_user"
+
+    def __post_init__(self):
+        """Validate planner configuration parameters."""
+        if self.interval_s <= 0:
+            raise ValueError(f"`interval_s` must be positive, got {self.interval_s}.")
+        if self.first_plan_timeout_s <= 0:
+            raise ValueError(f"`first_plan_timeout_s` must be positive, got {self.first_plan_timeout_s}.")
+        if self.max_output_tokens < 1:
+            raise ValueError(f"`max_output_tokens` must be at least 1, got {self.max_output_tokens}.")

--- a/src/opentau/configs/train.py
+++ b/src/opentau/configs/train.py
@@ -32,7 +32,7 @@ from huggingface_hub.errors import HfHubHTTPError
 
 from opentau.configs import parser
 from opentau.configs.default import DatasetMixtureConfig, EvalConfig, WandBConfig
-from opentau.configs.deployment import ServerConfig
+from opentau.configs.deployment import PlannerConfig, ServerConfig
 from opentau.configs.policies import (
     PreTrainedConfig,
     load_resolved_config_dict,
@@ -139,6 +139,9 @@ class TrainPipelineConfig(HubMixin):
             resolves to "eval_success" when sim eval is configured (env set and eval_freq > 0),
             otherwise "val_loss". Only used when `running_best_count` >= 1. Defaults to "auto".
         server: Configuration for the gRPC inference server. Defaults to ServerConfig().
+        planner: Configuration for the high-level planner of the gRPC inference server
+            (`server.py`). Disabled by default, in which case only the VLA policy is
+            served. Defaults to PlannerConfig().
     """
 
     dataset_mixture: DatasetMixtureConfig
@@ -194,6 +197,8 @@ class TrainPipelineConfig(HubMixin):
     running_best_metric: str = "auto"  # "auto" | "eval_success" | "val_loss"
     # gRPC inference server configuration
     server: ServerConfig = field(default_factory=ServerConfig)
+    # high-level planner configuration for the hierarchical gRPC inference server
+    planner: PlannerConfig = field(default_factory=PlannerConfig)
 
     def __post_init__(self):
         """Initialize post-creation attributes and validate batch size configuration."""

--- a/src/opentau/planner/__init__.py
+++ b/src/opentau/planner/__init__.py
@@ -45,6 +45,9 @@ Main Classes:
       GPT-4o and open-source vision-language models (CogVLM, SmolVLM variants).
     - **NavHighLevelPlanner**: Specialized planner for navigation tasks with
       support for processing multiple camera views.
+    - **GeminiERPlanner**: Memory-as-language planner backed by Gemini
+      Robotics-ER; each call rewrites a memory string and returns the next
+      subtask for a low-level VLA policy.
     - **Memory**: Conversation history manager that stores and retrieves
       multi-turn conversations between user and LLM assistant.
 
@@ -52,7 +55,8 @@ Supported Models:
 
     - **Open-source**: CogVLM-Chat-HF, SmolVLM-256M-Instruct,
       SmolVLM-500M-Instruct, SmolVLM2-2.2B-Instruct
-    - **Closed-source**: GPT-4o (via OpenAI API)
+    - **Closed-source**: GPT-4o (via OpenAI API), Gemini Robotics-ER
+      (via google-genai API)
 
 Modules:
 
@@ -77,6 +81,8 @@ Example:
         ... )
 """
 
+from .gemini_er_planner import GeminiERPlanner as GeminiERPlanner
+from .gemini_er_planner import PlanResult as PlanResult
 from .high_level_planner import HighLevelPlanner as HighLevelPlanner
 from .high_level_planner import NavHighLevelPlanner as NavHighLevelPlanner
 from .utils.memory import Memory as Memory

--- a/src/opentau/planner/gemini_er_planner.py
+++ b/src/opentau/planner/gemini_er_planner.py
@@ -1,0 +1,290 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""High-level planner backed by Gemini Robotics-ER.
+
+The planner implements the "memory-as-language" pattern: each call receives the
+overall task, the memory string the model wrote on the previous call, the
+current camera images and (optionally) the robot proprioceptive state, and
+returns a rewritten memory plus the next subtask. The subtask is phrased as a
+short imperative language command suitable for conditioning a low-level VLA
+policy.
+
+Example:
+    >>> from opentau.planner import GeminiERPlanner
+    >>> planner = GeminiERPlanner()  # needs GEMINI_API_KEY in the environment
+    >>> result = planner.plan(
+    ...     task="put all the blocks in the bin",
+    ...     images=[jpeg_bytes],
+    ...     state=[0.0] * 7,
+    ...     memory="",
+    ... )
+    >>> result.subtask, result.memory
+"""
+
+import io
+import json
+import logging
+import os
+import re
+import time
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+import torch
+from google import genai
+from google.genai import types as genai_types
+from PIL import Image
+
+from opentau.planner.utils.utils import load_prompt_library
+
+logger = logging.getLogger(__name__)
+
+# Image types accepted by `GeminiERPlanner.plan`: encoded bytes (assumed JPEG),
+# a `(bytes, encoding)` tuple ("jpeg" or "png"), a PIL image, or a float tensor
+# of shape (3, H, W) or (1, 3, H, W) with values in [0, 1].
+PlannerImage = bytes | tuple[bytes, str] | Image.Image | torch.Tensor
+
+_JSON_FENCE_RE = re.compile(r"^```(?:json)?\s*|\s*```$")
+
+_PLAN_RESPONSE_SCHEMA = {
+    "type": "OBJECT",
+    "properties": {
+        "memory": {"type": "STRING"},
+        "subtask": {"type": "STRING"},
+    },
+    "required": ["memory", "subtask"],
+}
+
+
+@dataclass(frozen=True)
+class PlanResult:
+    """Result of one high-level planning call.
+
+    Args:
+        subtask: The next subtask for the low-level VLA policy.
+        memory: The rewritten memory-as-language string.
+        raw_text: Raw model output text, for logging/debugging.
+        latency_s: Wall-clock seconds the model call took.
+    """
+
+    subtask: str
+    memory: str
+    raw_text: str
+    latency_s: float
+
+
+def _parse_plan_response(text: str, prev_memory: str) -> tuple[str, str]:
+    """Parse the planner's JSON response into ``(subtask, memory)``.
+
+    Args:
+        text: Raw model output, possibly wrapped in markdown code fences.
+        prev_memory: Memory from the previous call, used as a fallback when the
+            response omits the ``memory`` key.
+
+    Returns:
+        Tuple of ``(subtask, memory)``.
+
+    Raises:
+        ValueError: If the response is not valid JSON or lacks a ``subtask``.
+    """
+    cleaned = _JSON_FENCE_RE.sub("", text.strip())
+    try:
+        parsed = json.loads(cleaned)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Planner response is not valid JSON: {text!r}") from e
+    if not isinstance(parsed, dict):
+        raise ValueError(f"Planner response is not a JSON object: {text!r}")
+
+    subtask = parsed.get("subtask")
+    if not isinstance(subtask, str) or not subtask.strip():
+        raise ValueError(f"Planner response has no 'subtask': {text!r}")
+
+    memory = parsed.get("memory")
+    if not isinstance(memory, str) or not memory.strip():
+        memory = prev_memory
+
+    return subtask.strip(), memory.strip()
+
+
+def _to_part(image: PlannerImage) -> genai_types.Part:
+    """Convert a supported image input into a google-genai content ``Part``.
+
+    Encoded bytes are forwarded verbatim (no re-encode); PIL images and float
+    tensors are JPEG-encoded.
+    """
+    if isinstance(image, bytes):
+        return genai_types.Part.from_bytes(data=image, mime_type="image/jpeg")
+    if isinstance(image, tuple):
+        data, encoding = image
+        return genai_types.Part.from_bytes(data=data, mime_type=f"image/{encoding.lower()}")
+    if isinstance(image, torch.Tensor):
+        tensor = image.detach().squeeze(0) if image.dim() == 4 else image.detach()
+        if tensor.dim() != 3:
+            raise ValueError(f"Expected image tensor of shape (3, H, W) or (1, 3, H, W), got {image.shape}")
+        tensor = (tensor.to(dtype=torch.float32, device="cpu").clamp(0, 1) * 255.0).to(torch.uint8)
+        image = Image.fromarray(tensor.permute(1, 2, 0).numpy())
+    if isinstance(image, Image.Image):
+        buffer = io.BytesIO()
+        image.convert("RGB").save(buffer, format="JPEG")
+        return genai_types.Part.from_bytes(data=buffer.getvalue(), mime_type="image/jpeg")
+    raise TypeError(f"Unsupported planner image type: {type(image)}")
+
+
+class GeminiERPlanner:
+    """High-level planner that queries Gemini Robotics-ER for the next subtask.
+
+    Unlike the conversation-history planners in ``high_level_planner.py``, the
+    only persistent state is the memory string the model itself rewrites on
+    every call — the caller owns it and passes it back in.
+    """
+
+    DEFAULT_MODEL = "gemini-robotics-er-1.5-preview"
+
+    def __init__(
+        self,
+        model: str = DEFAULT_MODEL,
+        api_key: str | None = None,
+        api_key_env: str = "GEMINI_API_KEY",
+        max_output_tokens: int = 512,
+        temperature: float = 0.0,
+        system_prompt_key: str = "gemini_er_planner_system",
+        user_prompt_key: str = "gemini_er_planner_user",
+        client: genai.Client | None = None,
+    ):
+        """Initialize the planner.
+
+        Args:
+            model: Gemini model ID.
+            api_key: Explicit API key. When None, ``api_key_env`` then
+                ``GOOGLE_API_KEY`` are tried.
+            api_key_env: Environment variable to read the API key from.
+            max_output_tokens: Generation cap for the planner response.
+            temperature: Sampling temperature.
+            system_prompt_key: Key into ``planner/prompts.yaml`` for the system prompt.
+            user_prompt_key: Key into ``planner/prompts.yaml`` for the user prompt.
+            client: Pre-built genai client (used in tests). When provided,
+                no API key is required.
+
+        Raises:
+            ValueError: If no API key is resolvable or a prompt key is missing.
+        """
+        self.model = model
+        self.max_output_tokens = max_output_tokens
+        self.temperature = temperature
+
+        prompts_path = Path(__file__).resolve().parent / "prompts.yaml"
+        prompt_library = load_prompt_library(str(prompts_path))
+        if not prompt_library:
+            raise ValueError(f"Could not load prompt library from {prompts_path}")
+        prompts = prompt_library["prompts"]
+        for key in (system_prompt_key, user_prompt_key):
+            if key not in prompts:
+                raise ValueError(f"Prompt key '{key}' not found in {prompts_path}")
+        self.system_prompt = prompts[system_prompt_key]["template"]
+        self.user_prompt_template = prompts[user_prompt_key]["template"]
+
+        if client is not None:
+            self.client = client
+        else:
+            api_key = api_key or os.environ.get(api_key_env) or os.environ.get("GOOGLE_API_KEY")
+            if not api_key:
+                raise ValueError(
+                    f"No Gemini API key found: pass `api_key` or set ${api_key_env} (or $GOOGLE_API_KEY)."
+                )
+            self.client = genai.Client(api_key=api_key)
+
+        # Structured-output support is unverified on the ER preview family;
+        # fall back to mime-type-only JSON once if the API rejects the schema.
+        self._schema_supported = True
+
+    def _build_user_prompt(self, task: str, memory: str, state: Sequence[float] | None) -> str:
+        """Fill the user prompt template with task, memory and state."""
+        state_str = "(not provided)" if state is None else str([round(float(s), 4) for s in state])
+        return self.user_prompt_template.format(
+            task=task,
+            memory=memory.strip() or "(empty — first call)",
+            state=state_str,
+        )
+
+    def _generate(self, contents: list) -> str:
+        """Call the model, retrying once without ``response_schema`` if rejected."""
+        config_kwargs = {
+            "system_instruction": self.system_prompt,
+            "temperature": self.temperature,
+            "max_output_tokens": self.max_output_tokens,
+            "response_mime_type": "application/json",
+        }
+        if self._schema_supported:
+            try:
+                response = self.client.models.generate_content(
+                    model=self.model,
+                    contents=contents,
+                    config=genai_types.GenerateContentConfig(
+                        **config_kwargs, response_schema=_PLAN_RESPONSE_SCHEMA
+                    ),
+                )
+                return self._response_text(response)
+            except genai.errors.APIError as e:
+                if "schema" not in str(e).lower():
+                    raise
+                logger.warning("Model %s rejected response_schema; retrying without it: %s", self.model, e)
+                self._schema_supported = False
+
+        response = self.client.models.generate_content(
+            model=self.model,
+            contents=contents,
+            config=genai_types.GenerateContentConfig(**config_kwargs),
+        )
+        return self._response_text(response)
+
+    @staticmethod
+    def _response_text(response) -> str:
+        text = (response.text or "").strip()
+        if not text:
+            finish_reason = response.candidates[0].finish_reason if response.candidates else None
+            raise ValueError(f"Planner response had no text (finish_reason={finish_reason}).")
+        return text
+
+    def plan(
+        self,
+        task: str,
+        images: Sequence[PlannerImage],
+        state: Sequence[float] | None = None,
+        memory: str = "",
+    ) -> PlanResult:
+        """Run one planning step.
+
+        Args:
+            task: The overall task the robot must complete.
+            images: Current camera images (see ``PlannerImage`` for accepted types).
+            state: Optional robot proprioceptive state vector.
+            memory: Memory string returned by the previous call ("" on the first).
+
+        Returns:
+            PlanResult with the next subtask and the rewritten memory.
+
+        Raises:
+            ValueError: If the model response cannot be parsed into a plan.
+        """
+        contents: list = [self._build_user_prompt(task, memory, state)]
+        contents.extend(_to_part(image) for image in images)
+
+        start = time.perf_counter()
+        raw_text = self._generate(contents)
+        latency_s = time.perf_counter() - start
+
+        subtask, new_memory = _parse_plan_response(raw_text, memory)
+        return PlanResult(subtask=subtask, memory=new_memory, raw_text=raw_text, latency_s=latency_s)

--- a/src/opentau/planner/gemini_er_planner.py
+++ b/src/opentau/planner/gemini_er_planner.py
@@ -44,6 +44,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import torch
+from einops import rearrange
 from google import genai
 from google.genai import types as genai_types
 from PIL import Image
@@ -131,11 +132,11 @@ def _to_part(image: PlannerImage) -> genai_types.Part:
         data, encoding = image
         return genai_types.Part.from_bytes(data=data, mime_type=f"image/{encoding.lower()}")
     if isinstance(image, torch.Tensor):
-        tensor = image.detach().squeeze(0) if image.dim() == 4 else image.detach()
+        tensor = rearrange(image.detach(), "1 c h w -> c h w") if image.dim() == 4 else image.detach()
         if tensor.dim() != 3:
             raise ValueError(f"Expected image tensor of shape (3, H, W) or (1, 3, H, W), got {image.shape}")
         tensor = (tensor.to(dtype=torch.float32, device="cpu").clamp(0, 1) * 255.0).to(torch.uint8)
-        image = Image.fromarray(tensor.permute(1, 2, 0).numpy())
+        image = Image.fromarray(rearrange(tensor, "c h w -> h w c").numpy())
     if isinstance(image, Image.Image):
         buffer = io.BytesIO()
         image.convert("RGB").save(buffer, format="JPEG")

--- a/src/opentau/planner/prompts.yaml
+++ b/src/opentau/planner/prompts.yaml
@@ -48,6 +48,48 @@ prompts:
       If an action must be repeated, write it as: 'move legs ahead ///xN' where N is the number of repetitions.
       The series of simple actions are :
 
+  gemini_er_planner_system:
+    id: "ROBOT-SYS-ER-001"
+    version: 1.0
+    description: "System prompt for the Gemini Robotics-ER high-level planner: rewrites a memory-as-language scratchpad and emits the next subtask for a low-level VLA policy."
+    template: |
+      You are the high-level planner for a robot manipulation system. A low-level vision-language-action
+      (VLA) policy executes short language subtasks; your job is to decide which subtask it should work
+      on right now.
+
+      On every call you receive:
+      1. The overall task the robot must complete.
+      2. Your memory: the notes you wrote on the previous call (empty on the first call).
+      3. The current camera images from the robot.
+      4. Optionally, the robot's proprioceptive state vector.
+
+      You must do two things:
+      1. Rewrite your memory from scratch. It is your only persistent state, so record everything you
+         will need later: which subtasks are already completed, key observations about the scene
+         (object locations, container states, obstacles), and what remains to be done. Keep it concise
+         English prose, a few sentences at most.
+      2. Choose the single next subtask. It must be a short imperative command phrased the way a robot
+         policy is prompted, e.g. "pick up the yellow lego block" or "open the top drawer". Use the
+         images to judge whether the previous subtask succeeded before moving on; if it has not been
+         completed, repeat it. Do not output conditional or compound subtasks.
+
+      Respond with ONLY a JSON object of the form:
+      {"memory": "<your rewritten memory>", "subtask": "<the next subtask>"}
+
+  gemini_er_planner_user:
+    id: "ROBOT-USER-ER-001"
+    version: 1.0
+    description: "User prompt for the Gemini Robotics-ER high-level planner. Placeholders: {task}, {memory}, {state}; the current camera images are attached after the text."
+    template: |
+      Overall task: {task}
+
+      Your memory from the previous call:
+      {memory}
+
+      Robot proprioceptive state: {state}
+
+      The current camera images follow. Update your memory and output the next subtask as JSON.
+
   robot_system_navigation:
     id: "NAV-SYS-001"
     version: 1.0

--- a/src/opentau/scripts/grpc/server.py
+++ b/src/opentau/scripts/grpc/server.py
@@ -17,13 +17,40 @@
 This server loads an ML policy model and serves inference requests from
 robots running ROS 2. Designed to run on a server with a ML GPU.
 
+Optionally (``--planner.enabled=true``) it also spins up a Gemini Robotics-ER
+high-level planner that runs asynchronously alongside the VLA policy:
+
+- The request ``prompt`` is treated as the *overall task*. The planner consumes
+  the latest cached observation (images, state), the task and its own
+  memory-as-language string, and produces the subtask the VLA policy is
+  actually conditioned on.
+- The planner runs on its own free-running background loop, replanning every
+  ``planner.interval_s`` wall-clock seconds — fully decoupled from request
+  arrival. It skips a cycle when no new observation has arrived since the last
+  plan, so an idle server makes no API calls.
+- The VLA inference path never blocks on the planner — it reads whatever
+  subtask is currently available. The one exception is the start of a task
+  (the first request, or the first after the prompt changes), which blocks
+  (up to ``planner.first_plan_timeout_s``) so the policy starts on a real
+  subtask rather than the raw task.
+
+With the planner disabled (the default) the server serves the VLA policy only.
+The wire API is identical either way.
+
 Usage:
     python src/opentau/scripts/grpc/server.py --config_path=/path/to/config.json \\
         --server.port=50051 --server.max_workers=4
+
+    # with the high-level planner
+    GEMINI_API_KEY=... python src/opentau/scripts/grpc/server.py \\
+        --config_path=/path/to/config.json \\
+        --server.port=50051 --planner.enabled=true --planner.interval_s=5
 """
 
 import io
 import logging
+import threading
+import time
 import traceback
 from concurrent import futures
 from dataclasses import asdict
@@ -40,6 +67,7 @@ import grpc
 from opentau.configs import parser
 from opentau.configs.train import TrainPipelineConfig
 from opentau.datasets.lerobot_dataset import BaseDataset
+from opentau.planner.gemini_er_planner import GeminiERPlanner
 from opentau.policies.factory import get_policy_class
 from opentau.scripts.grpc import robot_inference_pb2, robot_inference_pb2_grpc
 from opentau.utils.random_utils import set_seed
@@ -53,13 +81,22 @@ logger = logging.getLogger(__name__)
 
 
 class RobotPolicyServicer(robot_inference_pb2_grpc.RobotPolicyServiceServicer):
-    """gRPC servicer implementing the RobotPolicyService."""
+    """gRPC servicer implementing the RobotPolicyService.
+
+    When ``cfg.planner.enabled`` is set, a high-level planner runs alongside
+    the policy on its own free-running daemon thread, replanning periodically
+    from the latest cached observation. Shared planner state (latest
+    observation, task, subtask, memory) is guarded by a single lock; the
+    network-bound Gemini call happens outside the lock, so it never stalls
+    policy inference.
+    """
 
     def __init__(self, cfg: TrainPipelineConfig):
         """Initialize the servicer with model and configuration.
 
         Args:
-            cfg: Training pipeline configuration including policy settings.
+            cfg: Training pipeline configuration including policy, server and
+                planner settings.
         """
         self.cfg = cfg
         self.device = auto_torch_device()
@@ -69,6 +106,158 @@ class RobotPolicyServicer(robot_inference_pb2_grpc.RobotPolicyServiceServicer):
 
         # Load the policy model
         self._load_policy()
+
+        # Optionally spin up the high-level planner
+        self._init_planner(cfg.planner)
+
+    def _init_planner(self, pcfg):
+        """Set up the high-level planner and start its background loop (if enabled)."""
+        self._planner: GeminiERPlanner | None = None
+        self._planner_thread: threading.Thread | None = None
+
+        self._interval_s = pcfg.interval_s
+        self._first_plan_timeout_s = pcfg.first_plan_timeout_s
+        self._include_state = pcfg.include_state
+
+        self._lock = threading.Lock()
+        # Shared state, all guarded by self._lock.
+        self._latest_images: list[tuple[bytes, str]] = []
+        self._latest_state: list[float] | None = None
+        self._task: str | None = None
+        self._subtask: str | None = None
+        self._memory: str = ""
+        # Incremented whenever a request caches a fresh observation; the loop
+        # only replans when there is something new to plan on, so an idle
+        # server makes no planner API calls.
+        self._obs_seq: int = 0
+        self._last_planned_seq: int = 0
+        # Bumped on task change so a stale in-flight plan cannot commit.
+        self._plan_generation: int = 0
+
+        # Loop control. ``_subtask_ready`` is set when a plan for the current
+        # task has been committed (start-of-inference requests wait on it);
+        # ``_replan_event`` short-circuits the interval sleep on task change.
+        self._stop_event = threading.Event()
+        self._subtask_ready = threading.Event()
+        self._replan_event = threading.Event()
+
+        if pcfg.enabled:
+            # Fails fast here if no API key is resolvable.
+            self._planner = GeminiERPlanner(
+                model=pcfg.model,
+                api_key_env=pcfg.api_key_env,
+                max_output_tokens=pcfg.max_output_tokens,
+                temperature=pcfg.temperature,
+                system_prompt_key=pcfg.system_prompt_key,
+                user_prompt_key=pcfg.user_prompt_key,
+            )
+            self._planner_thread = threading.Thread(target=self._planner_loop, name="planner", daemon=True)
+            self._planner_thread.start()
+            logger.info(
+                f"High-level planner enabled: model={pcfg.model}, interval_s={pcfg.interval_s}, "
+                f"first_plan_timeout_s={pcfg.first_plan_timeout_s}"
+            )
+
+    def _update_shared_state(self, request: robot_inference_pb2.ObservationRequest) -> None:
+        """Cache the latest observation; reset planner state on task change."""
+        with self._lock:
+            self._latest_images = [(img.image_data, img.encoding) for img in request.images]
+            self._latest_state = list(request.robot_state.state) or None
+            self._obs_seq += 1
+            if request.prompt != self._task:
+                logger.info(f"New task: {request.prompt!r} — resetting planner memory")
+                self._task = request.prompt
+                self._subtask = None
+                self._memory = ""
+                self._plan_generation += 1
+                self._subtask_ready.clear()
+                self._replan_event.set()
+
+    def _planner_loop(self) -> None:
+        """Free-running planner: replan every ``interval_s`` on fresh observations.
+
+        Runs fully decoupled from request handling — requests only cache the
+        latest observation; this loop periodically turns it into a subtask.
+        """
+        idle_poll_s = 0.05
+        while not self._stop_event.is_set():
+            with self._lock:
+                has_new_obs = self._obs_seq != self._last_planned_seq
+            if not has_new_obs:
+                # Nothing new to plan on (no robot connected, or it stopped
+                # sending) — idle cheaply instead of burning API calls.
+                self._stop_event.wait(idle_poll_s)
+                continue
+            # The plan below runs on the freshest state, so it satisfies any
+            # replan request raised up to this point.
+            self._replan_event.clear()
+            self._run_plan()
+            # Sleep out the planning interval; a task change (or shutdown)
+            # short-circuits it so a new task replans immediately.
+            self._replan_event.wait(timeout=self._interval_s)
+
+    def _run_plan(self) -> None:
+        """One planner step: snapshot state, call the model, commit the result."""
+        with self._lock:
+            task = self._task
+            images = list(self._latest_images)
+            state = self._latest_state if self._include_state else None
+            memory = self._memory
+            generation = self._plan_generation
+            self._last_planned_seq = self._obs_seq
+        try:
+            # Network-bound call, deliberately outside the lock.
+            result = self._planner.plan(task=task, images=images, state=state, memory=memory)
+            with self._lock:
+                if self._plan_generation == generation:
+                    self._subtask = result.subtask
+                    self._memory = result.memory
+                    self._subtask_ready.set()
+            logger.info(
+                f"Planner ({result.latency_s:.2f}s) subtask={result.subtask!r} memory={result.memory!r}"
+            )
+        except Exception:
+            # A planner failure must never crash the server or clear an
+            # existing subtask — a stale subtask beats no subtask.
+            logger.exception("High-level planner call failed; keeping previous subtask")
+
+    def _current_subtask(self) -> str | None:
+        with self._lock:
+            return self._subtask
+
+    def _apply_planner(self, request: robot_inference_pb2.ObservationRequest) -> None:
+        """Rewrite ``request.prompt`` to the planner's current subtask.
+
+        No-op when the planner is disabled. The request prompt is treated as
+        the overall task; the policy is conditioned on the subtask instead.
+        Non-blocking except at the start of inference for a task (subtask not
+        yet available), where it waits for the planner loop's first plan.
+        """
+        if self._planner is None:
+            return
+
+        self._update_shared_state(request)
+        # Start of inference for this task (no subtask yet): wait for the
+        # initial subtask so the policy starts on a real subtask rather than
+        # the raw task.
+        if self._current_subtask() is None and not self._subtask_ready.wait(
+            timeout=self._first_plan_timeout_s
+        ):
+            logger.warning(
+                f"First plan not ready after {self._first_plan_timeout_s}s; "
+                "falling back to the raw task prompt"
+            )
+
+        subtask = self._current_subtask()
+        if subtask is not None:
+            request.prompt = subtask
+
+    def close(self) -> None:
+        """Stop the planner loop (an in-flight Gemini call may delay exit briefly)."""
+        self._stop_event.set()
+        self._replan_event.set()
+        if self._planner_thread is not None:
+            self._planner_thread.join(timeout=5)
 
     def _load_policy(self):
         """Load the policy model from pretrained weights."""
@@ -258,14 +447,16 @@ class RobotPolicyServicer(robot_inference_pb2_grpc.RobotPolicyServiceServicer):
         Returns:
             ActionChunkResponse containing the predicted action chunk.
         """
-        import time
-
         start_time = time.perf_counter()
         response = robot_inference_pb2.ActionChunkResponse()
         response.request_id = request.request_id
         response.timestamp_ns = time.time_ns()
 
         try:
+            # Substitute the high-level planner's subtask for the prompt (no-op
+            # when the planner is disabled).
+            self._apply_planner(request)
+
             # Prepare observation batch
             batch, action_prefix, delay = self._prepare_observation(request)
 
@@ -375,6 +566,7 @@ def serve(cfg: TrainPipelineConfig):
     except KeyboardInterrupt:
         logger.info("Shutting down server...")
         server.stop(grace=5)
+        servicer.close()
 
 
 @parser.wrap()

--- a/tests/planner/test_gemini_er_planner.py
+++ b/tests/planner/test_gemini_er_planner.py
@@ -1,0 +1,177 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the Gemini Robotics-ER high-level planner (no network)."""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+from google import genai
+
+from opentau.planner.gemini_er_planner import (
+    GeminiERPlanner,
+    _parse_plan_response,
+    _to_part,
+)
+
+
+class TestParsePlanResponse:
+    def test_clean_json(self):
+        subtask, memory = _parse_plan_response(
+            '{"memory": "picked up the block", "subtask": "place the block in the bin"}',
+            prev_memory="old",
+        )
+        assert subtask == "place the block in the bin"
+        assert memory == "picked up the block"
+
+    def test_fenced_json(self):
+        text = '```json\n{"memory": "m", "subtask": "s"}\n```'
+        assert _parse_plan_response(text, prev_memory="") == ("s", "m")
+
+    def test_missing_memory_falls_back_to_previous(self):
+        subtask, memory = _parse_plan_response('{"subtask": "s"}', prev_memory="kept")
+        assert subtask == "s"
+        assert memory == "kept"
+
+    def test_empty_memory_falls_back_to_previous(self):
+        _, memory = _parse_plan_response('{"memory": "  ", "subtask": "s"}', prev_memory="kept")
+        assert memory == "kept"
+
+    def test_missing_subtask_raises(self):
+        with pytest.raises(ValueError, match="no 'subtask'"):
+            _parse_plan_response('{"memory": "m"}', prev_memory="")
+
+    def test_garbage_raises(self):
+        with pytest.raises(ValueError, match="not valid JSON"):
+            _parse_plan_response("not json at all", prev_memory="")
+
+    def test_non_object_raises(self):
+        with pytest.raises(ValueError, match="not a JSON object"):
+            _parse_plan_response('["a", "b"]', prev_memory="")
+
+
+class TestToPart:
+    def test_raw_bytes_pass_through(self):
+        part = _to_part(b"\xff\xd8fakejpeg")
+        assert part.inline_data.data == b"\xff\xd8fakejpeg"
+        assert part.inline_data.mime_type == "image/jpeg"
+
+    def test_bytes_with_encoding(self):
+        part = _to_part((b"fakepng", "png"))
+        assert part.inline_data.data == b"fakepng"
+        assert part.inline_data.mime_type == "image/png"
+
+    def test_tensor_chw_and_batched(self):
+        for shape in [(3, 8, 8), (1, 3, 8, 8)]:
+            part = _to_part(torch.rand(*shape))
+            assert part.inline_data.mime_type == "image/jpeg"
+            assert part.inline_data.data[:2] == b"\xff\xd8"  # JPEG magic
+
+    def test_bad_tensor_shape_raises(self):
+        with pytest.raises(ValueError, match="shape"):
+            _to_part(torch.rand(8, 8))
+
+    def test_unsupported_type_raises(self):
+        with pytest.raises(TypeError, match="Unsupported"):
+            _to_part(123)
+
+
+def _make_planner(response_text: str) -> tuple[GeminiERPlanner, MagicMock]:
+    client = MagicMock(spec=genai.Client)
+    response = MagicMock()
+    response.text = response_text
+    client.models.generate_content.return_value = response
+    planner = GeminiERPlanner(client=client)
+    return planner, client
+
+
+class TestGeminiERPlanner:
+    def test_missing_api_key_raises(self, monkeypatch):
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+        with pytest.raises(ValueError, match="No Gemini API key"):
+            GeminiERPlanner()
+
+    def test_unknown_prompt_key_raises(self):
+        with pytest.raises(ValueError, match="not found"):
+            GeminiERPlanner(client=MagicMock(spec=genai.Client), system_prompt_key="nope")
+
+    def test_build_user_prompt_substitution(self):
+        planner, _ = _make_planner("{}")
+        prompt = planner._build_user_prompt("stack the cups", "did step one", [0.123456, 1.0])
+        assert "stack the cups" in prompt
+        assert "did step one" in prompt
+        assert "[0.1235, 1.0]" in prompt
+
+    def test_build_user_prompt_empty_memory_and_state(self):
+        planner, _ = _make_planner("{}")
+        prompt = planner._build_user_prompt("t", "", None)
+        assert "(empty — first call)" in prompt
+        assert "(not provided)" in prompt
+
+    def test_plan_end_to_end(self):
+        raw = json.dumps({"memory": "saw two blocks", "subtask": "pick up the red block"})
+        planner, client = _make_planner(raw)
+
+        result = planner.plan(
+            task="put the blocks in the bin",
+            images=[b"\xff\xd8fakejpeg", (b"fakepng", "png")],
+            state=[0.0, 1.0],
+            memory="",
+        )
+
+        assert result.subtask == "pick up the red block"
+        assert result.memory == "saw two blocks"
+        assert result.raw_text == raw
+        assert result.latency_s >= 0
+
+        _, kwargs = client.models.generate_content.call_args
+        assert kwargs["model"] == GeminiERPlanner.DEFAULT_MODEL
+        assert kwargs["config"].response_mime_type == "application/json"
+        assert kwargs["config"].temperature == 0.0
+        # 1 text part + 2 image parts
+        assert len(kwargs["contents"]) == 3
+        assert "put the blocks in the bin" in kwargs["contents"][0]
+
+    def test_plan_empty_response_raises(self):
+        planner, _ = _make_planner("")
+        with pytest.raises(ValueError, match="no text"):
+            planner.plan(task="t", images=[b"img"], memory="")
+
+    def test_schema_rejected_falls_back_once(self):
+        client = MagicMock(spec=genai.Client)
+        good = MagicMock()
+        good.text = '{"memory": "m", "subtask": "s"}'
+        schema_error = genai.errors.APIError(400, {"error": {"message": "response_schema is not supported"}})
+        client.models.generate_content.side_effect = [schema_error, good, good]
+
+        planner = GeminiERPlanner(client=client)
+        result = planner.plan(task="t", images=[b"img"], memory="")
+        assert result.subtask == "s"
+        assert planner._schema_supported is False
+
+        # Subsequent calls go straight to the schemaless path: one more call, no error.
+        planner.plan(task="t", images=[b"img"], memory="m")
+        assert client.models.generate_content.call_count == 3
+
+    def test_non_schema_api_error_propagates(self):
+        client = MagicMock(spec=genai.Client)
+        client.models.generate_content.side_effect = genai.errors.APIError(
+            500, {"error": {"message": "internal failure"}}
+        )
+        planner = GeminiERPlanner(client=client)
+        with pytest.raises(genai.errors.APIError):
+            planner.plan(task="t", images=[b"img"], memory="")

--- a/tests/scripts/test_grpc_planner_server.py
+++ b/tests/scripts/test_grpc_planner_server.py
@@ -1,0 +1,246 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the high-level-planner orchestration in the gRPC server.
+
+These tests exercise the planner logic in ``RobotPolicyServicer`` only: policy
+loading is patched out and the Gemini planner is replaced with a controllable
+fake. CPU-only, no network.
+"""
+
+import threading
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from opentau.configs.deployment import PlannerConfig
+from opentau.planner.gemini_er_planner import PlanResult
+from opentau.scripts.grpc import robot_inference_pb2
+from opentau.scripts.grpc.server import RobotPolicyServicer
+
+
+class FakePlanner:
+    """Controllable stand-in for GeminiERPlanner."""
+
+    def __init__(self):
+        self.calls: list[dict] = []
+        self.results: list[PlanResult | Exception] = []
+        self.release = threading.Event()
+        self.release.set()  # non-blocking by default
+
+    def queue(self, *results: PlanResult | Exception):
+        self.results.extend(results)
+
+    def plan(self, task, images, state=None, memory=""):
+        self.calls.append({"task": task, "images": images, "state": state, "memory": memory})
+        assert self.release.wait(timeout=10), "FakePlanner was never released"
+        result = self.results.pop(0)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+
+def _plan(subtask: str, memory: str) -> PlanResult:
+    return PlanResult(subtask=subtask, memory=memory, raw_text="{}", latency_s=0.0)
+
+
+def _request(prompt: str = "make a sandwich") -> robot_inference_pb2.ObservationRequest:
+    request = robot_inference_pb2.ObservationRequest(prompt=prompt)
+    request.images.add(image_data=b"\xff\xd8fakejpeg", encoding="jpeg")
+    request.robot_state.state.extend([0.1, 0.2, 0.3])
+    return request
+
+
+@pytest.fixture
+def make_servicer():
+    """Factory building a servicer with a patched policy path and fake planner."""
+    servicers = []
+
+    def _make(**planner_overrides) -> tuple[RobotPolicyServicer, FakePlanner]:
+        planner_cfg = PlannerConfig(**planner_overrides)
+        cfg = SimpleNamespace(planner=planner_cfg, policy=SimpleNamespace(type="pi05"))
+        fake_planner = FakePlanner()
+        with (
+            patch.object(RobotPolicyServicer, "_load_policy"),
+            patch("opentau.scripts.grpc.server.GeminiERPlanner", return_value=fake_planner),
+        ):
+            servicer = RobotPolicyServicer(cfg)
+        servicers.append(servicer)
+        return servicer, fake_planner
+
+    yield _make
+    for servicer in servicers:
+        servicer.close()
+
+
+class TestPlannerDisabled:
+    def test_prompt_untouched_and_no_planner(self, make_servicer):
+        servicer, fake_planner = make_servicer(enabled=False)
+        assert servicer._planner is None
+        assert servicer._planner_thread is None
+
+        request = _request("raw task")
+        servicer._apply_planner(request)
+
+        assert request.prompt == "raw task"
+        assert fake_planner.calls == []
+
+
+class TestPlannerEnabled:
+    def test_first_request_blocks_and_uses_subtask(self, make_servicer):
+        servicer, fake_planner = make_servicer(enabled=True)
+        fake_planner.queue(_plan("pick up the bread", "started"))
+
+        request = _request("make a sandwich")
+        servicer._apply_planner(request)
+
+        assert request.prompt == "pick up the bread"
+        assert fake_planner.calls[0]["task"] == "make a sandwich"
+        assert fake_planner.calls[0]["memory"] == ""
+        assert fake_planner.calls[0]["images"] == [(b"\xff\xd8fakejpeg", "jpeg")]
+        # Proto floats are float32, so compare approximately.
+        assert fake_planner.calls[0]["state"] == pytest.approx([0.1, 0.2, 0.3])
+        assert servicer._memory == "started"
+
+    def test_first_plan_timeout_falls_back_to_raw_prompt(self, make_servicer):
+        servicer, fake_planner = make_servicer(enabled=True, first_plan_timeout_s=0.1)
+        fake_planner.release.clear()  # block the plan
+        fake_planner.queue(_plan("subtask", "memory"))
+
+        request = _request("raw task")
+        servicer._apply_planner(request)
+        assert request.prompt == "raw task"
+
+        # Let the in-flight plan finish; its result must still be committed.
+        fake_planner.release.set()
+        _wait_until(lambda: servicer._current_subtask() == "subtask")
+        request = _request("raw task")
+        servicer._apply_planner(request)
+        assert request.prompt == "subtask"
+
+    def test_interval_gating(self, make_servicer):
+        servicer, fake_planner = make_servicer(enabled=True, interval_s=100.0)
+        fake_planner.queue(_plan("subtask", "memory"))
+
+        for _ in range(3):
+            request = _request()
+            servicer._apply_planner(request)
+
+        # Only the bootstrap plan ran; interval (100s) never elapsed again.
+        assert len(fake_planner.calls) == 1
+        assert request.prompt == "subtask"
+
+    def test_replans_after_interval_with_updated_memory(self, make_servicer):
+        servicer, fake_planner = make_servicer(enabled=True, interval_s=100.0)
+        fake_planner.queue(_plan("first subtask", "first memory"), _plan("second subtask", "second memory"))
+
+        servicer._apply_planner(_request())
+        servicer._apply_planner(_request())  # caches a fresh observation
+        # Short-circuit the 100s interval sleep instead of waiting it out.
+        servicer._replan_event.set()
+        _wait_until(lambda: len(fake_planner.calls) == 2)
+        _wait_until(lambda: servicer._current_subtask() == "second subtask")
+
+        assert fake_planner.calls[1]["memory"] == "first memory"
+        request = _request()
+        servicer._apply_planner(request)
+        assert request.prompt == "second subtask"
+
+    def test_requests_during_inflight_plan_do_not_stack_plans(self, make_servicer):
+        servicer, fake_planner = make_servicer(enabled=True, first_plan_timeout_s=0.1)
+        fake_planner.release.clear()
+        fake_planner.queue(_plan("subtask", "memory"))
+
+        servicer._apply_planner(_request())  # bootstrap, times out, plan in flight
+        servicer._apply_planner(_request())
+        servicer._apply_planner(_request())
+
+        fake_planner.release.set()
+        _wait_until(lambda: servicer._current_subtask() == "subtask")
+        # The loop ran exactly one plan; the extra requests only refreshed the
+        # cached observation (next replan comes after interval_s = 100s).
+        assert len(fake_planner.calls) == 1
+
+    def test_task_change_resets_memory_and_replans(self, make_servicer):
+        servicer, fake_planner = make_servicer(enabled=True, interval_s=100.0)
+        fake_planner.queue(_plan("subtask A", "memory A"), _plan("subtask B", "memory B"))
+
+        request_a = _request("task A")
+        servicer._apply_planner(request_a)
+        assert request_a.prompt == "subtask A"
+
+        request_b = _request("task B")
+        servicer._apply_planner(request_b)
+        assert request_b.prompt == "subtask B"
+        assert fake_planner.calls[1]["task"] == "task B"
+        assert fake_planner.calls[1]["memory"] == ""  # reset, not "memory A"
+
+    def test_planner_exception_keeps_previous_subtask(self, make_servicer):
+        servicer, fake_planner = make_servicer(enabled=True, interval_s=100.0)
+        fake_planner.queue(_plan("good subtask", "memory"), RuntimeError("api down"))
+
+        servicer._apply_planner(_request())
+        servicer._apply_planner(_request())  # caches a fresh observation
+        servicer._replan_event.set()  # short-circuit the interval sleep
+        _wait_until(lambda: len(fake_planner.calls) == 2)
+
+        request = _request()
+        servicer._apply_planner(request)
+        assert request.prompt == "good subtask"
+
+    def test_stale_plan_does_not_commit_after_task_change(self, make_servicer):
+        servicer, fake_planner = make_servicer(enabled=True, first_plan_timeout_s=0.1)
+        fake_planner.release.clear()
+        fake_planner.queue(_plan("stale subtask", "stale memory"), _plan("fresh subtask", "fresh memory"))
+
+        servicer._apply_planner(_request("task A"))  # plan for A stuck in flight
+
+        # Task changes while A's plan is still running.
+        thread = threading.Thread(target=servicer._apply_planner, args=(_request("task B"),))
+        thread.start()
+        _wait_until(lambda: servicer._task == "task B")
+        fake_planner.release.set()
+        thread.join(timeout=10)
+        assert not thread.is_alive()
+
+        _wait_until(lambda: len(fake_planner.calls) == 2)
+        _wait_until(lambda: servicer._current_subtask() == "fresh subtask")
+        assert servicer._memory == "fresh memory"
+
+    def test_get_action_chunk_uses_subtask_end_to_end(self, make_servicer):
+        """GetActionChunk substitutes the subtask before preparing the observation."""
+        servicer, fake_planner = make_servicer(enabled=True)
+        fake_planner.queue(_plan("pick up the bread", "started"))
+
+        servicer._prepare_observation = MagicMock(return_value=({}, None, None))
+        servicer.policy = MagicMock()
+        servicer.policy.sample_actions.return_value = torch.zeros((1, 2, 3))
+
+        response = servicer.GetActionChunk(_request("make a sandwich"), MagicMock())
+
+        prepared_request = servicer._prepare_observation.call_args.args[0]
+        assert prepared_request.prompt == "pick up the bread"
+        assert len(response.action_chunk) == 2
+
+
+def _wait_until(predicate, timeout: float = 10.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.005)
+    raise AssertionError("condition not met within timeout")


### PR DESCRIPTION
## What this does

Adds an optional asynchronous high-level planner to the gRPC inference server, enabling hierarchical VLA inference (🗃️ Feature).

- **`GeminiERPlanner`** (`src/opentau/planner/gemini_er_planner.py`): a new high-level planner backed by Gemini Robotics-ER (`gemini-robotics-er-1.5-preview`) implementing the *memory-as-language* pattern — each call takes the overall task, the current camera images, optionally the proprioceptive state, and the memory string the model wrote on its previous call, and returns a rewritten memory plus the next subtask as a short imperative command for the low-level VLA policy. Accepts encoded JPEG/PNG bytes, PIL images, or float CHW tensors; uses structured JSON output with a one-time fallback if the ER preview rejects `response_schema`.
- **`PlannerConfig`** (`src/opentau/configs/deployment.py`, wired into `TrainPipelineConfig` as `planner`): disabled by default; configures model, API key env var, replan interval, first-plan timeout, sampling params, and prompt keys.
- **Server integration** (`src/opentau/scripts/grpc/server.py`): with `--planner.enabled=true`, the servicer runs the planner on a free-running daemon thread that replans every `planner.interval_s` seconds from the latest cached observation (skipping cycles when no new observation arrived). The request `prompt` is treated as the overall task and rewritten to the planner's current subtask before policy inference. The VLA path never blocks on replanning — the only blocking point is the first request of a task (up to `planner.first_plan_timeout_s`), which falls back to the raw task prompt on timeout. The Gemini call happens outside the shared-state lock, and a planner failure keeps the previous subtask. The wire API is unchanged; with the planner disabled the server behaves exactly as before.
- New planner prompt templates in `src/opentau/planner/prompts.yaml`; `prompts.yaml` is now shipped in wheels via `pyproject.toml` package data; `GeminiERPlanner`/`PlanResult` exported from `opentau.planner`.

## How it was tested

- Added `tests/planner/test_gemini_er_planner.py` (response parsing, image conversion for all accepted input types, prompt construction, schema-rejection fallback, plan round-trip against a mocked `genai.Client`).
- Added `tests/scripts/test_grpc_planner_server.py` (planner-disabled no-op path, subtask substitution, first-plan blocking + timeout fallback, background-loop replanning and observation gating, failure keeps previous subtask, clean shutdown) using a `FakePlanner` and a mocked policy.
- All 30 new tests pass locally on CPU in ~1s (no API key or GPU needed): `pytest -q tests/planner/test_gemini_er_planner.py tests/scripts/test_grpc_planner_server.py`.
- Pre-commit hooks pass on the changed files.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/planner/test_gemini_er_planner.py tests/scripts/test_grpc_planner_server.py
```

Run the server with the planner enabled (any trained policy config works; the wire API is unchanged):

GEMINI_API_KEY=... python src/opentau/scripts/grpc/server.py \
    --config_path=/path/to/config.json \
    --server.port=50051 --planner.enabled=true --planner.interval_s=5

With --planner.enabled unset, the server serves the VLA policy only, as before.

Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.