### PR TITLE
chore: bump version to 0.7.0

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,8 +30,8 @@ project = "OpenTau"
 copyright = "2026, Tensor Auto Inc"
 author = "Tensor Auto Inc"
 
-version = "0.1.0"
-release = "0.1.0"
+version = "0.7.0"
+release = "0.7.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ huggingface = "https://huggingface.co/TensorAuto"
 
 [project]
 name = "opentau"
-version = "0.6.0"
+version = "0.7.0"
 description = "OpenTau: Tensor's VLA Training Infrastructure for Real-World Robotics in Pytorch"
 authors = [
     { name = "Shuheng Liu", email = "wish1104@icloud.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -2157,7 +2157,7 @@ wheels = [
 
 [[package]]
 name = "opentau"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
## What this does
Bumps the package version from 0.6.0 to 0.7.0 (🗃️ Feature release prep):
- `pyproject.toml`: `version = "0.7.0"`
- `uv.lock`: regenerated via `uv lock` (only the `opentau` entry changed)
- `docs/source/conf.py`: synced the Sphinx `version`/`release` to 0.7.0 (was stale at 0.1.0, never tracked previous bumps)

## How it was tested
- `uv lock` resolved cleanly with only the `opentau v0.6.0 -> v0.7.0` change.
- `pre-commit run` on the changed files: all hooks pass.
- No code changes — version metadata only; `opentau.__version__` reads it from package metadata at import time.

## How to checkout & try? (for the reviewer)
```bash
git checkout bump-version-0.7.0
uv sync --extra dev
python -c "import opentau; print(opentau.__version__)"  # 0.7.0
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).