### PR TITLE
fix(policies): respect skip_normalization_weights on checkpoint load

### DIFF
--- a/src/opentau/policies/factory.py
+++ b/src/opentau/policies/factory.py
@@ -298,7 +298,20 @@ def make_policy(
     # have them, otherwise raise a clear error rather than letting the first
     # forward fail mid-step.
     if cfg.pretrained_path and per_norm_key_stats is not None:
-        policy._inject_stats(per_norm_key_stats, dataset_names=norm_keys)
+        # Repopulate normalization buffers ONLY when the checkpoint carried no
+        # stats (buffers are still the +inf sentinel — the
+        # `save_normalization_stats=False` round-trip). When the checkpoint's
+        # stats loaded cleanly (`skip_normalization_weights=False`) or were
+        # freshly built from the current mixture
+        # (`skip_normalization_weights=True`, which strips the saved buffers and
+        # keeps the per_dataset_stats-initialised ones), keep them as-is.
+        # Unconditionally injecting here clobbered a deliberately-loaded
+        # checkpoint normalization, which made `skip_normalization_weights=False`
+        # a silent no-op for mixture fine-tunes.
+        if policy._norm_buffers_have_inf():
+            policy._inject_stats(per_norm_key_stats, dataset_names=norm_keys)
+        else:
+            policy._check_norm_stats_loaded()
     elif cfg.pretrained_path:
         policy._check_norm_stats_loaded()
 

--- a/src/opentau/policies/pretrained.py
+++ b/src/opentau/policies/pretrained.py
@@ -24,6 +24,7 @@ and safetensors for efficient serialization.
 import abc
 import logging
 import os
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Type, TypeVar
 
@@ -629,29 +630,46 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
             # the dataset->norm-row map should update `config.dataset_to_norm_index`
             # before reinstantiating the policy.
 
+    @staticmethod
+    def _iter_norm_buffer_params(owner: nn.Module) -> Iterator[tuple[str, Tensor]]:
+        """Yield ``(qualified_name, param)`` for every Normalize/Unnormalize
+        buffer parameter on ``owner`` across :data:`NORM_MODULE_NAMES`.
+
+        Single source of truth for the buffer walk shared by the three
+        inf-sentinel guards (:meth:`_norm_buffers_have_inf`,
+        :meth:`_check_norm_stats_loaded`,
+        :meth:`_assert_normalize_buffers_initialized`) so they cannot drift.
+        A ``@staticmethod`` taking the owner explicitly so the classmethod guard
+        (which receives a ``model`` that may be any ``nn.Module``, e.g. a test
+        fixture) and the instance guards can all share it.
+        ``Normalize`` registers stats as ``nn.Parameter(requires_grad=False)``,
+        so these live under ``named_parameters()``, not ``named_buffers()`` —
+        same convention as the inline ``Normalize.forward`` checks.
+        """
+        for module_attr in NORM_MODULE_NAMES:
+            module = getattr(owner, module_attr, None)
+            if module is None:
+                continue
+            for name, param in module.named_parameters(recurse=True):
+                if name.startswith("buffer_"):
+                    yield f"{module_attr}.{name}", param
+
     def _norm_buffers_have_inf(self) -> bool:
         """Return True if any Normalize/Unnormalize buffer still holds the +inf
         sentinel — i.e. the buffer was neither loaded from a checkpoint nor
         initialised from stats.
 
-        Mirrors the iteration in :meth:`_check_norm_stats_loaded` but returns a
-        bool instead of raising, so ``make_policy`` can decide *whether* to
-        repopulate. The contract: inject stats only when buffers are still ∞
-        (the ``save_normalization_stats=False`` round-trip), and otherwise keep
-        the buffers that were deliberately loaded (``skip_normalization_weights
+        Like :meth:`_check_norm_stats_loaded` but returns a bool instead of
+        raising, so ``make_policy`` can decide *whether* to repopulate. The
+        contract: inject stats only when buffers are still ∞ (the
+        ``save_normalization_stats=False`` round-trip), and otherwise keep the
+        buffers that were deliberately loaded (``skip_normalization_weights
         =False``) or freshly built from the current mixture
         (``skip_normalization_weights=True``). Unconditionally injecting would
         clobber a loaded checkpoint's normalization, which silently turned
         ``skip_normalization_weights=False`` into a no-op for mixture fine-tunes.
         """
-        for module_attr in NORM_MODULE_NAMES:
-            module = getattr(self, module_attr, None)
-            if module is None:
-                continue
-            for name, param in module.named_parameters(recurse=True):
-                if name.startswith("buffer_") and torch.isinf(param).any():
-                    return True
-        return False
+        return any(torch.isinf(param).any() for _, param in self._iter_norm_buffer_params(self))
 
     def _check_norm_stats_loaded(self) -> None:
         """Raise a clear error if any Normalize/Unnormalize buffer is still ∞.
@@ -663,14 +681,7 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
         ``save_normalization_stats=False`` round-trip mistake at
         policy-construction time rather than at the first forward.
         """
-        bad: list[str] = []
-        for module_attr in NORM_MODULE_NAMES:
-            module = getattr(self, module_attr, None)
-            if module is None:
-                continue
-            for name, param in module.named_parameters(recurse=True):
-                if name.startswith("buffer_") and torch.isinf(param).any():
-                    bad.append(f"{module_attr}.{name}")
+        bad = [name for name, param in self._iter_norm_buffer_params(self) if torch.isinf(param).any()]
         if bad:
             raise RuntimeError(
                 "Normalization buffers were not initialised from a checkpoint "
@@ -981,10 +992,9 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
         """
         if not stripped_keys:
             return
-        # Walk the same NORM_MODULE_NAMES attribute tree that
-        # `_check_norm_stats_loaded` iterates, so the two guards stay
-        # synchronized with `_save_pretrained`'s detach/restore loop and
-        # `_inject_stats`.
+        # Walk the same buffer params as the sibling guards via the shared
+        # `_iter_norm_buffer_params`, so they stay synchronized with
+        # `_save_pretrained`'s detach/restore loop and `_inject_stats`.
         #
         # Note: the check intentionally does NOT cross-reference each inf
         # buffer against ``stripped_keys`` (which would be a stricter
@@ -1008,14 +1018,11 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
         # ``accelerator.prepare`` today (so params are still plain Tensors
         # here), but the call is cheap on plain Tensors and keeps the
         # helper safe for any future caller that invokes it post-wrap.
-        inf_buffers: list[str] = []
-        for module_attr in NORM_MODULE_NAMES:
-            module = getattr(model, module_attr, None)
-            if module is None:
-                continue
-            for name, param in module.named_parameters(recurse=True):
-                if name.startswith("buffer_") and torch.isinf(_materialize(param)).any():
-                    inf_buffers.append(f"{module_attr}.{name}")
+        inf_buffers = [
+            name
+            for name, param in cls._iter_norm_buffer_params(model)
+            if torch.isinf(_materialize(param)).any()
+        ]
         if inf_buffers:
             raise ValueError(
                 "skip_normalization_weights=True requires `per_dataset_stats` "

--- a/src/opentau/policies/pretrained.py
+++ b/src/opentau/policies/pretrained.py
@@ -629,6 +629,30 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
             # the dataset->norm-row map should update `config.dataset_to_norm_index`
             # before reinstantiating the policy.
 
+    def _norm_buffers_have_inf(self) -> bool:
+        """Return True if any Normalize/Unnormalize buffer still holds the +inf
+        sentinel — i.e. the buffer was neither loaded from a checkpoint nor
+        initialised from stats.
+
+        Mirrors the iteration in :meth:`_check_norm_stats_loaded` but returns a
+        bool instead of raising, so ``make_policy`` can decide *whether* to
+        repopulate. The contract: inject stats only when buffers are still ∞
+        (the ``save_normalization_stats=False`` round-trip), and otherwise keep
+        the buffers that were deliberately loaded (``skip_normalization_weights
+        =False``) or freshly built from the current mixture
+        (``skip_normalization_weights=True``). Unconditionally injecting would
+        clobber a loaded checkpoint's normalization, which silently turned
+        ``skip_normalization_weights=False`` into a no-op for mixture fine-tunes.
+        """
+        for module_attr in NORM_MODULE_NAMES:
+            module = getattr(self, module_attr, None)
+            if module is None:
+                continue
+            for name, param in module.named_parameters(recurse=True):
+                if name.startswith("buffer_") and torch.isinf(param).any():
+                    return True
+        return False
+
     def _check_norm_stats_loaded(self) -> None:
         """Raise a clear error if any Normalize/Unnormalize buffer is still ∞.
 

--- a/tests/policies/test_pretrained_skip_normalization.py
+++ b/tests/policies/test_pretrained_skip_normalization.py
@@ -598,3 +598,60 @@ class TestSkipNormalizationMultiHeadRoundTrip:
                     "observation.state": torch.zeros(1, 4),
                 }
             )
+
+
+class TestNormBufferInfGate:
+    """``make_policy`` injects mixture stats only when the loaded buffers are
+    still the +inf sentinel. With valid loaded buffers it must KEEP them, so
+    ``skip_normalization_weights=False`` actually reuses the checkpoint's
+    normalization instead of being silently clobbered by the current mixture's
+    recomputed stats.
+    """
+
+    def test_have_inf_false_for_valid_buffers_true_when_sentinel(self):
+        policy = _make_multihead_policy(["a::1", "b::2"], base=_NEW_BASE, skip=False)
+        assert policy._norm_buffers_have_inf() is False
+        with torch.no_grad():
+            policy.normalize_targets.buffer_action["mean"].fill_(float("inf"))
+        assert policy._norm_buffers_have_inf() is True
+
+    def test_skip_false_keeps_checkpoint_stats_when_buffers_valid(self):
+        """The fix: a clean ``skip_normalization_weights=False`` load leaves the
+        buffers finite, so the factory gate skips ``_inject_stats`` and the
+        checkpoint's stats survive (the current-mixture ``_NEW_BASE`` stats do
+        NOT overwrite the loaded ``_CKPT_BASE`` ones)."""
+        ckpt = _make_multihead_policy(["a::1", "b::2"], base=_CKPT_BASE, skip=False)
+        policy = _make_multihead_policy(["a::1", "b::2"], base=_NEW_BASE, skip=False)
+        _replay_norm_load(policy, ckpt.state_dict(), strict=True)
+
+        assert policy._norm_buffers_have_inf() is False
+        # Replicate the factory gate (factory.py make_policy):
+        new_stats = _build_head_stats(2, _NEW_BASE)
+        if policy._norm_buffers_have_inf():
+            policy._inject_stats(new_stats, dataset_names=["a::1", "b::2"])
+
+        mean = policy.normalize_targets.buffer_action["mean"]
+        for h in range(2):
+            torch.testing.assert_close(mean[h], torch.full((3,), _CKPT_BASE + h))
+
+    def test_inf_buffers_repopulated_by_inject(self):
+        """The save_normalization_stats=False round-trip: buffers load as +inf,
+        the gate sees them and injects the current mixture's stats."""
+        policy = _make_multihead_policy(["a::1", "b::2"], base=_NEW_BASE, skip=False)
+        with torch.no_grad():
+            for module_attr in ("normalize_inputs", "normalize_targets", "unnormalize_outputs"):
+                module = getattr(policy, module_attr)
+                buf_attr = (
+                    "buffer_action" if module_attr != "normalize_inputs" else "buffer_observation_state"
+                )
+                getattr(module, buf_attr)["mean"].fill_(float("inf"))
+        assert policy._norm_buffers_have_inf() is True
+
+        new_stats = _build_head_stats(2, _NEW_BASE)
+        if policy._norm_buffers_have_inf():
+            policy._inject_stats(new_stats, dataset_names=["a::1", "b::2"])
+
+        assert policy._norm_buffers_have_inf() is False
+        mean = policy.normalize_targets.buffer_action["mean"]
+        for h in range(2):
+            torch.testing.assert_close(mean[h], torch.full((3,), _NEW_BASE + h))


### PR DESCRIPTION
## What this does

Fixes a bug where `skip_normalization_weights` was silently ignored when fine-tuning a policy from a checkpoint via `make_policy(..., ds_meta=...)`.

`make_policy` calls `policy._inject_stats(per_norm_key_stats, ...)` **after** `from_pretrained`, with the comment that it repopulates buffers that were saved as `+inf` (the `save_normalization_stats=False` round-trip). But it called it **unconditionally** whenever the run trains from a dataset mixture, so it always overwrote the loaded checkpoint's `normalize_*` / `unnormalize_*` buffers with the current mixture's recomputed stats. The effect:

- `skip_normalization_weights=False` (the default, meaning "keep the checkpoint's normalization") was a **no-op for any mixture fine-tune** — the saved stats were always clobbered by recomputed ones.
- When the fine-tune mixture differs from the checkpoint's training mixture (e.g. a dataset is dropped), the recomputed per-group action std can shift substantially. In a real fine-tune this pushed some sources' normalized actions past **1000 sigma** (vs ~50 during pretraining), which spiked the regression MSE (~0.2 to ~40 at the first step) and destabilized gradients — even though the model and its checkpointed normalization were both fine.

The fix gates the post-load injection on a new `PreTrainedPolicy._norm_buffers_have_inf()`: only repopulate when buffers are still the `+inf` sentinel. Otherwise keep the buffers that were deliberately loaded (`skip_normalization_weights=False`) or freshly built from the current mixture (`skip_normalization_weights=True`, which already strips the saved buffers and initializes from `per_dataset_stats`). This makes the flag behave as documented in all three cases.

🐛 Bug

## How it was tested

- Added `TestNormBufferInfGate` in `tests/policies/test_pretrained_skip_normalization.py` (3 tests):
  - `_norm_buffers_have_inf()` returns `False` for valid buffers, `True` once a buffer is set to the sentinel.
  - A clean `skip_normalization_weights=False` load keeps the checkpoint's stats (the gate skips `_inject_stats`, so the current-mixture stats do **not** overwrite the loaded ones).
  - `+inf` buffers (the `save_normalization_stats=False` case) are still repopulated by the gated `_inject_stats`.
- Ran the full CPU policies suite: `pytest tests/policies -m "not gpu and not network"` -> **467 passed, 2 skipped**.
- End-to-end: a fine-tune from a checkpoint onto a reduced mixture that previously started at MSE ~40 with normalized-action outliers ~1000 now starts at MSE ~0.24 with outliers ~45 (the pretraining-tolerable range) and stable gradients, confirming the loaded normalization is preserved.

This change is in policy construction / checkpoint-loading code (`make_policy`, `PreTrainedPolicy`), not in model math, the training loop, the optimizer, or the sampler, and is fully covered by CPU tests — so the policy / GPU-pytest checklist boxes are left unchecked.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/policies/test_pretrained_skip_normalization.py::TestNormBufferInfGate
```

```bash
pytest tests/policies -m "not gpu and not network"
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
