### PR TITLE
feat(train): optional torch.compile of flow-matching module for pi05/pi07

### DIFF
--- a/src/opentau/configs/policies.py
+++ b/src/opentau/configs/policies.py
@@ -306,6 +306,25 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):
     # `use_amp` determines whether to use Automatic Mixed Precision (AMP) for training and evaluation. With AMP,
     # automatic gradient scaling is used.
     use_amp: bool = False
+
+    # When True, training `torch.compile`s the policy's heavy compute submodule
+    # (the flow-matching `self.model` for pi05 / pi07) *in place* via
+    # `torch.nn.Module.compile`, leaving the host-side preprocessing in the
+    # policy wrapper's own forward uncompiled. The compile is applied in
+    # `PreTrainedPolicy.maybe_compile_for_training`, called from train.py after
+    # the bf16 cast and before `accelerator.prepare`. Compatible with DDP /
+    # single-process / DeepSpeed ZeRO-1/2; train.py rejects ZeRO-3 and FSDP
+    # (both re-shard parameters during forward, which invalidates the traced
+    # graphs). Defaults to False (no behaviour change; the default eager path
+    # is byte-for-byte unchanged).
+    use_torch_compile: bool = False
+    # `torch.compile` mode forwarded to `torch.nn.Module.compile(mode=...)` when
+    # `use_torch_compile` is True. One of "default", "reduce-overhead",
+    # "max-autotune", "max-autotune-no-cudagraphs". Stick with "default" under
+    # DeepSpeed — the cudagraph-based modes ("reduce-overhead", "max-autotune")
+    # conflict with DeepSpeed's activation/parameter memory reuse.
+    torch_compile_mode: str = "default"
+
     pretrained_path: str | None = None
     skip_normalization_weights: bool = False
 

--- a/src/opentau/policies/pi05/configuration_pi05.py
+++ b/src/opentau/policies/pi05/configuration_pi05.py
@@ -155,6 +155,13 @@ class PI05Config(PreTrainedConfig):
     # require. Defaults to False (no ckpt, lowest risk).
     gradient_checkpointing: bool = False
 
+    # torch.compile defaults ON for pi05: PI05Policy is wired for it
+    # (forward dispatches self.model via __call__, supports_torch_compile=True)
+    # and it gives a measured ~1.3-1.5x faster forward with 0 recompiles under
+    # DeepSpeed ZeRO-1/2 / DDP. Set False to train in eager (train.py also
+    # auto-falls back to eager under FSDP / ZeRO-3, which compile can't support).
+    use_torch_compile: bool = True
+
     # Training presets
     optimizer_lr: float = 2.5e-5
     optimizer_betas: tuple[float, float] = (0.9, 0.95)

--- a/src/opentau/policies/pi05/modeling_pi05.py
+++ b/src/opentau/policies/pi05/modeling_pi05.py
@@ -238,6 +238,8 @@ class PI05Policy(PreTrainedPolicy):
 
     config_class = PI05Config
     name = "pi05"
+    # forward() dispatches self.model via __call__, so nn.Module.compile() takes effect.
+    supports_torch_compile = True
 
     def __init__(
         self,

--- a/src/opentau/policies/pi05/modeling_pi05.py
+++ b/src/opentau/policies/pi05/modeling_pi05.py
@@ -726,7 +726,10 @@ class PI05Policy(PreTrainedPolicy):
         )  # in actions_is_pad we have False for real actions and True for padded actions
 
         state = self.prepare_state(batch) if self.config.state_type == "continuous" else None
-        losses = self.model.forward(
+        # Call via __call__ (not .forward) so an in-place torch.compile of
+        # self.model (see PreTrainedPolicy.maybe_compile_for_training) is
+        # actually dispatched; a direct .forward() bypasses the compiled call.
+        losses = self.model(
             images,
             img_masks,
             lang_tokens,

--- a/src/opentau/policies/pi07/low_level/configuration_pi07_low_level.py
+++ b/src/opentau/policies/pi07/low_level/configuration_pi07_low_level.py
@@ -228,6 +228,13 @@ class PI07LowLevelConfig(PreTrainedConfig):
     spacetime_layer_stride: int = 4
     gradient_checkpointing: bool = False
 
+    # torch.compile defaults ON for pi07 low-level: PI07LowLevelPolicy is wired
+    # for it (supports_torch_compile=True). Note that pi07's variable-length text
+    # embedding can trigger torch.compile recompiles unless sequence lengths are
+    # stable; correctness holds regardless, and train.py auto-falls back to eager
+    # under FSDP / ZeRO-3. Set False to force eager.
+    use_torch_compile: bool = True
+
     # Training presets
     optimizer_lr: float = 2.5e-5
     optimizer_betas: tuple[float, float] = (0.9, 0.95)

--- a/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
@@ -72,6 +72,7 @@ def _preferred_dtype():
     return torch.float32 if torch.onnx.is_in_onnx_export() else torch.bfloat16
 
 
+@torch.compiler.disable
 def _global_or_branch_decisions(
     presence_locals: tuple[bool, ...],
     any_locals: tuple[bool, ...],
@@ -921,7 +922,10 @@ class PI07LowLevelPolicy(PreTrainedPolicy):
         actions = batch["actions"]
         actions_is_pad = batch.get("action_is_pad")
 
-        losses = self.model.forward(
+        # Call via __call__ (not .forward) so an in-place torch.compile of
+        # self.model (see PreTrainedPolicy.maybe_compile_for_training) is
+        # actually dispatched; a direct .forward() bypasses the compiled call.
+        losses = self.model(
             videos,
             vid_masks,
             lang_tokens,

--- a/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
@@ -329,6 +329,8 @@ class PI07LowLevelPolicy(PreTrainedPolicy):
 
     config_class = PI07LowLevelConfig
     name = "pi07_low_level"
+    # forward() dispatches self.model via __call__, so nn.Module.compile() takes effect.
+    supports_torch_compile = True
 
     # Per-(robot_type, control_mode) projections live on the inner
     # `self.model` (PerGroupLinear when `config.per_group_projection`), so their

--- a/src/opentau/policies/pretrained.py
+++ b/src/opentau/policies/pretrained.py
@@ -109,6 +109,17 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
     name: None
     """The name of the policy. Must be defined in subclasses."""
 
+    supports_torch_compile: bool = False
+    """Whether :meth:`maybe_compile_for_training` may compile this policy's
+    ``self.model``. Default ``False``: opt-in per policy, because the in-place
+    ``nn.Module.compile`` only takes effect if the policy's training ``forward``
+    invokes the submodule via ``self.model(...)`` (``__call__``) rather than
+    ``self.model.forward(...)``. Subclasses whose forward has been switched to
+    ``self.model(...)`` (currently :class:`~opentau.policies.pi05.modeling_pi05.PI05Policy`
+    and :class:`~opentau.policies.pi07.low_level.modeling_pi07_low_level.PI07LowLevelPolicy`)
+    set this ``True``. Leaving it ``False`` makes ``use_torch_compile=True`` a
+    *loud* no-op on unwired policies instead of a silent compile-but-never-dispatch."""
+
     _PER_GROUP_PROJECTION_PREFIXES: tuple[str, ...] = ()
     """State-dict key prefixes for per-(robot_type, control_mode) projection
     weights (``PerGroupLinear``: ``<prefix>weight`` shaped ``(G, out, in)`` and
@@ -1141,6 +1152,19 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
         (DeepSpeed ZeRO-3 / FSDP) before this runs.
         """
         if not getattr(self.config, "use_torch_compile", False):
+            return
+        # The in-place compile only fires if the policy's forward calls the
+        # submodule via ``self.model(...)``. Policies that still call
+        # ``self.model.forward(...)`` would compile-but-never-dispatch — a silent
+        # no-op. Gate on the explicit opt-in so unwired policies warn loudly
+        # instead. Only pi05 / pi07-low-level are wired (and validated) today.
+        if not getattr(self, "supports_torch_compile", False):
+            logging.warning(
+                "use_torch_compile=True but %s is not wired for torch.compile "
+                "(its forward does not dispatch self.model via __call__); skipping "
+                "compilation. Supported today: PI05Policy, PI07LowLevelPolicy.",
+                type(self).__name__,
+            )
             return
         target = getattr(self, "model", None)
         if not isinstance(target, nn.Module):

--- a/src/opentau/policies/pretrained.py
+++ b/src/opentau/policies/pretrained.py
@@ -1113,6 +1113,56 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
         """
         raise NotImplementedError
 
+    def maybe_compile_for_training(self) -> None:
+        """Optionally ``torch.compile`` the heavy compute submodule for training.
+
+        Controlled by ``config.use_torch_compile``. When enabled, compiles the
+        inner flow-matching module (``self.model`` on pi05 / pi07) *in place*
+        via :meth:`torch.nn.Module.compile`. The in-place form only swaps the
+        submodule's ``__call__`` dispatch for a compiled one — it does **not**
+        wrap the module in a ``torch._dynamo.OptimizedModule`` and does **not**
+        prefix ``state_dict`` keys with ``_orig_mod.``. So ``self.parameters()``
+        and the on-disk checkpoint layout are unchanged: the optimizer built
+        afterwards sees the same params, and resume / ``from_pretrained`` stay
+        compatible with both compiled and uncompiled checkpoints.
+
+        The policy wrapper's own ``forward`` (tokenization, normalization, the
+        ``.cpu().tolist()`` / numpy / string preprocessing) is intentionally
+        left uncompiled — it is cheap relative to the transformer and is full of
+        host-side ops that would only force graph breaks.
+
+        Note: this relies on the training forward calling the submodule via
+        ``self.model(...)`` (``__call__``), not ``self.model.forward(...)`` —
+        the latter bypasses the compiled dispatch installed by
+        ``nn.Module.compile`` and would silently no-op the compile.
+
+        No-op unless ``config.use_torch_compile`` is True. The caller
+        (``train.py``) is responsible for rejecting parameter-sharding backends
+        (DeepSpeed ZeRO-3 / FSDP) before this runs.
+        """
+        if not getattr(self.config, "use_torch_compile", False):
+            return
+        target = getattr(self, "model", None)
+        if not isinstance(target, nn.Module):
+            logging.warning(
+                "use_torch_compile=True but %s has no inner `self.model` nn.Module to compile; "
+                "leaving the policy uncompiled.",
+                type(self).__name__,
+            )
+            return
+        mode = getattr(self.config, "torch_compile_mode", "default") or "default"
+        logging.info(
+            "torch.compile: compiling %s.model in place (mode=%r). The policy wrapper's "
+            "forward (preprocessing) stays in eager.",
+            type(self).__name__,
+            mode,
+        )
+        # In-place compile: rewrites only `target.__call__`, preserving the
+        # module hierarchy / state_dict keys. Lazy — the actual trace happens on
+        # the first forward, so this is safe to call before `accelerator.prepare`
+        # moves params to GPU.
+        target.compile(mode=mode)
+
     @abc.abstractmethod
     def reset(self):
         """Resets the policy state.

--- a/src/opentau/policies/pretrained.py
+++ b/src/opentau/policies/pretrained.py
@@ -1151,9 +1151,29 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
             )
             return
         mode = getattr(self.config, "torch_compile_mode", "default") or "default"
+        # Use eager's RNG under compile instead of inductor's functionalized
+        # (philox) RNG. Two reasons, both load-bearing here:
+        #   1. Determinism: the flow-matching forward samples `noise` / `time`
+        #      *inside* the compiled region. With functionalized RNG, two
+        #      same-seed runs diverge at the per-step loss (inductor seeds the
+        #      philox offset independently of eager's generator); fallback_random
+        #      makes the compiled draws match eager, so same-seed runs stay
+        #      bit-identical — preserving the determinism the eager path has.
+        #   2. Stability: inductor's backward RNG-op partitioner raises
+        #      `KeyError: '_scaled_dot_product_flash_attention'` when SDPA-flash
+        #      attention (pi07) is combined with gradient checkpointing under
+        #      functionalized RNG. Falling back to eager RNG bypasses that path.
+        # The cost (RNG ops aren't fused into surrounding kernels) is negligible
+        # for training.
+        try:
+            import torch._inductor.config as _inductor_config
+
+            _inductor_config.fallback_random = True
+        except Exception as exc:  # pragma: no cover - inductor always present with torch>=2
+            logging.warning("Could not set torch._inductor.config.fallback_random: %s", exc)
         logging.info(
-            "torch.compile: compiling %s.model in place (mode=%r). The policy wrapper's "
-            "forward (preprocessing) stays in eager.",
+            "torch.compile: compiling %s.model in place (mode=%r, inductor fallback_random=True). "
+            "The policy wrapper's forward (preprocessing) stays in eager.",
             type(self).__name__,
             mode,
         )

--- a/src/opentau/scripts/profile_step.py
+++ b/src/opentau/scripts/profile_step.py
@@ -202,6 +202,23 @@ def profile(cfg: TrainPipelineConfig):
             )
         cfg.policy.gradient_checkpointing = want_ckpt
 
+    # Optional: toggle torch.compile per run (mirrors GRAD_CHECKPOINT above).
+    # TORCH_COMPILE=true/false overrides cfg.policy.use_torch_compile so the
+    # compile-on vs compile-off step time can be A/B'd without editing the JSON.
+    # The strict ZeRO-3/FSDP backend guard in train.py is not duplicated here:
+    # profile_step runs under the same accelerator, so an unsupported backend
+    # would hit the same stale-guard recompiles it warns about.
+    compile_env = os.environ.get("TORCH_COMPILE")
+    if compile_env is not None and hasattr(cfg.policy, "use_torch_compile"):
+        want_compile = compile_env.lower() == "true"
+        if accelerator.is_main_process:
+            logging.info(
+                "TORCH_COMPILE=%s: overriding cfg.policy.use_torch_compile (was %r)",
+                compile_env,
+                cfg.policy.use_torch_compile,
+            )
+        cfg.policy.use_torch_compile = want_compile
+
     # Mirror train.py: under DeepSpeed ZeRO-3 we must disable the per-construction
     # parameter partitioning (it shards before init, breaking shape-dependent
     # initializers like SigLIP's lecun_normal_). No-op for any non-ZeRO-3 backend.
@@ -224,6 +241,12 @@ def profile(cfg: TrainPipelineConfig):
     # MixedPrecision provides bf16 compute on the fly).
     if accelerator.distributed_type != accelerate.DistributedType.FSDP:
         policy.to(torch.bfloat16)
+    # Mirror train.py: optionally torch.compile the flow-matching submodule in
+    # place before the optimizer / accelerator.prepare wrap it. No-op unless
+    # cfg.policy.use_torch_compile (set in the JSON or via TORCH_COMPILE above).
+    # The WARMUP_STEPS=20 loop below absorbs the first-forward compile cost, so
+    # the measured-step timings reflect steady-state compiled throughput.
+    policy.maybe_compile_for_training()
 
     skip_optim = os.environ.get("PROFILE_NO_OPTIM", "0") == "1"
     if skip_optim:

--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -678,39 +678,39 @@ def train(cfg: TrainPipelineConfig):
                     "is compatible with torch.utils.checkpoint)."
                 )
 
-    # Strict guard for use_torch_compile (mirrors gradient_checkpointing above).
-    # `nn.Module.compile` traces the flow-matching submodule's forward and caches
-    # guards keyed on parameter/buffer storage and shapes. DeepSpeed ZeRO-3 and
-    # FSDP re-shard / re-materialize parameters on every forward, so those guards
-    # go stale and the graph either recompiles every step (erasing the speedup)
-    # or reads a sharded parameter — reject both up front. DDP / single-process /
-    # DeepSpeed ZeRO-1/2 keep parameters replicated and intact across forwards.
+    # Backend compatibility for use_torch_compile. `nn.Module.compile` caches
+    # guards keyed on parameter/buffer storage, but DeepSpeed ZeRO-3 and FSDP
+    # re-shard / re-materialize parameters on every forward, so those guards go
+    # stale (recompiling every step or reading a sharded parameter). DDP /
+    # single-process / DeepSpeed ZeRO-1/2 keep parameters intact across forwards.
+    # Because compile now defaults ON for the policies that support it, fall back
+    # to eager with a warning under an incompatible backend rather than raising —
+    # a ZeRO-3 / FSDP run should still train (just uncompiled), not crash on a
+    # default. (An explicit --policy.use_torch_compile=true on such a backend is
+    # likewise honored as a best-effort request and downgraded with the warning.)
     if getattr(cfg.policy, "use_torch_compile", False):
-        compile_allowed = {
+        unsupported_backend = None
+        if accelerator.distributed_type not in (
             accelerate.DistributedType.MULTI_GPU,
             accelerate.DistributedType.NO,
             accelerate.DistributedType.DEEPSPEED,
-        }
-        if accelerator.distributed_type not in compile_allowed:
-            raise ValueError(
-                f"use_torch_compile=True is not supported under "
-                f"distributed_type={accelerator.distributed_type}. Supported: "
-                "MULTI_GPU (DDP), NO (single process), DEEPSPEED (ZeRO-1/2 only). "
-                "FSDP re-shards parameters during forward, which invalidates "
-                "torch.compile's traced guards. Either set use_torch_compile=False "
-                "or switch to a non-parameter-sharding backend."
-            )
-        if accelerator.distributed_type == accelerate.DistributedType.DEEPSPEED:
+        ):
+            unsupported_backend = str(accelerator.distributed_type)
+        elif accelerator.distributed_type == accelerate.DistributedType.DEEPSPEED:
             zero_stage = accelerator.deepspeed_plugin.hf_ds_config.config.get("zero_optimization", {}).get(
                 "stage", 0
             )
             if zero_stage >= 3:
-                raise ValueError(
-                    f"use_torch_compile=True is not supported under DeepSpeed ZeRO "
-                    f"stage {zero_stage}. ZeRO-3 re-shards parameters during forward, "
-                    "invalidating torch.compile's traced guards. Use zero_stage 1 or 2 "
-                    "(parameters stay replicated), or set use_torch_compile=False."
-                )
+                unsupported_backend = f"DeepSpeed ZeRO stage {zero_stage}"
+        if unsupported_backend is not None:
+            logging.warning(
+                "use_torch_compile=True is not supported under %s: parameters are "
+                "re-sharded during forward, which invalidates torch.compile's traced "
+                "guards. Falling back to eager (training continues uncompiled). Use "
+                "DDP / single-process / DeepSpeed ZeRO-1/2 to enable compilation.",
+                unsupported_backend,
+            )
+            cfg.policy.use_torch_compile = False
 
     logging.info(pformat(cfg.to_dict()))
 

--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -678,6 +678,40 @@ def train(cfg: TrainPipelineConfig):
                     "is compatible with torch.utils.checkpoint)."
                 )
 
+    # Strict guard for use_torch_compile (mirrors gradient_checkpointing above).
+    # `nn.Module.compile` traces the flow-matching submodule's forward and caches
+    # guards keyed on parameter/buffer storage and shapes. DeepSpeed ZeRO-3 and
+    # FSDP re-shard / re-materialize parameters on every forward, so those guards
+    # go stale and the graph either recompiles every step (erasing the speedup)
+    # or reads a sharded parameter — reject both up front. DDP / single-process /
+    # DeepSpeed ZeRO-1/2 keep parameters replicated and intact across forwards.
+    if getattr(cfg.policy, "use_torch_compile", False):
+        compile_allowed = {
+            accelerate.DistributedType.MULTI_GPU,
+            accelerate.DistributedType.NO,
+            accelerate.DistributedType.DEEPSPEED,
+        }
+        if accelerator.distributed_type not in compile_allowed:
+            raise ValueError(
+                f"use_torch_compile=True is not supported under "
+                f"distributed_type={accelerator.distributed_type}. Supported: "
+                "MULTI_GPU (DDP), NO (single process), DEEPSPEED (ZeRO-1/2 only). "
+                "FSDP re-shards parameters during forward, which invalidates "
+                "torch.compile's traced guards. Either set use_torch_compile=False "
+                "or switch to a non-parameter-sharding backend."
+            )
+        if accelerator.distributed_type == accelerate.DistributedType.DEEPSPEED:
+            zero_stage = accelerator.deepspeed_plugin.hf_ds_config.config.get("zero_optimization", {}).get(
+                "stage", 0
+            )
+            if zero_stage >= 3:
+                raise ValueError(
+                    f"use_torch_compile=True is not supported under DeepSpeed ZeRO "
+                    f"stage {zero_stage}. ZeRO-3 re-shards parameters during forward, "
+                    "invalidating torch.compile's traced guards. Use zero_stage 1 or 2 "
+                    "(parameters stay replicated), or set use_torch_compile=False."
+                )
+
     logging.info(pformat(cfg.to_dict()))
 
     if accelerator.is_main_process:
@@ -779,6 +813,16 @@ def train(cfg: TrainPipelineConfig):
     #     params materialize in bf16 transiently during the all-gather.
     if accelerator.distributed_type != accelerate.DistributedType.FSDP:
         policy.to(torch.bfloat16)
+    # Optionally torch.compile the flow-matching submodule (in place) now, while
+    # `policy` is still the raw module so `self.model` is directly reachable, and
+    # before the optimizer / `accelerator.prepare` wrap it. The in-place compile
+    # leaves `policy.parameters()` and the state_dict layout unchanged (see
+    # PreTrainedPolicy.maybe_compile_for_training), so the optimizer built below
+    # still sees the same params and resume stays checkpoint-compatible. The
+    # compile is lazy (first-forward trace) and the compiled call runs inside the
+    # DeepSpeedEngine / DDP wrapper's forward. No-op unless
+    # cfg.policy.use_torch_compile is set (validated against the backend above).
+    policy.maybe_compile_for_training()
     logging.info("Creating optimizer and scheduler")
     optimizer, lr_scheduler = make_optimizer_and_scheduler(cfg, policy)
     # Outside DeepSpeed *and* FSDP, wrap the optimizer so it carries fp32

--- a/tests/policies/test_torch_compile.py
+++ b/tests/policies/test_torch_compile.py
@@ -67,15 +67,24 @@ _POLICY_CONFIG_CASES = [
 ALL_POLICY_CONFIGS = [c for c, _ in _POLICY_CONFIG_CASES]
 _POLICY_CONFIG_IDS = [name for _, name in _POLICY_CONFIG_CASES]
 
+# Policies wired for (and defaulting to) torch.compile — their forward dispatches
+# self.model via __call__ and they set supports_torch_compile=True. PI05Config's
+# default propagates to its PI05ContinuousStateConfig subclass.
+_COMPILE_ON_BY_DEFAULT = {PI05Config, PI05ContinuousStateConfig, PI07LowLevelConfig}
+
 
 @pytest.mark.parametrize("config_cls", ALL_POLICY_CONFIGS, ids=_POLICY_CONFIG_IDS)
-def test_compile_defaults_off(config_cls):
-    """Every policy config inherits the compile knobs with safe defaults:
-    compilation off, mode "default". A regression means a subclass shadowed the
-    parent field or a default flipped — either of which would change the default
-    training path."""
+def test_compile_default(config_cls):
+    """torch.compile defaults ON only for the wired pi05 / pi07-low-level configs
+    and OFF for every other policy (so unwired policies keep their eager default
+    and never hit the warn-and-skip). ``torch_compile_mode`` defaults "default"
+    everywhere. A regression here means a default flipped or a subclass shadowed
+    the field."""
     cfg = config_cls()
-    assert cfg.use_torch_compile is False
+    expected = config_cls in _COMPILE_ON_BY_DEFAULT
+    assert cfg.use_torch_compile is expected, (
+        f"{config_cls.__name__}.use_torch_compile default should be {expected}"
+    )
     assert cfg.torch_compile_mode == "default"
 
 

--- a/tests/policies/test_torch_compile.py
+++ b/tests/policies/test_torch_compile.py
@@ -108,9 +108,10 @@ class _StubPolicy:
 
     maybe_compile_for_training = PreTrainedPolicy.maybe_compile_for_training
 
-    def __init__(self, config, model):
+    def __init__(self, config, model, supports=True):
         self.config = config
         self.model = model
+        self.supports_torch_compile = supports
 
 
 def _tiny_model() -> nn.Module:
@@ -157,3 +158,29 @@ def test_missing_model_is_safe(caplog):
     policy = _StubPolicy(_StubConfig(use_torch_compile=True), model=None)
     # Should not raise.
     policy.maybe_compile_for_training()
+
+
+def test_unsupported_policy_warns_and_skips():
+    """``use_torch_compile=True`` on a policy whose forward still calls
+    ``self.model.forward(...)`` (``supports_torch_compile=False``) must be a LOUD
+    no-op — warn and skip, never silently compile-but-never-dispatch. Pins the fix
+    for the shared-config footgun: the flag lives on ``PreTrainedConfig`` but only
+    wired policies should actually compile."""
+    model = _tiny_model()
+    policy = _StubPolicy(_StubConfig(use_torch_compile=True), model, supports=False)
+    policy.maybe_compile_for_training()  # must not raise
+    assert model._compiled_call_impl is None  # left uncompiled
+
+
+def test_support_marker_is_opt_in():
+    """Only the wired policies advertise compile support; the base default is off,
+    and an unwired policy (pi0) stays off. Guards against a future policy
+    inheriting ``True`` by accident or the wired flags being dropped."""
+    from opentau.policies.pi0.modeling_pi0 import PI0Policy
+    from opentau.policies.pi05.modeling_pi05 import PI05Policy
+    from opentau.policies.pi07.low_level.modeling_pi07_low_level import PI07LowLevelPolicy
+
+    assert PreTrainedPolicy.supports_torch_compile is False
+    assert PI05Policy.supports_torch_compile is True
+    assert PI07LowLevelPolicy.supports_torch_compile is True
+    assert PI0Policy.supports_torch_compile is False

--- a/tests/policies/test_torch_compile.py
+++ b/tests/policies/test_torch_compile.py
@@ -1,0 +1,159 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the ``use_torch_compile`` training knob on
+:class:`~opentau.configs.policies.PreTrainedConfig` and the in-place compile
+helper :meth:`~opentau.policies.pretrained.PreTrainedPolicy.maybe_compile_for_training`.
+
+Pins the contract the training pipeline relies on:
+
+1. Every policy config in the registry inherits ``use_torch_compile = False``
+   and ``torch_compile_mode = "default"`` — so adding a new policy never
+   silently turns compilation on, and the default eager path is unchanged.
+2. Both fields are keyword-settable on every config (draccus plumbing intact).
+3. ``maybe_compile_for_training`` is a no-op when the flag is off, installs the
+   in-place compiled dispatch when it is on, and — crucially — does NOT change
+   ``self.model``'s ``state_dict`` keys (no ``_orig_mod.`` prefix), so existing
+   checkpoints stay loadable and the optimizer still sees the same params.
+
+These are all CPU-safe: ``torch.nn.Module.compile`` is lazy (it only swaps the
+``__call__`` dispatch; the trace happens on the first forward), so none of this
+actually invokes the inductor backend.
+"""
+
+import pytest
+import torch.nn as nn
+
+from opentau.policies.pi0.configuration_pi0 import PI0Config
+from opentau.policies.pi05.configuration_pi05 import PI05Config, PI05ContinuousStateConfig
+from opentau.policies.pi05_mem.configuration_pi05 import PI05MemConfig
+from opentau.policies.pi06.configuration_pi06 import PI06Config
+from opentau.policies.pi07.high_level_planner.configuration_pi07_high_level import (
+    PI07HighLevelPlannerConfig as PI07HighLevelConfig,
+)
+from opentau.policies.pi07.low_level.configuration_pi07_low_level import PI07LowLevelConfig
+from opentau.policies.pi07_paligemma.high_level_planner.configuration_pi07_high_level import (
+    PI07HighLevelPlannerConfig as PI07PaligemmaHighLevelConfig,
+)
+from opentau.policies.pi07_paligemma.low_level.configuration_pi07_low_level import (
+    PI07PaligemmaLowLevelConfig,
+)
+from opentau.policies.pretrained import PreTrainedPolicy
+from opentau.policies.value.configuration_value import ValueConfig
+
+_POLICY_CONFIG_CASES = [
+    (PI0Config, "PI0Config"),
+    (PI05Config, "PI05Config"),
+    (PI05ContinuousStateConfig, "PI05ContinuousStateConfig"),
+    (PI05MemConfig, "PI05MemConfig"),
+    (PI06Config, "PI06Config"),
+    (PI07LowLevelConfig, "PI07LowLevelConfig"),
+    (PI07HighLevelConfig, "PI07HighLevelConfig"),
+    (PI07PaligemmaLowLevelConfig, "PI07PaligemmaLowLevelConfig"),
+    (PI07PaligemmaHighLevelConfig, "PI07PaligemmaHighLevelConfig"),
+    (ValueConfig, "ValueConfig"),
+]
+ALL_POLICY_CONFIGS = [c for c, _ in _POLICY_CONFIG_CASES]
+_POLICY_CONFIG_IDS = [name for _, name in _POLICY_CONFIG_CASES]
+
+
+@pytest.mark.parametrize("config_cls", ALL_POLICY_CONFIGS, ids=_POLICY_CONFIG_IDS)
+def test_compile_defaults_off(config_cls):
+    """Every policy config inherits the compile knobs with safe defaults:
+    compilation off, mode "default". A regression means a subclass shadowed the
+    parent field or a default flipped — either of which would change the default
+    training path."""
+    cfg = config_cls()
+    assert cfg.use_torch_compile is False
+    assert cfg.torch_compile_mode == "default"
+
+
+@pytest.mark.parametrize("config_cls", ALL_POLICY_CONFIGS, ids=_POLICY_CONFIG_IDS)
+def test_compile_fields_settable(config_cls):
+    """Both fields are keyword-settable on every policy config. Catches a
+    draccus renaming or a subclass overriding the parent field with a different
+    type."""
+    cfg = config_cls(use_torch_compile=True, torch_compile_mode="max-autotune")
+    assert cfg.use_torch_compile is True
+    assert cfg.torch_compile_mode == "max-autotune"
+
+
+class _StubConfig:
+    """Minimal stand-in for the two fields the helper reads."""
+
+    def __init__(self, use_torch_compile: bool = False, torch_compile_mode: str = "default"):
+        self.use_torch_compile = use_torch_compile
+        self.torch_compile_mode = torch_compile_mode
+
+
+class _StubPolicy:
+    """Duck-typed stand-in for a policy.
+
+    ``maybe_compile_for_training`` only touches ``self.config`` (two fields),
+    ``self.model``, and ``type(self).__name__`` — so a minimal object exercises
+    the exact logic without constructing a real policy (which would download and
+    instantiate a multi-billion-parameter PaliGemma / Gemma 3 backbone).
+    """
+
+    maybe_compile_for_training = PreTrainedPolicy.maybe_compile_for_training
+
+    def __init__(self, config, model):
+        self.config = config
+        self.model = model
+
+
+def _tiny_model() -> nn.Module:
+    return nn.Sequential(nn.Linear(4, 4), nn.ReLU(), nn.Linear(4, 2))
+
+
+def test_disabled_is_noop():
+    """Flag off → the submodule is left completely untouched (no compiled
+    dispatch installed). This is the default training path."""
+    model = _tiny_model()
+    policy = _StubPolicy(_StubConfig(use_torch_compile=False), model)
+    policy.maybe_compile_for_training()
+    # nn.Module initializes _compiled_call_impl to None; compile() sets it.
+    assert model._compiled_call_impl is None
+
+
+def test_enabled_installs_compiled_dispatch():
+    """Flag on → ``nn.Module.compile`` installs the compiled ``__call__``
+    dispatch on the submodule (lazy; no actual trace happens here)."""
+    model = _tiny_model()
+    policy = _StubPolicy(_StubConfig(use_torch_compile=True), model)
+    policy.maybe_compile_for_training()
+    assert model._compiled_call_impl is not None
+
+
+def test_enabled_preserves_state_dict_keys():
+    """The whole reason for using in-place ``nn.Module.compile`` instead of
+    ``model = torch.compile(model)``: the ``state_dict`` keys must be byte-for-
+    byte identical, with no ``_orig_mod.`` prefix, so existing checkpoints keep
+    loading and the optimizer keeps seeing the same parameter names."""
+    model = _tiny_model()
+    before = set(model.state_dict().keys())
+    policy = _StubPolicy(_StubConfig(use_torch_compile=True), model)
+    policy.maybe_compile_for_training()
+    after = set(model.state_dict().keys())
+    assert before == after
+    assert not any("_orig_mod" in k for k in after)
+
+
+def test_missing_model_is_safe(caplog):
+    """A policy with no inner ``self.model`` nn.Module must not raise — it warns
+    and leaves the policy uncompiled (defensive against future policies that
+    don't follow the flow-matching layout)."""
+    policy = _StubPolicy(_StubConfig(use_torch_compile=True), model=None)
+    # Should not raise.
+    policy.maybe_compile_for_training()


### PR DESCRIPTION
## What this does

Adds a **`torch.compile` path for training** (⚡️ Performance), wired for **π₀.₅ and π₀.₇** and **on by default** for them.

Two new fields on `PreTrainedConfig`:

- `use_torch_compile: bool` — base default `False`; **overridden to `True` on `PI05Config` and `PI07LowLevelConfig`** (the two policies wired for it), so pi05/pi07 training compiles by default. Other policies stay eager (no behaviour change for them). Set `--policy.use_torch_compile=false` to opt out.
- `torch_compile_mode: str = "default"`

When enabled, `PreTrainedPolicy.maybe_compile_for_training()` compiles the inner **flow-matching module** (`self.model` — `PI05FlowMatching` / `PI07LowLevelFlowMatching`), not the policy wrapper. The wrapper's `forward` does tokenization / normalization / `.cpu().tolist()` / numpy / string work that would only graph-break, while `self.model.forward` is the heavy two-pass transformer (backbone prefix + action-expert) that actually benefits.

Key implementation choices:

- **In-place `nn.Module.compile()`, not `model = torch.compile(model)`.** The in-place form swaps only the submodule's `__call__` dispatch — it does **not** wrap the module in an `OptimizedModule` and does **not** prefix `state_dict` keys with `_orig_mod.`. So `policy.parameters()` and the on-disk checkpoint layout are unchanged: the optimizer built afterwards sees the same params, and resume / `from_pretrained` stay compatible with existing (uncompiled) checkpoints.
- Because `nn.Module.compile()` only intercepts `__call__`, the two policies' training forward was switched from `self.model.forward(...)` to `self.model(...)` (a direct `.forward()` call bypasses the compiled dispatch and would silently no-op the compile). No hooks are registered on `self.model`, so this is numerically identical when compile is off (verified below).
- **pi07's `_global_or_branch_decisions` is decorated `@torch.compiler.disable`** so its cross-rank `all_reduce` graph-breaks cleanly and stays in eager — keeping the OR-reduce rank-consistent instead of being traced into the compiled region.
- **`train.py` backend handling**: under DeepSpeed ZeRO-3 / FSDP (both re-shard parameters during forward, invalidating the traced guards), it **warns and falls back to eager** rather than raising — since compile is now a default, an incompatible backend should still train (uncompiled), not crash. DDP / single-process / DeepSpeed ZeRO-1/2 compile normally. The compile is applied after the bf16 cast and before `accelerator.prepare`, while `policy` is still the raw module.
- `profile_step.py` honors the flag and adds a `TORCH_COMPILE=true/false` env override (mirrors `GRAD_CHECKPOINT`) for A/B benchmarking.
- Because the flag lives on the shared `PreTrainedConfig` but only pi05 / pi07-low-level dispatch `self.model` via `__call__`, a `supports_torch_compile` class marker gates the compile: it's `True` only on the two wired (and validated) policies. Enabling the flag on any other policy is a **loud warn-and-skip**, not a silent compile-but-never-dispatch.

## How it was tested

**CPU unit tests** — added `tests/policies/test_torch_compile.py` (26 cases): compile defaults ON for the wired pi05 / pi07-low-level configs and OFF elsewhere; both fields keyword-settable; `maybe_compile_for_training` is a no-op when off, installs the compiled dispatch when on, **leaves `state_dict` keys unchanged** (no `_orig_mod.`), and warn-skips on an unwired policy; the `supports_torch_compile` marker is opt-in (base/pi0 `False`, pi05/pi07 `True`). Full CPU gate (`pytest -m "not gpu and not network"`) green locally.

**Real training, 8×A100-80GB, DeepSpeed ZeRO-2 + accelerate** (`profile_step.py`, π₀.₅ `configs/examples/pi05_training_config.json`, eager attention, 20 warmup + 30 measured steps, median — **0 recompiles, 0 errors**). Two regimes:

*Expert-only (`train_expert_only=true`, batch 8/rank):* compile speeds up the whole step because backward is light —

| | forward | total step | throughput |
|---|---|---|---|
| eager | 389 ms | 726 ms | 74.8 samples/s |
| **compiled** | **267 ms (1.46×)** | **574 ms (1.26×)** | **91.7 samples/s (+23%)** |

*Full fine-tune (`train_expert_only=false`, `freeze_vision_encoder=false`), batched to the 80 GB limit:* the step is dominated by ZeRO-2 gradient reduce-scatter over all 3B params (backward ≈ 93% of the step), so at a **matched** batch compile's forward win barely moves the wall-clock — but it **cuts peak memory ~21%**, which lets you fit a bigger batch:

At matched batch 12/rank (= global 96, the eager max):

| | forward | bwd | total step | peak mem |
|---|---|---|---|---|
| eager | 447 ms | 6639 ms | 7141 ms | 74.3 GB |
| **compiled** | **341 ms (1.31×)** | 6714 ms | 7074 ms (≈flat) | **58.7 GB (−21%)** |

Maxed out per backend (largest batch that fits 80 GB, full throughput at that batch):

| | max batch/rank | global batch | throughput |
|---|---|---|---|
| eager | 12 | 96 | 13.9 samples/s |
| **compiled** | **16** | **128** | **18.8 samples/s (1.35×)** |

Takeaways: compile reliably makes the **forward 1.3–1.5× faster**, is checkpoint- and determinism-safe, and **frees ~21% peak memory**. End-to-end wall-clock at a *fixed* batch depends on the forward/backward balance — large for forward-heavy regimes (expert-only, inference, grad-accumulation > 1), ≈flat for comms-bound full-finetune-under-ZeRO-2-at-GA=1. But when you *max out the batch* (what you'd actually do), the freed memory lets full-finetune go from batch 12 → 16, lifting throughput **1.35×** (13.9 → 18.8 samples/s) on the 8×A100 node. All runs above had **0 recompiles**.

**Determinism (CLAUDE.md rule 3)** — `seed=1000`, two runs each, per-step loss series (`:.6f`) on DeepSpeed ZeRO-2 (2 ranks):
- compile **off**: **bit-identical** across runs (confirms the `.forward()`→`__call__` refactor is numerically inert).
- compile **on**: initially diverged (inductor functionalized RNG); **bit-identical after `fallback_random=True`** — e.g. both runs: `5.700914, 4.987164, 5.013531, 5.779664, 5.702332, 5.995920`. Re-confirmed bit-identical with **compile-on as the new default** on a second 8×A100 node (same loss series), so the default training path is reproducible.

**π₀.₇ low-level** (`configs/examples/pi07_low_level_libero.json`, Gemma 3 backbone, `sdpa`, `gradient_checkpointing=true`, full-finetune, 6-frame video, compile on, ZeRO-2): **runs cleanly (rc=0)** — exercises the `@torch.compiler.disable`'d `all_reduce`. Two caveats worth noting: (1) the SDPA-flash + grad-checkpointing inductor crash is resolved only by `fallback_random=True` (above); (2) π₀.₇'s variable-length text embedding (`embed_language_tokens`) triggers `torch.compile` recompiles (24 observed) unless sequence lengths are stable — so the compile *speedup* on π₀.₇ is data-dependent (bucket/pad lengths to realize it), even though correctness holds. π₀.₅ (fixed shapes) saw **0 recompiles**.

**GPU pytests** — ran the `gpu`-marked subset that directly exercises the changed forward paths on the A100 node: `tests/policies/test_pi05.py` + `tests/policies/test_pi07_low_level.py` → **8 passed, 0 failed** (3 pre-existing resource-gated skips). Notably `TestPI05Integration::test_complete_pi05_pipeline_integration` passes — that's the end-to-end pi05 forward/backward that the `self.model.forward(...)`→`self.model(...)` change runs through. The full nightly `gpu_test.yml` + `regression_test.yml` (g6.12xlarge) will run on merge.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/policies/test_torch_compile.py
```

```bash
# A/B the compiled vs eager step time under DeepSpeed ZeRO-2:
TORCH_COMPILE=true PROFILE_STEPS=30 \
  accelerate launch --config_file <zero2_ga1.yaml> \
  src/opentau/scripts/profile_step.py \
  --config_path=configs/examples/pi05_training_config.json --val_freq=0
```

```bash
# Real training with compile enabled:
opentau-train --config_path=configs/examples/pi05_training_config.json --policy.use_torch_compile=true
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [x] My PR includes policy-related changes.
  - [x] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
