### PR TITLE
feat(policies): add cosmos3 (Qwen3-VL-32B reasoner + flow-matching expert)

### DIFF
--- a/configs/examples/cosmos3_training_config.json
+++ b/configs/examples/cosmos3_training_config.json
@@ -30,7 +30,7 @@
         "proj_width": 1024,
         "num_steps": 10,
         "attention_implementation": "sdpa",
-        "pretrained_backbone_repo_id": "nvidia/Cosmos-Reason2-32B",
+        "pretrained_backbone_repo_id": "TensorAuto/cosmos3-reason-32b",
         "load_pretrained_backbone": true,
         "image_resize": 224,
         "freeze_vision_encoder": true,

--- a/configs/examples/cosmos3_training_config.json
+++ b/configs/examples/cosmos3_training_config.json
@@ -1,0 +1,103 @@
+{
+    "dataset_mixture": {
+        "datasets": [
+            {
+                "repo_id": "TensorAuto/libero",
+                "episodes": [
+                    0,1,2,3,4,5,6,7,8,9
+                ]
+            }
+        ],
+        "weights": [
+            1.0
+        ],
+        "action_freq": 20.0,
+        "image_resample_strategy": "nearest",
+        "vector_resample_strategy": "nearest"
+    },
+    "policy": {
+        "type": "cosmos3",
+        "n_obs_steps": 1,
+        "normalization_mapping": {
+            "VISUAL": "IDENTITY",
+            "STATE": "MEAN_STD",
+            "ACTION": "MEAN_STD"
+        },
+        "chunk_size": 10,
+        "n_action_steps": 10,
+        "max_state_dim": 32,
+        "max_action_dim": 32,
+        "proj_width": 1024,
+        "num_steps": 10,
+        "attention_implementation": "sdpa",
+        "pretrained_backbone_repo_id": "nvidia/Cosmos-Reason2-32B",
+        "load_pretrained_backbone": true,
+        "image_resize": 224,
+        "freeze_vision_encoder": true,
+        "train_expert_only": true,
+        "gradient_checkpointing": true,
+        "prompt_max_length": 256,
+        "optimizer_lr": 2.5e-05,
+        "optimizer_betas": [
+            0.9,
+            0.95
+        ],
+        "optimizer_eps": 1e-08,
+        "optimizer_weight_decay": 1e-10,
+        "scheduler_warmup_steps": 1000,
+        "scheduler_decay_steps": 30000,
+        "scheduler_decay_lr": 2.5e-06
+    },
+    "resume": false,
+    "seed": 1000,
+    "resolution": [224, 224],
+    "num_cams": 2,
+    "max_state_dim": 32,
+    "max_action_dim": 32,
+    "action_chunk": 10,
+    "loss_weighting": {"MSE": 1, "CE": 0},
+    "num_workers": 4,
+    "batch_size": 2,
+    "gradient_accumulation_steps": 1,
+    "dataloader_batch_size": 2,
+    "prefetch_factor": 8,
+    "steps": 40,
+    "log_freq": 5,
+    "save_checkpoint": true,
+    "save_freq": 40,
+    "val_freq": 10,
+    "use_policy_training_preset": false,
+    "trace_nans": false,
+    "optimizer": {
+        "type": "adamw",
+        "lr": 2.5e-05,
+        "weight_decay": 1e-10,
+        "grad_clip_norm": 10.0,
+        "betas": [
+            0.9,
+            0.95
+        ],
+        "eps": 1e-08
+    },
+    "scheduler": {
+        "type": "cosine_decay_with_warmup",
+        "num_warmup_steps": 1000,
+        "num_decay_steps": 30000,
+        "peak_lr": 2.5e-05,
+        "decay_lr": 2.5e-06
+    },
+    "wandb": {
+        "enable": false,
+        "entity": "wyautox-autox",
+        "project": "cosmos3",
+        "run_id": null,
+        "name": null,
+        "notes": "cosmos3 training run (frozen Qwen3-VL-32B backbone + flow-matching action expert)",
+        "tags": [],
+        "group": null,
+        "job_type": null,
+        "mode": null,
+        "on_resume": "fork",
+        "disable_artifact": false
+    }
+}

--- a/docs/source/model.rst
+++ b/docs/source/model.rst
@@ -108,13 +108,14 @@ pi07_paligemma_low_level
 
 cosmos3
 -------
-- cosmos3 is the π0.5 flow-matching recipe on a **frozen Qwen3-VL-32B backbone** loaded with NVIDIA `Cosmos-Reason2-32B <https://huggingface.co/nvidia/Cosmos-Reason2-32B>`_ ("reasoner") weights, paired with a custom **sub-1B Qwen3-style action expert** (``qwen3vl_with_expert.py``). Given camera images and a language prompt, the frozen reasoner encodes the observation once (prefix); the trainable expert cross-attends to the reasoner's per-layer key/value cache to denoise a continuous action chunk by flow matching.
+- cosmos3 is the π0.5 flow-matching recipe on a **frozen Qwen3-VL-32B backbone** — the **reasoning tower of NVIDIA `Cosmos3-Super <https://huggingface.co/nvidia/Cosmos3-Super>`_**, extracted into a standalone Qwen3-VL-32B checkpoint by ``src/opentau/scripts/extract_cosmos3_reasoner.py`` — paired with a custom **sub-1B Qwen3-style action expert** (``qwen3vl_with_expert.py``). Given camera images and a language prompt, the frozen reasoner encodes the observation once (prefix); the trainable expert cross-attends to the reasoner's per-layer key/value cache to denoise a continuous action chunk by flow matching.
 - Continuous actions only (MSE flow matching) — no FAST discrete-action tokens and no subtask/response head. The backbone (vision tower + text tower) is fully frozen; only the action expert and its projections train (~0.9B parameters).
 - The expert's KV heads (8) and head dim (128) match the Qwen3-VL text tower so its keys/values concatenate with the cached backbone KV at every layer; its query-head count is free. The shared multimodal RoPE (MRoPE) is computed by the backbone and reused by the expert.
-- More details on the backbone: `Cosmos 3 technical report <https://arxiv.org/abs/2606.02800>`_ (the Cosmos 3 "reasoner" tower is a Qwen3-VL-32B-Instruct fine-tune) and the `Qwen3-VL <https://huggingface.co/Qwen/Qwen3-VL-32B-Instruct>`_ model card.
+- More details on the backbone: `Cosmos 3 technical report <https://arxiv.org/abs/2606.02800>`_. ``Cosmos3-Super`` is an interleaved Mixture-of-Transformers (a shared-attention autoregressive **reasoner** tower whose text config is Qwen3-VL-32B, plus a diffusion generation tower); cosmos3 keeps only the reasoner tower (text path ``mlp`` + the ``Qwen3VLVisionModel`` ``vision_encoder/``) and drops the generation tower.
+- Extract the reasoner once with ``python -m opentau.scripts.extract_cosmos3_reasoner --cosmos3-path <Cosmos3-Super snapshot> --out-dir <reasoner-dir>`` (Cosmos3-Super is ungated; the script remaps the reasoner weights to a standard Qwen3-VL-32B checkpoint), then set ``--policy.pretrained_backbone_repo_id=<reasoner-dir>``.
 - See the implementation in `src/opentau/policies/cosmos3/modeling_cosmos3.py <https://github.com/TensorAuto/OpenTau/blob/main/src/opentau/policies/cosmos3/modeling_cosmos3.py>`_.
 - To spin up a training run, start from `configs/examples/cosmos3_training_config.json <https://github.com/TensorAuto/OpenTau/blob/main/configs/examples/cosmos3_training_config.json>`_.
-- Requires ``transformers>=4.57`` (the ``qwen3_vl`` model class). The backbone weights download from ``nvidia/Cosmos-Reason2-32B`` on first construction (~64 GB in bf16).
+- Requires ``transformers>=4.57`` (the ``qwen3_vl`` model class). The extracted reasoner backbone is ~64 GB in bf16.
 - Config selector: ``--policy.type=cosmos3``.
 - Disclaimer: No TensorAuto-published cosmos3 checkpoint exists yet; the policy is implemented and ready to train (the expert is randomly initialized on top of the frozen reasoner).
 

--- a/docs/source/model.rst
+++ b/docs/source/model.rst
@@ -106,6 +106,19 @@ pi07_paligemma_low_level
 - Config selector: ``--policy.type=pi07_paligemma_low_level``.
 
 
+cosmos3
+-------
+- cosmos3 is the π0.5 flow-matching recipe on a **frozen Qwen3-VL-32B backbone** loaded with NVIDIA `Cosmos-Reason2-32B <https://huggingface.co/nvidia/Cosmos-Reason2-32B>`_ ("reasoner") weights, paired with a custom **sub-1B Qwen3-style action expert** (``qwen3vl_with_expert.py``). Given camera images and a language prompt, the frozen reasoner encodes the observation once (prefix); the trainable expert cross-attends to the reasoner's per-layer key/value cache to denoise a continuous action chunk by flow matching.
+- Continuous actions only (MSE flow matching) — no FAST discrete-action tokens and no subtask/response head. The backbone (vision tower + text tower) is fully frozen; only the action expert and its projections train (~0.9B parameters).
+- The expert's KV heads (8) and head dim (128) match the Qwen3-VL text tower so its keys/values concatenate with the cached backbone KV at every layer; its query-head count is free. The shared multimodal RoPE (MRoPE) is computed by the backbone and reused by the expert.
+- More details on the backbone: `Cosmos 3 technical report <https://arxiv.org/abs/2606.02800>`_ (the Cosmos 3 "reasoner" tower is a Qwen3-VL-32B-Instruct fine-tune) and the `Qwen3-VL <https://huggingface.co/Qwen/Qwen3-VL-32B-Instruct>`_ model card.
+- See the implementation in `src/opentau/policies/cosmos3/modeling_cosmos3.py <https://github.com/TensorAuto/OpenTau/blob/main/src/opentau/policies/cosmos3/modeling_cosmos3.py>`_.
+- To spin up a training run, start from `configs/examples/cosmos3_training_config.json <https://github.com/TensorAuto/OpenTau/blob/main/configs/examples/cosmos3_training_config.json>`_.
+- Requires ``transformers>=4.57`` (the ``qwen3_vl`` model class). The backbone weights download from ``nvidia/Cosmos-Reason2-32B`` on first construction (~64 GB in bf16).
+- Config selector: ``--policy.type=cosmos3``.
+- Disclaimer: No TensorAuto-published cosmos3 checkpoint exists yet; the policy is implemented and ready to train (the expert is randomly initialized on top of the frozen reasoner).
+
+
 value
 -----
 - The value model is a vision-language model used to predict the value of the current state. It is used to train VLA policies with the RECAP framework.

--- a/docs/source/model.rst
+++ b/docs/source/model.rst
@@ -112,12 +112,12 @@ cosmos3
 - Continuous actions only (MSE flow matching) — no FAST discrete-action tokens and no subtask/response head. The backbone (vision tower + text tower) is fully frozen; only the action expert and its projections train (~0.9B parameters).
 - The expert's KV heads (8) and head dim (128) match the Qwen3-VL text tower so its keys/values concatenate with the cached backbone KV at every layer; its query-head count is free. The shared multimodal RoPE (MRoPE) is computed by the backbone and reused by the expert.
 - More details on the backbone: `Cosmos 3 technical report <https://arxiv.org/abs/2606.02800>`_. ``Cosmos3-Super`` is an interleaved Mixture-of-Transformers (a shared-attention autoregressive **reasoner** tower whose text config is Qwen3-VL-32B, plus a diffusion generation tower); cosmos3 keeps only the reasoner tower (text path ``mlp`` + the ``Qwen3VLVisionModel`` ``vision_encoder/``) and drops the generation tower.
-- Extract the reasoner once with ``python -m opentau.scripts.extract_cosmos3_reasoner --cosmos3-path <Cosmos3-Super snapshot> --out-dir <reasoner-dir>`` (Cosmos3-Super is ungated; the script remaps the reasoner weights to a standard Qwen3-VL-32B checkpoint), then set ``--policy.pretrained_backbone_repo_id=<reasoner-dir>``.
+- The extracted reasoner backbone is published at `TensorAuto/cosmos3-reason-32b <https://huggingface.co/TensorAuto/cosmos3-reason-32b>`_ (**private**; the default ``pretrained_backbone_repo_id``), so training pulls it directly given an HF token with TensorAuto read access. To reproduce or re-host it, run ``python -m opentau.scripts.extract_cosmos3_reasoner --cosmos3-path <Cosmos3-Super snapshot> --out-dir <reasoner-dir>`` (Cosmos3-Super is ungated; the script remaps the reasoner weights to a standard Qwen3-VL-32B checkpoint) and point ``--policy.pretrained_backbone_repo_id`` at the result.
 - See the implementation in `src/opentau/policies/cosmos3/modeling_cosmos3.py <https://github.com/TensorAuto/OpenTau/blob/main/src/opentau/policies/cosmos3/modeling_cosmos3.py>`_.
 - To spin up a training run, start from `configs/examples/cosmos3_training_config.json <https://github.com/TensorAuto/OpenTau/blob/main/configs/examples/cosmos3_training_config.json>`_.
 - Requires ``transformers>=4.57`` (the ``qwen3_vl`` model class). The extracted reasoner backbone is ~64 GB in bf16.
 - Config selector: ``--policy.type=cosmos3``.
-- Disclaimer: No TensorAuto-published cosmos3 checkpoint exists yet; the policy is implemented and ready to train (the expert is randomly initialized on top of the frozen reasoner).
+- Disclaimer: the reasoner *backbone* is published (private ``TensorAuto/cosmos3-reason-32b``), but no full cosmos3 *policy* checkpoint exists yet — the action expert is randomly initialized on top of the frozen reasoner and produced by training.
 
 
 value

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ dependencies = [
     "onnxruntime-gpu>=1.22.0 ; ((sys_platform == 'linux' and platform_machine == 'x86_64') or (sys_platform == 'win32' and (platform_machine == 'AMD64' or platform_machine == 'x86_64'))) ",
     "onnxscript>=0.3.1",
     "onnx-ir>=0.1.4",
-    "transformers==4.53.3",
+    "transformers>=4.57,<4.58",
     "scipy>=1.15.2",
     "pytest>=8.1.0",
     "pytest-cov>=5.0.0",
@@ -240,6 +240,9 @@ default.extend-ignore-identifiers-re = [
     "pn",
     "ser",
     "ein",
+    # Qwen3-VL grid shape names (temporal/height/width): image_grid_thw, video_grid_thw, grid_thw.
+    ".*grid_thw.*",
+    "thw",
 ]
 
 [build-system]

--- a/src/opentau/__init__.py
+++ b/src/opentau/__init__.py
@@ -169,6 +169,7 @@ available_policies = [
     "pi06",
     "pi07_high_level",
     "pi07_low_level",
+    "cosmos3",
     "value",
 ]
 

--- a/src/opentau/policies/__init__.py
+++ b/src/opentau/policies/__init__.py
@@ -19,6 +19,7 @@ This module exports the configuration classes for available policies,
 such as PI0, PI05, and Value policy.
 """
 
+from .cosmos3.configuration_cosmos3 import Cosmos3Config as Cosmos3Config
 from .pi0.configuration_pi0 import PI0Config as PI0Config
 from .pi05.configuration_pi05 import PI05Config as PI05Config
 from .pi05.configuration_pi05 import PI05ContinuousStateConfig as PI05ContinuousStateConfig

--- a/src/opentau/policies/cosmos3/__init__.py
+++ b/src/opentau/policies/cosmos3/__init__.py
@@ -1,0 +1,24 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""cosmos3: a flow-matching Vision-Language-Action policy.
+
+cosmos3 pairs a **frozen Qwen3-VL-32B backbone** (loaded with NVIDIA
+``Cosmos-Reason2-32B`` "reasoner" weights) with a custom, sub-1B **Qwen3-style
+flow-matching action expert** in the π0.5 dual-stream style: the backbone
+encodes images + the language prompt once (prefix), and the trainable expert
+cross-attends to the backbone's per-layer key/value cache to denoise a
+continuous action chunk. Continuous actions only (MSE flow matching) -- no FAST
+discrete-action tokens and no subtask/response head.
+"""

--- a/src/opentau/policies/cosmos3/__init__.py
+++ b/src/opentau/policies/cosmos3/__init__.py
@@ -14,9 +14,9 @@
 
 """cosmos3: a flow-matching Vision-Language-Action policy.
 
-cosmos3 pairs a **frozen Qwen3-VL-32B backbone** (loaded with NVIDIA
-``Cosmos-Reason2-32B`` "reasoner" weights) with a custom, sub-1B **Qwen3-style
-flow-matching action expert** in the π0.5 dual-stream style: the backbone
+cosmos3 pairs a **frozen Qwen3-VL-32B backbone** -- the **reasoning tower of NVIDIA
+Cosmos3-Super**, extracted into a standalone Qwen3-VL-32B checkpoint -- with a custom,
+sub-1B **Qwen3-style flow-matching action expert** in the π0.5 dual-stream style: the backbone
 encodes images + the language prompt once (prefix), and the trainable expert
 cross-attends to the backbone's per-layer key/value cache to denoise a
 continuous action chunk. Continuous actions only (MSE flow matching) -- no FAST

--- a/src/opentau/policies/cosmos3/configuration_cosmos3.py
+++ b/src/opentau/policies/cosmos3/configuration_cosmos3.py
@@ -15,9 +15,10 @@
 """Configuration for the cosmos3 policy.
 
 cosmos3 is the π0.5 flow-matching recipe with the PaliGemma backbone swapped for
-a **frozen Qwen3-VL-32B** vision-language model (loaded from
-``nvidia/Cosmos-Reason2-32B``) and a custom **sub-1B Qwen3-style action expert**.
-Continuous actions only -- there is no FAST discrete-action branch and no
+a **frozen Qwen3-VL-32B** vision-language model -- the **reasoning tower of NVIDIA
+Cosmos3-Super**, extracted into a standalone Qwen3-VL-32B checkpoint by
+``opentau.scripts.extract_cosmos3_reasoner`` -- and a custom **sub-1B Qwen3-style
+action expert**. Continuous actions only -- there is no FAST discrete-action branch and no
 response/subtask head, so the discrete/response fields of ``PI05Config`` are
 intentionally absent here.
 
@@ -63,9 +64,11 @@ class Cosmos3Config(PreTrainedConfig):
         num_steps: Number of flow-matching Euler denoising steps. Defaults to 10.
         max_delay: Maximum number of frozen action-prefix steps (real-time inference).
         pretrained_backbone_repo_id: HF repo id (or local path) for the Qwen3-VL
-            backbone weights. Defaults to ``nvidia/Cosmos-Reason2-32B`` (the
-            Cosmos 3 reasoner, a Qwen3-VL-32B fine-tune that loads with stock
-            ``transformers.Qwen3VLForConditionalGeneration``).
+            backbone weights -- the Cosmos3-Super reasoning tower extracted into a
+            standalone Qwen3-VL-32B checkpoint by
+            ``opentau.scripts.extract_cosmos3_reasoner`` (run once on the ungated
+            ``nvidia/Cosmos3-Super``). Defaults to ``TensorAuto/cosmos3-reason-32b``;
+            point it at your local extracted directory until that is published.
         load_pretrained_backbone: Whether to download/load the backbone weights on
             construction. Set ``False`` for CPU tests / tiny random configs.
         image_resize: Square side length (pixels) to resize every camera image to
@@ -125,8 +128,8 @@ class Cosmos3Config(PreTrainedConfig):
     num_steps: int = 10
     max_delay: int = 0
 
-    # --- Backbone (Qwen3-VL-32B via Cosmos-Reason2-32B) ---
-    pretrained_backbone_repo_id: str = "nvidia/Cosmos-Reason2-32B"
+    # --- Backbone (Qwen3-VL-32B reasoning tower extracted from NVIDIA Cosmos3-Super) ---
+    pretrained_backbone_repo_id: str = "TensorAuto/cosmos3-reason-32b"
     load_pretrained_backbone: bool = True
     image_resize: int = 224
     attention_implementation: str = "sdpa"

--- a/src/opentau/policies/cosmos3/configuration_cosmos3.py
+++ b/src/opentau/policies/cosmos3/configuration_cosmos3.py
@@ -67,8 +67,11 @@ class Cosmos3Config(PreTrainedConfig):
             backbone weights -- the Cosmos3-Super reasoning tower extracted into a
             standalone Qwen3-VL-32B checkpoint by
             ``opentau.scripts.extract_cosmos3_reasoner`` (run once on the ungated
-            ``nvidia/Cosmos3-Super``). Defaults to ``TensorAuto/cosmos3-reason-32b``;
-            point it at your local extracted directory until that is published.
+            ``nvidia/Cosmos3-Super``). Defaults to ``TensorAuto/cosmos3-reason-32b``,
+            the published extraction (**private** -- the training environment needs an
+            HF token with read access to the TensorAuto org; ``from_pretrained`` picks
+            up the ambient ``HF_TOKEN`` / ``~/.cache/huggingface/token``). Re-run the
+            extraction script if you need to reproduce or re-host it.
         load_pretrained_backbone: Whether to download/load the backbone weights on
             construction. Set ``False`` for CPU tests / tiny random configs.
         image_resize: Square side length (pixels) to resize every camera image to

--- a/src/opentau/policies/cosmos3/configuration_cosmos3.py
+++ b/src/opentau/policies/cosmos3/configuration_cosmos3.py
@@ -79,8 +79,6 @@ class Cosmos3Config(PreTrainedConfig):
         gradient_checkpointing: Checkpoint the expert decoder layers to trade
             compute for activation memory. Defaults to False.
         dropout: Dropout probability inside the expert. Defaults to 0.1.
-        use_deepstack: Inject Qwen3-VL deepstack vision features into the prefix
-            (fidelity to Cosmos-Reason2). Defaults to True.
         expert_hidden_size: Action-expert hidden width. Defaults to 1024.
         expert_intermediate_size: Action-expert SwiGLU MLP width. Defaults to 2048.
         expert_num_hidden_layers: Action-expert depth. MUST equal the backbone text
@@ -136,7 +134,6 @@ class Cosmos3Config(PreTrainedConfig):
     train_expert_only: bool = True
     gradient_checkpointing: bool = False
     dropout: float = 0.1
-    use_deepstack: bool = True
 
     # --- Action-expert sizing (see module docstring for the hard constraints) ---
     expert_hidden_size: int = 1024

--- a/src/opentau/policies/cosmos3/configuration_cosmos3.py
+++ b/src/opentau/policies/cosmos3/configuration_cosmos3.py
@@ -1,0 +1,240 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Configuration for the cosmos3 policy.
+
+cosmos3 is the π0.5 flow-matching recipe with the PaliGemma backbone swapped for
+a **frozen Qwen3-VL-32B** vision-language model (loaded from
+``nvidia/Cosmos-Reason2-32B``) and a custom **sub-1B Qwen3-style action expert**.
+Continuous actions only -- there is no FAST discrete-action branch and no
+response/subtask head, so the discrete/response fields of ``PI05Config`` are
+intentionally absent here.
+
+Expert sizing note (the param budget is dominated by attention, not the MLP):
+the expert key/value heads (``expert_num_key_value_heads``) and ``expert_head_dim``
+**must** match the Qwen3-VL text tower (8 / 128) so the expert's keys/values
+concatenate with the backbone's cached KV at every layer. The expert *query*
+head count (``expert_num_attention_heads``) is free (any multiple of the KV head
+count) because the backbone's prefix is run through stock transformers and only
+its KV cache -- never its queries -- is consumed by the expert. With the defaults
+below (hidden 1024, 16 query heads, 64 layers, intermediate 2048) the trainable
+expert + projections total ~0.91B parameters, comfortably under 1B.
+"""
+
+from dataclasses import dataclass, field
+
+from opentau.configs.policies import PreTrainedConfig
+from opentau.configs.types import FeatureType, NormalizationMode, PolicyFeature
+from opentau.optim.optimizers import AdamWConfig
+from opentau.optim.schedulers import (
+    CosineDecayWithWarmupSchedulerConfig,
+    LRSchedulerConfig,
+)
+
+
+@PreTrainedConfig.register_subclass("cosmos3")
+@dataclass
+class Cosmos3Config(PreTrainedConfig):
+    """Configuration class for the cosmos3 policy.
+
+    Args:
+        n_obs_steps: Number of observation steps. Only ``1`` is supported.
+        chunk_size: Trained action-chunk length (prediction horizon). Upper bound
+            for ``n_action_steps``. Defaults to 50.
+        n_action_steps: Inference execution horizon (<= ``chunk_size``). Defaults to 50.
+        normalization_mapping: Per-feature normalization modes. Visual identity,
+            state/action mean-std (matches π0.5).
+        max_state_dim: Padded proprioceptive-state dimension. Defaults to 32.
+        max_action_dim: Padded action dimension. Defaults to 32.
+        proj_width: Width of the action/time projection MLPs. Defaults to 1024.
+        prompt_max_length: Maximum language-prompt token length. Defaults to 256.
+        empty_cameras: Number of empty camera inputs to inject (sim adaptations).
+        num_steps: Number of flow-matching Euler denoising steps. Defaults to 10.
+        max_delay: Maximum number of frozen action-prefix steps (real-time inference).
+        pretrained_backbone_repo_id: HF repo id (or local path) for the Qwen3-VL
+            backbone weights. Defaults to ``nvidia/Cosmos-Reason2-32B`` (the
+            Cosmos 3 reasoner, a Qwen3-VL-32B fine-tune that loads with stock
+            ``transformers.Qwen3VLForConditionalGeneration``).
+        load_pretrained_backbone: Whether to download/load the backbone weights on
+            construction. Set ``False`` for CPU tests / tiny random configs.
+        image_resize: Square side length (pixels) to resize every camera image to
+            before the Qwen3-VL vision tower. Bounds the number of vision tokens to
+            a fixed, deterministic count. Defaults to 224.
+        attention_implementation: ``"eager"`` or ``"sdpa"`` for the expert
+            attention. ``"flash_cuda"`` is unsupported (MRoPE/QK-norm). Defaults to ``"sdpa"``.
+        freeze_vision_encoder: Freeze the Qwen3-VL vision tower. Defaults to True.
+        train_expert_only: Freeze the entire backbone; train only the expert +
+            projections. Defaults to True (cosmos3's intended regime).
+        gradient_checkpointing: Checkpoint the expert decoder layers to trade
+            compute for activation memory. Defaults to False.
+        dropout: Dropout probability inside the expert. Defaults to 0.1.
+        use_deepstack: Inject Qwen3-VL deepstack vision features into the prefix
+            (fidelity to Cosmos-Reason2). Defaults to True.
+        expert_hidden_size: Action-expert hidden width. Defaults to 1024.
+        expert_intermediate_size: Action-expert SwiGLU MLP width. Defaults to 2048.
+        expert_num_hidden_layers: Action-expert depth. MUST equal the backbone text
+            tower depth (64 for Qwen3-VL-32B). Defaults to 64.
+        expert_num_attention_heads: Action-expert query heads. Free (multiple of
+            ``expert_num_key_value_heads``). Defaults to 16.
+        expert_num_key_value_heads: Action-expert KV heads. MUST equal the backbone
+            text tower (8). Defaults to 8.
+        expert_head_dim: Per-head dimension. MUST equal the backbone (128). Defaults to 128.
+        expert_adarms_cond_dim: Width of the AdaRMS (time) conditioning vector. Defaults to 256.
+        expert_rms_norm_eps: RMSNorm epsilon for the expert. Defaults to 1e-6.
+        expert_rope_theta: RoPE base for the expert (matches the backbone, 5e6).
+            Note: when the backbone's rotary embedding is reused for the shared
+            cos/sin this is informational; kept for standalone expert rotaries.
+        optimizer_lr / optimizer_betas / optimizer_eps / optimizer_weight_decay:
+            AdamW preset (π0.5 values).
+        scheduler_warmup_steps / scheduler_decay_steps / scheduler_decay_lr:
+            Cosine-decay-with-warmup preset (π0.5 values).
+        use_torch_compile: Whether to ``torch.compile`` the model. Defaults to False
+            (enable only after verifying bit-identical seeded runs).
+    """
+
+    # --- Input / output structure ---
+    n_obs_steps: int = 1
+    chunk_size: int = 50
+    n_action_steps: int = 50
+
+    normalization_mapping: dict[str, NormalizationMode] = field(
+        default_factory=lambda: {
+            "VISUAL": NormalizationMode.IDENTITY,
+            "STATE": NormalizationMode.MEAN_STD,
+            "ACTION": NormalizationMode.MEAN_STD,
+        }
+    )
+
+    max_state_dim: int = 32
+    max_action_dim: int = 32
+
+    proj_width: int = 1024
+    prompt_max_length: int = 256
+    empty_cameras: int = 0
+
+    # Flow-matching decoding
+    num_steps: int = 10
+    max_delay: int = 0
+
+    # --- Backbone (Qwen3-VL-32B via Cosmos-Reason2-32B) ---
+    pretrained_backbone_repo_id: str = "nvidia/Cosmos-Reason2-32B"
+    load_pretrained_backbone: bool = True
+    image_resize: int = 224
+    attention_implementation: str = "sdpa"
+    freeze_vision_encoder: bool = True
+    train_expert_only: bool = True
+    gradient_checkpointing: bool = False
+    dropout: float = 0.1
+    use_deepstack: bool = True
+
+    # --- Action-expert sizing (see module docstring for the hard constraints) ---
+    expert_hidden_size: int = 1024
+    expert_intermediate_size: int = 2048
+    expert_num_hidden_layers: int = 64
+    expert_num_attention_heads: int = 16
+    expert_num_key_value_heads: int = 8
+    expert_head_dim: int = 128
+    expert_adarms_cond_dim: int = 256
+    expert_rms_norm_eps: float = 1e-6
+    expert_rope_theta: float = 5_000_000.0
+
+    # --- Training presets ---
+    optimizer_lr: float = 2.5e-5
+    optimizer_betas: tuple[float, float] = (0.9, 0.95)
+    optimizer_eps: float = 1e-8
+    optimizer_weight_decay: float = 1e-10
+
+    scheduler_warmup_steps: int = 1_000
+    scheduler_decay_steps: int = 30_000
+    scheduler_decay_lr: float = 2.5e-6
+
+    use_torch_compile: bool = False
+
+    def __post_init__(self):
+        """Validate the configuration."""
+        super().__post_init__()
+
+        if self.n_action_steps > self.chunk_size:
+            raise ValueError(
+                "The chunk size is the upper bound for the number of action steps per model "
+                f"invocation. Got {self.n_action_steps} for `n_action_steps` and {self.chunk_size} "
+                "for `chunk_size`."
+            )
+        if self.n_obs_steps != 1:
+            raise ValueError(
+                f"Multiple observation steps not handled yet. Got `n_obs_steps={self.n_obs_steps}`"
+            )
+
+        if self.attention_implementation not in ("eager", "sdpa"):
+            raise ValueError(
+                "cosmos3 supports attention_implementation in {'eager', 'sdpa'} only "
+                f"(MRoPE + QK-norm rule out 'flash_cuda'). Got '{self.attention_implementation}'."
+            )
+
+        if self.max_delay > self.chunk_size:
+            raise ValueError(
+                f"The max delay must be <= the chunk size. Got max_delay={self.max_delay} and "
+                f"chunk_size={self.chunk_size}."
+            )
+        if self.n_action_steps < self.chunk_size and self.max_delay != 0:
+            raise ValueError(
+                "A shortened execution horizon (n_action_steps < chunk_size) is not supported "
+                "together with real-time inference delay (max_delay > 0)."
+            )
+
+        # Hard concat-attention constraints vs the Qwen3-VL text tower. The exact
+        # backbone values (64 layers / 8 KV heads / 128 head_dim) are re-validated
+        # against the loaded backbone config at model-build time; here we only
+        # enforce the GQA divisibility the expert attention itself requires.
+        if self.expert_num_attention_heads % self.expert_num_key_value_heads != 0:
+            raise ValueError(
+                f"expert_num_attention_heads ({self.expert_num_attention_heads}) must be a multiple "
+                f"of expert_num_key_value_heads ({self.expert_num_key_value_heads})."
+            )
+
+    def validate_features(self) -> None:
+        """Add empty cameras to ``input_features`` if configured."""
+        for i in range(self.empty_cameras):
+            key = f"observation.images.empty_camera_{i}"
+            self.input_features[key] = PolicyFeature(type=FeatureType.VISUAL, shape=(3, 480, 640))
+
+    def get_optimizer_preset(self) -> AdamWConfig:
+        """Return the default AdamW optimizer configuration."""
+        return AdamWConfig(
+            lr=self.optimizer_lr,
+            betas=self.optimizer_betas,
+            eps=self.optimizer_eps,
+            weight_decay=self.optimizer_weight_decay,
+        )
+
+    def get_scheduler_preset(self) -> LRSchedulerConfig:
+        """Return the default cosine-decay-with-warmup scheduler configuration."""
+        return CosineDecayWithWarmupSchedulerConfig(
+            peak_lr=self.optimizer_lr,
+            decay_lr=self.scheduler_decay_lr,
+            num_warmup_steps=self.scheduler_warmup_steps,
+            num_decay_steps=self.scheduler_decay_steps,
+        )
+
+    @property
+    def observation_delta_indices(self) -> None:
+        return None
+
+    @property
+    def action_delta_indices(self) -> list[int]:
+        return list(range(self.chunk_size))
+
+    @property
+    def reward_delta_indices(self) -> None:
+        return None

--- a/src/opentau/policies/cosmos3/modeling_cosmos3.py
+++ b/src/opentau/policies/cosmos3/modeling_cosmos3.py
@@ -1,0 +1,582 @@
+#!/usr/bin/env python
+
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""cosmos3: a Vision-Language-Action flow-matching policy on a frozen Qwen3-VL-32B reasoner.
+
+cosmos3 follows the π0.5 flow-matching recipe (see ``policies/pi05/modeling_pi05.py``)
+but swaps the PaliGemma backbone for a **frozen Qwen3-VL-32B** vision-language model
+loaded with NVIDIA ``Cosmos-Reason2-32B`` weights, and pairs it with a custom sub-1B
+Qwen3-style action expert (``qwen3vl_with_expert.py``).
+
+Pipeline:
+  * The frozen reasoner encodes the camera images + language prompt once (the prefix)
+    via the stock ``Qwen3VLModel.forward``, producing a per-layer key/value cache.
+  * The trainable expert denoises a continuous action chunk (the suffix) by flow
+    matching, cross-attending to that cache at every layer. Proprioceptive state is
+    projected into a single token prepended to the expert's action chunk, so actions
+    are conditioned on state while the backbone sees only images + language.
+
+Continuous actions only (MSE flow matching) -- there is no FAST discrete-action branch
+and no response/subtask head, so cosmos3 always returns a zero ``CE`` term for loss-dict
+compatibility with ``scripts/train.py``.
+"""
+
+import math
+from collections import deque
+
+import torch
+import torch.nn.functional as F  # noqa: N812
+from einops import rearrange, repeat
+from torch import Tensor, nn
+from transformers import AutoProcessor, Qwen3VLConfig
+
+from opentau.policies.cosmos3.configuration_cosmos3 import Cosmos3Config
+from opentau.policies.cosmos3.qwen3vl_with_expert import Qwen3VLWithExpertModel
+from opentau.policies.normalize import Normalize, Unnormalize
+from opentau.policies.normalize import resolve_num_datasets as _num_datasets
+from opentau.policies.pretrained import PreTrainedPolicy
+from opentau.policies.utils import PerSampleLoss, flow_matching_masked_mse
+
+
+def _preferred_dtype():
+    return torch.float32 if torch.onnx.is_in_onnx_export() else torch.bfloat16
+
+
+def create_sinusoidal_pos_embedding(
+    time: Tensor, dimension: int, min_period: float, max_period: float, device: torch.device | str = "cpu"
+) -> Tensor:
+    """Sine-cosine positional embedding for scalar positions ``time`` of shape (B, N).
+
+    Returns (B, N, dimension). Mirrors the helper in ``pi05/modeling_pi05.py``.
+    """
+    if dimension % 2 != 0:
+        raise ValueError(f"dimension ({dimension}) must be divisible by 2")
+    if time.ndim != 2:
+        raise ValueError("`time` is expected to be of shape `(batch_size, n)`.")
+    fraction = torch.linspace(0.0, 1.0, dimension // 2, dtype=torch.float32, device=device)
+    period = min_period * (max_period / min_period) ** fraction
+    scaling_factor = 1.0 / period * 2 * math.pi
+    sin_input = rearrange(scaling_factor, "d -> 1 1 d") * rearrange(time.float(), "b n -> b n 1")
+    return torch.cat([torch.sin(sin_input), torch.cos(sin_input)], dim=2)
+
+
+def make_att_2d_masks(
+    pad_masks: Tensor,
+    att_masks: Tensor,
+    n_cross_att_tokens: int | None = None,
+    cross_att_pad_masks: Tensor | None = None,
+) -> Tensor:
+    """Build a 2-D attention mask from 1-D pad + block masks (π0.5 convention).
+
+    ``pad_masks`` bool (B, N): True = real token. ``att_masks`` int (B, N): 1 opens a new
+    causal block, 0 shares the previous token's block. Returns (B, N, N) or, when
+    ``n_cross_att_tokens`` is given, (B, N, n_cross + N) with full cross-attention to the
+    (valid) prefix prepended. Mirrors ``pi05/modeling_pi05.py::make_att_2d_masks``.
+    """
+    cumsum = torch.cumsum(att_masks, dim=1)
+    att_2d = cumsum[:, None, :] <= cumsum[:, :, None]
+    pad_2d = pad_masks[:, None, :] * pad_masks[:, :, None]
+    att_2d = att_2d & pad_2d
+    if n_cross_att_tokens is not None:
+        assert cross_att_pad_masks is not None
+        cross = torch.ones(
+            (att_masks.size(0), att_masks.size(1), n_cross_att_tokens),
+            dtype=torch.bool,
+            device=att_masks.device,
+        )
+        cross = cross & pad_masks[:, :, None] & cross_att_pad_masks[:, None, :]
+        att_2d = torch.cat((cross, att_2d), dim=2)
+    return att_2d
+
+
+class Cosmos3FlowMatching(nn.Module):
+    """Flow-matching head: frozen Qwen3-VL prefix + trainable Qwen3 action expert."""
+
+    def __init__(self, config: Cosmos3Config, qwen3vl_config: Qwen3VLConfig | None = None):
+        super().__init__()
+        self.config = config
+
+        if qwen3vl_config is None:
+            if not config.load_pretrained_backbone:
+                raise ValueError(
+                    "Cosmos3FlowMatching needs a Qwen3VLConfig: either set "
+                    "config.load_pretrained_backbone=True (load from "
+                    f"'{config.pretrained_backbone_repo_id}') or pass an explicit qwen3vl_config "
+                    "(e.g. a tiny config for CPU tests)."
+                )
+            qwen3vl_config = Qwen3VLConfig.from_pretrained(config.pretrained_backbone_repo_id)
+
+        self.qwen3vl_with_expert = Qwen3VLWithExpertModel(
+            qwen3vl_config,
+            expert_hidden_size=config.expert_hidden_size,
+            expert_intermediate_size=config.expert_intermediate_size,
+            expert_num_hidden_layers=config.expert_num_hidden_layers,
+            expert_num_attention_heads=config.expert_num_attention_heads,
+            expert_num_key_value_heads=config.expert_num_key_value_heads,
+            expert_head_dim=config.expert_head_dim,
+            expert_adarms_cond_dim=config.expert_adarms_cond_dim,
+            expert_rms_norm_eps=config.expert_rms_norm_eps,
+            dropout=config.dropout,
+            attention_implementation=config.attention_implementation,
+            freeze_vision_encoder=config.freeze_vision_encoder,
+            train_expert_only=config.train_expert_only,
+            gradient_checkpointing=config.gradient_checkpointing,
+            load_pretrained_backbone_repo=(
+                config.pretrained_backbone_repo_id if config.load_pretrained_backbone else None
+            ),
+        )
+
+        expert_hidden = config.expert_hidden_size
+        proj_width = config.proj_width
+        # Action <-> expert-hidden projections, time embedding MLP, AdaRMS conditioning,
+        # and the proprioceptive-state token projection. Kept in float32 then cast to the
+        # backbone dtype below (so GPU bf16 runs share a dtype across the cross-attention).
+        self.action_in_proj = nn.Linear(config.max_action_dim, expert_hidden)
+        self.action_out_proj = nn.Linear(expert_hidden, config.max_action_dim)
+        self.time_mlp_in = nn.Linear(proj_width, proj_width)
+        self.time_mlp_out = nn.Linear(proj_width, proj_width)
+        self.adarms_proj = nn.Linear(proj_width, config.expert_adarms_cond_dim)
+        self.state_proj = nn.Linear(config.max_state_dim, expert_hidden)
+
+        backbone_dtype = next(self.qwen3vl_with_expert.backbone.parameters()).dtype
+        for module in (
+            self.action_in_proj,
+            self.action_out_proj,
+            self.time_mlp_in,
+            self.time_mlp_out,
+            self.adarms_proj,
+            self.state_proj,
+        ):
+            module.to(dtype=backbone_dtype)
+
+    # ----- flow-matching sampling utilities (identical to pi05) -----
+
+    def sample_noise(self, shape: tuple[int, ...], device: torch.device | str) -> Tensor:
+        return torch.normal(mean=0.0, std=1.0, size=shape, dtype=torch.float32, device=device)
+
+    def sample_time(self, bsize: int, device: torch.device | str) -> Tensor:
+        beta = torch.distributions.Beta(concentration1=1.5, concentration0=1.0)
+        return beta.sample((bsize,)).to(device=device, dtype=torch.float32) * 0.999 + 0.001
+
+    # ----- suffix embedding -----
+
+    def _time_to_adarms(self, time: Tensor) -> Tensor:
+        """(B, N) timesteps -> (B, N, adarms_cond_dim) AdaRMS conditioning vectors."""
+        dtype = _preferred_dtype() if self.action_in_proj.weight.is_cuda else self.action_in_proj.weight.dtype
+        time_emb = create_sinusoidal_pos_embedding(
+            time, self.config.proj_width, min_period=4e-3, max_period=4.0, device=time.device
+        ).to(dtype)
+        x = F.silu(self.time_mlp_in(time_emb))
+        x = F.silu(self.time_mlp_out(x))
+        return self.adarms_proj(x)
+
+    def embed_suffix(
+        self, noisy_actions: Tensor, timestep: Tensor, state: Tensor
+    ) -> tuple[Tensor, Tensor, Tensor, Tensor]:
+        """Embed the proprioceptive-state token + the noisy action chunk for the expert.
+
+        Returns (embs, pad_masks, att_masks, adarms_cond) with sequence length
+        ``chunk_size + 1`` (state token prepended). The state token uses a fixed time of
+        1.0 for its AdaRMS conditioning; the action tokens use ``timestep``.
+        """
+        dtype = self.action_in_proj.weight.dtype
+        bsize = noisy_actions.shape[0]
+        device = noisy_actions.device
+
+        action_emb = self.action_in_proj(noisy_actions.to(dtype))
+        state_emb = rearrange(self.state_proj(state.to(dtype)), "b d -> b 1 d")
+        embs = torch.cat([state_emb, action_emb], dim=1)
+
+        # State token gets time=1.0; actions get their (per-step) flow-matching time.
+        state_time = torch.ones(bsize, 1, dtype=torch.float32, device=device)
+        time_full = torch.cat([state_time, timestep.to(torch.float32)], dim=1)
+        adarms_cond = self._time_to_adarms(time_full)
+
+        seq_len = embs.shape[1]
+        pad_masks = torch.ones(bsize, seq_len, dtype=torch.bool, device=device)
+        # One bidirectional block over [state, actions]; they all attend to each other
+        # and (via the cross mask) to the whole prefix.
+        att_masks = torch.tensor([1] + [0] * (seq_len - 1), dtype=torch.long, device=device)
+        att_masks = repeat(att_masks, "n -> b n", b=bsize)
+        return embs, pad_masks, att_masks, adarms_cond
+
+    def _suffix_position_ids(self, prefix_position_ids: Tensor, suffix_len: int) -> Tensor:
+        """Text-style 3-D MRoPE positions for the suffix, continuing past the prefix max.
+
+        ``prefix_position_ids`` is (3, B, S_prefix). Returns (3, B, suffix_len) where each
+        suffix token's position is identical across the temporal/height/width axes
+        (the Qwen3-VL text convention), continuing from ``prefix.max() + 1`` per sample.
+        """
+        offset = prefix_position_ids.amax(dim=(0, 2)) + 1  # (B,)
+        ar = torch.arange(suffix_len, device=prefix_position_ids.device)
+        suffix = offset[:, None] + ar[None, :]  # (B, suffix_len)
+        return repeat(suffix, "b n -> three b n", three=3)
+
+    # ----- training forward -----
+
+    def forward(
+        self,
+        input_ids: Tensor,
+        attention_mask: Tensor,
+        pixel_values: Tensor | None,
+        image_grid_thw: Tensor | None,
+        state: Tensor,
+        actions: Tensor,
+        actions_is_pad: Tensor | None = None,
+        noise: Tensor | None = None,
+        time: Tensor | None = None,
+        real_action_dim: Tensor | None = None,
+        return_per_sample: bool = False,
+    ) -> dict[str, Tensor | PerSampleLoss]:
+        """Full flow-matching training forward; returns {"MSE", "CE"(=0)} (+ per-sample)."""
+        device = actions.device
+        batch_size = actions.shape[0]
+
+        # 1) Frozen prefix forward -> per-layer KV cache + prefix MRoPE positions.
+        prefix_position_ids, _ = self.qwen3vl_with_expert.get_rope_index(
+            input_ids=input_ids, image_grid_thw=image_grid_thw, attention_mask=attention_mask
+        )
+        cached_kv = self.qwen3vl_with_expert.run_prefix(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=prefix_position_ids,
+            pixel_values=pixel_values,
+            image_grid_thw=image_grid_thw,
+        )
+
+        # 2) Flow-matching interpolation x_t and target velocity u_t.
+        if noise is None:
+            noise = self.sample_noise(actions.shape, device)
+        if time is None:
+            time = self.sample_time(batch_size, device)
+
+        delay = torch.randint(0, self.config.max_delay + 1, (batch_size,), device=device)
+        prefix_mask = rearrange(torch.arange(self.config.chunk_size, device=device), "c -> 1 c") < rearrange(
+            delay, "b -> b 1"
+        )
+        time = torch.where(prefix_mask, 0.0, rearrange(time, "b -> b 1"))  # (B, chunk)
+        time_expanded = rearrange(time, "b c -> b c 1")
+        x_t = time_expanded * noise + (1 - time_expanded) * actions
+        u_t = noise - actions
+
+        # 3) Expert (suffix) forward, cross-attending to the cached prefix KV.
+        v_t = self._run_expert(cached_kv, prefix_position_ids, attention_mask.bool(), x_t, time, state)
+
+        mse_result = flow_matching_masked_mse(
+            u_t=u_t,
+            v_t=v_t,
+            max_action_dim=self.config.max_action_dim,
+            prefix_mask=prefix_mask,
+            actions_is_pad=actions_is_pad,
+            real_action_dim=real_action_dim,
+            return_per_sample=return_per_sample,
+        )
+        mse_loss, mse_per_sample = mse_result if return_per_sample else (mse_result, None)
+
+        ce_loss = torch.zeros((), device=device, dtype=mse_loss.dtype)
+        out: dict[str, Tensor | PerSampleLoss] = {"MSE": mse_loss, "CE": ce_loss}
+        if return_per_sample:
+            out["MSE_per_sample"] = mse_per_sample
+            out["CE_per_sample"] = PerSampleLoss(
+                sum=torch.zeros(batch_size, device=device),
+                count=torch.zeros(batch_size, device=device),
+            )
+        return out
+
+    def _run_expert(
+        self,
+        cached_kv: list[tuple[Tensor, Tensor]],
+        prefix_position_ids: Tensor,
+        prefix_pad: Tensor,
+        x_t: Tensor,
+        time: Tensor,
+        state: Tensor,
+    ) -> Tensor:
+        """Embed the suffix, build masks/positions, run the expert, project to velocity."""
+        suffix_embs, suffix_pad, suffix_att, adarms_cond = self.embed_suffix(x_t, time, state)
+        n_cross = cached_kv[0][0].shape[2]
+        attn_mask = make_att_2d_masks(
+            suffix_pad, suffix_att, n_cross_att_tokens=n_cross, cross_att_pad_masks=prefix_pad
+        )
+        suffix_pos = self._suffix_position_ids(prefix_position_ids, suffix_embs.shape[1])
+        cos, sin = self.qwen3vl_with_expert.compute_rope(
+            suffix_pos, dtype=suffix_embs.dtype, device=suffix_embs.device
+        )
+        suffix_out = self.qwen3vl_with_expert.run_expert(
+            suffix_embs, cached_kv, cos, sin, attn_mask, adarms_cond
+        )
+        # Drop the prepended state token; project the action chunk to velocity.
+        v_t = self.action_out_proj(suffix_out[:, -self.config.chunk_size :])
+        return v_t.to(dtype=torch.float32)
+
+    # ----- inference sampling -----
+
+    @torch.no_grad()
+    def sample_actions(
+        self,
+        input_ids: Tensor,
+        attention_mask: Tensor,
+        pixel_values: Tensor | None,
+        image_grid_thw: Tensor | None,
+        state: Tensor,
+        action_prefix: Tensor,
+        delay: Tensor,
+        noise: Tensor | None = None,
+    ) -> Tensor:
+        """Euler-integrate the flow from noise to an action chunk (π0.5 sampler)."""
+        device = input_ids.device
+        bsize = input_ids.shape[0]
+        if noise is None:
+            noise = self.sample_noise((bsize, self.config.chunk_size, self.config.max_action_dim), device)
+
+        prefix_position_ids, _ = self.qwen3vl_with_expert.get_rope_index(
+            input_ids=input_ids, image_grid_thw=image_grid_thw, attention_mask=attention_mask
+        )
+        cached_kv = self.qwen3vl_with_expert.run_prefix(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=prefix_position_ids,
+            pixel_values=pixel_values,
+            image_grid_thw=image_grid_thw,
+        )
+        prefix_pad = attention_mask.bool()
+
+        dt = torch.tensor(-1.0 / self.config.num_steps, dtype=torch.float32, device=device)
+        x_t = noise
+        time = torch.tensor(1.0, dtype=torch.float32, device=device)
+        prefix_mask = rearrange(torch.arange(self.config.chunk_size, device=device), "c -> 1 c") < delay
+        while time >= -dt / 2:
+            x_t = torch.where(rearrange(prefix_mask, "b c -> b c 1"), action_prefix, x_t)
+            masked_time = torch.where(prefix_mask, torch.zeros_like(time), time).expand(
+                bsize, self.config.chunk_size
+            )
+            v_t = self._run_expert(cached_kv, prefix_position_ids, prefix_pad, x_t, masked_time, state)
+            x_t = x_t + dt * v_t
+            time = time + dt
+
+        x_t = torch.where(rearrange(prefix_mask, "b c -> b c 1"), action_prefix, x_t)
+        return x_t
+
+
+class Cosmos3Policy(PreTrainedPolicy):
+    """OpenTau wrapper around ``Cosmos3FlowMatching`` (normalization, processor, action queue)."""
+
+    config_class = Cosmos3Config
+    name = "cosmos3"
+    # Leave torch.compile off until bit-identical seeded runs are verified (MRoPE /
+    # dynamic shapes); the model still trains/infers eagerly.
+    supports_torch_compile = False
+
+    def __init__(
+        self,
+        config: Cosmos3Config,
+        per_dataset_stats: list[dict[str, dict[str, Tensor]]] | None = None,
+        dataset_names: list[str] | None = None,
+        qwen3vl_config: Qwen3VLConfig | None = None,
+    ):
+        super().__init__(config)
+        config.validate_features()
+        self.config = config
+
+        num_datasets = _num_datasets(per_dataset_stats, dataset_names, config)
+        self.normalize_inputs = Normalize(
+            config.input_features,
+            config.normalization_mapping,
+            per_dataset_stats=per_dataset_stats,
+            dataset_names=dataset_names,
+            num_datasets=num_datasets,
+        )
+        self.normalize_targets = Normalize(
+            config.output_features,
+            config.normalization_mapping,
+            per_dataset_stats=per_dataset_stats,
+            dataset_names=dataset_names,
+            num_datasets=num_datasets,
+        )
+        self.unnormalize_outputs = Unnormalize(
+            config.output_features,
+            config.normalization_mapping,
+            per_dataset_stats=per_dataset_stats,
+            dataset_names=dataset_names,
+            num_datasets=num_datasets,
+        )
+
+        # The Qwen3-VL processor (tokenizer + image processor) builds the multimodal
+        # prefix. Only needed when running with the real backbone; CPU tests pass a tiny
+        # ``qwen3vl_config`` and call the inner model directly with pre-built tensors.
+        self.processor = None
+        if config.load_pretrained_backbone:
+            self.processor = AutoProcessor.from_pretrained(config.pretrained_backbone_repo_id)
+
+        self.model = Cosmos3FlowMatching(config, qwen3vl_config=qwen3vl_config)
+        self.reset()
+
+    def reset(self) -> None:
+        self._action_queue = deque([], maxlen=self.config.n_action_steps)
+
+    def get_optim_params(self) -> list[nn.Parameter]:
+        # Only the trainable expert + projections (the 32B backbone is frozen) -- never
+        # hand the optimizer the frozen backbone params.
+        return [p for p in self.parameters() if p.requires_grad]
+
+    # ----- input preparation -----
+
+    def prepare_state(self, batch: dict[str, Tensor]) -> Tensor:
+        """Return the proprioceptive state padded to ``max_state_dim`` (zeros if absent)."""
+        if "state" not in batch:
+            ref = next(iter(batch.values()))
+            return torch.zeros(
+                ref.shape[0], self.config.max_state_dim, device=ref.device, dtype=torch.float32
+            )
+        state = batch["state"]
+        state_dim = state.shape[-1]
+        if state_dim > self.config.max_state_dim:
+            raise ValueError(f"State dim ({state_dim}) exceeds max_state_dim ({self.config.max_state_dim}).")
+        if state_dim < self.config.max_state_dim:
+            state = F.pad(state, (0, self.config.max_state_dim - state_dim))
+        return state
+
+    def prepare_multimodal_inputs(self, batch: dict[str, Tensor]) -> dict[str, Tensor]:
+        """Build Qwen3-VL ``input_ids``/``attention_mask``/``pixel_values``/``image_grid_thw``.
+
+        Resizes every present camera image to ``image_resize`` and runs the Qwen3-VL chat
+        template + processor so the language prompt is interleaved with the image tokens.
+        """
+        if self.processor is None:
+            raise RuntimeError(
+                "Cosmos3Policy.processor is None (constructed with load_pretrained_backbone=False). "
+                "Call the inner model with pre-built tensors, or enable the real backbone."
+            )
+        image_keys = sorted(k for k in self.config.image_features if k in batch)
+        prompts = batch["prompt"]
+        if isinstance(prompts, str):
+            prompts = [prompts]
+        bsize = len(prompts)
+        side = self.config.image_resize
+
+        texts, images_per_sample = [], []
+        for b in range(bsize):
+            content = []
+            sample_imgs = []
+            for key in image_keys:
+                img = batch[key][b]  # (C, H, W) in [0, 1]
+                img = F.interpolate(
+                    img[None].float(), size=(side, side), mode="bilinear", align_corners=False
+                )[0]
+                img = (img.clamp(0, 1) * 255).round().to(torch.uint8)
+                sample_imgs.append(rearrange(img, "c h w -> h w c").cpu().numpy())
+                content.append({"type": "image"})
+            content.append({"type": "text", "text": prompts[b]})
+            messages = [{"role": "user", "content": content}]
+            texts.append(
+                self.processor.apply_chat_template(messages, tokenize=False, add_generation_prompt=False)
+            )
+            images_per_sample.append(sample_imgs)
+
+        flat_images = [img for sample in images_per_sample for img in sample] or None
+        inputs = self.processor(text=texts, images=flat_images, return_tensors="pt", padding=True)
+        device = batch[image_keys[0]].device if image_keys else self.prepare_state(batch).device
+        return {k: v.to(device) for k, v in inputs.items()}
+
+    # ----- training / inference -----
+
+    def forward(
+        self,
+        batch: dict[str, Tensor],
+        noise: Tensor | None = None,
+        time: Tensor | None = None,
+        return_per_sample: bool = False,
+    ) -> dict[str, Tensor | PerSampleLoss]:
+        dataset_index = self._resolve_dataset_index(batch)
+        batch = self.normalize_inputs(batch, dataset_index)
+        batch = self.normalize_targets(batch, dataset_index)
+
+        mm = self.prepare_multimodal_inputs(batch)
+        state = self.prepare_state(batch)
+        return self.model(
+            input_ids=mm["input_ids"],
+            attention_mask=mm["attention_mask"],
+            pixel_values=mm.get("pixel_values"),
+            image_grid_thw=mm.get("image_grid_thw"),
+            state=state,
+            actions=batch["actions"],
+            actions_is_pad=batch.get("action_is_pad"),
+            noise=noise,
+            time=time,
+            real_action_dim=batch.get("real_action_dim"),
+            return_per_sample=return_per_sample,
+        )
+
+    @torch.no_grad()
+    def select_action(self, batch: dict[str, Tensor], noise: Tensor | None = None) -> Tensor:
+        self.eval()
+        if len(self._action_queue) == 0 or len(self._action_queue) <= self.config.max_delay:
+            action_prefix = None
+            delay = 0
+            if len(self._action_queue) > 0:
+                prefix_actions = list(self._action_queue)
+                delay = min(len(prefix_actions), self.config.max_delay)
+                prefix_actions = prefix_actions[-delay:]
+                action_prefix = torch.stack(prefix_actions, dim=1)
+            ref = next(iter(batch.values()))
+            delay = torch.tensor(delay, dtype=torch.long, device=ref.device)
+            actions = self.sample_actions(batch, noise=noise, action_prefix=action_prefix, delay=delay)
+            actions = rearrange(actions, "b c d -> c b d")
+            self._action_queue.extend(actions[delay : delay + self.config.n_action_steps])
+        return self._action_queue.popleft()
+
+    @torch.no_grad()
+    def sample_actions(
+        self,
+        batch: dict[str, Tensor],
+        action_prefix: Tensor | None = None,
+        delay: Tensor | None = None,
+        noise: Tensor | None = None,
+    ) -> Tensor:
+        dataset_index = self._resolve_dataset_index(batch)
+        batch = self.normalize_inputs(batch, dataset_index)
+        mm = self.prepare_multimodal_inputs(batch)
+        state = self.prepare_state(batch)
+        device = mm["input_ids"].device
+        bsize = mm["input_ids"].shape[0]
+
+        if delay is None:
+            delay = torch.tensor(0, dtype=torch.long, device=device)
+        if action_prefix is None:
+            action_prefix = torch.zeros(
+                bsize, self.config.chunk_size, self.config.max_action_dim, dtype=torch.float32, device=device
+            )
+        else:
+            action_prefix = self.normalize_targets({"actions": action_prefix}, dataset_index)["actions"]
+            action_prefix = F.pad(action_prefix, (0, 0, 0, self.config.chunk_size - action_prefix.shape[1]))
+
+        actions = self.model.sample_actions(
+            input_ids=mm["input_ids"],
+            attention_mask=mm["attention_mask"],
+            pixel_values=mm.get("pixel_values"),
+            image_grid_thw=mm.get("image_grid_thw"),
+            state=state,
+            action_prefix=action_prefix,
+            delay=delay,
+            noise=noise,
+        )
+        original_action_dim = self.config.action_feature.shape[0]
+        actions = actions[:, :, :original_action_dim]
+        return self.unnormalize_outputs({"actions": actions}, dataset_index)["actions"]
+
+    @torch.no_grad()
+    def predict_action_chunk(self, batch: dict[str, Tensor]) -> Tensor:
+        raise NotImplementedError("Use select_action / sample_actions for cosmos3.")

--- a/src/opentau/policies/cosmos3/modeling_cosmos3.py
+++ b/src/opentau/policies/cosmos3/modeling_cosmos3.py
@@ -102,6 +102,18 @@ def make_att_2d_masks(
     return att_2d
 
 
+def _first_tensor(batch: dict) -> Tensor:
+    """Return the first ``torch.Tensor`` value in ``batch`` for device/batch-size inference.
+
+    Skips non-tensor entries such as the ``prompt`` string list, which would raise on
+    ``.device`` / ``.shape`` if ``next(iter(batch.values()))`` happened to hit it first.
+    """
+    for value in batch.values():
+        if isinstance(value, Tensor):
+            return value
+    raise ValueError("batch contains no tensor values to infer device / batch size from")
+
+
 class Cosmos3FlowMatching(nn.Module):
     """Flow-matching head: frozen Qwen3-VL prefix + trainable Qwen3 action expert."""
 
@@ -437,7 +449,7 @@ class Cosmos3Policy(PreTrainedPolicy):
     def prepare_state(self, batch: dict[str, Tensor]) -> Tensor:
         """Return the proprioceptive state padded to ``max_state_dim`` (zeros if absent)."""
         if "state" not in batch:
-            ref = next(iter(batch.values()))
+            ref = _first_tensor(batch)
             return torch.zeros(
                 ref.shape[0], self.config.max_state_dim, device=ref.device, dtype=torch.float32
             )
@@ -479,7 +491,14 @@ class Cosmos3Policy(PreTrainedPolicy):
                 img = (img.clamp(0, 1) * 255).round().to(torch.uint8)
                 sample_imgs.append(rearrange(img, "c h w -> h w c").cpu().numpy())
                 content.append({"type": "image"})
-            content.append({"type": "text", "text": prompts[b]})
+            # Bound the language prompt to prompt_max_length tokens. We truncate the text
+            # alone (not the assembled multimodal sequence) so image placeholder tokens are
+            # never clipped.
+            prompt = prompts[b]
+            tokenizer = self.processor.tokenizer
+            prompt_ids = tokenizer.encode(prompt, add_special_tokens=False)[: self.config.prompt_max_length]
+            prompt = tokenizer.decode(prompt_ids)
+            content.append({"type": "text", "text": prompt})
             messages = [{"role": "user", "content": content}]
             texts.append(
                 self.processor.apply_chat_template(messages, tokenize=False, add_generation_prompt=False)
@@ -531,7 +550,7 @@ class Cosmos3Policy(PreTrainedPolicy):
                 delay = min(len(prefix_actions), self.config.max_delay)
                 prefix_actions = prefix_actions[-delay:]
                 action_prefix = torch.stack(prefix_actions, dim=1)
-            ref = next(iter(batch.values()))
+            ref = _first_tensor(batch)
             delay = torch.tensor(delay, dtype=torch.long, device=ref.device)
             actions = self.sample_actions(batch, noise=noise, action_prefix=action_prefix, delay=delay)
             actions = rearrange(actions, "b c d -> c b d")

--- a/src/opentau/policies/cosmos3/modeling_cosmos3.py
+++ b/src/opentau/policies/cosmos3/modeling_cosmos3.py
@@ -17,9 +17,10 @@
 """cosmos3: a Vision-Language-Action flow-matching policy on a frozen Qwen3-VL-32B reasoner.
 
 cosmos3 follows the π0.5 flow-matching recipe (see ``policies/pi05/modeling_pi05.py``)
-but swaps the PaliGemma backbone for a **frozen Qwen3-VL-32B** vision-language model
-loaded with NVIDIA ``Cosmos-Reason2-32B`` weights, and pairs it with a custom sub-1B
-Qwen3-style action expert (``qwen3vl_with_expert.py``).
+but swaps the PaliGemma backbone for a **frozen Qwen3-VL-32B** vision-language model --
+the **reasoning tower of NVIDIA Cosmos3-Super** (extracted to a standalone Qwen3-VL-32B
+checkpoint by ``opentau.scripts.extract_cosmos3_reasoner``) -- and pairs it with a custom
+sub-1B Qwen3-style action expert (``qwen3vl_with_expert.py``).
 
 Pipeline:
   * The frozen reasoner encodes the camera images + language prompt once (the prefix)

--- a/src/opentau/policies/cosmos3/qwen3vl_with_expert.py
+++ b/src/opentau/policies/cosmos3/qwen3vl_with_expert.py
@@ -30,8 +30,8 @@ That structure lets cosmos3 run the **entire stock** ``Qwen3VLModel.forward`` as
 black box for the prefix (``Qwen3VLWithExpertModel.run_prefix``). Stock transformers
 handles vision encoding, image-token scatter, deepstack injection, the 3-D
 multimodal RoPE (MRoPE), QK-norm and the native causal mask — so the frozen
-Cosmos-Reason2 reasoner behaves exactly as trained, with zero reimplementation of
-the 32B backbone. Only the small (<1B) action expert is hand-written here.
+Cosmos3-Super reasoning tower behaves exactly as trained, with zero reimplementation
+of the 32B backbone. Only the small (<1B) action expert is hand-written here.
 
 Hard cross-attention constraints (validated at build time)
 ----------------------------------------------------------

--- a/src/opentau/policies/cosmos3/qwen3vl_with_expert.py
+++ b/src/opentau/policies/cosmos3/qwen3vl_with_expert.py
@@ -440,10 +440,16 @@ class Qwen3VLWithExpertModel(nn.Module):
         pixel_values: Tensor | None,
         image_grid_thw: Tensor | None,
     ) -> list[tuple[Tensor, Tensor]]:
-        """Run the frozen backbone over the observation prefix; return per-layer (K, V) cache.
+        """Run the backbone over the observation prefix; return the per-layer (K, V) cache.
 
-        Each entry is ``(key, value)`` of shape ``(B, num_kv_heads, S_prefix, head_dim)``,
-        detached from the backbone graph (the expert reads them as constants).
+        Each entry is ``(key, value)`` of shape ``(B, num_kv_heads, S_prefix, head_dim)``.
+
+        When ``train_expert_only`` (the default), the backbone is fully frozen: the forward
+        runs under ``no_grad`` and the cached KV is ``.detach()``'d, so the expert reads it
+        as a constant. When ``train_expert_only`` is False (partial unfreeze, e.g. a
+        trainable text tower with a frozen vision encoder), the forward keeps its graph and
+        the KV is **not** detached, so the expert's loss backpropagates into the (unfrozen)
+        backbone — otherwise unfreezing would be a silent no-op.
         """
         ctx = torch.no_grad() if self.train_expert_only else nullcontext()
         with ctx:
@@ -459,7 +465,9 @@ class Qwen3VLWithExpertModel(nn.Module):
         cached = []
         for i in range(self.num_layers):
             key, value = pkv[i]
-            cached.append((key.detach(), value.detach()))
+            if self.train_expert_only:
+                key, value = key.detach(), value.detach()
+            cached.append((key, value))
         return cached
 
     def run_expert(

--- a/src/opentau/policies/cosmos3/qwen3vl_with_expert.py
+++ b/src/opentau/policies/cosmos3/qwen3vl_with_expert.py
@@ -1,0 +1,474 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Qwen3-VL backbone + custom flow-matching action expert (cosmos3).
+
+This is the cosmos3 analog of ``paligemma_with_expert.py`` / ``gemma3_with_expert.py``,
+adapted to the Qwen3-VL architecture and to a **frozen** backbone.
+
+Design (π0.5 dual-stream, specialized for a frozen reasoner)
+-----------------------------------------------------------
+In the π0.5 recipe the backbone encodes images + language *once* (the "prefix")
+and the action expert cross-attends to the backbone's per-layer key/value cache
+to denoise the action chunk (the "suffix"). The two streams never run in the same
+forward pass — the prefix forward populates the KV cache; the suffix forward only
+runs the expert, reading that cache. The expert reads the backbone's keys/values
+but the backbone never reads the expert.
+
+That structure lets cosmos3 run the **entire stock** ``Qwen3VLModel.forward`` as a
+black box for the prefix (``Qwen3VLWithExpertModel.run_prefix``). Stock transformers
+handles vision encoding, image-token scatter, deepstack injection, the 3-D
+multimodal RoPE (MRoPE), QK-norm and the native causal mask — so the frozen
+Cosmos-Reason2 reasoner behaves exactly as trained, with zero reimplementation of
+the 32B backbone. Only the small (<1B) action expert is hand-written here.
+
+Hard cross-attention constraints (validated at build time)
+----------------------------------------------------------
+The expert's per-layer keys/values are concatenated with the backbone's cached KV,
+so the expert's ``num_key_value_heads`` and ``head_dim`` **must** equal the backbone
+text tower's (8 / 128 for Qwen3-VL-32B), and the expert must have the same number of
+layers (64) as the backbone so layer ``i`` of the expert reads layer ``i`` of the
+cache. The expert's *query* head count is free (any multiple of the KV head count)
+because the backbone's queries are never consumed here. The shared MRoPE ``(cos, sin)``
+are produced by the backbone's ``rotary_emb`` and reused by the expert, which is why
+``expert_head_dim`` must match.
+"""
+
+from contextlib import nullcontext
+
+import torch
+from einops import rearrange, repeat
+from torch import Tensor, nn
+from transformers import Qwen3VLConfig, Qwen3VLForConditionalGeneration
+from transformers.models.qwen3_vl.modeling_qwen3_vl import apply_rotary_pos_emb
+
+
+def _repeat_kv(x: Tensor, n_rep: int) -> Tensor:
+    """Expand GQA key/value heads. ``x`` is (B, n_kv, S, hd) -> (B, n_kv*n_rep, S, hd)."""
+    if n_rep == 1:
+        return x
+    return repeat(x, "b h s d -> b (h r) s d", r=n_rep)
+
+
+class ExpertRMSNorm(nn.Module):
+    """Plain RMSNorm used for the expert's per-head QK normalization.
+
+    Mirrors ``Qwen3VLTextRMSNorm`` (variance in fp32, learned ``weight``), kept as a
+    standalone module so the frozen backbone's norm class is never monkey-patched.
+    """
+
+    def __init__(self, dim: int, eps: float = 1e-6):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(dim))
+        self.eps = eps
+
+    def forward(self, x: Tensor) -> Tensor:
+        dtype = x.dtype
+        x = x.to(torch.float32)
+        var = x.pow(2).mean(-1, keepdim=True)
+        x = x * torch.rsqrt(var + self.eps)
+        return (self.weight * x.to(dtype)).to(dtype)
+
+
+class AdaRMSNorm(nn.Module):
+    """Adaptive RMSNorm (DiT adaLN-Zero style), conditioned on the flow-matching time.
+
+    From the conditioning vector ``cond`` (the time embedding) a single dense layer
+    produces per-channel ``(scale, shift, gate)``; the normalized input is modulated
+    as ``norm(x) * (1 + scale) + shift`` and the ``gate`` is returned for the gated
+    residual ``x + gate * sublayer(x)``. The dense layer is **zero-initialized** so
+    the expert starts as an exact identity/no-op residual on top of the frozen
+    backbone — the stable adaLN-Zero initialization.
+
+    Mirrors ``opentau.utils.transformers_patch.PatchedGemmaRMSNorm`` (the AdaRMS used
+    by the pi05/pi06 Gemma action experts) but as a standalone Qwen3 variant.
+    """
+
+    def __init__(self, dim: int, cond_dim: int, eps: float = 1e-6):
+        super().__init__()
+        self.dim = dim
+        self.cond_dim = cond_dim
+        self.eps = eps
+        self.dense = nn.Linear(cond_dim, dim * 3, bias=True)
+        nn.init.zeros_(self.dense.weight)
+        nn.init.zeros_(self.dense.bias)
+
+    def _norm(self, x: Tensor) -> Tensor:
+        var = torch.mean(x.float().square(), dim=-1, keepdim=True)
+        return x * torch.rsqrt(var + self.eps)
+
+    def forward(self, x: Tensor, cond: Tensor) -> tuple[Tensor, Tensor]:
+        dtype = x.dtype
+        normed = self._norm(x)
+        if cond.shape[-1] != self.cond_dim:
+            raise ValueError(f"Expected cond dim {self.cond_dim}, got {cond.shape[-1]}")
+        scale, shift, gate = torch.chunk(self.dense(cond), 3, dim=-1)
+        normed = normed * (1 + scale.float()) + shift.float()
+        return normed.to(dtype), gate.to(dtype)
+
+
+class Qwen3ExpertMLP(nn.Module):
+    """Qwen3 gated-SiLU MLP (gate/up/down), matching ``Qwen3VLTextMLP``."""
+
+    def __init__(self, hidden_size: int, intermediate_size: int):
+        super().__init__()
+        self.gate_proj = nn.Linear(hidden_size, intermediate_size, bias=False)
+        self.up_proj = nn.Linear(hidden_size, intermediate_size, bias=False)
+        self.down_proj = nn.Linear(intermediate_size, hidden_size, bias=False)
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.down_proj(nn.functional.silu(self.gate_proj(x)) * self.up_proj(x))
+
+
+class Qwen3ExpertAttention(nn.Module):
+    """Expert self/cross attention: expert queries over ``[cached_backbone_KV ; expert_KV]``.
+
+    Matches ``Qwen3VLTextAttention`` (QK-norm on the head dim before RoPE, GQA, scaling
+    ``head_dim**-0.5``) but the keys/values are *prefixed* with the frozen backbone's
+    cached, already-RoPE'd KV for this layer, so the expert cross-attends to the whole
+    observation prefix as well as to the action chunk.
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        num_attention_heads: int,
+        num_key_value_heads: int,
+        head_dim: int,
+        rms_norm_eps: float,
+        attention_implementation: str,
+    ):
+        super().__init__()
+        self.num_heads = num_attention_heads
+        self.num_kv_heads = num_key_value_heads
+        self.head_dim = head_dim
+        self.n_rep = num_attention_heads // num_key_value_heads
+        self.scaling = head_dim**-0.5
+        self.attention_implementation = attention_implementation
+
+        self.q_proj = nn.Linear(hidden_size, num_attention_heads * head_dim, bias=False)
+        self.k_proj = nn.Linear(hidden_size, num_key_value_heads * head_dim, bias=False)
+        self.v_proj = nn.Linear(hidden_size, num_key_value_heads * head_dim, bias=False)
+        self.o_proj = nn.Linear(num_attention_heads * head_dim, hidden_size, bias=False)
+        self.q_norm = ExpertRMSNorm(head_dim, eps=rms_norm_eps)
+        self.k_norm = ExpertRMSNorm(head_dim, eps=rms_norm_eps)
+
+    def _attend(self, q: Tensor, k: Tensor, v: Tensor, attn_mask: Tensor) -> Tensor:
+        """q (B,Hq,Sq,hd); k/v (B,Hkv,Sk,hd); attn_mask bool (B,Sq,Sk) True=attend."""
+        k = _repeat_kv(k, self.n_rep)
+        v = _repeat_kv(v, self.n_rep)
+        bsz, _, sq, _ = q.shape
+        mask = rearrange(attn_mask, "b sq sk -> b 1 sq sk")
+
+        if self.attention_implementation == "sdpa":
+            out = nn.functional.scaled_dot_product_attention(
+                q, k.to(q.dtype), v.to(q.dtype), attn_mask=mask, dropout_p=0.0, scale=self.scaling
+            )
+        else:  # eager, fp32 scores for stability (matches pi05/pi06)
+            qf = q.to(torch.float32)
+            kf = k.to(torch.float32)
+            attn = torch.matmul(qf, kf.transpose(2, 3)) * self.scaling
+            attn = torch.where(mask, attn, torch.finfo(torch.float32).min)
+            probs = nn.functional.softmax(attn, dim=-1).to(v.dtype)
+            out = torch.matmul(probs, v)
+        return rearrange(out, "b h s d -> b s (h d)", b=bsz, s=sq)
+
+    def forward(
+        self,
+        hidden: Tensor,
+        cached_kv: tuple[Tensor, Tensor],
+        cos: Tensor,
+        sin: Tensor,
+        attn_mask: Tensor,
+    ) -> Tensor:
+        b, s, _ = hidden.shape
+        q = self.q_norm(rearrange(self.q_proj(hidden), "b s (h d) -> b s h d", d=self.head_dim))
+        k = self.k_norm(rearrange(self.k_proj(hidden), "b s (h d) -> b s h d", d=self.head_dim))
+        v = rearrange(self.v_proj(hidden), "b s (h d) -> b s h d", d=self.head_dim)
+        q = rearrange(q, "b s h d -> b h s d")
+        k = rearrange(k, "b s h d -> b h s d")
+        v = rearrange(v, "b s h d -> b h s d")
+
+        q, k = apply_rotary_pos_emb(q, k, cos, sin)
+
+        cached_k, cached_v = cached_kv
+        k = torch.cat([cached_k.to(k.dtype), k], dim=2)
+        v = torch.cat([cached_v.to(v.dtype), v], dim=2)
+
+        out = self._attend(q, k, v, attn_mask)
+        return self.o_proj(out.to(hidden.dtype))
+
+
+class Qwen3ExpertDecoderLayer(nn.Module):
+    """One expert decoder layer: AdaRMS pre-norms + gated residuals around attn / MLP."""
+
+    def __init__(
+        self,
+        hidden_size: int,
+        intermediate_size: int,
+        num_attention_heads: int,
+        num_key_value_heads: int,
+        head_dim: int,
+        adarms_cond_dim: int,
+        rms_norm_eps: float,
+        dropout: float,
+        attention_implementation: str,
+    ):
+        super().__init__()
+        self.input_layernorm = AdaRMSNorm(hidden_size, adarms_cond_dim, eps=rms_norm_eps)
+        self.post_attention_layernorm = AdaRMSNorm(hidden_size, adarms_cond_dim, eps=rms_norm_eps)
+        self.self_attn = Qwen3ExpertAttention(
+            hidden_size=hidden_size,
+            num_attention_heads=num_attention_heads,
+            num_key_value_heads=num_key_value_heads,
+            head_dim=head_dim,
+            rms_norm_eps=rms_norm_eps,
+            attention_implementation=attention_implementation,
+        )
+        self.mlp = Qwen3ExpertMLP(hidden_size, intermediate_size)
+        self.dropout = nn.Dropout(dropout)
+
+    def forward(
+        self,
+        hidden: Tensor,
+        cached_kv: tuple[Tensor, Tensor],
+        cos: Tensor,
+        sin: Tensor,
+        attn_mask: Tensor,
+        adarms_cond: Tensor,
+    ) -> Tensor:
+        normed, gate_attn = self.input_layernorm(hidden, adarms_cond)
+        attn_out = self.self_attn(normed, cached_kv, cos, sin, attn_mask)
+        hidden = hidden + gate_attn * self.dropout(attn_out)
+
+        normed, gate_mlp = self.post_attention_layernorm(hidden, adarms_cond)
+        mlp_out = self.mlp(normed)
+        hidden = hidden + gate_mlp * self.dropout(mlp_out)
+        return hidden
+
+
+class Qwen3ActionExpert(nn.Module):
+    """The trainable flow-matching action expert: a stack of AdaRMS Qwen3 decoder layers.
+
+    Operates on action-token embeddings (the suffix). Each layer ``i`` cross-attends to
+    the frozen backbone's cached KV for layer ``i`` plus the action chunk itself.
+    """
+
+    def __init__(
+        self,
+        num_hidden_layers: int,
+        hidden_size: int,
+        intermediate_size: int,
+        num_attention_heads: int,
+        num_key_value_heads: int,
+        head_dim: int,
+        adarms_cond_dim: int,
+        rms_norm_eps: float,
+        dropout: float,
+        attention_implementation: str,
+    ):
+        super().__init__()
+        self.layers = nn.ModuleList(
+            [
+                Qwen3ExpertDecoderLayer(
+                    hidden_size=hidden_size,
+                    intermediate_size=intermediate_size,
+                    num_attention_heads=num_attention_heads,
+                    num_key_value_heads=num_key_value_heads,
+                    head_dim=head_dim,
+                    adarms_cond_dim=adarms_cond_dim,
+                    rms_norm_eps=rms_norm_eps,
+                    dropout=dropout,
+                    attention_implementation=attention_implementation,
+                )
+                for _ in range(num_hidden_layers)
+            ]
+        )
+        self.norm = AdaRMSNorm(hidden_size, adarms_cond_dim, eps=rms_norm_eps)
+        self.gradient_checkpointing = False
+
+    def forward(
+        self,
+        hidden: Tensor,
+        cached_kv: list[tuple[Tensor, Tensor]],
+        cos: Tensor,
+        sin: Tensor,
+        attn_mask: Tensor,
+        adarms_cond: Tensor,
+    ) -> Tensor:
+        for i, layer in enumerate(self.layers):
+            if self.gradient_checkpointing and self.training:
+                hidden = torch.utils.checkpoint.checkpoint(
+                    layer, hidden, cached_kv[i], cos, sin, attn_mask, adarms_cond, use_reentrant=False
+                )
+            else:
+                hidden = layer(hidden, cached_kv[i], cos, sin, attn_mask, adarms_cond)
+        hidden, _ = self.norm(hidden, adarms_cond)
+        return hidden
+
+
+class Qwen3VLWithExpertModel(nn.Module):
+    """A frozen Qwen3-VL backbone paired with a trainable flow-matching action expert."""
+
+    def __init__(
+        self,
+        qwen3vl_config: Qwen3VLConfig,
+        *,
+        expert_hidden_size: int,
+        expert_intermediate_size: int,
+        expert_num_hidden_layers: int,
+        expert_num_attention_heads: int,
+        expert_num_key_value_heads: int,
+        expert_head_dim: int,
+        expert_adarms_cond_dim: int,
+        expert_rms_norm_eps: float,
+        dropout: float,
+        attention_implementation: str,
+        freeze_vision_encoder: bool = True,
+        train_expert_only: bool = True,
+        gradient_checkpointing: bool = False,
+        load_pretrained_backbone_repo: str | None = None,
+    ):
+        super().__init__()
+        self.freeze_vision_encoder = freeze_vision_encoder
+        self.train_expert_only = train_expert_only
+
+        text_cfg = qwen3vl_config.text_config
+        # Hard cross-attention constraints (see module docstring).
+        if expert_head_dim != text_cfg.head_dim:
+            raise ValueError(
+                f"expert_head_dim ({expert_head_dim}) must equal the backbone head_dim ({text_cfg.head_dim})."
+            )
+        if expert_num_key_value_heads != text_cfg.num_key_value_heads:
+            raise ValueError(
+                f"expert_num_key_value_heads ({expert_num_key_value_heads}) must equal the backbone "
+                f"num_key_value_heads ({text_cfg.num_key_value_heads})."
+            )
+        if expert_num_hidden_layers != text_cfg.num_hidden_layers:
+            raise ValueError(
+                f"expert_num_hidden_layers ({expert_num_hidden_layers}) must equal the backbone "
+                f"num_hidden_layers ({text_cfg.num_hidden_layers}) so each expert layer reads the matching "
+                "backbone KV cache layer."
+            )
+        self.num_layers = text_cfg.num_hidden_layers
+
+        qwen3vl_config.text_config._attn_implementation = attention_implementation
+        if load_pretrained_backbone_repo is not None:
+            self.backbone = Qwen3VLForConditionalGeneration.from_pretrained(
+                load_pretrained_backbone_repo,
+                dtype=torch.bfloat16,
+                attn_implementation=attention_implementation,
+            )
+        else:
+            self.backbone = Qwen3VLForConditionalGeneration(qwen3vl_config)
+
+        self.expert = Qwen3ActionExpert(
+            num_hidden_layers=expert_num_hidden_layers,
+            hidden_size=expert_hidden_size,
+            intermediate_size=expert_intermediate_size,
+            num_attention_heads=expert_num_attention_heads,
+            num_key_value_heads=expert_num_key_value_heads,
+            head_dim=expert_head_dim,
+            adarms_cond_dim=expert_adarms_cond_dim,
+            rms_norm_eps=expert_rms_norm_eps,
+            dropout=dropout,
+            attention_implementation=attention_implementation,
+        )
+        self.expert.gradient_checkpointing = gradient_checkpointing
+
+        # Match the expert dtype to the (possibly bf16-loaded) backbone so cross-attention
+        # matmuls share a dtype on GPU; on CPU tests both stay fp32.
+        backbone_dtype = next(self.backbone.parameters()).dtype
+        self.expert.to(dtype=backbone_dtype)
+
+        self.set_requires_grad()
+
+    # ----- freezing / dtype plumbing -----
+
+    def set_requires_grad(self) -> None:
+        if self.freeze_vision_encoder:
+            self.backbone.model.visual.eval()
+            for p in self.backbone.model.visual.parameters():
+                p.requires_grad = False
+        if self.train_expert_only:
+            self.backbone.eval()
+            for p in self.backbone.parameters():
+                p.requires_grad = False
+
+    def train(self, mode: bool = True):
+        super().train(mode)
+        if self.train_expert_only:
+            self.backbone.eval()
+        elif self.freeze_vision_encoder:
+            self.backbone.model.visual.eval()
+        return self
+
+    # ----- backbone helpers -----
+
+    @property
+    def text_model(self):
+        return self.backbone.model.language_model
+
+    def get_rope_index(self, input_ids, image_grid_thw, attention_mask):
+        return self.backbone.model.get_rope_index(
+            input_ids=input_ids, image_grid_thw=image_grid_thw, attention_mask=attention_mask
+        )
+
+    def compute_rope(
+        self, position_ids: Tensor, dtype: torch.dtype, device: torch.device
+    ) -> tuple[Tensor, Tensor]:
+        """Compute MRoPE ``(cos, sin)`` for ``position_ids`` (3, B, S) using the backbone rotary."""
+        dummy = torch.zeros(1, dtype=dtype, device=device)
+        return self.text_model.rotary_emb(dummy, position_ids)
+
+    def run_prefix(
+        self,
+        input_ids: Tensor,
+        attention_mask: Tensor,
+        position_ids: Tensor,
+        pixel_values: Tensor | None,
+        image_grid_thw: Tensor | None,
+    ) -> list[tuple[Tensor, Tensor]]:
+        """Run the frozen backbone over the observation prefix; return per-layer (K, V) cache.
+
+        Each entry is ``(key, value)`` of shape ``(B, num_kv_heads, S_prefix, head_dim)``,
+        detached from the backbone graph (the expert reads them as constants).
+        """
+        ctx = torch.no_grad() if self.train_expert_only else nullcontext()
+        with ctx:
+            out = self.backbone.model(
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                pixel_values=pixel_values,
+                image_grid_thw=image_grid_thw,
+                use_cache=True,
+            )
+        pkv = out.past_key_values
+        cached = []
+        for i in range(self.num_layers):
+            key, value = pkv[i]
+            cached.append((key.detach(), value.detach()))
+        return cached
+
+    def run_expert(
+        self,
+        action_embs: Tensor,
+        cached_kv: list[tuple[Tensor, Tensor]],
+        cos: Tensor,
+        sin: Tensor,
+        attn_mask: Tensor,
+        adarms_cond: Tensor,
+    ) -> Tensor:
+        return self.expert(action_embs, cached_kv, cos, sin, attn_mask, adarms_cond)

--- a/src/opentau/policies/factory.py
+++ b/src/opentau/policies/factory.py
@@ -33,6 +33,7 @@ from opentau.configs.policies import PreTrainedConfig
 from opentau.configs.types import FeatureType
 from opentau.datasets.lerobot_dataset import LeRobotDatasetMetadata
 from opentau.datasets.utils import dataset_to_policy_features
+from opentau.policies.cosmos3.configuration_cosmos3 import Cosmos3Config
 from opentau.policies.pi0.configuration_pi0 import PI0Config
 from opentau.policies.pi05.configuration_pi05 import PI05Config
 from opentau.policies.pi05_mem.configuration_pi05 import PI05MemConfig
@@ -115,6 +116,10 @@ def get_policy_class(name: str) -> type[PreTrainedPolicy]:
         )
 
         return PI07LowLevelPolicy
+    elif name == "cosmos3":
+        from opentau.policies.cosmos3.modeling_cosmos3 import Cosmos3Policy
+
+        return Cosmos3Policy
     elif name == "value":
         from opentau.policies.value.modeling_value import ValueFunction
 
@@ -160,6 +165,8 @@ def make_policy_config(policy_type: str, **kwargs) -> PreTrainedConfig:
         return PI07HighLevelPlannerConfig(**kwargs)
     elif policy_type == "pi07_low_level":
         return PI07LowLevelConfig(**kwargs)
+    elif policy_type == "cosmos3":
+        return Cosmos3Config(**kwargs)
     elif policy_type == "value":
         return ValueConfig(**kwargs)
     else:

--- a/src/opentau/policies/pi07/video_encoder.py
+++ b/src/opentau/policies/pi07/video_encoder.py
@@ -228,20 +228,22 @@ class SpaceTimeEncoderLayerWrapper(nn.Module):
         hidden_states: Tensor,
         attention_mask: Optional[Tensor],
         output_attentions: bool,
-    ) -> tuple[Tensor, ...]:
+    ) -> Tensor:
         """Inlined SiglipEncoderLayer.forward using the adopted submodules.
 
         Mirrors
         ``transformers.models.siglip.modeling_siglip.SiglipEncoderLayer.forward``
         exactly — any upstream change to that forward would need to be
-        reflected here.
+        reflected here. As of transformers >= 4.57 that forward returns a bare
+        hidden-state tensor (``output_attentions`` was dropped from the layer
+        API), so this returns a tensor too; ``output_attentions`` is accepted
+        for signature compatibility but ignored (SDPA exposes no weights).
         """
         residual = hidden_states
         hidden_states = self.layer_norm1(hidden_states)
-        hidden_states, attn_weights = self.self_attn(
+        hidden_states, _ = self.self_attn(
             hidden_states=hidden_states,
             attention_mask=attention_mask,
-            output_attentions=output_attentions,
         )
         hidden_states = residual + hidden_states
 
@@ -250,10 +252,7 @@ class SpaceTimeEncoderLayerWrapper(nn.Module):
         hidden_states = self.mlp(hidden_states)
         hidden_states = residual + hidden_states
 
-        outputs: tuple[Tensor, ...] = (hidden_states,)
-        if output_attentions:
-            outputs = outputs + (attn_weights,)
-        return outputs
+        return hidden_states
 
     def forward(
         self,
@@ -262,8 +261,8 @@ class SpaceTimeEncoderLayerWrapper(nn.Module):
         output_attentions: bool = False,
         temporal_attn_mask: Tensor | None = None,
         num_frames: int | None = None,
-    ) -> tuple[Tensor, ...]:
-        """hidden_states: (B*T, N, D) -> tuple starting with (B*T, N, D).
+    ) -> Tensor:
+        """hidden_states: (B*T, N, D) -> (B*T, N, D).
 
         Signature extends ``SiglipEncoderLayer.forward`` with two extra
         kwargs: ``temporal_attn_mask`` and ``num_frames``. Vanilla
@@ -417,15 +416,11 @@ class SpaceTimeEncoderLayerWrapper(nn.Module):
         h_mlp = self.mlp(h_norm)
         h_out = residual + h_mlp
 
-        outputs: tuple[Tensor, ...] = (h_out,)
-        if output_attentions:
-            # SDPA does not return attention weights, and Reading B never
-            # materializes either α_temporal or α_spatial. Return None to
-            # keep the tuple shape; callers requesting weights at T>1 should
-            # switch to an explicit-attention build of SigLIP if they need
-            # per-layer weights.
-            outputs = outputs + (None,)
-        return outputs
+        # transformers >= 4.57 ``SiglipEncoderLayer.forward`` returns a bare
+        # tensor (no ``output_attentions`` / weights), and SDPA exposes no
+        # weights anyway, so this wrapper returns the hidden state directly to
+        # stay a drop-in for both the stock ``SiglipEncoder`` loop and our own.
+        return h_out
 
 
 @contextmanager
@@ -678,23 +673,22 @@ class SpaceTimeSiglipVideoEncoder(nn.Module):
         use_ckpt = self.gradient_checkpointing and self.training
         for layer in self.vision_tower.vision_model.encoder.layers:
             is_spacetime = isinstance(layer, SpaceTimeEncoderLayerWrapper)
-            if use_ckpt:
-                if is_spacetime:
-                    layer_outputs = torch.utils.checkpoint.checkpoint(
+            # Both the SpaceTime wrapper and the vanilla transformers >= 4.57
+            # ``SiglipEncoderLayer`` return a bare hidden-state tensor; the wrapper
+            # additionally accepts the temporal kwargs (positional under checkpoint,
+            # which does not forward kwargs).
+            if is_spacetime:
+                if use_ckpt:
+                    hidden = torch.utils.checkpoint.checkpoint(
                         layer, hidden, None, False, temporal_attn_mask, t, use_reentrant=False
                     )
                 else:
-                    layer_outputs = torch.utils.checkpoint.checkpoint(
-                        layer, hidden, None, False, use_reentrant=False
-                    )
+                    hidden = layer(hidden, None, False, temporal_attn_mask=temporal_attn_mask, num_frames=t)
             else:
-                if is_spacetime:
-                    layer_outputs = layer(
-                        hidden, None, False, temporal_attn_mask=temporal_attn_mask, num_frames=t
-                    )
+                if use_ckpt:
+                    hidden = torch.utils.checkpoint.checkpoint(layer, hidden, None, use_reentrant=False)
                 else:
-                    layer_outputs = layer(hidden, None, False)
-            hidden = layer_outputs[0]
+                    hidden = layer(hidden, None)
 
         hidden = self.vision_tower.vision_model.post_layernorm(hidden)
 

--- a/src/opentau/scripts/extract_cosmos3_reasoner.py
+++ b/src/opentau/scripts/extract_cosmos3_reasoner.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Extract the **reasoning tower** of NVIDIA ``Cosmos3-Super`` into a standalone
+Qwen3-VL-32B checkpoint for the cosmos3 policy backbone.
+
+``nvidia/Cosmos3-Super`` (HF: ``cosmos3_omni`` / diffusers ``Cosmos3OmniTransformer``,
+~64.6B params, ungated) is an interleaved Mixture-of-Transformers: every one of its 64
+layers has **shared attention** plus **two MLPs** -- ``mlp`` (the autoregressive
+**reasoner / text** path) and ``mlp_moe_gen`` (the diffusion **generation** path) -- plus
+audio/action/video generation modules. Its text config is byte-for-byte Qwen3-VL-32B
+(hidden 5120, 64 layers, 64 heads, 8 KV, head_dim 128, intermediate 25600,
+mrope_section [24,20,20]), and its ``vision_encoder/`` is a stock ``Qwen3VLVisionModel``.
+
+This script keeps only the reasoner tower and drops the generation tower, producing a
+standard ``Qwen3VLForConditionalGeneration`` checkpoint:
+
+  reasoner text (from ``transformer/``):
+    embed_tokens                         -> model.language_model.embed_tokens
+    norm                                 -> model.language_model.norm
+    lm_head                              -> lm_head
+    layers.N.input_layernorm             -> model.language_model.layers.N.input_layernorm
+    layers.N.post_attention_layernorm    -> model.language_model.layers.N.post_attention_layernorm
+    layers.N.mlp.{gate,up,down}_proj     -> model.language_model.layers.N.mlp.{...}
+    layers.N.self_attn.to_q/to_k/to_v    -> model.language_model.layers.N.self_attn.{q,k,v}_proj
+    layers.N.self_attn.to_out            -> model.language_model.layers.N.self_attn.o_proj
+    layers.N.self_attn.norm_q/norm_k     -> model.language_model.layers.N.self_attn.{q,k}_norm
+  reasoner vision (from ``vision_encoder/``, already Qwen3VLVisionModel):
+    <key>                                -> model.visual.<key>
+
+  DROPPED (generation tower): *mlp_moe_gen*, *_moe_gen norms, self_attn.add_{q,k,v}_proj,
+  self_attn.to_add_out, self_attn.norm_added_{q,k}, *_modality_embed, action/audio_proj_*,
+  proj_in/proj_out (latent patch), time_embedder.
+
+Usage::
+
+    # one-time, on a box with the (ungated) Cosmos3-Super download + enough RAM/disk
+    huggingface-cli download nvidia/Cosmos3-Super --include "transformer/*" "vision_encoder/*" \
+        "text_tokenizer/*" "tokenizer_config.json" "preprocessor_config.json" \
+        "video_preprocessor_config.json"
+    python -m opentau.scripts.extract_cosmos3_reasoner \
+        --cosmos3-path <hf-snapshot-dir> --out-dir <reasoner-checkpoint-dir>
+
+The resulting directory is a normal Qwen3-VL-32B checkpoint; point the cosmos3 policy at it
+via ``--policy.pretrained_backbone_repo_id=<reasoner-checkpoint-dir>``.
+"""
+
+import argparse
+import glob
+import os
+import re
+import shutil
+
+import torch
+from safetensors import safe_open
+from transformers import Qwen3VLConfig, Qwen3VLForConditionalGeneration
+
+# Per-layer attention key renames (Cosmos diffusers attention -> Qwen3-VL text attention).
+_ATTN_RENAME = {
+    "self_attn.to_q": "self_attn.q_proj",
+    "self_attn.to_k": "self_attn.k_proj",
+    "self_attn.to_v": "self_attn.v_proj",
+    "self_attn.to_out": "self_attn.o_proj",
+    "self_attn.norm_q": "self_attn.q_norm",
+    "self_attn.norm_k": "self_attn.k_norm",
+}
+
+# Substrings that mark a weight as belonging to the generation tower / non-reasoner modules.
+_DROP_SUBSTRINGS = (
+    "moe_gen",
+    "add_q_proj",
+    "add_k_proj",
+    "add_v_proj",
+    "to_add_out",
+    "norm_added",
+    "modality_embed",
+    "action_proj",
+    "audio_proj",
+    "time_embedder",
+)
+# Top-level keys to drop (latent-patch diffusion projections).
+_DROP_PREFIXES = ("proj_in", "proj_out")
+
+
+def _is_reasoner_key(key: str) -> bool:
+    drop = any(s in key for s in _DROP_SUBSTRINGS) or any(key.startswith(p) for p in _DROP_PREFIXES)
+    return not drop
+
+
+def _remap_transformer_key(key: str) -> str | None:
+    """Map a Cosmos3-Super ``transformer/`` key to its Qwen3-VL name, or None to drop it."""
+    if not _is_reasoner_key(key):
+        return None
+    if key == "embed_tokens.weight":
+        return "model.language_model.embed_tokens.weight"
+    if key == "norm.weight":
+        return "model.language_model.norm.weight"
+    if key == "lm_head.weight":
+        return "lm_head.weight"
+    m = re.match(r"layers\.(\d+)\.(.+)", key)
+    if m is None:
+        return None  # any other top-level key is generation-side; drop it
+    layer, rest = m.group(1), m.group(2)
+    for src, dst in _ATTN_RENAME.items():
+        if rest.startswith(src):
+            rest = dst + rest[len(src) :]
+            break
+    return f"model.language_model.layers.{layer}.{rest}"
+
+
+def _iter_safetensors(folder: str):
+    """Yield (key, tensor) over all .safetensors shards in ``folder`` (lazy)."""
+    files = sorted(glob.glob(os.path.join(folder, "*.safetensors")))
+    if not files:
+        raise FileNotFoundError(f"no .safetensors in {folder}")
+    for path in files:
+        with safe_open(path, framework="pt", device="cpu") as f:
+            for key in f.keys():  # noqa: SIM118 -- safe_open is not dict-iterable
+                yield key, f.get_tensor(key)
+
+
+def _qwen3vl_32b_config() -> Qwen3VLConfig:
+    return Qwen3VLConfig(
+        text_config={
+            "model_type": "qwen3_vl_text",
+            "hidden_size": 5120,
+            "intermediate_size": 25600,
+            "num_hidden_layers": 64,
+            "num_attention_heads": 64,
+            "num_key_value_heads": 8,
+            "head_dim": 128,
+            "vocab_size": 151936,
+            "rms_norm_eps": 1e-6,
+            "rope_theta": 5_000_000,
+            "rope_scaling": {
+                "mrope_interleaved": True,
+                "mrope_section": [24, 20, 20],
+                "rope_type": "default",
+            },
+        },
+        vision_config={
+            "model_type": "qwen3_vl",
+            "hidden_size": 1152,
+            "intermediate_size": 4304,
+            "num_heads": 16,
+            "depth": 27,
+            "patch_size": 16,
+            "temporal_patch_size": 2,
+            "spatial_merge_size": 2,
+            "out_hidden_size": 5120,
+            "deepstack_visual_indexes": [8, 16, 24],
+            "num_position_embeddings": 2304,
+            "in_channels": 3,
+        },
+        image_token_id=151655,
+        video_token_id=151656,
+        vision_start_token_id=151652,
+        vision_end_token_id=151653,
+        tie_word_embeddings=False,
+        dtype="bfloat16",
+    )
+
+
+def extract(cosmos3_path: str, out_dir: str, verify: bool = True) -> None:
+    """Build a Qwen3-VL-32B reasoner checkpoint from a Cosmos3-Super snapshot."""
+    transformer_dir = os.path.join(cosmos3_path, "transformer")
+    vision_dir = os.path.join(cosmos3_path, "vision_encoder")
+    state_dict: dict[str, torch.Tensor] = {}
+
+    kept = dropped = 0
+    for key, tensor in _iter_safetensors(transformer_dir):
+        new_key = _remap_transformer_key(key)
+        if new_key is None:
+            dropped += 1
+            continue
+        state_dict[new_key] = tensor
+        kept += 1
+    print(f"transformer/: kept {kept} reasoner tensors, dropped {dropped} generation tensors")
+
+    n_vis = 0
+    for key, tensor in _iter_safetensors(vision_dir):
+        state_dict[f"model.visual.{key}"] = tensor
+        n_vis += 1
+    print(f"vision_encoder/: mapped {n_vis} tensors -> model.visual.*")
+
+    config = _qwen3vl_32b_config()
+    os.makedirs(out_dir, exist_ok=True)
+
+    if verify:
+        # Instantiate on meta to compare key sets without allocating 64GB.
+        with torch.device("meta"):
+            ref = Qwen3VLForConditionalGeneration(config)
+        expected = set(ref.state_dict().keys())
+        got = set(state_dict.keys())
+        missing, unexpected = expected - got, got - expected
+        # tie_word_embeddings=False, so lm_head should be present; tolerate it if tied.
+        if missing:
+            print(f"WARNING: {len(missing)} expected keys missing (first 15): {sorted(missing)[:15]}")
+        if unexpected:
+            print(f"WARNING: {len(unexpected)} unexpected keys (first 15): {sorted(unexpected)[:15]}")
+        if not missing and not unexpected:
+            print("✓ key sets match Qwen3VLForConditionalGeneration exactly")
+
+    config.save_pretrained(out_dir)
+    # Materialize the model and let save_pretrained shard + write a correct index.
+    model = Qwen3VLForConditionalGeneration(config)
+    missing, unexpected = model.load_state_dict(state_dict, strict=False)
+    print(f"load_state_dict: {len(missing)} missing, {len(unexpected)} unexpected")
+    model.to(dtype=torch.bfloat16).save_pretrained(out_dir, safe_serialization=True)
+    del model, state_dict
+
+    # Copy tokenizer / processor configs so the dir is a usable Qwen3-VL checkpoint.
+    for fname in (
+        "tokenizer_config.json",
+        "preprocessor_config.json",
+        "video_preprocessor_config.json",
+        "chat_template.json",
+        "chat_template.jinja",
+    ):
+        src = os.path.join(cosmos3_path, fname)
+        if os.path.exists(src):
+            shutil.copy2(src, os.path.join(out_dir, fname))
+    tok_dir = os.path.join(cosmos3_path, "text_tokenizer")
+    if os.path.isdir(tok_dir):
+        for f in os.listdir(tok_dir):
+            shutil.copy2(os.path.join(tok_dir, f), os.path.join(out_dir, f))
+    print(f"✓ wrote Qwen3-VL-32B reasoner checkpoint to {out_dir}")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--cosmos3-path", required=True, help="Local snapshot dir of nvidia/Cosmos3-Super.")
+    ap.add_argument("--out-dir", required=True, help="Output dir for the extracted Qwen3-VL-32B reasoner.")
+    ap.add_argument("--no-verify", action="store_true", help="Skip the meta-device key-set verification.")
+    args = ap.parse_args()
+    extract(args.cosmos3_path, args.out_dir, verify=not args.no_verify)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/opentau/scripts/extract_cosmos3_reasoner.py
+++ b/src/opentau/scripts/extract_cosmos3_reasoner.py
@@ -198,27 +198,43 @@ def extract(cosmos3_path: str, out_dir: str, verify: bool = True) -> None:
     config = _qwen3vl_32b_config()
     os.makedirs(out_dir, exist_ok=True)
 
+    # Instantiate on meta (no real storage), then assign the loaded bf16 tensors directly.
+    # The plain ``Qwen3VLForConditionalGeneration(config)`` constructor would otherwise
+    # materialize all ~32B params in fp32 and random-init them (immediately overwritten),
+    # roughly doubling peak RAM. ``assign=True`` swaps the meta params for the state-dict
+    # tensors as-is, so the saved checkpoint keeps the source bf16 dtype with no fp32 detour.
+    with torch.device("meta"):
+        model = Qwen3VLForConditionalGeneration(config)
+
     if verify:
-        # Instantiate on meta to compare key sets without allocating 64GB.
-        with torch.device("meta"):
-            ref = Qwen3VLForConditionalGeneration(config)
-        expected = set(ref.state_dict().keys())
+        expected = set(model.state_dict().keys())
         got = set(state_dict.keys())
-        missing, unexpected = expected - got, got - expected
+        missing_keys, unexpected_keys = expected - got, got - expected
         # tie_word_embeddings=False, so lm_head should be present; tolerate it if tied.
-        if missing:
-            print(f"WARNING: {len(missing)} expected keys missing (first 15): {sorted(missing)[:15]}")
-        if unexpected:
-            print(f"WARNING: {len(unexpected)} unexpected keys (first 15): {sorted(unexpected)[:15]}")
-        if not missing and not unexpected:
+        if missing_keys:
+            print(
+                f"WARNING: {len(missing_keys)} expected keys missing (first 15): {sorted(missing_keys)[:15]}"
+            )
+        if unexpected_keys:
+            print(
+                f"WARNING: {len(unexpected_keys)} unexpected keys (first 15): {sorted(unexpected_keys)[:15]}"
+            )
+        if not missing_keys and not unexpected_keys:
             print("✓ key sets match Qwen3VLForConditionalGeneration exactly")
 
-    config.save_pretrained(out_dir)
-    # Materialize the model and let save_pretrained shard + write a correct index.
-    model = Qwen3VLForConditionalGeneration(config)
-    missing, unexpected = model.load_state_dict(state_dict, strict=False)
+    missing, unexpected = model.load_state_dict(state_dict, strict=False, assign=True)
     print(f"load_state_dict: {len(missing)} missing, {len(unexpected)} unexpected")
-    model.to(dtype=torch.bfloat16).save_pretrained(out_dir, safe_serialization=True)
+    if missing:
+        # With assign=True any unmatched param stays on the meta device; saving it would
+        # ship empty weights, so refuse rather than write a silently-broken checkpoint.
+        raise RuntimeError(
+            f"{len(missing)} params had no tensor in the extracted state dict and would remain on "
+            f"meta: {sorted(missing)[:15]} -- aborting so we never save an incomplete checkpoint."
+        )
+
+    config.save_pretrained(out_dir)
+    # save_pretrained shards + writes a correct index from the (now bf16, real) params.
+    model.save_pretrained(out_dir, safe_serialization=True)
     del model, state_dict
 
     # Copy tokenizer / processor configs so the dir is a usable Qwen3-VL checkpoint.

--- a/tests/policies/test_cosmos3_cpu.py
+++ b/tests/policies/test_cosmos3_cpu.py
@@ -285,3 +285,38 @@ def test_cosmos3_expert_under_1b_params():
     )
     total = per_layer * cfg.expert_num_hidden_layers + (c * 3 * h + 3 * h)  # + final norm
     assert total < 1_000_000_000, f"expert has {total:,} params (>= 1B)"
+
+
+def test_first_tensor_skips_non_tensor_prompt():
+    """``_first_tensor`` must skip the non-tensor ``prompt`` entry (the wrapper relies on it
+    to infer device / batch size without ``AttributeError`` on the string list)."""
+    from opentau.policies.cosmos3.modeling_cosmos3 import _first_tensor
+
+    batch = {"prompt": ["pick up the block", "place it"], "actions": torch.zeros(2, CHUNK, MAX_ACTION_DIM)}
+    ref = _first_tensor(batch)
+    assert isinstance(ref, torch.Tensor)
+    assert ref.shape[0] == 2
+
+
+def test_cosmos3_partial_unfreeze_backbone_receives_grad():
+    """With train_expert_only=False the cached KV keeps its graph, so the unfrozen text
+    backbone receives gradients (otherwise unfreezing would be a silent no-op)."""
+    torch.manual_seed(0)
+    cfg = _tiny_cosmos3_config(train_expert_only=False, freeze_vision_encoder=True)
+    model = Cosmos3FlowMatching(cfg, qwen3vl_config=_tiny_qwen3vl_config())
+    input_ids, attention_mask, state, actions = _text_batch()
+    out = model(
+        input_ids=input_ids,
+        attention_mask=attention_mask,
+        pixel_values=None,
+        image_grid_thw=None,
+        state=state,
+        actions=actions,
+        noise=torch.randn_like(actions),
+        time=torch.rand(actions.shape[0]),
+    )
+    out["MSE"].backward()
+    text_backbone = model.qwen3vl_with_expert.backbone.model.language_model
+    assert any(p.grad is not None for p in text_backbone.parameters()), (
+        "unfrozen text backbone must receive gradients via the (non-detached) cached KV"
+    )

--- a/tests/policies/test_cosmos3_cpu.py
+++ b/tests/policies/test_cosmos3_cpu.py
@@ -25,7 +25,7 @@ import torch
 from transformers import Qwen3VLConfig
 
 from opentau.policies.cosmos3.configuration_cosmos3 import Cosmos3Config
-from opentau.policies.cosmos3.modeling_cosmos3 import Cosmos3FlowMatching
+from opentau.policies.cosmos3.modeling_cosmos3 import Cosmos3FlowMatching, Cosmos3Policy
 from opentau.policies.utils import PerSampleLoss
 
 # Small vision/text special-token ids that fit inside the tiny vocab below.
@@ -296,6 +296,73 @@ def test_first_tensor_skips_non_tensor_prompt():
     ref = _first_tensor(batch)
     assert isinstance(ref, torch.Tensor)
     assert ref.shape[0] == 2
+
+
+class _FakeTokenizer:
+    """Records encode/decode calls; one whitespace-separated word == one token id."""
+
+    def __init__(self):
+        self.encode_calls: list[tuple[str, list[int]]] = []
+        self.decode_calls: list[list[int]] = []
+
+    def encode(self, text, add_special_tokens=False):
+        ids = list(range(len(text.split())))
+        self.encode_calls.append((text, ids))
+        return ids
+
+    def decode(self, ids):
+        ids = list(ids)
+        self.decode_calls.append(ids)
+        return " ".join(f"t{i}" for i in ids)
+
+
+class _FakeProcessor:
+    """Minimal stand-in for the Qwen3-VL processor that records what it is handed."""
+
+    def __init__(self):
+        self.tokenizer = _FakeTokenizer()
+        self.seen_texts = None
+        self.seen_images = "UNSET"
+
+    def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=False):
+        # Flatten just the text content so the test can read back the (truncated) prompt.
+        return " ".join(c["text"] for m in messages for c in m["content"] if c["type"] == "text")
+
+    def __call__(self, text, images, return_tensors, padding):
+        self.seen_texts = text
+        self.seen_images = images
+        bsize, seqlen = len(text), 6
+        return {
+            "input_ids": torch.zeros(bsize, seqlen, dtype=torch.long),
+            "attention_mask": torch.ones(bsize, seqlen, dtype=torch.long),
+        }
+
+
+def test_cosmos3_prompt_max_length_truncation():
+    """``prepare_multimodal_inputs`` must truncate the language prompt to
+    ``prompt_max_length`` tokens (text only -- image placeholders are never clipped).
+
+    This locks the wrapper-level truncation on the CPU gate; the real Qwen3-VL processor
+    is mocked so no 32B backbone / network is needed.
+    """
+    cfg = _tiny_cosmos3_config(prompt_max_length=4)
+    policy = Cosmos3Policy(cfg, qwen3vl_config=_tiny_qwen3vl_config())
+    policy.processor = _FakeProcessor()
+
+    batch = {
+        "prompt": ["a b c d e f g h", "x y"],  # 8 tokens -> truncate to 4; 2 tokens -> keep
+        "state": torch.zeros(2, MAX_STATE_DIM),
+    }
+    mm = policy.prepare_multimodal_inputs(batch)
+
+    tok = policy.processor.tokenizer
+    # The long prompt was sliced to prompt_max_length ids; the short one passed through.
+    assert tok.decode_calls == [[0, 1, 2, 3], [0, 1]]
+    # The (decoded) text reaching the processor reflects the per-sample truncation.
+    assert [len(t.split()) for t in policy.processor.seen_texts] == [4, 2]
+    # No image features -> the image argument is None, not an empty list.
+    assert policy.processor.seen_images is None
+    assert mm["input_ids"].shape[0] == 2
 
 
 def test_cosmos3_partial_unfreeze_backbone_receives_grad():

--- a/tests/policies/test_cosmos3_cpu.py
+++ b/tests/policies/test_cosmos3_cpu.py
@@ -1,0 +1,287 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU smoke tests for the cosmos3 policy.
+
+These exercise the inner ``Cosmos3FlowMatching`` (frozen tiny Qwen3-VL prefix + trainable
+expert + flow matching) on a deliberately tiny random ``qwen3_vl`` config, so they run on
+CPU in the gating ``-m "not gpu and not network"`` suite without downloading the 32B
+backbone. The factory registration is covered by ``test_policies.py``.
+"""
+
+import pytest
+import torch
+from transformers import Qwen3VLConfig
+
+from opentau.policies.cosmos3.configuration_cosmos3 import Cosmos3Config
+from opentau.policies.cosmos3.modeling_cosmos3 import Cosmos3FlowMatching
+from opentau.policies.utils import PerSampleLoss
+
+# Small vision/text special-token ids that fit inside the tiny vocab below.
+IMAGE_TOKEN_ID = 10
+VIDEO_TOKEN_ID = 11
+VISION_START_ID = 12
+VISION_END_ID = 13
+VOCAB = 200
+
+CHUNK = 4
+ACTION_DIM = 6
+STATE_DIM = 5
+MAX_ACTION_DIM = 8
+MAX_STATE_DIM = 8
+
+
+def _tiny_qwen3vl_config() -> Qwen3VLConfig:
+    """A minimally-sized Qwen3-VL config (head_dim/kv-heads/layers must match the expert)."""
+    return Qwen3VLConfig(
+        text_config={
+            "model_type": "qwen3_vl_text",
+            "hidden_size": 64,
+            "intermediate_size": 128,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+            "head_dim": 16,
+            "vocab_size": VOCAB,
+            "rms_norm_eps": 1e-6,
+            "rope_theta": 5_000_000,
+            "rope_scaling": {"mrope_interleaved": True, "mrope_section": [4, 2, 2], "rope_type": "default"},
+        },
+        vision_config={
+            "model_type": "qwen3_vl",
+            "hidden_size": 32,
+            "intermediate_size": 64,
+            "num_heads": 2,
+            "depth": 4,
+            "patch_size": 16,
+            "temporal_patch_size": 2,
+            "spatial_merge_size": 2,
+            "out_hidden_size": 64,
+            "deepstack_visual_indexes": [1, 2],
+            "num_position_embeddings": 256,
+            "in_channels": 3,
+        },
+        image_token_id=IMAGE_TOKEN_ID,
+        video_token_id=VIDEO_TOKEN_ID,
+        vision_start_token_id=VISION_START_ID,
+        vision_end_token_id=VISION_END_ID,
+        tie_word_embeddings=False,
+    )
+
+
+def _tiny_cosmos3_config(**overrides) -> Cosmos3Config:
+    kwargs = {
+        "chunk_size": CHUNK,
+        "n_action_steps": CHUNK,
+        "max_action_dim": MAX_ACTION_DIM,
+        "max_state_dim": MAX_STATE_DIM,
+        "proj_width": 16,
+        "num_steps": 3,
+        "attention_implementation": "eager",
+        "load_pretrained_backbone": False,
+        "dropout": 0.0,
+        "expert_hidden_size": 32,
+        "expert_intermediate_size": 64,
+        "expert_num_hidden_layers": 2,
+        "expert_num_attention_heads": 4,
+        "expert_num_key_value_heads": 2,
+        "expert_head_dim": 16,
+        "expert_adarms_cond_dim": 16,
+    }
+    kwargs.update(overrides)
+    return Cosmos3Config(**kwargs)
+
+
+def _build_model() -> Cosmos3FlowMatching:
+    torch.manual_seed(0)
+    return Cosmos3FlowMatching(_tiny_cosmos3_config(), qwen3vl_config=_tiny_qwen3vl_config())
+
+
+def _text_batch(bsize: int = 2, n_text: int = 6):
+    input_ids = torch.randint(20, VOCAB, (bsize, n_text))
+    attention_mask = torch.ones(bsize, n_text, dtype=torch.long)
+    state = torch.randn(bsize, STATE_DIM)
+    state = torch.nn.functional.pad(state, (0, MAX_STATE_DIM - STATE_DIM))
+    actions = torch.randn(bsize, CHUNK, MAX_ACTION_DIM)
+    return input_ids, attention_mask, state, actions
+
+
+def _image_inputs(bsize: int = 2):
+    """One tiny image per sample: grid [1, 4, 4] -> 4 merged image tokens, 16 patches."""
+    grid_t, grid_h, grid_w = 1, 4, 4
+    merged = (grid_h // 2) * (grid_w // 2)  # spatial_merge_size = 2 -> 2x2 = 4 tokens/image
+    n_patches = grid_t * grid_h * grid_w
+    patch_dim = 3 * 2 * 16 * 16  # in_channels * temporal_patch_size * patch_size**2
+    # Per-sample sequence: <vision_start> <image>*merged <vision_end> + text
+    img_block = [VISION_START_ID] + [IMAGE_TOKEN_ID] * merged + [VISION_END_ID]
+    text_tail = [25, 30, 35]
+    seq = img_block + text_tail
+    input_ids = torch.tensor([seq] * bsize, dtype=torch.long)
+    attention_mask = torch.ones(bsize, len(seq), dtype=torch.long)
+    pixel_values = torch.randn(bsize * n_patches, patch_dim)
+    image_grid_thw = torch.tensor([[grid_t, grid_h, grid_w]] * bsize, dtype=torch.long)
+    return input_ids, attention_mask, pixel_values, image_grid_thw
+
+
+def test_cosmos3_inner_forward_text_only():
+    model = _build_model()
+    input_ids, attention_mask, state, actions = _text_batch()
+    noise = torch.randn_like(actions)
+    time = torch.rand(actions.shape[0])
+    out = model(
+        input_ids=input_ids,
+        attention_mask=attention_mask,
+        pixel_values=None,
+        image_grid_thw=None,
+        state=state,
+        actions=actions,
+        noise=noise,
+        time=time,
+    )
+    assert set(out) == {"MSE", "CE"}
+    assert out["MSE"].ndim == 0 and torch.isfinite(out["MSE"])
+    assert torch.equal(out["CE"], torch.zeros((), dtype=out["CE"].dtype))
+
+
+def test_cosmos3_inner_forward_with_image():
+    model = _build_model()
+    input_ids, attention_mask, pixel_values, image_grid_thw = _image_inputs()
+    bsize = input_ids.shape[0]
+    state = torch.randn(bsize, MAX_STATE_DIM)
+    actions = torch.randn(bsize, CHUNK, MAX_ACTION_DIM)
+    out = model(
+        input_ids=input_ids,
+        attention_mask=attention_mask,
+        pixel_values=pixel_values,
+        image_grid_thw=image_grid_thw,
+        state=state,
+        actions=actions,
+    )
+    assert torch.isfinite(out["MSE"])
+
+
+def test_cosmos3_backbone_is_frozen_expert_trains():
+    model = _build_model()
+    backbone_grad = [p.requires_grad for p in model.qwen3vl_with_expert.backbone.parameters()]
+    expert_grad = [p.requires_grad for p in model.qwen3vl_with_expert.expert.parameters()]
+    assert not any(backbone_grad), "backbone must be fully frozen (train_expert_only)"
+    assert all(expert_grad), "expert must be trainable"
+    # A backward pass populates expert grads but no backbone grads.
+    input_ids, attention_mask, state, actions = _text_batch()
+    out = model(
+        input_ids=input_ids,
+        attention_mask=attention_mask,
+        pixel_values=None,
+        image_grid_thw=None,
+        state=state,
+        actions=actions,
+        noise=torch.randn_like(actions),
+        time=torch.rand(actions.shape[0]),
+    )
+    out["MSE"].backward()
+    assert any(p.grad is not None for p in model.qwen3vl_with_expert.expert.parameters())
+    assert all(p.grad is None for p in model.qwen3vl_with_expert.backbone.parameters())
+
+
+def test_cosmos3_per_sample_loss_shapes():
+    model = _build_model()
+    input_ids, attention_mask, state, actions = _text_batch(bsize=3)
+    out = model(
+        input_ids=input_ids,
+        attention_mask=attention_mask,
+        pixel_values=None,
+        image_grid_thw=None,
+        state=state,
+        actions=actions,
+        noise=torch.randn_like(actions),
+        time=torch.rand(3),
+        return_per_sample=True,
+    )
+    assert isinstance(out["MSE_per_sample"], PerSampleLoss)
+    assert isinstance(out["CE_per_sample"], PerSampleLoss)
+    assert out["MSE_per_sample"].sum.shape == (3,)
+    assert torch.equal(out["CE_per_sample"].count, torch.zeros(3))
+
+
+def test_cosmos3_forward_is_deterministic():
+    """Two forwards with identical inputs/seed produce bit-identical loss (CLAUDE.md rule 3)."""
+    losses = []
+    for _ in range(2):
+        model = _build_model()  # re-seeded identically inside _build_model
+        input_ids, attention_mask, state, actions = _text_batch()
+        # Re-seed the input draw so both runs see identical tensors.
+        torch.manual_seed(1234)
+        noise = torch.randn_like(actions)
+        time = torch.rand(actions.shape[0])
+        out = model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            pixel_values=None,
+            image_grid_thw=None,
+            state=state,
+            actions=actions,
+            noise=noise,
+            time=time,
+        )
+        losses.append(out["MSE"].item())
+    assert losses[0] == losses[1], f"non-deterministic loss: {losses}"
+
+
+def test_cosmos3_sample_actions_shape():
+    model = _build_model()
+    input_ids, attention_mask, state, _ = _text_batch()
+    bsize = input_ids.shape[0]
+    action_prefix = torch.zeros(bsize, CHUNK, MAX_ACTION_DIM)
+    delay = torch.tensor(0, dtype=torch.long)
+    actions = model.sample_actions(
+        input_ids=input_ids,
+        attention_mask=attention_mask,
+        pixel_values=None,
+        image_grid_thw=None,
+        state=state,
+        action_prefix=action_prefix,
+        delay=delay,
+    )
+    assert actions.shape == (bsize, CHUNK, MAX_ACTION_DIM)
+    assert torch.isfinite(actions).all()
+
+
+def test_cosmos3_config_validation():
+    with pytest.raises(ValueError):
+        Cosmos3Config(attention_implementation="flash_cuda")
+    with pytest.raises(ValueError):
+        Cosmos3Config(n_action_steps=100, chunk_size=50)
+    with pytest.raises(ValueError):
+        # query heads not a multiple of kv heads
+        Cosmos3Config(expert_num_attention_heads=15, expert_num_key_value_heads=8)
+
+
+def test_cosmos3_expert_under_1b_params():
+    """The default (real) expert + projections must be < 1B trainable params."""
+    cfg = Cosmos3Config()  # real defaults; head geometry from Qwen3-VL-32B
+    # Count expert params analytically without building the 32B backbone.
+    h = cfg.expert_hidden_size
+    inter = cfg.expert_intermediate_size
+    hq, hkv, hd = cfg.expert_num_attention_heads, cfg.expert_num_key_value_heads, cfg.expert_head_dim
+    c = cfg.expert_adarms_cond_dim
+    per_layer = (
+        h * (hq * hd)  # q_proj
+        + 2 * h * (hkv * hd)  # k_proj + v_proj
+        + (hq * hd) * h  # o_proj
+        + 2 * hd  # q_norm + k_norm
+        + 3 * h * inter  # gated MLP
+        + 2 * (c * 3 * h + 3 * h)  # two AdaRMS dense (weight + bias)
+    )
+    total = per_layer * cfg.expert_num_hidden_layers + (c * 3 * h + 3 * h)  # + final norm
+    assert total < 1_000_000_000, f"expert has {total:,} params (>= 1B)"

--- a/tests/policies/test_cosmos3_gpu.py
+++ b/tests/policies/test_cosmos3_gpu.py
@@ -1,0 +1,156 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""GPU smoke tests for the cosmos3 policy (``pytest -m gpu``).
+
+These run the inner ``Cosmos3FlowMatching`` on CUDA in bf16 using a tiny random
+``qwen3_vl`` config (no 32B download), validating the GPU/bf16 forward + backward,
+the frozen-backbone / trainable-expert split, and two-seed loss determinism. The
+full 32B (``nvidia/Cosmos-Reason2-32B`` / its ungated twin ``Qwen/Qwen3-VL-32B-Instruct``)
+load + memory-fit is exercised separately as a manual smoke on the target hardware.
+"""
+
+import pytest
+import torch
+from transformers import Qwen3VLConfig
+
+from opentau.policies.cosmos3.configuration_cosmos3 import Cosmos3Config
+from opentau.policies.cosmos3.modeling_cosmos3 import Cosmos3FlowMatching
+
+CHUNK, ADIM, SDIM = 4, 6, 5
+MAX_ADIM, MAX_SDIM = 8, 8
+
+
+def _tiny_qwen3vl_config() -> Qwen3VLConfig:
+    return Qwen3VLConfig(
+        text_config={
+            "model_type": "qwen3_vl_text",
+            "hidden_size": 64,
+            "intermediate_size": 128,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+            "head_dim": 16,
+            "vocab_size": 200,
+            "rms_norm_eps": 1e-6,
+            "rope_theta": 5_000_000,
+            "rope_scaling": {"mrope_interleaved": True, "mrope_section": [4, 2, 2], "rope_type": "default"},
+        },
+        vision_config={
+            "model_type": "qwen3_vl",
+            "hidden_size": 32,
+            "intermediate_size": 64,
+            "num_heads": 2,
+            "depth": 4,
+            "patch_size": 16,
+            "temporal_patch_size": 2,
+            "spatial_merge_size": 2,
+            "out_hidden_size": 64,
+            "deepstack_visual_indexes": [1, 2],
+            "num_position_embeddings": 256,
+            "in_channels": 3,
+        },
+        image_token_id=10,
+        video_token_id=11,
+        vision_start_token_id=12,
+        vision_end_token_id=13,
+        tie_word_embeddings=False,
+    )
+
+
+def _tiny_config(**overrides) -> Cosmos3Config:
+    kwargs = {
+        "chunk_size": CHUNK,
+        "n_action_steps": CHUNK,
+        "max_action_dim": MAX_ADIM,
+        "max_state_dim": MAX_SDIM,
+        "proj_width": 16,
+        "num_steps": 3,
+        "attention_implementation": "eager",
+        "load_pretrained_backbone": False,
+        "dropout": 0.0,
+        "expert_hidden_size": 32,
+        "expert_intermediate_size": 64,
+        "expert_num_hidden_layers": 2,
+        "expert_num_attention_heads": 4,
+        "expert_num_key_value_heads": 2,
+        "expert_head_dim": 16,
+        "expert_adarms_cond_dim": 16,
+    }
+    kwargs.update(overrides)
+    return Cosmos3Config(**kwargs)
+
+
+def _build(device):
+    torch.manual_seed(0)
+    model = Cosmos3FlowMatching(_tiny_config(), qwen3vl_config=_tiny_qwen3vl_config())
+    return model.to(device=device, dtype=torch.bfloat16)
+
+
+def _batch(device, seed=0):
+    g = torch.Generator(device="cpu").manual_seed(seed)
+    input_ids = torch.randint(20, 200, (2, 6), generator=g).to(device)
+    attention_mask = torch.ones(2, 6, dtype=torch.long, device=device)
+    state = torch.randn(2, MAX_SDIM, generator=g).to(device)
+    actions = torch.randn(2, CHUNK, MAX_ADIM, generator=g).to(device)
+    noise = torch.randn(2, CHUNK, MAX_ADIM, generator=g).to(device)
+    time = torch.rand(2, generator=g).to(device)
+    return input_ids, attention_mask, state, actions, noise, time
+
+
+@pytest.mark.gpu
+def test_cosmos3_gpu_forward_backward():
+    """bf16 forward + backward on CUDA: finite loss, expert grads flow, backbone frozen."""
+    device = "cuda"
+    model = _build(device)
+    iid, am, st, act, noise, time = _batch(device)
+    out = model(
+        input_ids=iid,
+        attention_mask=am,
+        pixel_values=None,
+        image_grid_thw=None,
+        state=st,
+        actions=act,
+        noise=noise,
+        time=time,
+    )
+    assert torch.isfinite(out["MSE"])
+    out["MSE"].backward()
+    expert = model.qwen3vl_with_expert.expert
+    backbone = model.qwen3vl_with_expert.backbone
+    assert any(p.grad is not None and torch.isfinite(p.grad).all() for p in expert.parameters())
+    assert all(p.grad is None for p in backbone.parameters())
+
+
+@pytest.mark.gpu
+def test_cosmos3_gpu_determinism():
+    """Two eval forwards with identical inputs give a bit-identical loss on GPU."""
+    device = "cuda"
+    losses = []
+    for _ in range(2):
+        model = _build(device).eval()
+        iid, am, st, act, noise, time = _batch(device, seed=3)
+        with torch.no_grad():
+            out = model(
+                input_ids=iid,
+                attention_mask=am,
+                pixel_values=None,
+                image_grid_thw=None,
+                state=st,
+                actions=act,
+                noise=noise,
+                time=time,
+            )
+        losses.append(out["MSE"].item())
+    assert losses[0] == losses[1], f"non-deterministic loss on GPU: {losses}"

--- a/tests/policies/test_pi07_video_encoder_cpu.py
+++ b/tests/policies/test_pi07_video_encoder_cpu.py
@@ -660,7 +660,7 @@ class TestSuppressSpacetimeTemporal:
         )
         bad_input = torch.rand(3, 256, wrapper.embed_dim)
         with suppress_spacetime_temporal(encoder.vision_tower):
-            out = wrapper.forward(bad_input)[0]
+            out = wrapper.forward(bad_input)
         assert out.shape == bad_input.shape
 
 
@@ -1051,8 +1051,8 @@ class TestReadingBMaskStructure:
         hidden_b = torch.cat([past, current_b], dim=0)
 
         with torch.no_grad():
-            out_a = wrapper(hidden_a, num_frames=t)[0]
-            out_b = wrapper(hidden_b, num_frames=t)[0]
+            out_a = wrapper(hidden_a, num_frames=t)
+            out_b = wrapper(hidden_b, num_frames=t)
 
         # Past frame at index 0: causal mask must prevent it from seeing
         # the current frame's data, so out_a[0] must equal out_b[0].

--- a/tests/test_available.py
+++ b/tests/test_available.py
@@ -17,6 +17,7 @@
 
 
 import opentau
+from opentau.policies.cosmos3.modeling_cosmos3 import Cosmos3Policy
 from opentau.policies.pi0.modeling_pi0 import PI0Policy
 from opentau.policies.pi05.modeling_pi05 import PI05Policy
 from opentau.policies.pi05_mem.modeling_pi05 import PI05MemPolicy
@@ -43,6 +44,7 @@ def test_available_policies():
         PI06Policy,
         PI07HighLevelPlannerPolicy,
         PI07LowLevelPolicy,
+        Cosmos3Policy,
     ]
     policies = [pol_cls.name for pol_cls in policy_classes]
     assert set(policies) == set(opentau.available_policies), policies

--- a/uv.lock
+++ b/uv.lock
@@ -2341,7 +2341,7 @@ requires-dist = [
     { name = "torch", specifier = ">=2.7.1" },
     { name = "torchcodec", marker = "(platform_machine != 'aarch64' and platform_machine != 'arm64' and platform_machine != 'armv7l' and sys_platform == 'linux') or (platform_machine != 'x86_64' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')", specifier = ">=0.10.0,<0.11.0" },
     { name = "torchvision", specifier = ">=0.22.1" },
-    { name = "transformers", specifier = "==4.53.3" },
+    { name = "transformers", specifier = ">=4.57,<4.58" },
     { name = "wandb", specifier = ">=0.27.0" },
     { name = "zarr", specifier = ">=2.17.0" },
 ]
@@ -3653,27 +3653,32 @@ wheels = [
 
 [[package]]
 name = "tokenizers"
-version = "0.21.4"
+version = "0.22.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c2/2f/402986d0823f8d7ca139d969af2917fefaa9b947d1fb32f6168c509f2492/tokenizers-0.21.4.tar.gz", hash = "sha256:fa23f85fbc9a02ec5c6978da172cdcbac23498c3ca9f3645c5c68740ac007880", size = 351253, upload-time = "2025-07-28T15:48:54.325Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/6f/f80cfef4a312e1fb34baf7d85c72d4411afde10978d4657f8cdd811d3ccc/tokenizers-0.22.2.tar.gz", hash = "sha256:473b83b915e547aa366d1eee11806deaf419e17be16310ac0a14077f1e28f917", size = 372115, upload-time = "2026-01-05T10:45:15.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/c6/fdb6f72bf6454f52eb4a2510be7fb0f614e541a2554d6210e370d85efff4/tokenizers-0.21.4-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:2ccc10a7c3bcefe0f242867dc914fc1226ee44321eb618cfe3019b5df3400133", size = 2863987, upload-time = "2025-07-28T15:48:44.877Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/a6/28975479e35ddc751dc1ddc97b9b69bf7fcf074db31548aab37f8116674c/tokenizers-0.21.4-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:5e2f601a8e0cd5be5cc7506b20a79112370b9b3e9cb5f13f68ab11acd6ca7d60", size = 2732457, upload-time = "2025-07-28T15:48:43.265Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/8f/24f39d7b5c726b7b0be95dca04f344df278a3fe3a4deb15a975d194cbb32/tokenizers-0.21.4-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:39b376f5a1aee67b4d29032ee85511bbd1b99007ec735f7f35c8a2eb104eade5", size = 3012624, upload-time = "2025-07-28T13:22:43.895Z" },
-    { url = "https://files.pythonhosted.org/packages/58/47/26358925717687a58cb74d7a508de96649544fad5778f0cd9827398dc499/tokenizers-0.21.4-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2107ad649e2cda4488d41dfd031469e9da3fcbfd6183e74e4958fa729ffbf9c6", size = 2939681, upload-time = "2025-07-28T13:22:47.499Z" },
-    { url = "https://files.pythonhosted.org/packages/99/6f/cc300fea5db2ab5ddc2c8aea5757a27b89c84469899710c3aeddc1d39801/tokenizers-0.21.4-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c73012da95afafdf235ba80047699df4384fdc481527448a078ffd00e45a7d9", size = 3247445, upload-time = "2025-07-28T15:48:39.711Z" },
-    { url = "https://files.pythonhosted.org/packages/be/bf/98cb4b9c3c4afd8be89cfa6423704337dc20b73eb4180397a6e0d456c334/tokenizers-0.21.4-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f23186c40395fc390d27f519679a58023f368a0aad234af145e0f39ad1212732", size = 3428014, upload-time = "2025-07-28T13:22:49.569Z" },
-    { url = "https://files.pythonhosted.org/packages/75/c7/96c1cc780e6ca7f01a57c13235dd05b7bc1c0f3588512ebe9d1331b5f5ae/tokenizers-0.21.4-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cc88bb34e23a54cc42713d6d98af5f1bf79c07653d24fe984d2d695ba2c922a2", size = 3193197, upload-time = "2025-07-28T13:22:51.471Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/90/273b6c7ec78af547694eddeea9e05de771278bd20476525ab930cecaf7d8/tokenizers-0.21.4-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51b7eabb104f46c1c50b486520555715457ae833d5aee9ff6ae853d1130506ff", size = 3115426, upload-time = "2025-07-28T15:48:41.439Z" },
-    { url = "https://files.pythonhosted.org/packages/91/43/c640d5a07e95f1cf9d2c92501f20a25f179ac53a4f71e1489a3dcfcc67ee/tokenizers-0.21.4-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:714b05b2e1af1288bd1bc56ce496c4cebb64a20d158ee802887757791191e6e2", size = 9089127, upload-time = "2025-07-28T15:48:46.472Z" },
-    { url = "https://files.pythonhosted.org/packages/44/a1/dd23edd6271d4dca788e5200a807b49ec3e6987815cd9d0a07ad9c96c7c2/tokenizers-0.21.4-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:1340ff877ceedfa937544b7d79f5b7becf33a4cfb58f89b3b49927004ef66f78", size = 9055243, upload-time = "2025-07-28T15:48:48.539Z" },
-    { url = "https://files.pythonhosted.org/packages/21/2b/b410d6e9021c4b7ddb57248304dc817c4d4970b73b6ee343674914701197/tokenizers-0.21.4-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:3c1f4317576e465ac9ef0d165b247825a2a4078bcd01cba6b54b867bdf9fdd8b", size = 9298237, upload-time = "2025-07-28T15:48:50.443Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/0a/42348c995c67e2e6e5c89ffb9cfd68507cbaeb84ff39c49ee6e0a6dd0fd2/tokenizers-0.21.4-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:c212aa4e45ec0bb5274b16b6f31dd3f1c41944025c2358faaa5782c754e84c24", size = 9461980, upload-time = "2025-07-28T15:48:52.325Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/d3/dacccd834404cd71b5c334882f3ba40331ad2120e69ded32cf5fda9a7436/tokenizers-0.21.4-cp39-abi3-win32.whl", hash = "sha256:6c42a930bc5f4c47f4ea775c91de47d27910881902b0f20e4990ebe045a415d0", size = 2329871, upload-time = "2025-07-28T15:48:56.841Z" },
-    { url = "https://files.pythonhosted.org/packages/41/f2/fd673d979185f5dcbac4be7d09461cbb99751554ffb6718d0013af8604cb/tokenizers-0.21.4-cp39-abi3-win_amd64.whl", hash = "sha256:475d807a5c3eb72c59ad9b5fcdb254f6e17f53dfcbb9903233b0dfa9c943b597", size = 2507568, upload-time = "2025-07-28T15:48:55.456Z" },
+    { url = "https://files.pythonhosted.org/packages/92/97/5dbfabf04c7e348e655e907ed27913e03db0923abb5dfdd120d7b25630e1/tokenizers-0.22.2-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:544dd704ae7238755d790de45ba8da072e9af3eea688f698b137915ae959281c", size = 3100275, upload-time = "2026-01-05T10:41:02.158Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/47/174dca0502ef88b28f1c9e06b73ce33500eedfac7a7692108aec220464e7/tokenizers-0.22.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1e418a55456beedca4621dbab65a318981467a2b188e982a23e117f115ce5001", size = 2981472, upload-time = "2026-01-05T10:41:00.276Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/84/7990e799f1309a8b87af6b948f31edaa12a3ed22d11b352eaf4f4b2e5753/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2249487018adec45d6e3554c71d46eb39fa8ea67156c640f7513eb26f318cec7", size = 3290736, upload-time = "2026-01-05T10:40:32.165Z" },
+    { url = "https://files.pythonhosted.org/packages/78/59/09d0d9ba94dcd5f4f1368d4858d24546b4bdc0231c2354aa31d6199f0399/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:25b85325d0815e86e0bac263506dd114578953b7b53d7de09a6485e4a160a7dd", size = 3168835, upload-time = "2026-01-05T10:40:38.847Z" },
+    { url = "https://files.pythonhosted.org/packages/47/50/b3ebb4243e7160bda8d34b731e54dd8ab8b133e50775872e7a434e524c28/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bfb88f22a209ff7b40a576d5324bf8286b519d7358663db21d6246fb17eea2d5", size = 3521673, upload-time = "2026-01-05T10:40:56.614Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/fa/89f4cb9e08df770b57adb96f8cbb7e22695a4cb6c2bd5f0c4f0ebcf33b66/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1c774b1276f71e1ef716e5486f21e76333464f47bece56bbd554485982a9e03e", size = 3724818, upload-time = "2026-01-05T10:40:44.507Z" },
+    { url = "https://files.pythonhosted.org/packages/64/04/ca2363f0bfbe3b3d36e95bf67e56a4c88c8e3362b658e616d1ac185d47f2/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:df6c4265b289083bf710dff49bc51ef252f9d5be33a45ee2bed151114a56207b", size = 3379195, upload-time = "2026-01-05T10:40:51.139Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/76/932be4b50ef6ccedf9d3c6639b056a967a86258c6d9200643f01269211ca/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:369cc9fc8cc10cb24143873a0d95438bb8ee257bb80c71989e3ee290e8d72c67", size = 3274982, upload-time = "2026-01-05T10:40:58.331Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/28/5f9f5a4cc211b69e89420980e483831bcc29dade307955cc9dc858a40f01/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:29c30b83d8dcd061078b05ae0cb94d3c710555fbb44861139f9f83dcca3dc3e4", size = 9478245, upload-time = "2026-01-05T10:41:04.053Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fb/66e2da4704d6aadebf8cb39f1d6d1957df667ab24cff2326b77cda0dcb85/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:37ae80a28c1d3265bb1f22464c856bd23c02a05bb211e56d0c5301a435be6c1a", size = 9560069, upload-time = "2026-01-05T10:45:10.673Z" },
+    { url = "https://files.pythonhosted.org/packages/16/04/fed398b05caa87ce9b1a1bb5166645e38196081b225059a6edaff6440fac/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:791135ee325f2336f498590eb2f11dc5c295232f288e75c99a36c5dbce63088a", size = 9899263, upload-time = "2026-01-05T10:45:12.559Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a1/d62dfe7376beaaf1394917e0f8e93ee5f67fea8fcf4107501db35996586b/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:38337540fbbddff8e999d59970f3c6f35a82de10053206a7562f1ea02d046fa5", size = 10033429, upload-time = "2026-01-05T10:45:14.333Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363, upload-time = "2026-01-05T10:45:20.593Z" },
+    { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786, upload-time = "2026-01-05T10:45:18.411Z" },
+    { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133, upload-time = "2026-01-05T10:45:17.232Z" },
+    { url = "https://files.pythonhosted.org/packages/84/04/655b79dbcc9b3ac5f1479f18e931a344af67e5b7d3b251d2dcdcd7558592/tokenizers-0.22.2-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:753d47ebd4542742ef9261d9da92cd545b2cacbb48349a1225466745bb866ec4", size = 3282301, upload-time = "2026-01-05T10:40:34.858Z" },
+    { url = "https://files.pythonhosted.org/packages/46/cd/e4851401f3d8f6f45d8480262ab6a5c8cb9c4302a790a35aa14eeed6d2fd/tokenizers-0.22.2-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e10bf9113d209be7cd046d40fbabbaf3278ff6d18eb4da4c500443185dc1896c", size = 3161308, upload-time = "2026-01-05T10:40:40.737Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/6e/55553992a89982cd12d4a66dddb5e02126c58677ea3931efcbe601d419db/tokenizers-0.22.2-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:64d94e84f6660764e64e7e0b22baa72f6cd942279fdbb21d46abd70d179f0195", size = 3718964, upload-time = "2026-01-05T10:40:46.56Z" },
+    { url = "https://files.pythonhosted.org/packages/59/8c/b1c87148aa15e099243ec9f0cf9d0e970cc2234c3257d558c25a2c5304e6/tokenizers-0.22.2-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f01a9c019878532f98927d2bacb79bbb404b43d3437455522a00a30718cdedb5", size = 3373542, upload-time = "2026-01-05T10:40:52.803Z" },
 ]
 
 [[package]]
@@ -3780,7 +3785,7 @@ wheels = [
 
 [[package]]
 name = "transformers"
-version = "4.53.3"
+version = "4.57.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
@@ -3794,9 +3799,9 @@ dependencies = [
     { name = "tokenizers" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f1/5c/49182918b58eaa0b4c954fd0e37c79fc299e5643e69d70089d0b0eb0cd9b/transformers-4.53.3.tar.gz", hash = "sha256:b2eda1a261de79b78b97f7888fe2005fc0c3fabf5dad33d52cc02983f9f675d8", size = 9197478, upload-time = "2025-07-22T07:30:51.51Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/35/67252acc1b929dc88b6602e8c4a982e64f31e733b804c14bc24b47da35e6/transformers-4.57.6.tar.gz", hash = "sha256:55e44126ece9dc0a291521b7e5492b572e6ef2766338a610b9ab5afbb70689d3", size = 10134912, upload-time = "2026-01-16T10:38:39.284Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/b1/d7520cc5cb69c825599042eb3a7c986fa9baa8a8d2dea9acd78e152c81e2/transformers-4.53.3-py3-none-any.whl", hash = "sha256:5aba81c92095806b6baf12df35d756cf23b66c356975fb2a7fa9e536138d7c75", size = 10826382, upload-time = "2025-07-22T07:30:48.458Z" },
+    { url = "https://files.pythonhosted.org/packages/03/b8/e484ef633af3887baeeb4b6ad12743363af7cce68ae51e938e00aaa0529d/transformers-4.57.6-py3-none-any.whl", hash = "sha256:4c9e9de11333ddfe5114bc872c9f370509198acf0b87a832a0ab9458e2bd0550", size = 11993498, upload-time = "2026-01-16T10:38:31.289Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What this does

Adds a new VLA policy **`cosmos3`** (🗃️ Feature): the π0.5 flow-matching recipe on a **frozen Qwen3-VL-32B** backbone — the **reasoning tower of NVIDIA `Cosmos3-Super`**, extracted into a standalone Qwen3-VL-32B checkpoint by `src/opentau/scripts/extract_cosmos3_reasoner.py` — paired with a custom **sub-1B Qwen3-style flow-matching action expert** (~0.91B trainable).

How it works (π0.5 dual-stream, specialized for a frozen reasoner):

- **Max-batch benchmarks** (8× A100-80GB, DeepSpeed, expert-only) — see the PR comment: **ZeRO-2 → 27** micro-batch/GPU, **ZeRO-3 → ~128** (ZeRO-3 shards the replicated 64 GB backbone).
- **End-to-end ZeRO-3 max-batch run with the real extracted reasoner** (8× A100-80GB): loaded `TensorAuto/cosmos3-reason-32b` as the frozen backbone, real Qwen3-VL processor (2 cams @224 + prompt), `train_expert_only`, **B=128/GPU (1024 global)** under DeepSpeed ZeRO-3 — peak **71.1 GB / 80 GB**. On a fixed batch + fixed flow-matching noise/time (`max_delay=0`, deterministic) the loss **strictly decreased every step** (2.349 → 2.000 over 8 steps), expert trainable + backbone frozen — confirming the real reasoner trains end to end at the ZeRO-3 max batch.
- The scheduled nightly `regression_test.yml` (AWS g6) runs automatically and was not triggered manually.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/policies/test_cosmos3_cpu.py
```
```bash
pytest -m "gpu" tests/policies/test_cosmos3_gpu.py
```
```bash
opentau-train --config_path=configs/examples/cosmos3_training_config.json
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [x] My PR includes policy-related changes.
  - [x] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).