### PR TITLE
feat(deepspeed): validate ZeRO-3 for pi05 full fine-tune + ZeRO-2 benchmark

### DIFF
--- a/docs/source/tutorials/benchmarking.rst
+++ b/docs/source/tutorials/benchmarking.rst
@@ -281,3 +281,95 @@ out candidates in order of likelihood:
     #    touching any config file:
     FUSED_ADAMW=false accelerate launch ... profile_step.py ...
     FUSED_ADAMW=true  accelerate launch ... profile_step.py ...
+
+DeepSpeed ZeRO-2 vs ZeRO-3 for pi05 full fine-tuning
+----------------------------------------------------
+
+ZeRO-3 shards the model *parameters* across ranks on top of the gradient and
+optimizer-state sharding that ZeRO-2 already does. That extra sharding pays off
+only when a single replica of the model does not fit in one GPU's memory — it
+adds a per-layer parameter all-gather in the forward (and a matching
+reduce-scatter in the backward) that ZeRO-2 does not need. pi05 is ≈3.3B
+parameters and fits comfortably replicated on an 80 GB GPU, so ZeRO-3 has
+nothing to gain and pays the all-gather cost.
+
+Measured on **8×A100-80GB, full fine-tuning (no frozen weights;
+``freeze_vision_encoder=false``, ``train_expert_only=false``), bf16, sdpa
+attention, ``use_torch_compile=false``, ``gradient_accumulation_steps=1``, 8
+ranks**, with the ``configs/examples/accelerate_deepspeed*`` configs and the
+pi05 reference policy (2 cameras at 224×224, ``chunk_size=10``,
+``predict_response=true``) on ``TensorAuto/libero``:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 14 14 12 12 14 14
+
+   * - Backend
+     - Per-rank batch
+     - Global batch
+     - sec/step
+     - samples/s
+     - Peak GPU mem
+   * - ZeRO-2
+     - 8
+     - 64
+     - 5.64
+     - 11.4
+     - 53.3 GiB
+   * - ZeRO-3
+     - 8
+     - 64
+     - 7.71
+     - 8.3
+     - 62.8 GiB
+   * - ZeRO-2
+     - 16
+     - 128
+     - 5.29
+     - 24.2
+     - 78.7 GiB
+   * - ZeRO-3
+     - 16
+     - 128
+     - 9.86
+     - 13.0
+     - 79.2 GiB
+
+Both backends OOM at the same per-rank batch size on this hardware (16 fits,
+18 OOMs): ZeRO-3 frees ~5 GB of replicated parameters per rank, but its
+parameter all-gather/prefetch buffers plus the extra allocator fragmentation
+consume a comparable amount, so the maximum batch is unchanged. At a matched
+batch size ZeRO-2 is ~1.4× faster at batch 8 and ~1.9× faster at batch 16
+(the per-step parameter all-gather is the difference; both keep fp32 master
+weights and step the optimizer identically).
+
+**Recommendation:** use plain DDP (fastest) or ZeRO-2 for pi05 and similarly
+sized policies. Reach for ZeRO-3 only when a single replica no longer fits per
+GPU (much larger backbones / many-billion-parameter experts). ZeRO-3 *is* fully
+supported and validated for pi05 — training, checkpoint save, resume, offline
+checkpoint consolidation (``convert_checkpoint.sh``), and in-training validation
+all work — it is simply not the throughput-optimal choice at this model size.
+
+To reproduce, run the same config under each accelerate file (both at 8 ranks /
+``gradient_accumulation_steps=1``) and read the per-step time from the logs;
+``samples/s = per_rank_batch × num_ranks ÷ sec_per_step``:
+
+.. code-block:: bash
+
+    COMMON="--policy.freeze_vision_encoder=false --policy.train_expert_only=false \
+        --policy.use_torch_compile=false --policy.attention_implementation=sdpa \
+        --batch_size=16 --dataloader_batch_size=16 --gradient_accumulation_steps=1"
+
+    # ZeRO-2
+    accelerate launch --config_file configs/examples/accelerate_deepspeed_config.yaml --num_processes 8 \
+        src/opentau/scripts/train.py --config_path=configs/examples/pi05_training_config.json $COMMON
+
+    # ZeRO-3
+    accelerate launch --config_file configs/examples/accelerate_deepspeed_zero3_config.yaml \
+        src/opentau/scripts/train.py --config_path=configs/examples/pi05_training_config.json $COMMON
+
+.. note::
+   If a ZeRO-3 run OOMs from fragmentation (the error mentions
+   "reserved but unallocated" memory), set
+   ``PYTORCH_ALLOC_CONF=expandable_segments:True`` in the environment to recover
+   the fragmented blocks.

--- a/docs/source/tutorials/training.rst
+++ b/docs/source/tutorials/training.rst
@@ -16,6 +16,11 @@ The recommended distributed setup for the pi05 reference policy (and other polic
 
 A DeepSpeed ZeRO-2 example is also available at `configs/examples/accelerate_deepspeed_config.yaml <https://github.com/TensorAuto/OpenTau/blob/main/configs/examples/accelerate_deepspeed_config.yaml>`_ for memory-constrained scenarios; it is the config used by our CI pipelines so we keep coverage for that path. For mid-sized policies like pi05, DDP is significantly faster — see issue #177 for benchmarks.
 
+A DeepSpeed ZeRO-3 example is available at `configs/examples/accelerate_deepspeed_zero3_config.yaml <https://github.com/TensorAuto/OpenTau/blob/main/configs/examples/accelerate_deepspeed_zero3_config.yaml>`_. ZeRO-3 additionally shards the model *parameters* across ranks (on top of ZeRO-2's gradient and optimizer-state sharding), so it is the right choice only when a single replica of the model does not fit in one GPU's memory. ZeRO-3 is fully supported for pi05 — full fine-tuning (no frozen weights), checkpointing, resume, and in-training validation all work — but for a model that fits replicated it is not the fastest option: pi05 (≈3.3B params) fits comfortably on an 80 GB GPU, and a measured 8×A100-80GB full fine-tune found DDP and ZeRO-2 both faster than ZeRO-3 at the same batch size while reaching a comparable maximum batch size. ZeRO-3's per-layer parameter all-gather/prefetch buffers add memory and communication overhead that the parameter sharding does not pay back at this model size. See the :doc:`benchmarking` guide for the full ZeRO-2 vs ZeRO-3 comparison. Reach for ZeRO-3 when scaling to a model too large to replicate per GPU.
+
+.. note::
+   ``gradient_checkpointing`` and ``use_torch_compile`` are not compatible with ZeRO-3: parameters are re-sharded on every forward, which ``torch.utils.checkpoint`` and ``torch.compile`` guards do not handle. The launcher rejects ``gradient_checkpointing=True`` under ZeRO-3 and downgrades ``use_torch_compile`` to eager with a warning (use FSDP or ZeRO-1/2 if you need either). If you hit fragmentation-driven OOMs under ZeRO-3, set ``PYTORCH_ALLOC_CONF=expandable_segments:True`` in the environment.
+
 To train a model, run the following command:
 
 .. code-block:: bash

--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -526,6 +526,29 @@ def _find_unused_params_from_env() -> bool:
     return os.environ.get("FIND_UNUSED_PARAMS", "true").lower() == "true"
 
 
+def _deepspeed_zero_stage(accelerator: accelerate.Accelerator) -> int:
+    """Return the active DeepSpeed ZeRO stage, or 0 when DeepSpeed is not the backend.
+
+    Centralizes the ``accelerator.deepspeed_plugin.hf_ds_config.config`` lookup
+    that gates every ZeRO-3-specific code path in ``train()`` — the
+    per-construction parameter-partitioning suppression
+    (``_zero3_disabled_init_context``) and the gradient-checkpointing /
+    ``use_torch_compile`` / in-training-sim-eval guards, all of which branch on
+    "is this ZeRO-3?". Returning 0 for non-DeepSpeed backends lets callers test
+    ``>= 3`` without first checking ``distributed_type``.
+
+    Args:
+        accelerator: The active accelerate ``Accelerator``.
+
+    Returns:
+        int: The configured ZeRO optimization stage (0, 1, 2, or 3). 0 when the
+        distributed backend is not DeepSpeed (so ``< 3`` everywhere it matters).
+    """
+    if accelerator.distributed_type != accelerate.DistributedType.DEEPSPEED:
+        return 0
+    return accelerator.deepspeed_plugin.hf_ds_config.config.get("zero_optimization", {}).get("stage", 0)
+
+
 @contextmanager
 def _zero3_disabled_init_context(accelerator: accelerate.Accelerator):
     """Context manager that suppresses ZeRO-3 per-construction param partitioning.
@@ -551,11 +574,7 @@ def _zero3_disabled_init_context(accelerator: accelerate.Accelerator):
     Args:
         accelerator: The active accelerate ``Accelerator``.
     """
-    if accelerator.distributed_type != accelerate.DistributedType.DEEPSPEED:
-        yield
-        return
-    zero_stage = accelerator.deepspeed_plugin.hf_ds_config.config.get("zero_optimization", {}).get("stage", 0)
-    if zero_stage < 3:
+    if _deepspeed_zero_stage(accelerator) < 3:
         yield
         return
 
@@ -663,20 +682,17 @@ def train(cfg: TrainPipelineConfig):
                 "Either set gradient_checkpointing=False or switch to a "
                 "supported backend."
             )
-        if accelerator.distributed_type == accelerate.DistributedType.DEEPSPEED:
-            zero_stage = accelerator.deepspeed_plugin.hf_ds_config.config.get("zero_optimization", {}).get(
-                "stage", 0
+        zero_stage = _deepspeed_zero_stage(accelerator)
+        if zero_stage >= 3:
+            raise ValueError(
+                f"gradient_checkpointing=True is not supported under "
+                f"DeepSpeed ZeRO stage {zero_stage}. ZeRO-3 re-shards parameters "
+                "during forward and needs deepspeed.checkpointing.checkpoint "
+                "rather than torch.utils.checkpoint. Either set "
+                "gradient_checkpointing=False, use zero_stage: 1 or 2, or "
+                "switch to FSDP (which has equivalent param sharding and "
+                "is compatible with torch.utils.checkpoint)."
             )
-            if zero_stage >= 3:
-                raise ValueError(
-                    f"gradient_checkpointing=True is not supported under "
-                    f"DeepSpeed ZeRO stage {zero_stage}. ZeRO-3 re-shards parameters "
-                    "during forward and needs deepspeed.checkpointing.checkpoint "
-                    "rather than torch.utils.checkpoint. Either set "
-                    "gradient_checkpointing=False, use zero_stage: 1 or 2, or "
-                    "switch to FSDP (which has equivalent param sharding and "
-                    "is compatible with torch.utils.checkpoint)."
-                )
 
     # Backend compatibility for use_torch_compile. `nn.Module.compile` caches
     # guards keyed on parameter/buffer storage, but DeepSpeed ZeRO-3 and FSDP
@@ -697,9 +713,7 @@ def train(cfg: TrainPipelineConfig):
         ):
             unsupported_backend = str(accelerator.distributed_type)
         elif accelerator.distributed_type == accelerate.DistributedType.DEEPSPEED:
-            zero_stage = accelerator.deepspeed_plugin.hf_ds_config.config.get("zero_optimization", {}).get(
-                "stage", 0
-            )
+            zero_stage = _deepspeed_zero_stage(accelerator)
             if zero_stage >= 3:
                 unsupported_backend = f"DeepSpeed ZeRO stage {zero_stage}"
         if unsupported_backend is not None:
@@ -754,12 +768,10 @@ def train(cfg: TrainPipelineConfig):
         # Under parameter sharding the forward still all-gathers params per layer,
         # which WOULD desync across the independent rollouts and hang at NCCL — fail
         # fast instead of hanging hours into a run.
-        sharded_params = accelerator.distributed_type == accelerate.DistributedType.FSDP
-        if accelerator.distributed_type == accelerate.DistributedType.DEEPSPEED:
-            zero_stage = accelerator.deepspeed_plugin.hf_ds_config.config.get("zero_optimization", {}).get(
-                "stage", 0
-            )
-            sharded_params = zero_stage >= 3
+        sharded_params = (
+            accelerator.distributed_type == accelerate.DistributedType.FSDP
+            or _deepspeed_zero_stage(accelerator) >= 3
+        )
         if sharded_params:
             raise ValueError(
                 "In-training simulation eval (eval_freq > 0 with a sim env) is not "

--- a/tests/scripts/test_train.py
+++ b/tests/scripts/test_train.py
@@ -35,6 +35,7 @@ import wandb
 from opentau.scripts.train import (
     _bucket_per_sample,
     _commit_wandb_step,
+    _deepspeed_zero_stage,
     _eval_with_fresh_envs,
     _find_unused_params_from_env,
     _init_wandb_trackers,
@@ -154,6 +155,56 @@ def test_deepspeed_mismatch_non_main_overrides_without_warning(caplog):
     assert accelerator.deepspeed_plugin.hf_ds_config.config["gradient_accumulation_steps"] == 4
     assert accelerator.deepspeed_plugin.gradient_accumulation_steps == 4
     assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+def _make_stage_accelerator(distributed_type, zero_optimization=None):
+    """Accelerator stub exposing the deepspeed plugin config ``_deepspeed_zero_stage`` reads.
+
+    ``zero_optimization`` is the dict placed under the DeepSpeed config's
+    ``"zero_optimization"`` key; pass ``None`` to model a config that never
+    declared it.
+    """
+    config = {}
+    if zero_optimization is not None:
+        config["zero_optimization"] = zero_optimization
+    plugin = SimpleNamespace(hf_ds_config=SimpleNamespace(config=config))
+    return SimpleNamespace(distributed_type=distributed_type, deepspeed_plugin=plugin)
+
+
+class TestDeepspeedZeroStage:
+    """``_deepspeed_zero_stage`` extracts the active ZeRO stage; 0 for non-DeepSpeed."""
+
+    @pytest.mark.parametrize(
+        "distributed_type",
+        [
+            accelerate.DistributedType.NO,
+            accelerate.DistributedType.MULTI_GPU,
+            accelerate.DistributedType.FSDP,
+        ],
+    )
+    def test_non_deepspeed_is_zero(self, distributed_type):
+        # Non-DeepSpeed backends must short-circuit to 0 *without* touching the
+        # deepspeed plugin (which is None / unconfigured here) -- that is what
+        # lets the ZeRO-3 guards in train() test ``>= 3`` directly.
+        acc = SimpleNamespace(distributed_type=distributed_type, deepspeed_plugin=None)
+        assert _deepspeed_zero_stage(acc) == 0
+
+    @pytest.mark.parametrize("stage", [0, 1, 2, 3])
+    def test_deepspeed_returns_configured_stage(self, stage):
+        acc = _make_stage_accelerator(
+            accelerate.DistributedType.DEEPSPEED, zero_optimization={"stage": stage}
+        )
+        assert _deepspeed_zero_stage(acc) == stage
+
+    def test_deepspeed_without_zero_optimization_is_zero(self):
+        # A DeepSpeed config that never declared zero_optimization (or declared
+        # it without a stage) means no parameter sharding -> treat as stage 0 so
+        # the ZeRO-3-only guards stay off.
+        acc_missing = _make_stage_accelerator(accelerate.DistributedType.DEEPSPEED, zero_optimization=None)
+        assert _deepspeed_zero_stage(acc_missing) == 0
+
+        acc_no_stage = _make_stage_accelerator(accelerate.DistributedType.DEEPSPEED, zero_optimization={})
+        assert _deepspeed_zero_stage(acc_no_stage) == 0
 
 
 def _make_tracker(


### PR DESCRIPTION
## What this does

🗃️ Feature / 📝 Documentation — makes DeepSpeed **ZeRO-3** a first-class, validated, documented training backend for **pi05** full fine-tuning, and adds a measured **ZeRO-2 vs ZeRO-3** comparison.

ZeRO-3 already ran for pi05 via the FSDP/ZeRO-3 plumbing added for pi07 (`_zero3_disabled_init_context`, the per-backend precision regime, the grad-checkpoint / `torch.compile` / sim-eval guards), but it had never been validated for pi05, was undocumented, and had no test coverage. This PR closes those gaps:

- **Validated end-to-end on 8×A100-80GB**, full fine-tune with **no frozen weights** (`freeze_vision_encoder=false`, `train_expert_only=false`): forward/backward/optimizer step, checkpoint save (sharded `pytorch_model/`), resume from the sharded checkpoint, offline consolidation (`zero_to_fp32` → 13.4 GB fp32 weights), and in-training validation all work. ZeRO-3 keeps fp32 master partitions alongside the bf16 params (correct mixed precision) and produces a **bit-identical step-1 loss** and **matching grad norms** vs ZeRO-2, confirming the sharded dual-tower forward/backward is numerically correct.
- **`train.py` refactor:** the ZeRO-stage lookup `accelerator.deepspeed_plugin.hf_ds_config.config[...]["stage"]` was duplicated at 4 sites that gate all ZeRO-3 behavior. Centralized into one `_deepspeed_zero_stage()` helper (returns 0 for non-DeepSpeed) so the guards are DRY and unit-testable. Pure control-flow change — pre/post-refactor ZeRO-3 runs give bit-identical losses.
- **Docs:** `training.rst` now documents ZeRO-3 as a supported pi05 backend, its `gradient_checkpointing` / `use_torch_compile` incompatibility (re-sharding every forward), and the `PYTORCH_ALLOC_CONF=expandable_segments:True` fragmentation tip. `benchmarking.rst` gains a measured ZeRO-2 vs ZeRO-3 table.

### Benchmark (8×A100-80GB, full unfreeze, bf16, sdpa, `use_torch_compile=false`, `gradient_accumulation_steps=1`, 8 ranks)

| Backend | Per-rank batch | Global batch | sec/step | samples/s | Peak GPU mem |
|---------|----------------|--------------|----------|-----------|--------------|
| ZeRO-2  | 8  | 64  | 5.64 | 11.4 | 53.3 GiB |
| ZeRO-3  | 8  | 64  | 7.71 |  8.3 | 62.8 GiB |
| ZeRO-2  | 16 | 128 | 5.29 | 24.2 | 78.7 GiB |
| ZeRO-3  | 16 | 128 | 9.86 | 13.0 | 79.2 GiB |

Both backends OOM at the same per-rank batch (16 fits, 18 OOMs): ZeRO-3 frees ~5 GB of replicated params per rank, but its per-layer parameter all-gather/prefetch buffers + allocator fragmentation consume a comparable amount, so max batch is unchanged. At a matched batch ZeRO-2 is **~1.4× faster at b8 and ~1.9× faster at b16**. **Takeaway:** for a 3.3B model that fits replicated, ZeRO-3's parameter sharding gives no capacity gain and its all-gather costs throughput — use DDP/ZeRO-2 for pi05; reach for ZeRO-3 only when a single replica no longer fits per GPU.

## How it was tested

- **CPU:** added `TestDeepspeedZeroStage` in `tests/scripts/test_train.py` (non-DeepSpeed → 0, each configured ZeRO stage, missing `zero_optimization` → 0). Full file passes: `pytest -q tests/scripts/test_train.py` → 36 passed. `pre-commit run --files ...` clean on all four files.
- **GPU (8×A100-80GB):** ran full pi05 fine-tuning end-to-end under `accelerate_deepspeed_zero3_config.yaml` with no frozen weights — 30-step run (exit 0, stable loss), partial-freeze run, checkpoint save + resume (step 12 → 18), `zero_to_fp32` consolidation, and a `val_freq>0` run (per-dataset validation metrics gathered without hang). Re-ran the post-refactor code and confirmed losses are bit-identical to the pre-refactor ZeRO-3 run (the change does not touch the loss path). Same runs produced the benchmark table above.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/scripts/test_train.py::TestDeepspeedZeroStage
```
```bash
# Full ZeRO-3 fine-tune of pi05 with no frozen weights (8 GPUs)
accelerate launch --config_file configs/examples/accelerate_deepspeed_zero3_config.yaml \
    src/opentau/scripts/train.py --config_path=configs/examples/pi05_training_config.json \
    --policy.freeze_vision_encoder=false --policy.train_expert_only=false \
    --batch_size=16 --dataloader_batch_size=16 --gradient_accumulation_steps=1 --steps=30
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
