### PR TITLE
feat(robocasa): per-task official horizon for sim eval

### DIFF
--- a/src/opentau/envs/configs.py
+++ b/src/opentau/envs/configs.py
@@ -329,6 +329,9 @@ class RoboCasaEnv(EnvConfig):
             auto-expands to the upstream task list and auto-sets ``split``.
         fps: RoboCasa control frequency (Hz); also the ``render_fps`` for videos.
         episode_length: Maximum steps per episode (``_max_episode_steps``).
+            Defaults to 1000; set to ``null`` (None) to use RoboCasa's official
+            per-task horizon from the dataset registry (e.g. OpenCabinet=1050,
+            TurnOnMicrowave=450) instead of a single global cap.
         obs_type: ``"pixels"`` or ``"pixels_agent_pos"``.
         render_mode: Rendering mode for the environment.
         camera_name: Comma-separated raw RoboCasa camera names to render. The
@@ -356,7 +359,7 @@ class RoboCasaEnv(EnvConfig):
 
     task: str = "CloseFridge"
     fps: int = 20
-    episode_length: int = 1000
+    episode_length: int | None = 1000
     obs_type: str = "pixels_agent_pos"
     render_mode: str = "rgb_array"
     camera_name: str = "robot0_agentview_left,robot0_eye_in_hand,robot0_agentview_right"

--- a/src/opentau/envs/robocasa.py
+++ b/src/opentau/envs/robocasa.py
@@ -357,6 +357,30 @@ def _resolve_tasks(task: str) -> tuple[list[str], str | None]:
     return names, None
 
 
+def _official_task_horizon(task: str) -> int | None:
+    r"""RoboCasa's official per-task horizon (max env steps), read from the dataset
+    registry -- e.g. ``OpenCabinet``=1050, ``CloseFridge``=900, ``TurnOnMicrowave``=450.
+
+    Used as the default episode length so each task is evaluated for its intended
+    duration instead of a single global cap. Returns ``None`` if the task is absent
+    from the registry (the caller then falls back to the 1000-step default). The
+    robocasa import is deferred to here, mirroring ``_resolve_tasks``.
+    """
+    try:
+        _import_robocasa_with_version_shim()
+        from robocasa.utils.dataset_registry import (
+            ATOMIC_TASK_DATASETS,
+            COMPOSITE_TASK_DATASETS,
+        )
+    except Exception:
+        return None
+    for registry in (ATOMIC_TASK_DATASETS, COMPOSITE_TASK_DATASETS):
+        entry = registry.get(task)
+        if isinstance(entry, dict) and entry.get("horizon") is not None:
+            return int(entry["horizon"])
+    return None
+
+
 # RoboCasa ships its assets as separately-downloaded packs. Every kitchen scene needs the
 # base textures (plain + AI-generated wall/floor textures) and lightwheel fixtures; object
 # meshes depend on which registries the env samples from (``obj_registries``). Keys below
@@ -835,6 +859,13 @@ def create_robocasa_envs(
 
     out: dict[str, dict[int, Any]] = defaultdict(dict)
     for task_name in task_names:
+        # With no explicit episode_length, default to RoboCasa's official per-task
+        # horizon from the dataset registry (e.g. OpenCabinet=1050, TurnOnMicrowave=450)
+        # so each task runs for its intended length rather than one global cap.
+        # None -> RoboCasaEnv's 1000-step fallback.
+        task_episode_length = (
+            episode_length if episode_length is not None else _official_task_horizon(task_name)
+        )
         fns = _make_env_fns(
             task=task_name,
             n_envs=n_envs,
@@ -846,11 +877,14 @@ def create_robocasa_envs(
             visualization_width=visualization_width,
             visualization_height=visualization_height,
             split=split,
-            episode_length=episode_length,
+            episode_length=task_episode_length,
             obj_registries=obj_registries,
         )
         out[task_name][0] = env_cls(fns)
-        acc_print(f"Built vec env | task={task_name} | n_envs={n_envs}")
+        acc_print(
+            f"Built vec env | task={task_name} | n_envs={n_envs} | "
+            f"horizon={task_episode_length if task_episode_length is not None else 1000}"
+        )
 
     # return plain dicts for predictability
     return {name: dict(task_map) for name, task_map in out.items()}

--- a/src/opentau/envs/robocasa.py
+++ b/src/opentau/envs/robocasa.py
@@ -372,7 +372,13 @@ def _official_task_horizon(task: str) -> int | None:
             ATOMIC_TASK_DATASETS,
             COMPOSITE_TASK_DATASETS,
         )
-    except Exception:
+    except Exception as err:
+        # Surface the degradation: without this, a renamed key / moved module in the
+        # registry would silently revert *every* task to the 1000-step cap, invisibly.
+        acc_print(
+            f"[opentau] could not read RoboCasa per-task horizon for '{task}' "
+            f"({type(err).__name__}: {err}); falling back to the 1000-step default."
+        )
         return None
     for registry in (ATOMIC_TASK_DATASETS, COMPOSITE_TASK_DATASETS):
         entry = registry.get(task)

--- a/tests/envs/test_robocasa.py
+++ b/tests/envs/test_robocasa.py
@@ -23,6 +23,7 @@ action/camera helpers are all exercisable without a GPU or the sim installed.
 Real sim rollouts are validated separately on a CUDA box.
 """
 
+import contextlib
 import json
 import os
 from pathlib import Path
@@ -47,6 +48,7 @@ from opentau.envs.robocasa import (
     _internal_robocasa_pkg_dir,
     _maybe_relink_robocasa_assets,
     _needed_asset_packs,
+    _official_task_horizon,
     _parse_camera_names,
     _resolve_robocasa_assets_root,
     _resolve_tasks,
@@ -192,6 +194,67 @@ class TestPureHelpers:
                 sys.modules["robocasa"] = saved
             else:
                 sys.modules.pop("robocasa", None)
+
+
+@contextlib.contextmanager
+def _fake_dataset_registry(atomic: dict, composite: dict):
+    """Inject a fake ``robocasa.utils.dataset_registry`` for the duration of the
+    block so ``_official_task_horizon`` resolves against it without the real sim.
+
+    The version shim is patched to a no-op (it would otherwise import mujoco/numpy
+    and assert versions); only the registry module is faked, mirroring how the
+    other tests stub ``robocasa`` in ``sys.modules``.
+    """
+    import sys
+    import types
+
+    mod = types.ModuleType("robocasa.utils.dataset_registry")
+    mod.ATOMIC_TASK_DATASETS = atomic
+    mod.COMPOSITE_TASK_DATASETS = composite
+    saved = sys.modules.get("robocasa.utils.dataset_registry")
+    sys.modules["robocasa.utils.dataset_registry"] = mod
+    try:
+        with patch("opentau.envs.robocasa._import_robocasa_with_version_shim"):
+            yield
+    finally:
+        if saved is not None:
+            sys.modules["robocasa.utils.dataset_registry"] = saved
+        else:
+            sys.modules.pop("robocasa.utils.dataset_registry", None)
+
+
+class TestOfficialTaskHorizon:
+    """``_official_task_horizon`` reads per-task horizons from the registry."""
+
+    def test_known_atomic_task_returns_registry_horizon(self):
+        with _fake_dataset_registry({"CloseFridge": {"horizon": 900}}, {}):
+            assert _official_task_horizon("CloseFridge") == 900
+
+    def test_known_composite_task_returns_registry_horizon(self):
+        with _fake_dataset_registry({}, {"ArrangeVegetables": {"horizon": 1200}}):
+            assert _official_task_horizon("ArrangeVegetables") == 1200
+
+    def test_horizon_is_coerced_to_int(self):
+        with _fake_dataset_registry({"CloseFridge": {"horizon": 450.0}}, {}):
+            result = _official_task_horizon("CloseFridge")
+        assert result == 450 and isinstance(result, int)
+
+    def test_unknown_task_returns_none(self):
+        with _fake_dataset_registry({"CloseFridge": {"horizon": 900}}, {}):
+            assert _official_task_horizon("NoSuchTask") is None
+
+    def test_entry_without_horizon_returns_none(self):
+        with _fake_dataset_registry({"WeirdTask": {"name": "x"}}, {}):
+            assert _official_task_horizon("WeirdTask") is None
+
+    def test_import_failure_returns_none(self):
+        # robocasa not installed -> the shim raises -> caught -> None (1000-step
+        # fallback). This is the path the new diagnostic log guards.
+        with patch(
+            "opentau.envs.robocasa._import_robocasa_with_version_shim",
+            side_effect=ImportError("no robocasa"),
+        ):
+            assert _official_task_horizon("CloseFridge") is None
 
 
 class TestRobocasaUnshadow:
@@ -345,6 +408,43 @@ class TestCreateRoboCasaEnvs:
     def test_rejects_non_callable_env_cls(self):
         with pytest.raises(ValueError, match="env_cls must be a callable"):
             create_robocasa_envs(task="A", n_envs=1, env_cls=None)
+
+    def test_episode_length_none_threads_official_horizon_into_env_fns(self):
+        # episode_length=None -> each task's official horizon is resolved and
+        # threaded into _make_env_fns (the per-task duration the eval runs for).
+        env_cls = Mock(return_value=Mock())
+        with (
+            patch("opentau.envs.robocasa.get_proc_accelerator", return_value=None),
+            patch("opentau.envs.robocasa._official_task_horizon", return_value=777) as horizon,
+            patch("opentau.envs.robocasa._make_env_fns", return_value=[lambda: None]) as make_fns,
+        ):
+            create_robocasa_envs(
+                task="CloseFridge",
+                n_envs=1,
+                env_cls=env_cls,
+                episode_length=None,
+                auto_download_assets=False,
+            )
+        horizon.assert_called_once_with("CloseFridge")
+        assert make_fns.call_args.kwargs["episode_length"] == 777
+
+    def test_explicit_episode_length_skips_official_horizon(self):
+        # An explicit int forces one global cap and never consults the registry.
+        env_cls = Mock(return_value=Mock())
+        with (
+            patch("opentau.envs.robocasa.get_proc_accelerator", return_value=None),
+            patch("opentau.envs.robocasa._official_task_horizon") as horizon,
+            patch("opentau.envs.robocasa._make_env_fns", return_value=[lambda: None]) as make_fns,
+        ):
+            create_robocasa_envs(
+                task="CloseFridge",
+                n_envs=1,
+                env_cls=env_cls,
+                episode_length=450,
+                auto_download_assets=False,
+            )
+        horizon.assert_not_called()
+        assert make_fns.call_args.kwargs["episode_length"] == 450
 
 
 class TestMakeEnvsDispatch:


### PR DESCRIPTION
## What this does
RoboCasa simulation eval now defaults each task to its **official per-task horizon** from the RoboCasa dataset registry (e.g. `OpenCabinet`=1050, `TurnOnMicrowave`=450) instead of one global `episode_length` cap, so a multi-task eval list evaluates every task for its intended length.

- `envs/robocasa.py`: new `_official_task_horizon()` reads the per-task horizon from `robocasa.utils.dataset_registry` (`ATOMIC_TASK_DATASETS` / `COMPOSITE_TASK_DATASETS`); `create_robocasa_envs` resolves it per task when `episode_length` is `None`, and logs the chosen horizon per built vec env. The registry-read except path now logs the failure (via `acc_print`) so a renamed/moved registry surfaces a diagnostic instead of silently reverting every task to the 1000-step cap.
- `envs/configs.py`: `RoboCasaEnv.episode_length` is now `int | None` (default `1000` unchanged for back-compat); setting it to `null` selects the per-task registry horizon.

🗃️ Feature

## How it was tested
- CPU suite: `pytest -m "not gpu and not network" tests/envs/test_robocasa.py` — 62 passed.
- New unit tests (`TestOfficialTaskHorizon` + two `TestCreateRoboCasaEnvs` cases) lock in the behavior with a faked `dataset_registry`: known atomic/composite task → its horizon, float horizon coerced to `int`, unknown task / missing-`horizon` entry → `None`, import failure → `None` (1000 fallback); and `create_robocasa_envs(episode_length=None)` threads the resolved horizon into `_make_env_fns` while an explicit int skips the registry lookup.
- Validated live on a 2-node (16×A100) DeepSpeed ZeRO-2 eval: 16 `atomic_seen` tasks sharded one-per-GPU, each built at its official per-task horizon (900/750/600/450), per-task success gathered across ranks, clean exit.

## How to checkout & try? (for the reviewer)
```bash
pytest -sx tests/envs/test_robocasa.py
```
Set `env.episode_length=null` in a RoboCasa eval config to use the official per-task horizons; set an int to keep a single global cap.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.
