### PR TITLE
Adding learnable embeddings for modality specific

### DIFF
--- a/src/opentau/policies/pi05/configuration_pi05.py
+++ b/src/opentau/policies/pi05/configuration_pi05.py
@@ -138,6 +138,17 @@ class PI05Config(PreTrainedConfig):
     # maximum number of frozen actions
     max_delay: int = 0
 
+    # Modality-specific learnable embedding.
+    # When True, a learnable embedding selected by input modality (vision,
+    # language, state, response, discrete action, action expert) is *added* on
+    # top of every token embedding before the transformer. This is an additive
+    # positional signal that tells the model which modality each token came
+    # from, layered over the existing RoPE positions (it does not replace them).
+    # The table is zero-initialized so enabling it on an existing checkpoint is
+    # a no-op at step 0 and the signal is learned from there. Defaults to False
+    # (original behavior, what existing checkpoints expect).
+    use_modality_embedding: bool = False
+
     # Attention utils
     attention_implementation: str = "eager"
 

--- a/src/opentau/policies/pi05/modeling_pi05.py
+++ b/src/opentau/policies/pi05/modeling_pi05.py
@@ -988,6 +988,20 @@ class PI05FlowMatching(nn.Module):
     └──────────────────────────────────────────┘
     """
 
+    # Fixed modality slots indexing the learnable modality embedding added on
+    # top of each token embedding when ``config.use_modality_embedding`` is set
+    # (see ``embed_prefix`` / ``embed_suffix``). The first five live in VLM
+    # hidden space (prefix tokens); the action expert is embedded separately in
+    # ``proj_width`` space. Slots are fixed (not a running counter over present
+    # blocks) so a modality gets the same embedding whether or not optional
+    # blocks (state, response, discrete actions) appear in a given batch.
+    _MODALITY_VISION = 0
+    _MODALITY_LANGUAGE = 1
+    _MODALITY_STATE = 2
+    _MODALITY_RESPONSE = 3
+    _MODALITY_DISCRETE_ACTION = 4
+    _NUM_PREFIX_MODALITIES = 5
+
     def __init__(
         self,
         config: PI05Config,
@@ -1028,6 +1042,18 @@ class PI05FlowMatching(nn.Module):
 
         self.time_mlp_in = nn.Linear(self.config.proj_width, self.config.proj_width)
         self.time_mlp_out = nn.Linear(self.config.proj_width, self.config.proj_width)
+
+        # Optional modality-specific learnable embedding added on top of the
+        # token embeddings (layered over RoPE — see ``config.use_modality_embedding``).
+        # Prefix tokens live in VLM hidden space; the action expert lives in
+        # ``proj_width`` space, so they get separate tables. Both are zero-init
+        # so turning the feature on for an existing checkpoint is a no-op at step 0.
+        if self.config.use_modality_embedding:
+            vlm_hidden_size = self.paligemma_with_expert.config.paligemma_config.text_config.hidden_size
+            self.modality_embedding = nn.Embedding(self._NUM_PREFIX_MODALITIES, vlm_hidden_size)
+            self.action_modality_embedding = nn.Embedding(1, self.config.proj_width)
+            nn.init.zeros_(self.modality_embedding.weight)
+            nn.init.zeros_(self.action_modality_embedding.weight)
 
         if language_tokenizer is None:
             language_tokenizer = AutoTokenizer.from_pretrained("google/paligemma-3b-pt-224")
@@ -1112,11 +1138,19 @@ class PI05FlowMatching(nn.Module):
                 - embs: Concatenated embeddings tensor.
                 - pad_masks: Concatenated padding masks tensor.
                 - att_masks: Attention masks tensor.
+                - segment_ids: Per-token modality slot tensor (shape matches
+                  ``pad_masks``). Used to add the modality-specific embedding
+                  on top of ``embs`` when ``config.use_modality_embedding`` is
+                  set; also returned for downstream/diagnostic use.
         """
         # TODO: avoid list in python and torch.cat ; prefer pre-allocation with torch.empty
         embs = []
         pad_masks = []
         att_masks = []
+        # Per-token modality slot, parallel to ``att_masks``. Only consumed when
+        # ``config.use_modality_embedding`` is set, to add the learnable
+        # modality embedding on top of the token embeddings (see end of method).
+        segment_ids = []
 
         # TODO: remove for loop
         for (
@@ -1138,6 +1172,7 @@ class PI05FlowMatching(nn.Module):
 
             # Create attention masks so that image tokens attend to each other
             att_masks += [0] * num_img_embs
+            segment_ids += [self._MODALITY_VISION] * num_img_embs
 
         lang_emb = self.paligemma_with_expert.embed_language_tokens(lang_tokens)
 
@@ -1151,6 +1186,7 @@ class PI05FlowMatching(nn.Module):
         # full attention between image and language inputs
         num_lang_embs = lang_emb.shape[1]
         att_masks += [0] * num_lang_embs
+        segment_ids += [self._MODALITY_LANGUAGE] * num_lang_embs
 
         if self.config.state_type == "continuous" and state is not None:
             state_indicator_ids = self.language_tokenizer.encode("State: ", add_special_tokens=False)
@@ -1163,6 +1199,7 @@ class PI05FlowMatching(nn.Module):
             embs.append(state_indicator_emb)
             pad_masks.append(state_indicator_mask)
             att_masks += [0] * state_indicator_emb.shape[1]
+            segment_ids += [self._MODALITY_STATE] * state_indicator_emb.shape[1]
 
             state_emb = self.state_proj(state.to(dtype=_preferred_dtype()))
             state_emb = rearrange(state_emb, "b d -> b 1 d")
@@ -1171,6 +1208,7 @@ class PI05FlowMatching(nn.Module):
             embs.append(state_emb)
             pad_masks.append(state_mask)
             att_masks += [0]  # full attention with images and language
+            segment_ids += [self._MODALITY_STATE]
 
             state_end_indicator_ids = self.language_tokenizer.encode(":\n", add_special_tokens=False)
             state_end_indicator_tokens = torch.tensor(
@@ -1186,6 +1224,7 @@ class PI05FlowMatching(nn.Module):
             embs.append(state_end_indicator_emb)
             pad_masks.append(state_end_indicator_mask)
             att_masks += [0] * state_end_indicator_emb.shape[1]
+            segment_ids += [self._MODALITY_STATE] * state_end_indicator_emb.shape[1]
 
         if self.config.predict_response:
             response_indicator_ids = self.language_tokenizer.encode("Response: ", add_special_tokens=False)
@@ -1202,6 +1241,7 @@ class PI05FlowMatching(nn.Module):
             embs.append(response_indicator_emb)
             pad_masks.append(response_indicator_mask)
             att_masks += [1] * response_indicator_emb.shape[1]
+            segment_ids += [self._MODALITY_RESPONSE] * response_indicator_emb.shape[1]
 
         if response_tokens is not None:
             response_emb = self.paligemma_with_expert.embed_language_tokens(response_tokens)
@@ -1216,6 +1256,7 @@ class PI05FlowMatching(nn.Module):
             # full attention between image, language and response inputs
             num_response_embs = response_emb.shape[1]
             att_masks += [1] * num_response_embs
+            segment_ids += [self._MODALITY_RESPONSE] * num_response_embs
 
         if discrete_actions is not None:
             discrete_action_indicator_ids = self.language_tokenizer.encode(
@@ -1236,18 +1277,29 @@ class PI05FlowMatching(nn.Module):
             embs.append(discrete_action_indicator_emb)
             pad_masks.append(discrete_action_indicator_mask)
             att_masks += [1] * discrete_action_indicator_emb.shape[1]
+            segment_ids += [self._MODALITY_DISCRETE_ACTION] * discrete_action_indicator_emb.shape[1]
 
             discrete_action_emb = self.paligemma_with_expert.embed_discrete_actions(discrete_actions)
             embs.append(discrete_action_emb.to(dtype=_preferred_dtype()))
             pad_masks.append(discrete_action_masks)
             att_masks += [1] * discrete_action_emb.shape[1]
+            segment_ids += [self._MODALITY_DISCRETE_ACTION] * discrete_action_emb.shape[1]
 
         embs = torch.cat(embs, dim=1)
         pad_masks = torch.cat(pad_masks, dim=1)
         att_masks = torch.tensor(att_masks, dtype=torch.bool, device=pad_masks.device)
         att_masks = att_masks[None, :].expand(bsize, len(att_masks))
+        segment_ids = torch.tensor(segment_ids, dtype=torch.long, device=pad_masks.device)
+        segment_ids = segment_ids[None, :].expand(bsize, segment_ids.shape[0])
 
-        return embs, pad_masks, att_masks
+        # Add the learnable, modality-specific embedding on top of the token
+        # embeddings (layered over the existing RoPE positions, not a
+        # replacement). Zero-initialized, so this is a no-op until trained.
+        if self.config.use_modality_embedding:
+            modality_emb = self.modality_embedding(segment_ids)
+            embs = embs + modality_emb.to(dtype=embs.dtype)
+
+        return embs, pad_masks, att_masks, segment_ids
 
     def embed_suffix(self, noisy_actions: Tensor, timestep: Tensor) -> tuple[Tensor, Tensor, Tensor, Tensor]:
         """Embed noisy_actions, timestep to prepare for Expert Gemma processing.
@@ -1288,6 +1340,12 @@ class PI05FlowMatching(nn.Module):
 
         time_emb = time_emb.to(dtype=dtype)
         adarms_cond = time_mlp_func(time_emb)
+
+        # Add the learnable action-expert modality embedding (its own modality,
+        # in proj_width space), matching the prefix modality embedding in
+        # ``embed_prefix``. Zero-initialized, so a no-op until trained.
+        if self.config.use_modality_embedding:
+            action_emb = action_emb + self.action_modality_embedding.weight.to(dtype=action_emb.dtype)
 
         # Add to input tokens
         embs.append(action_emb)
@@ -1351,7 +1409,7 @@ class PI05FlowMatching(nn.Module):
             A dictionary containing the loss components ("MSE" and "CE").
         """
         # Run VLM first to get key value cache
-        prefix_embs, prefix_pad_masks, prefix_att_masks = self.embed_prefix(
+        prefix_embs, prefix_pad_masks, prefix_att_masks, _ = self.embed_prefix(
             images,
             img_masks,
             lang_tokens,
@@ -1583,7 +1641,7 @@ class PI05FlowMatching(nn.Module):
             actions_shape = (bsize, self.config.chunk_size, self.config.max_action_dim)
             noise = self.sample_noise(actions_shape, device)
 
-        prefix_embs, prefix_pad_masks, prefix_att_masks = self.embed_prefix(
+        prefix_embs, prefix_pad_masks, prefix_att_masks, _ = self.embed_prefix(
             images,
             img_masks,
             lang_tokens,

--- a/src/opentau/policies/pi05/modeling_pi05.py
+++ b/src/opentau/policies/pi05/modeling_pi05.py
@@ -1111,7 +1111,7 @@ class PI05FlowMatching(nn.Module):
         discrete_actions: Tensor | None = None,
         discrete_action_masks: Tensor | None = None,
         state: Tensor | None = None,
-    ) -> tuple[Tensor, Tensor, Tensor]:
+    ) -> tuple[Tensor, Tensor, Tensor, Tensor]:
         """Embed images with SigLIP and language tokens with embedding layer to prepare
         for PaliGemma transformer processing.
 

--- a/tests/policies/test_pi05.py
+++ b/tests/policies/test_pi05.py
@@ -341,7 +341,7 @@ class TestPI05Integration:
             )
             args1 = tuple(args1)
             result = original_embed_prefix(*args1, **kwargs)
-            prefix_embs, prefix_pad_masks, prefix_att_masks = result
+            prefix_embs, prefix_pad_masks, prefix_att_masks, prefix_segment_ids = result
             captured_variables["prefix_pad_masks"] = prefix_pad_masks.clone()
             return result
 
@@ -497,7 +497,7 @@ class TestPI05Integration:
 
         def capture_embed_prefix_select_action(*args, **kwargs):
             result = original_embed_prefix_select_action(*args, **kwargs)
-            prefix_embs, prefix_pad_masks, prefix_att_masks = result
+            prefix_embs, prefix_pad_masks, prefix_att_masks, prefix_segment_ids = result
             captured_variables_select_action["prefix_pad_masks"] = prefix_pad_masks.clone()
             return result
 
@@ -743,3 +743,196 @@ class TestPI05ExecutionHorizon:
         )
         pad_masks, att_masks = out[1], out[2]
         assert pad_masks.shape[1] == att_masks.shape[1] == cfg.chunk_size
+
+
+class TestPI05ModalityEmbedding:
+    """CPU coverage for the opt-in modality-specific learnable embedding.
+
+    ``embed_prefix`` gained a per-token ``segment_ids`` slot and an additive
+    learnable ``modality_embedding`` table gated on ``use_modality_embedding``.
+    These tests build a ``PI05FlowMatching`` shell with stubbed embedders (no
+    real PaliGemma weights, so they run on CPU) and guard two properties:
+
+      1. **Zero-init no-op** -- enabling ``use_modality_embedding`` on a freshly
+         (zero-)initialized table leaves the prefix embeddings bit-identical to
+         the feature being off, so turning it on for an existing checkpoint is a
+         no-op at step 0.
+      2. **``segment_ids`` length alignment** -- ``segment_ids`` stays the same
+         length as ``embs`` / ``pad_masks`` / ``att_masks`` across every
+         optional-block combination (state / response / discrete actions),
+         guarding the parallel ``segment_ids += [...]`` appends from drifting
+         out of sync with the ``att_masks`` appends if the layout changes later.
+    """
+
+    HIDDEN = 8
+    N_IMG_TOKENS = 3
+    MAX_STATE_DIM = 4
+    MAX_ACTION_DIM = 4
+
+    class _FakePaliGemma(torch.nn.Module):
+        """Deterministic, weight-free stand-in for ``paligemma_with_expert``."""
+
+        def __init__(self, hidden, n_img_tokens):
+            super().__init__()
+            self.hidden = hidden
+            self.n_img_tokens = n_img_tokens
+
+        def embed_image(self, img):
+            b = img.shape[0]
+            grid = torch.arange(self.n_img_tokens * self.hidden, dtype=torch.float32)
+            grid = grid.reshape(1, self.n_img_tokens, self.hidden) * 0.001
+            return grid.expand(b, -1, -1).clone()
+
+        def embed_language_tokens(self, tokens):
+            base = tokens.float().unsqueeze(-1)  # (b, t, 1)
+            return (base + torch.arange(self.hidden, dtype=torch.float32)) * 0.01
+
+        def embed_discrete_actions(self, discrete_actions):
+            base = discrete_actions.float().unsqueeze(-1)  # (b, t, 1)
+            return (base + 1.0 + torch.arange(self.hidden, dtype=torch.float32)) * 0.02
+
+    class _FakeTokenizer:
+        def encode(self, text, add_special_tokens=False):
+            # Deterministic, length-dependent so different indicator strings get
+            # different (but stable) token counts.
+            return list(range(len(text) % 3 + 1))
+
+    @classmethod
+    def _config(cls, *, use_modality_embedding, predict_response=False, state_type="discrete"):
+        return PI05Config(
+            n_obs_steps=1,
+            chunk_size=4,
+            n_action_steps=4,
+            max_state_dim=cls.MAX_STATE_DIM,
+            max_action_dim=cls.MAX_ACTION_DIM,
+            state_type=state_type,
+            predict_response=predict_response,
+            use_modality_embedding=use_modality_embedding,
+        )
+
+    def _build_fm(
+        self, monkeypatch, *, use_modality_embedding, predict_response=False, state_type="discrete", fill=None
+    ):
+        import torch.nn as nn
+
+        from opentau.policies.pi05.modeling_pi05 import PI05FlowMatching
+
+        mod = "opentau.policies.pi05.modeling_pi05"
+        monkeypatch.setattr(f"{mod}._preferred_dtype", lambda: torch.float32)
+
+        cfg = self._config(
+            use_modality_embedding=use_modality_embedding,
+            predict_response=predict_response,
+            state_type=state_type,
+        )
+        fm = object.__new__(PI05FlowMatching)
+        nn.Module.__init__(fm)  # set up _modules so we can attach stub layers
+        fm.config = cfg
+        # Seed so the random state_proj weights match across on/off builds, which
+        # the zero-init no-op equivalence check relies on.
+        torch.manual_seed(0)
+        fm.paligemma_with_expert = self._FakePaliGemma(self.HIDDEN, self.N_IMG_TOKENS)
+        fm.language_tokenizer = self._FakeTokenizer()
+        fm.state_proj = nn.Linear(self.MAX_STATE_DIM, self.HIDDEN)
+        if use_modality_embedding:
+            emb = nn.Embedding(PI05FlowMatching._NUM_PREFIX_MODALITIES, self.HIDDEN)
+            nn.init.zeros_(emb.weight)
+            if fill is not None:
+                with torch.no_grad():
+                    emb.weight.copy_(fill)
+            fm.modality_embedding = emb
+        return fm
+
+    def _inputs(self, bsize=2, *, state=False, response=False, discrete=False):
+        kwargs = {
+            "images": [torch.zeros(bsize, 3, 8, 8)],
+            "img_masks": [torch.ones(bsize, dtype=torch.bool)],
+            "lang_tokens": torch.arange(bsize * 5).reshape(bsize, 5) % 11,
+            "lang_masks": torch.ones(bsize, 5, dtype=torch.bool),
+        }
+        if state:
+            kwargs["state"] = torch.randn(bsize, self.MAX_STATE_DIM)
+        if response:
+            kwargs["response_tokens"] = torch.arange(bsize * 4).reshape(bsize, 4) % 7
+            kwargs["response_masks"] = torch.ones(bsize, 4, dtype=torch.bool)
+        if discrete:
+            kwargs["discrete_actions"] = torch.arange(bsize * 6).reshape(bsize, 6) % 13
+            kwargs["discrete_action_masks"] = torch.ones(bsize, 6, dtype=torch.bool)
+        return kwargs
+
+    def test_zero_init_modality_embedding_is_noop(self, monkeypatch):
+        """With a zero-initialized table, the additive modality embedding must
+        leave ``embs`` bit-identical to running with the feature off."""
+        from opentau.policies.pi05.modeling_pi05 import PI05FlowMatching
+
+        inputs = self._inputs(state=True, response=True, discrete=True)
+
+        fm_off = self._build_fm(
+            monkeypatch, use_modality_embedding=False, predict_response=True, state_type="continuous"
+        )
+        embs_off, pad_off, att_off, seg_off = PI05FlowMatching.embed_prefix(fm_off, **inputs)
+
+        fm_on = self._build_fm(
+            monkeypatch, use_modality_embedding=True, predict_response=True, state_type="continuous"
+        )
+        embs_on, pad_on, att_on, seg_on = PI05FlowMatching.embed_prefix(fm_on, **inputs)
+
+        assert torch.equal(embs_off, embs_on)  # zero-init -> exact no-op
+        assert torch.equal(pad_off, pad_on)
+        assert torch.equal(att_off, att_on)
+        assert torch.equal(seg_off, seg_on)
+
+    def test_nonzero_modality_embedding_shifts_embs(self, monkeypatch):
+        """A non-zero table must actually change ``embs`` (guards that the
+        additive branch fires), shifting each row by its modality vector."""
+        from opentau.policies.pi05.modeling_pi05 import PI05FlowMatching
+
+        inputs = self._inputs(state=True, response=True, discrete=True)
+
+        fm_off = self._build_fm(
+            monkeypatch, use_modality_embedding=False, predict_response=True, state_type="continuous"
+        )
+        embs_off, _, _, seg_off = PI05FlowMatching.embed_prefix(fm_off, **inputs)
+
+        fill = torch.arange(
+            PI05FlowMatching._NUM_PREFIX_MODALITIES * self.HIDDEN, dtype=torch.float32
+        ).reshape(PI05FlowMatching._NUM_PREFIX_MODALITIES, self.HIDDEN)
+        fm_on = self._build_fm(
+            monkeypatch,
+            use_modality_embedding=True,
+            predict_response=True,
+            state_type="continuous",
+            fill=fill,
+        )
+        embs_on, _, _, seg_on = PI05FlowMatching.embed_prefix(fm_on, **inputs)
+
+        assert torch.equal(seg_off, seg_on)
+        assert not torch.equal(embs_off, embs_on)
+        # The delta at each token must equal that token's modality vector.
+        expected_delta = fill[seg_on]
+        assert torch.allclose(embs_on - embs_off, expected_delta, atol=1e-5)
+
+    @pytest.mark.parametrize("state", [False, True])
+    @pytest.mark.parametrize("response", [False, True])
+    @pytest.mark.parametrize("discrete", [False, True])
+    def test_segment_ids_length_matches_embs(self, monkeypatch, state, response, discrete):
+        """``segment_ids`` must stay length-aligned with ``embs`` / ``pad_masks``
+        / ``att_masks`` across every optional-block combination."""
+        from opentau.policies.pi05.modeling_pi05 import PI05FlowMatching
+
+        inputs = self._inputs(state=state, response=response, discrete=discrete)
+        fm = self._build_fm(
+            monkeypatch,
+            use_modality_embedding=True,
+            predict_response=response,
+            state_type="continuous" if state else "discrete",
+        )
+        embs, pad_masks, att_masks, segment_ids = PI05FlowMatching.embed_prefix(fm, **inputs)
+
+        seq_len = embs.shape[1]
+        assert pad_masks.shape[1] == seq_len
+        assert att_masks.shape[1] == seq_len
+        assert segment_ids.shape == (embs.shape[0], seq_len)
+        # Slots must stay within the table the embedding was sized for.
+        assert int(segment_ids.max()) < PI05FlowMatching._NUM_PREFIX_MODALITIES
+        assert int(segment_ids.min()) >= 0


### PR DESCRIPTION
## What this does
Adds modality specific learned positional embeddings

## How it was tested
Trained on libero and performed better than baseline

internal: https://wandb.ai/wyautox-autox/pi05/runs/2jd9p4tw

## Checklist

- [X] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [X] My PR includes policy-related changes.
  - [X] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
