### PR TITLE
feat(eval): make eval simulation seeding reproducible and configurable

### DIFF
--- a/src/opentau/configs/default.py
+++ b/src/opentau/configs/default.py
@@ -586,6 +586,15 @@ class EvalConfig:
             never uploaded to wandb). Defaults to False.
         recording_root: Root directory for saving evaluation recordings.
             Defaults to None.
+        seed: Master seed for the eval simulations (env scene generation). When
+            set, takes precedence over the top-level `cfg.seed` for seeding the
+            eval environments; when None (default), falls back to `cfg.seed`.
+            Does not affect the global `set_seed`. Defaults to None.
+        decorrelate_rank_seeds: If True, each accelerator rank evaluates a
+            distinct, orthogonal slice of scenes (for tasks deliberately
+            replicated across ranks to gain coverage). If False (default), all
+            ranks seed identically, so the eval is reproducible across world
+            sizes. Defaults to False.
 
     Raises:
         ValueError: If `batch_size` is greater than `n_episodes`, or if any of
@@ -620,6 +629,28 @@ class EvalConfig:
     keep_per_episode_videos: bool = False
 
     recording_root: str | None = None
+
+    # Master seed for the evaluation *simulations* (env scene generation). When
+    # set, it takes precedence over the top-level `cfg.seed` for seeding the eval
+    # environments, so the eval scene set can be pinned independently of the
+    # training/global seed (e.g. hold the eval scenes fixed while sweeping the
+    # training seed, or vary the eval scenes without disturbing model init /
+    # dataset shuffling). When None (default), the eval falls back to the
+    # top-level `cfg.seed`. Resolved by `scripts/eval.py::_resolve_eval_seed`;
+    # only affects the env/scene seeding, NOT the global `set_seed`.
+    seed: int | None = None
+
+    # Whether each accelerator rank should evaluate a *different* set of scenes.
+    # Default False: every rank seeds its environments identically, so the scene a
+    # given (task, episode) maps to does not depend on the world size / node count
+    # — the eval is reproducible whether it runs on 1 GPU or 16, and two ranks that
+    # happen to share a task evaluate the same scenes. Set True only when you have
+    # deliberately replicated a task across ranks (listed it N x to fill N ranks via
+    # the round-robin sharding) to get N x *distinct* scenes instead of redundant
+    # copies; each rank then gets an orthogonal, non-overlapping slice of the seed
+    # line. Trades world-size reproducibility for extra per-task coverage. Plumbed
+    # by `scripts/eval.py::eval_policy` via `_rank_seed_offset`.
+    decorrelate_rank_seeds: bool = False
 
     # Which training-time norm head to use when calling `policy.select_action`
     # on eval observations. Either:

--- a/src/opentau/envs/robocasa.py
+++ b/src/opentau/envs/robocasa.py
@@ -536,8 +536,12 @@ class RoboCasaEnv(gym.Env):
             split: RoboCasa dataset split (``None``/``"all"``/``"pretrain"``/``"target"``).
             episode_length: Max steps per episode (``_max_episode_steps``); defaults to 1000.
             obj_registries: Object-mesh registries to sample assets from.
-            episode_index: Per-worker index (``0..n_envs-1``) used to spread the
-                ``reset`` seed so each sub-env explores a distinct layout.
+            episode_index: Per-worker index (``0..n_envs-1``) used as the
+                ``reset`` seed *only when reset is called unseeded*, so the
+                workers still explore distinct layouts. When ``reset`` is given an
+                explicit seed (the eval path) that seed is used verbatim and this
+                index is ignored — the vector env already made the seed
+                per-worker-distinct.
             camera_name_mapping: Optional mapping from raw camera names to
                 positional ``camera{i}`` keys; defaults to first→``camera0``, etc.
         """
@@ -684,14 +688,23 @@ class RoboCasaEnv(gym.Env):
         return self._env.render()
 
     def reset(self, seed=None, **kwargs) -> tuple[dict[str, Any], dict[str, Any]]:
-        r"""Reset the environment, deriving a per-worker seed from ``episode_index``."""
+        r"""Reset the environment.
+
+        Spreading the seed across the ``n_envs`` workers is the *caller's* job, not
+        this method's: gymnasium's ``SyncVectorEnv`` / ``AsyncVectorEnv`` already
+        hand each sub-env a distinct seed (``seed[i]`` for a list, ``seed + i`` for
+        an int), and the eval harness builds an explicit per-worker range (see
+        ``scripts/eval.py``). So an explicit ``seed`` is forwarded verbatim — adding
+        ``episode_index`` on top would *double*-shift an already-distinct seed and
+        make scene seeds collide across rollout batches (e.g. with ``n_envs=4`` the
+        spacing-of-2 makes batch 0 / slot 2 reuse batch 1 / slot 0), so an eval
+        samples fewer distinct scenes than ``n_episodes``. Only the *unseeded* path
+        falls back to ``episode_index`` so the workers still roll distinct scenes.
+        """
         self._ensure_env()
         assert self._env is not None
         super().reset(seed=seed)
-        # Spread the seed across workers so n_envs factories don't all roll the
-        # same scene: shift an explicit seed by episode_index; with no seed fall
-        # back to episode_index so each worker is still distinct.
-        worker_seed = seed + self.episode_index if seed is not None else self.episode_index
+        worker_seed = seed if seed is not None else self.episode_index
         raw_obs, _ = self._env.reset(seed=worker_seed)
 
         ep_meta = self._env.env.get_ep_meta()
@@ -756,8 +769,9 @@ def _make_env_fns(
 ) -> list[Callable[[], RoboCasaEnv]]:
     """Build ``n_envs`` factory callables for a single task.
 
-    Each factory carries a distinct ``episode_index`` (``0..n_envs-1``) so
-    ``RoboCasaEnv.reset()`` derives a per-worker seed from the rollout seed.
+    Each factory carries a distinct ``episode_index`` (``0..n_envs-1``) that
+    ``RoboCasaEnv.reset()`` uses as the seed only on an unseeded reset; under the
+    eval harness the per-worker seed comes from the explicit rollout seed range.
     """
 
     def _make_env(episode_index: int) -> RoboCasaEnv:

--- a/src/opentau/scripts/eval.py
+++ b/src/opentau/scripts/eval.py
@@ -256,6 +256,68 @@ def rollout(
     return ret
 
 
+def _resolve_eval_seed(cfg: TrainPipelineConfig) -> int | None:
+    """Master seed for the eval *simulations* (env scene generation).
+
+    ``cfg.eval.seed``, when set, takes precedence over the top-level ``cfg.seed``,
+    so the eval scene set can be pinned independently of the training/global seed.
+    Falls back to ``cfg.seed`` when ``cfg.eval.seed`` is None. Returns None only
+    when both are None — in which case the env seeds each worker by its slot index
+    (see ``RoboCasaEnv.reset``) rather than from a master seed.
+
+    Note this resolves *only* the env/scene seed threaded in as ``start_seed``; the
+    global ``set_seed`` (model init, dataset shuffling, policy sampling) always uses
+    the top-level ``cfg.seed`` and is intentionally left untouched.
+
+    Args:
+        cfg: The training/eval pipeline config carrying both ``cfg.seed`` (global)
+            and ``cfg.eval.seed`` (optional eval-simulation override).
+
+    Returns:
+        ``cfg.eval.seed`` if set, else ``cfg.seed``; ``None`` only if both are ``None``.
+    """
+    return cfg.eval.seed if cfg.eval.seed is not None else cfg.seed
+
+
+def _rank_seed_offset(*, process_index: int, decorrelate: bool, per_rank_span: int) -> int:
+    """Per-rank additive offset applied to every eval episode's seed.
+
+    Default (``decorrelate=False``) returns ``0``: every rank seeds its
+    environments identically, so the scene a given ``(task, episode)`` maps to is
+    independent of the world size / node count and the eval is reproducible whether
+    it ran on 1 GPU or 16.
+
+    When ``decorrelate=True`` each rank gets an orthogonal, non-overlapping block of
+    the integer seed line: rank ``r`` occupies ``[r * span, (r + 1) * span)`` where
+    ``span`` is the *exact* per-rank episode span (``n_batches * num_envs``). Because
+    the stride equals the span, the blocks tile the line with no gap or overlap — so
+    there is no magic constant and no collision regardless of how many episodes each
+    rank runs (unlike a fixed ``* 10000``, which silently collides once a rank
+    exceeds 10000 episodes). ``process_index`` must be the *global* rank (unique
+    across all nodes); the node-local ``local_process_index`` would alias rank 0 on
+    every node and is therefore wrong here.
+
+    Note the seeds within a block need not be "spread out": each integer is fed to
+    ``np.random.default_rng`` (which hashes it through a ``SeedSequence``), so even
+    adjacent seeds yield statistically independent scene streams.
+
+    Args:
+        process_index: This rank's *global* process index (``0..world_size-1``,
+            unique across nodes), used as the block index.
+        decorrelate: Whether ranks should evaluate distinct scenes. When False the
+            offset is always 0 (all ranks seed identically).
+        per_rank_span: The exact number of seeds one rank consumes
+            (``n_batches * num_envs``), used as the (collision-free) block stride.
+
+    Returns:
+        The additive seed offset for this rank: ``0`` when ``decorrelate`` is False,
+        else ``process_index * per_rank_span``.
+    """
+    if not decorrelate:
+        return 0
+    return process_index * per_rank_span
+
+
 def eval_policy(
     env: gym.vector.VectorEnv,
     policy: PreTrainedPolicy,
@@ -333,9 +395,16 @@ def eval_policy(
         if start_seed is None:
             seeds = None
         else:
-            # HACK: to get different seeds per accelerator process when using distributed eval.
+            # By default all ranks seed identically (offset 0), so the eval is
+            # reproducible across world sizes. Only when `eval.decorrelate_rank_seeds`
+            # is set does each rank take an orthogonal, non-overlapping slice of the
+            # seed line so a task replicated across ranks covers distinct scenes.
             acc = get_proc_accelerator()
-            acc_offset = acc.process_index * 10000 if acc else 0
+            acc_offset = _rank_seed_offset(
+                process_index=acc.process_index if acc else 0,
+                decorrelate=cfg.eval.decorrelate_rank_seeds,
+                per_rank_span=n_batches * env.num_envs,
+            )
             seeds = range(
                 start_seed + acc_offset + (batch_ix * env.num_envs),
                 start_seed + acc_offset + ((batch_ix + 1) * env.num_envs),
@@ -750,7 +819,7 @@ def eval_main(cfg: TrainPipelineConfig):
             max_episodes_rendered=cfg.eval.max_episodes_rendered,
             grid_size=cfg.eval.grid_size,
             videos_dir=eval_output_dir / "videos",
-            start_seed=cfg.seed,
+            start_seed=_resolve_eval_seed(cfg),
             max_parallel_tasks=cfg.env.max_parallel_tasks,
             return_episode_data=bool(cfg.eval.recording_root),
             subgoal_generator=subgoal_generator,

--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -48,6 +48,7 @@ from opentau.policies.factory import make_policy
 from opentau.policies.outlier_utils import OutlierRecord
 from opentau.policies.pretrained import PreTrainedPolicy, is_norm_buffer_key
 from opentau.scripts.eval import (
+    _resolve_eval_seed,
     collect_grid_summary_videos,
     consolidate_eval_info,
     eval_policy_all,
@@ -111,7 +112,7 @@ def _eval_with_fresh_envs(
                 videos_dir=cfg.output_dir / "eval" / f"videos_step_{step_id}",
                 max_episodes_rendered=cfg.eval.max_episodes_rendered,
                 grid_size=cfg.eval.grid_size,
-                start_seed=cfg.seed,
+                start_seed=_resolve_eval_seed(cfg),
                 max_parallel_tasks=cfg.env.max_parallel_tasks,
                 subgoal_generator=eval_subgoal_generator,
             )

--- a/tests/envs/test_robocasa.py
+++ b/tests/envs/test_robocasa.py
@@ -792,6 +792,61 @@ class TestRenderMultiCamera:
         assert env.render() is sentinel
 
 
+class TestResetSeed:
+    """``RoboCasaEnv.reset`` forwards an explicit seed to the sim verbatim.
+
+    Spreading the seed across the ``n_envs`` workers is the caller's job:
+    gymnasium's vector envs hand each sub-env a distinct ``seed[i]`` (or ``seed+i``
+    for an int) and the eval harness builds an explicit per-worker range. Adding
+    ``episode_index`` on top of an already-distinct seed would *double*-shift it and
+    make scene seeds collide across rollout batches (so an eval samples fewer
+    distinct scenes than ``n_episodes``). Only the unseeded path falls back to
+    ``episode_index`` to keep workers distinct.
+
+    CPU-only: ``_env`` is stubbed so ``_ensure_env`` is a no-op and no sim is built.
+    """
+
+    @staticmethod
+    def _stub_env(episode_index: int):
+        from opentau.envs.robocasa import RoboCasaEnv as RoboCasaGymEnv
+
+        env = RoboCasaGymEnv(task="CloseFridge", episode_index=episode_index)
+        env._env = Mock()  # non-None so _ensure_env() is a no-op (no sim build)
+        env._env.reset.return_value = ({}, {})  # (raw_obs, info); raw_obs unused below
+        env._env.env.get_ep_meta.return_value = {"lang": "close the fridge"}
+        return env
+
+    @pytest.mark.parametrize("episode_index", [0, 1, 5])
+    def test_explicit_seed_passes_through_without_episode_index_shift(self, episode_index):
+        env = self._stub_env(episode_index)
+        with patch.object(env, "_format_raw_obs", return_value={"pixels": {}}):
+            env.reset(seed=100)
+        # Seeded with exactly the caller's seed — NOT seed + episode_index.
+        env._env.reset.assert_called_once_with(seed=100)
+
+    @pytest.mark.parametrize("episode_index", [0, 1, 5])
+    def test_unseeded_reset_falls_back_to_episode_index(self, episode_index):
+        env = self._stub_env(episode_index)
+        with patch.object(env, "_format_raw_obs", return_value={"pixels": {}}):
+            env.reset()  # no seed → fall back to episode_index so workers differ
+        env._env.reset.assert_called_once_with(seed=episode_index)
+
+    def test_per_worker_range_yields_contiguous_collision_free_scene_seeds(self):
+        # Emulate the eval harness: gymnasium hands sub-env i its own seeds[i] from
+        # the per-worker range [S, S+1, ..., S+N-1]. The underlying scene seeds must
+        # be exactly those values — contiguous and distinct, no spacing-of-2 gaps
+        # that would alias across batches.
+        start, n_envs = 100, 4
+        scene_seeds = []
+        for i in range(n_envs):
+            env = self._stub_env(episode_index=i)
+            with patch.object(env, "_format_raw_obs", return_value={"pixels": {}}):
+                env.reset(seed=start + i)  # seeds[i] as distributed by the vector env
+            scene_seeds.append(env._env.reset.call_args.kwargs["seed"])
+        assert scene_seeds == [100, 101, 102, 103]
+        assert len(set(scene_seeds)) == n_envs  # no collisions
+
+
 @pytest.mark.gpu
 @pytest.mark.slow
 def test_robocasa_autodownload_and_rollout_from_relocated_root(monkeypatch):

--- a/tests/scripts/test_eval.py
+++ b/tests/scripts/test_eval.py
@@ -24,6 +24,8 @@ from opentau.configs.default import EvalConfig
 from opentau.envs.configs import RoboCasaEnv
 from opentau.scripts.eval import (
     _cleanup_episode_clips,
+    _rank_seed_offset,
+    _resolve_eval_seed,
     collect_grid_summary_videos,
     create_grid_summary_video,
     eval_policy_all,
@@ -244,3 +246,70 @@ def test_eval_config_rejects_out_of_range_video_params():
         EvalConfig(video_frame_stride=0)
     with pytest.raises(ValueError, match="video_preset"):
         EvalConfig(video_preset="turbo")
+
+
+class TestRankSeedOffset:
+    """`_rank_seed_offset` controls whether ranks evaluate the same or distinct scenes."""
+
+    def test_default_is_zero_so_all_ranks_seed_identically(self):
+        # decorrelate=False -> every rank gets offset 0, regardless of rank index,
+        # so the eval is reproducible across world sizes / node counts.
+        for r in range(16):
+            assert _rank_seed_offset(process_index=r, decorrelate=False, per_rank_span=12) == 0
+
+    def test_decorrelated_blocks_tile_without_gap_or_overlap(self):
+        # Each rank's seed block is [r*span, (r+1)*span); since stride == span the
+        # blocks partition [0, W*span) exactly — no collision, no wasted seeds,
+        # and no magic constant.
+        n_batches, num_envs, world_size = 3, 4, 5
+        span = n_batches * num_envs
+        blocks = [
+            set(
+                range(
+                    _rank_seed_offset(process_index=r, decorrelate=True, per_rank_span=span),
+                    _rank_seed_offset(process_index=r, decorrelate=True, per_rank_span=span) + span,
+                )
+            )
+            for r in range(world_size)
+        ]
+        union = set().union(*blocks)
+        assert len(union) == world_size * span  # pairwise disjoint (no overlap)
+        assert union == set(range(world_size * span))  # contiguous (no gap)
+
+    def test_offset_is_collision_free_even_beyond_10000_episodes(self):
+        # The old `* 10000` stride aliased once a rank exceeded 10000 episodes;
+        # the span-based stride never does, because the stride IS the span.
+        span = 12000  # a rank running >10000 episodes
+        assert _rank_seed_offset(process_index=0, decorrelate=True, per_rank_span=span) == 0
+        assert _rank_seed_offset(process_index=1, decorrelate=True, per_rank_span=span) == span
+        # rank 0's last seed (span-1) is strictly below rank 1's first seed (span).
+        assert span - 1 < _rank_seed_offset(process_index=1, decorrelate=True, per_rank_span=span)
+
+
+class TestResolveEvalSeed:
+    """`eval.seed` overrides the top-level `cfg.seed` for env scene seeding only."""
+
+    @staticmethod
+    def _cfg(*, top_seed, eval_seed):
+        cfg = Mock()
+        cfg.seed = top_seed
+        cfg.eval.seed = eval_seed
+        return cfg
+
+    def test_falls_back_to_top_level_seed_when_eval_seed_is_none(self):
+        assert _resolve_eval_seed(self._cfg(top_seed=1000, eval_seed=None)) == 1000
+
+    def test_eval_seed_takes_precedence_when_set(self):
+        assert _resolve_eval_seed(self._cfg(top_seed=1000, eval_seed=7)) == 7
+
+    def test_eval_seed_zero_is_an_explicit_seed_not_unset(self):
+        # 0 is a valid seed and must take precedence — not be treated as falsy/unset.
+        assert _resolve_eval_seed(self._cfg(top_seed=1000, eval_seed=0)) == 0
+
+    def test_returns_none_only_when_both_are_none(self):
+        assert _resolve_eval_seed(self._cfg(top_seed=None, eval_seed=None)) is None
+
+    def test_eval_config_default_seed_is_none(self):
+        # The field exists and defaults to None (fall back to cfg.seed).
+        assert EvalConfig().seed is None
+        assert EvalConfig(seed=42).seed == 42

--- a/tests/scripts/test_train.py
+++ b/tests/scripts/test_train.py
@@ -461,6 +461,7 @@ class TestEvalWithFreshEnvs:
                 n_episodes=2,
                 max_episodes_rendered=0,
                 grid_size=None,
+                seed=None,  # fall back to the top-level cfg.seed (see _resolve_eval_seed)
             ),
             policy=SimpleNamespace(use_amp=False),
             output_dir=Path("/tmp/opentau_eval_test"),


### PR DESCRIPTION
## What this does

Reworks how **evaluation** environments are seeded so the eval scene set is deterministic by default and independently controllable. (🗃️ Feature)

- **Rank-consistent by default.** Every accelerator rank now seeds its eval envs identically, so the scene a given `(task, episode)` maps to no longer depends on the world size / node count — an eval on 1 GPU and on 16 GPUs samples the same scenes. Previously each rank *always* diverged via a `process_index * 10000` offset, which made eval results non-reproducible across different GPU counts.
- **`eval.decorrelate_rank_seeds` (opt-in, default `False`).** Restores per-rank scene divergence for the case where a task is *deliberately* replicated across ranks (listed N× to fill N ranks via round-robin sharding) to gain coverage. Instead of the magic `* 10000` (which silently collides once a rank exceeds 10000 episodes), each rank takes an **orthogonal, non-overlapping** slice of the seed line whose stride is the *exact* per-rank span (`n_batches * num_envs`), so the blocks tile with no gap or overlap. It uses the **global** `process_index`, so blocks never collide across nodes.
- **`eval.seed` (default `None`).** Lets you pin the eval *simulations* independently of the top-level `cfg.seed` (e.g. hold the eval scene set fixed while sweeping the training seed). Falls back to `cfg.seed` when unset; the global `set_seed` for model init / dataset shuffling stays on `cfg.seed`.
- **Fix `RoboCasaEnv.reset` double-shift.** It added `episode_index` on top of an already-per-worker-distinct seed. gymnasium's `SyncVectorEnv` / `AsyncVectorEnv` and the eval harness already hand each sub-env a distinct seed, so the extra shift made scene seeds collide across rollout batches (e.g. with `n_envs=4`, batch 0 / slot 2 reused batch 1 / slot 0), yielding fewer distinct scenes than `n_episodes`. Explicit seeds now pass through verbatim; `episode_index` remains the seed only on an *unseeded* reset so workers still differ.

No model, training-loop, optimizer, or sampler behavior changes — the only `train.py` touch is the eval-seed source inside `_eval_with_fresh_envs`.

## How it was tested

CPU unit tests (this is the gate the changes are covered by; no GPU/sim behavior changes):

- Added `TestResetSeed` in `tests/envs/test_robocasa.py`: an explicit seed passes through `RoboCasaEnv.reset` verbatim (no `episode_index` shift), an unseeded reset falls back to `episode_index`, and a per-worker seed range yields contiguous collision-free scene seeds.
- Added `TestRankSeedOffset` in `tests/scripts/test_eval.py`: the default offset is 0 for all ranks (rank-consistent), decorrelated blocks partition `[0, W·span)` exactly (no gap/overlap), and the span-based stride stays collision-free past 10000 episodes/rank.
- Added `TestResolveEvalSeed` in `tests/scripts/test_eval.py`: `eval.seed` takes precedence when set (including the `0` edge case), falls back to `cfg.seed` when `None`, and returns `None` only when both are `None`.
- Updated `TestEvalWithFreshEnvs._cfg` in `tests/scripts/test_train.py` to carry `eval.seed=None`.

Full affected CPU suite green:

```
pytest -m "not gpu and not network" -n auto tests/scripts/test_eval.py tests/scripts/test_train.py tests/configs/ tests/envs/test_robocasa.py
# 251 passed
```

`pre-commit run --all-files`-equivalent on the changed files is clean.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/scripts/test_eval.py::TestRankSeedOffset
pytest -sx tests/scripts/test_eval.py::TestResolveEvalSeed
pytest -sx tests/envs/test_robocasa.py::TestResetSeed
```

Override the new knobs on any eval/training run that uses a sim env:

```bash
# Pin the eval scenes independently of the training seed:
opentau-eval --accelerate-config <yaml> --config_path=<json> --eval.seed=12345
# Opt back into per-rank scene divergence (only when a task is replicated across ranks):
opentau-eval --accelerate-config <yaml> --config_path=<json> --eval.decorrelate_rank_seeds=true
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
