### PR TITLE
docs(cosmos3): add tensor-flow ASCII diagram to model docs

### DIFF
--- a/docs/source/model.rst
+++ b/docs/source/model.rst
@@ -119,6 +119,86 @@ cosmos3
 - Config selector: ``--policy.type=cosmos3``.
 - Disclaimer: the reasoner *backbone* is published (private ``TensorAuto/cosmos3-reason-32b``), but no full cosmos3 *policy* checkpoint exists yet — the action expert is randomly initialized on top of the frozen reasoner and produced by training.
 
+The training-time tensor flow, from the raw batch through the frozen reasoner
+prefix and the trainable action expert to the flow-matching velocity head
+(shapes shown at config defaults: ``chunk_size=50``, ``max_action_dim=32``,
+``expert_hidden_size=1024``, 64 layers, 8 KV heads, ``head_dim=128``;
+``S`` = prefix length, ``B`` = batch):
+
+.. code-block:: text
+
+     raw batch                          normalize_inputs / normalize_targets
+     +--------------------------------------------------------------------+
+     | images   (B, C, H, W)        VISUAL: identity   (per-dataset       |
+     | state    (B, state_dim)      STATE : mean-std     stats, keyed     |
+     | actions  (B, 50, act_dim)    ACTION: mean-std     by dataset_idx)  |
+     | prompt   list[str]                                                 |
+     +--------------------------------------------------------------------+
+                |
+                v   prepare_multimodal_inputs / prepare_state
+     +--------------------------------------------------------------------+
+     | each image -> resize 224x224 -> uint8 ; prompt -> <=256 tokens     |
+     | Qwen3-VL chat template + processor (image tokens interleaved       |
+     | with text):                                                        |
+     |     input_ids (B, S) , attention_mask (B, S)                       |
+     |     pixel_values , image_grid_thw                                  |
+     | state -> pad to max_state_dim=32  ->  (B, 32)                      |
+     +--------------------------------------------------------------------+
+                |
+                v
+     ====== FROZEN Qwen3-VL-32B reasoner : prefix forward (no_grad) =======
+     +--------------------------------------------------------------------+
+     | get_rope_index -> MRoPE positions            (3, B, S)             |
+     | run_prefix = stock Qwen3VLModel.forward:                           |
+     |   vision tower -> image embeds scattered into the token            |
+     |   sequence, deepstack, MRoPE, QK-norm, native causal mask          |
+     | => per-layer KV cache: 64 x (K, V), each (B, 8, S, 128) --+        |
+     +--------------------------------------------------------------------+
+                |  (detached; backbone never reads the expert)   | cached_kv
+                v                                                |
+     ------------ flow-matching interpolation (suffix targets) ------------
+     +--------------------------------------------------------------------+
+     | noise ~ N(0,1)                      (B, 50, 32)                    |
+     | time  ~ Beta(1.5,1.0)*0.999+0.001 in [0.001,1]  (B,) -> (B,50)     |
+     |    (real-time-inference `delay` can pin the first `delay`          |
+     |     chunk steps to t=0; max_delay defaults to 0 = none pinned)     |
+     | x_t = t*noise + (1-t)*actions       (B, 50, 32)  expert input      |
+     | u_t = noise - actions               (B, 50, 32)  MSE target        |
+     +--------------------------------------------------------------------+
+                |
+                v   embed_suffix
+     +--------------------------------------------------------------------+
+     | action_in_proj(x_t)        (B, 50, 1024)                           |
+     | state_proj(state)          (B,  1, 1024)  <- prepended token       |
+     | embs = [state ; actions]   (B, 51, 1024)                           |
+     | time -> sinusoid -> MLP -> adarms_proj -> adarms_cond (B,51,256)   |
+     |    (state-token slot uses fixed t=1.0; 50 action slots use t)      |
+     +--------------------------------------------------------------------+
+                |
+                v
+     ============= TRAINABLE Qwen3 action expert  (64 layers) =============
+     +--------------------------------------------------------------------+
+     | for each layer i = 0..63:                                          |
+     |   AdaRMS(hidden, adarms_cond) -> q/k/v, QK-norm, MRoPE             |
+     |   K,V = concat( cached_kv[i] , expert K,V )  <- reasoner cache     |
+     |           (B,8,S,128)        (B,8,51,128)                          |
+     |   attn: expert queries over [prefix ; suffix] -> gated resid.      |
+     |   AdaRMS -> SwiGLU MLP -> gated residual                           |
+     | final AdaRMS norm                            (B, 51, 1024)         |
+     +--------------------------------------------------------------------+
+                |
+                v   drop state token -> last 50 ; action_out_proj  [HEAD]
+     +--------------------------------------------------------------------+
+     | v_t = action_out_proj(out[:, -50:])    (B, 50, 32)  velocity       |
+     +--------------------------------------------------------------------+
+                |
+                v
+          flow_matching_masked_mse(v_t, u_t)  ->  MSE loss   (CE = 0)
+
+     Inference swaps the interpolation block for Euler integration:
+     x_t = noise at t=1, run the expert num_steps (10) times,
+     x_t += dt*v_t, then unnormalize -> executed action chunk.
+
 
 value
 -----


### PR DESCRIPTION
## What this does
Adds an ASCII tensor-flow diagram to the `cosmos3` section of the model docs
(`docs/source/model.rst`). The diagram traces a tensor end-to-end — from the raw
batch through normalization and the Qwen3-VL processor, the frozen Qwen3-VL-32B
reasoner prefix forward (per-layer KV cache), the flow-matching interpolation,
the action expert's suffix embedding, the 64 AdaRMS decoder layers that
cross-attend to the cached backbone KV, and finally the `action_out_proj`
velocity head and the masked-MSE flow-matching loss. Inference (Euler
integration) is summarized below the training path. Shapes are annotated at the
config defaults (`chunk_size=50`, `max_action_dim=32`, `expert_hidden_size=1024`,
64 layers, 8 KV heads, `head_dim=128`).

Documentation only — no code changes. (📝 Documentation)

## How it was tested
- Verified the diagram against the source line-by-line
  (`modeling_cosmos3.py`, `qwen3vl_with_expert.py`, `configuration_cosmos3.py`):
  every shape, ordering step, and label (state token prepended with a fixed
  AdaRMS `t=1.0`, KV concat order `[cached ; expert]`, frozen/detached prefix,
  `Beta(1.5,1.0)*0.999+0.001` time, `CE=0`) matches the implementation.
- Built the HTML docs with `sphinx-build -b html source <out>`: `model.rst`
  produces **no** warnings/errors and the diagram renders inside the rendered
  `code-block`. (Pre-existing autosummary warnings for the cosmos3 modules are
  unrelated — they come from the local `transformers < 4.57` not exposing
  `Qwen3VLConfig`; the policy itself requires `transformers >= 4.57`.)
- `pre-commit run --files docs/source/model.rst` passes (trailing-whitespace,
  end-of-file-fixer, typos, etc.).

## How to checkout & try? (for the reviewer)
```bash
git checkout docs/cosmos3-tensor-flow-diagram
sphinx-build -b html docs/source /tmp/opentau-docs
# open /tmp/opentau-docs/model.html and scroll to the "cosmos3" section
```
Or just read the diagram directly:
```bash
sed -n '/^cosmos3$/,/^value$/p' docs/source/model.rst
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
