### PR TITLE
Adding motion module based on SSTS pipeline to video encoder

### DIFF
--- a/configs/examples/pi05_mem_motion_training_config.json
+++ b/configs/examples/pi05_mem_motion_training_config.json
@@ -1,0 +1,135 @@
+{
+    "dataset_mixture": {
+        "datasets": [
+            {
+                "repo_id": "TensorAuto/libero",
+                "episodes": [
+                    0,1,2,3,4,5,6,7,8,9
+                ]
+            }
+
+        ],
+        "weights": [
+            1.0
+        ],
+        "action_freq": 20.0,
+        "n_obs_history": 8,
+        "image_resample_strategy": "nearest",
+        "vector_resample_strategy": "nearest"
+    },
+    "policy": {
+        "type": "pi05_mem",
+        "pretrained_path": null,
+        "n_obs_steps": 8,
+        "normalization_mapping": {
+            "VISUAL": "IDENTITY",
+            "STATE": "MEAN_STD",
+            "ACTION": "MEAN_STD"
+        },
+        "chunk_size": 10,
+        "n_action_steps": 10,
+        "max_state_dim": 32,
+        "max_action_dim": 32,
+        "proj_width": 1024,
+        "dropout": 0.1,
+        "num_steps": 10,
+        "attention_implementation": "eager",
+        "freeze_vision_encoder": true,
+        "train_expert_only": false,
+        "prompt_max_length": 50,
+        "discrete_action_max_length": 100,
+        "spacetime_layer_stride": 4,
+        "use_motion": true,
+        "motion_insert_layer": null,
+        "motion_hidden_dim": 256,
+        "motion_window": [5, 9, 9],
+        "motion_corr_func": "cosine",
+        "motion_n_encoders": 1,
+        "motion_norm": "groupnorm",
+        "motion_int_mode": "lite",
+        "motion_zero_init": true,
+        "optimizer_lr": 2.5e-05,
+        "optimizer_betas": [
+            0.9,
+            0.95
+        ],
+        "optimizer_eps": 1e-08,
+        "optimizer_weight_decay": 1e-10,
+        "scheduler_warmup_steps": 1000,
+        "scheduler_decay_steps": 30000,
+        "scheduler_decay_lr": 2.5e-06
+    },
+    "resume": false,
+    "seed": 1000,
+    "resolution": [224, 224],
+    "num_cams": 2,
+    "max_state_dim": 32,
+    "max_action_dim": 32,
+    "action_chunk": 10,
+    "loss_weighting": {"MSE": 1, "CE": 1},
+    "num_workers": 4,
+    "batch_size": 2,
+    "gradient_accumulation_steps": 1,
+    "dataloader_batch_size": 2,
+    "prefetch_factor": 8,
+    "steps": 40,
+    "log_freq": 5,
+    "save_checkpoint": true,
+    "save_freq": 40,
+    "val_freq": 10,
+    "use_policy_training_preset": false,
+    "trace_nans": false,
+    "optimizer": {
+        "type": "adamw",
+        "lr": 2.5e-05,
+        "weight_decay": 1e-10,
+        "grad_clip_norm": 10.0,
+        "betas": [
+            0.9,
+            0.95
+        ],
+        "eps": 1e-08
+    },
+    "scheduler": {
+        "type": "cosine_decay_with_warmup",
+        "num_warmup_steps": 1000,
+        "num_decay_steps": 30000,
+        "peak_lr": 2.5e-05,
+        "decay_lr": 2.5e-06
+    },
+    "wandb": {
+        "enable": true,
+        "entity": "wyautox-autox",
+        "project": "pi05_mem",
+        "run_id": null,
+        "name": null,
+        "notes": "PI05 Mem + RLDX-1 STSS motion module (groupnorm, zero-init warm start)",
+        "tags": ["motion", "stss", "rldx"],
+        "group": null,
+        "job_type": null,
+        "mode": null,
+        "on_resume": "fork",
+        "disable_artifact": false
+    },
+    "env": {
+        "type": "libero",
+        "task": "libero_10",
+        "fps": 20,
+        "max_parallel_tasks": 1,
+        "task_ids": [0],
+        "episode_length": 100,
+        "obs_type": "pixels_agent_pos",
+        "render_mode": "rgb_array",
+        "camera_name": "agentview_image,robot0_eye_in_hand_image",
+        "init_states": true,
+        "camera_name_mapping": null
+    },
+    "eval": {
+        "n_episodes": 1,
+        "batch_size": 1,
+        "use_async_envs": true,
+        "max_episodes_rendered": 11,
+        "grid_size": null
+    },
+    "eval_freq": 10
+}

--- a/src/opentau/policies/pi05_mem/configuration_pi05.py
+++ b/src/opentau/policies/pi05_mem/configuration_pi05.py
@@ -158,6 +158,39 @@ class PI05MemConfig(PreTrainedConfig):
     # model-name / dtype field here.
     spacetime_layer_stride: int = 4
 
+    # STSS motion module (RLDX-1, https://github.com/RLWRLD/RLDX-1).
+    # When enabled, a space-time self-similarity motion module injects a residual
+    # update into the SigLIP hidden states at ``motion_insert_layer``, capturing
+    # temporal dynamics across the ``n_obs_steps`` frames. Unlike the space-time
+    # attention (zero new params), this DOES add new learnable parameters, so a
+    # plain pi05 checkpoint loads with ``strict=False`` (motion params init fresh).
+    # With ``motion_zero_init=True`` (default) the residual is zero-gated at init,
+    # so the policy is byte-identical at step 0 and the motion contribution warms
+    # up during training. The module stays trainable even when
+    # ``freeze_vision_encoder`` is set (the freeze only touches the SigLIP tower).
+    use_motion: bool = False
+    # 0-indexed encoder layer after which the motion residual is injected.
+    # ``None`` -> mid-stack (n_layers // 3), which is layer 9 for the 27-layer
+    # so400m tower (matching the RLDX-1 placement).
+    motion_insert_layer: int | None = None
+    # Internal correlation/feature width of the motion module (``in_proj`` target).
+    motion_hidden_dim: int = 256
+    # (L, kh, kw) space-time correlation window. Spatial size must fit the patch
+    # grid (<= 16 for a 224/14 grid).
+    motion_window: tuple[int, int, int] = (5, 9, 9)
+    # Correlation function: "cosine" / "dotproduct" / "dotproduct_softmax".
+    motion_corr_func: str = "cosine"
+    # Number of stacked STSS encoders (their outputs are summed).
+    motion_n_encoders: int = 1
+    # Norm inside the STSS 3D convs: "batchnorm" (RLDX default), "groupnorm"
+    # (per-sample, no cross-rank sync — recommended under FSDP/DeepSpeed/multi-rank,
+    # CLAUDE.md rule #5), or "syncbn".
+    motion_norm: str = "batchnorm"
+    # Integration conv: "lite" (single fuse conv) or "full" (3x3 conv stack).
+    motion_int_mode: str = "lite"
+    # Zero-init the residual so the module starts as a no-op (warm start).
+    motion_zero_init: bool = True
+
     # Training presets
     optimizer_lr: float = 2.5e-5
     optimizer_betas: tuple[float, float] = (0.9, 0.95)
@@ -221,6 +254,31 @@ class PI05MemConfig(PreTrainedConfig):
             raise ValueError(
                 f"`spacetime_layer_stride` must be a positive integer, got {self.spacetime_layer_stride}."
             )
+
+        if self.use_motion:
+            if self.motion_norm not in ("batchnorm", "groupnorm", "syncbn"):
+                raise ValueError(
+                    f"`motion_norm` must be one of batchnorm/groupnorm/syncbn, got {self.motion_norm!r}."
+                )
+            if self.motion_int_mode not in ("lite", "full"):
+                raise ValueError(f"`motion_int_mode` must be 'lite' or 'full', got {self.motion_int_mode!r}.")
+            if self.motion_corr_func not in ("cosine", "dotproduct", "dotproduct_softmax"):
+                raise ValueError(
+                    "`motion_corr_func` must be one of cosine/dotproduct/dotproduct_softmax, "
+                    f"got {self.motion_corr_func!r}."
+                )
+            if len(self.motion_window) != 3 or any(w < 1 for w in self.motion_window):
+                raise ValueError(
+                    f"`motion_window` must be 3 positive ints (L, kh, kw), got {self.motion_window}."
+                )
+            if self.motion_window[1] != self.motion_window[2]:
+                raise ValueError(
+                    f"`motion_window` spatial dims must be square, got {self.motion_window[1:]}."
+                )
+            if self.n_obs_steps < 2:
+                raise ValueError(
+                    f"`use_motion` requires `n_obs_steps` >= 2 (a real time axis), got {self.n_obs_steps}."
+                )
 
     def validate_features(self) -> None:
         """Validates the features and adds empty cameras if configured."""

--- a/src/opentau/policies/pi05_mem/modeling_pi05.py
+++ b/src/opentau/policies/pi05_mem/modeling_pi05.py
@@ -54,6 +54,7 @@ from opentau.policies.pi05.paligemma_with_expert import (
     PaliGemmaWithExpertModel,
 )
 from opentau.policies.pi05_mem.configuration_pi05 import PI05MemConfig
+from opentau.policies.pi07.rldx_video_encoder import RLDXVideoEncoder
 from opentau.policies.pi07.video_encoder import SpaceTimeSiglipVideoEncoder
 from opentau.policies.pretrained import PreTrainedPolicy, T
 from opentau.policies.utils import PerSampleLoss, ce_per_sample, flow_matching_masked_mse
@@ -896,13 +897,32 @@ class PI05MemFlowMatching(nn.Module):
         # Freezing and dtype-casting of these modules are already handled by
         # ``PaliGemmaWithExpertModel``. The encoder introduces no new learnable
         # parameters, so a regular pi05 checkpoint's state_dict loads directly.
-        self.video_encoder = SpaceTimeSiglipVideoEncoder(
-            vision_tower=self.paligemma_with_expert.paligemma.vision_tower,
-            multi_modal_projector=self.paligemma_with_expert.paligemma.multi_modal_projector,
-            max_num_frames=config.n_obs_steps,
-            spacetime_layer_stride=config.spacetime_layer_stride,
-            gradient_checkpointing=config.gradient_checkpointing,
-        )
+        if config.use_motion:
+            # RLDX-1 STSS motion variant: plain SigLIP + STSS motion module, NO
+            # space-time attention layers. Lives in rldx_video_encoder.py; the
+            # base space-time encoder is left untouched.
+            self.video_encoder = RLDXVideoEncoder(
+                vision_tower=self.paligemma_with_expert.paligemma.vision_tower,
+                multi_modal_projector=self.paligemma_with_expert.paligemma.multi_modal_projector,
+                max_num_frames=config.n_obs_steps,
+                gradient_checkpointing=config.gradient_checkpointing,
+                motion_insert_layer=config.motion_insert_layer,
+                motion_hidden_dim=config.motion_hidden_dim,
+                motion_window=config.motion_window,
+                motion_corr_func=config.motion_corr_func,
+                motion_n_encoders=config.motion_n_encoders,
+                motion_norm=config.motion_norm,
+                motion_int_mode=config.motion_int_mode,
+                motion_zero_init=config.motion_zero_init,
+            )
+        else:
+            self.video_encoder = SpaceTimeSiglipVideoEncoder(
+                vision_tower=self.paligemma_with_expert.paligemma.vision_tower,
+                multi_modal_projector=self.paligemma_with_expert.paligemma.multi_modal_projector,
+                max_num_frames=config.n_obs_steps,
+                spacetime_layer_stride=config.spacetime_layer_stride,
+                gradient_checkpointing=config.gradient_checkpointing,
+            )
 
         # Per-timestep state projection: each of the T state vectors becomes one token
         self.state_proj = nn.Linear(self.config.max_state_dim, vlm_hidden_size)

--- a/src/opentau/policies/pi07/motion_module.py
+++ b/src/opentau/policies/pi07/motion_module.py
@@ -1,0 +1,444 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Space-Time Self-Similarity (STSS) motion module.
+
+Ported from RLDX-1 (``rldx/model/modules/backbone/motion.py``,
+https://github.com/RLWRLD/RLDX-1), whose motion module in turn builds on the
+SELFY space-time self-similarity formulation (Kwon et al., "Learning
+Self-Similarity in Space and Time as Generalized Motion for Video Action
+Recognition", ICCV 2021).
+
+Rather than optical flow or raw frame differences, the module captures temporal
+dynamics by computing **local space-time self-similarity**: for every
+spatio-temporal patch feature it correlates against its neighbors within a
+``(L, kh, kw)`` window across frames, producing a similarity volume that a small
+3D-conv encoder turns into a motion feature. The result is a **residual** that
+is added back onto the vision features:
+
+    v~(t) = v(t) + S_theta(STSS(v(t)))
+
+In OpenTau this residual is injected at a single SigLIP encoder layer (see
+``SpaceTimeSiglipVideoEncoder`` in ``video_encoder.py``).
+
+Interface (matching the RLDX-1 reference so the math is easy to compare):
+
+    forward(x, grid_sizes)
+        x:          (sum_i T_i*H_i*W_i, C) flattened patch features, token order
+                    ``(b t h w)`` (batch-major, then time, then row-major patches).
+        grid_sizes: (B, 3) int tensor; each row is ``[T, H, W]`` for one video.
+        returns:    (sum_i T_i*H_i*W_i, C) residual, same layout as ``x``.
+
+Differences from the RLDX-1 reference, all behind flags:
+  - ``norm``: BatchNorm3d (RLDX default), "groupnorm" (GroupNorm(1, C) — per-sample,
+    no cross-rank stat sync, recommended under FSDP/DeepSpeed/multi-rank; see
+    CLAUDE.md rule #5), or "syncbn".
+  - ``zero_init_residual`` (default True): zero-initializes the output projection
+    (or the LayerScale) so the module starts as an exact no-op. A policy
+    fine-tuned from a pre-existing pi05 checkpoint is therefore byte-identical at
+    step 0 and the motion contribution warms up during training. RLDX-1 dropped
+    this zero-init so motion contributes from step 1 — pass
+    ``zero_init_residual=False`` to match that.
+  - The gradient-monitoring print hook from the reference is omitted.
+"""
+
+import torch
+import torch.nn.functional as F  # noqa: N812
+from einops import rearrange, repeat
+from einops.layers.torch import Rearrange
+from torch import Tensor, nn
+
+_NormKind = str  # one of {"batchnorm", "groupnorm", "syncbn"}
+
+
+def _make_norm3d(num_channels: int, norm: _NormKind) -> nn.Module:
+    """Norm layer for the STSS 3D-conv stack.
+
+    ``groupnorm`` uses ``GroupNorm(1, C)`` (a.k.a. per-sample LayerNorm over
+    channels+space) — it carries no running statistics and needs no cross-rank
+    synchronization, so it is the safe choice under FSDP / DeepSpeed / multi-rank
+    (CLAUDE.md rule #5). ``batchnorm`` matches the RLDX-1 default but, like any
+    BatchNorm, keeps running stats that diverge across ranks unless wrapped in
+    ``syncbn``.
+    """
+    if norm == "groupnorm":
+        return nn.GroupNorm(1, num_channels)
+    if norm == "syncbn":
+        return nn.SyncBatchNorm(num_channels)
+    if norm == "batchnorm":
+        return nn.BatchNorm3d(num_channels)
+    raise ValueError(f"Unknown norm '{norm}'; expected one of batchnorm/groupnorm/syncbn.")
+
+
+class STSSTransformation(nn.Module):
+    """Compute the local space-time self-similarity volume.
+
+    For each spatio-temporal patch feature, correlate it against the features of
+    nearby frames within a ``window[0]`` temporal span, then keep only a local
+    ``window[1] x window[2]`` spatial neighborhood of the correlation.
+    """
+
+    def __init__(self, window: tuple[int, int, int] = (5, 9, 9), corr_func: str = "cosine"):
+        super().__init__()
+        self.window = window
+        assert window[1] == window[2], "spatial correlation window must be square"
+        self.corr_func = corr_func
+        if self.corr_func == "dotproduct_softmax":
+            self.pad_value = -float("inf")
+        else:
+            self.pad_value = 0.0
+
+    def _convert_global_to_local(self, corr_g: Tensor) -> Tensor:
+        """Absolute (h,w)x(h,w) correlation -> local-window correlation.
+
+        Args:
+            corr_g: ``(b, h, w, h, w)`` global correlation tensor.
+        Returns:
+            ``(b, h, w, kh, kw)`` local-window correlation tensor.
+        """
+        max_d = self.window[1] // 2
+
+        # Extract spatial-row offsets via diagonals, padding out-of-range entries.
+        corr_l = [
+            F.pad(
+                torch.diagonal(corr_g, offset=i, dim1=1, dim2=3),
+                (abs(i) if i < 0 else 0, abs(i) if i >= 0 else 0),
+                value=self.pad_value,
+            )
+            for i in range(-max_d, max_d + 1)
+        ]
+        corr_l = torch.stack(corr_l, dim=-1)  # B, W1, W2, H1, H2 -> U
+
+        # Extract spatial-col offsets the same way.
+        corr_l = [
+            F.pad(
+                torch.diagonal(corr_l, offset=i, dim1=1, dim2=2),
+                (abs(i) if i < 0 else 0, abs(i) if i >= 0 else 0),
+                value=self.pad_value,
+            )
+            for i in range(-max_d, max_d + 1)
+        ]
+        corr_l = torch.stack(corr_l, dim=-1)  # B, H1, H2 -> U, W1, W2 -> V
+        corr_l = corr_l.transpose(2, 3).contiguous()  # B, H1, W1, U, V
+
+        return corr_l
+
+    def _correlation(self, feat1: Tensor, feat2: Tensor) -> Tensor:
+        if self.corr_func == "cosine":
+            feat1 = F.normalize(feat1, p=2, dim=1)
+            feat2 = F.normalize(feat2, p=2, dim=1)
+        elif self.corr_func in ("dotproduct", "dotproduct_softmax"):
+            scale = feat1.size(1) ** -0.5
+            feat1 = feat1 * scale
+
+        corr = torch.einsum("bchw,bcuv->bhwuv", feat1, feat2)
+        corr = self._convert_global_to_local(corr)
+
+        if self.corr_func == "dotproduct_softmax":
+            corr_shape = corr.shape
+            corr = rearrange(corr, "b h w u v -> b h w (u v)")
+            corr = F.softmax(corr, dim=-1)
+            corr = corr.reshape(corr_shape)
+
+        return corr
+
+    def forward(self, x: Tensor, grid_sizes: Tensor) -> Tensor:
+        t, h, w = (int(v) for v in grid_sizes[0])
+        if self.window[0] > 1:
+            x = rearrange(x, "(b t h w) c -> b t c h w", t=t, h=h, w=w)
+            x_src = repeat(x, "b t c h w -> (b t l) c h w", l=self.window[0])
+            # Replicate-pad the temporal axis: edge frames repeat instead of being
+            # zero-padded, so boundary correlations reflect "no motion" rather than
+            # "motion against a blank frame".
+            pad_t = self.window[0] // 2
+            x_pad = torch.cat(
+                [
+                    x[:, :1].expand(-1, pad_t, -1, -1, -1),
+                    x,
+                    x[:, -1:].expand(-1, pad_t, -1, -1, -1),
+                ],
+                dim=1,
+            )
+            x_tgt = x_pad.unfold(1, self.window[0], 1)
+            x_tgt = rearrange(x_tgt, "b t c h w l -> (b t l) c h w")
+        else:
+            x_src = x
+            x = rearrange(x, "(b t h w) c -> b t c h w", t=t, h=h, w=w)
+            x_tgt = torch.cat((x[:, 0].unsqueeze(1), x[:, :-1]), 1)
+            x_tgt = rearrange(x_tgt, "b t c h w -> (b t) c h w")
+
+        stss = self._correlation(x_src, x_tgt)
+        stss = rearrange(stss, "(b t l) h w u v -> b t h w 1 l u v", t=t, l=self.window[0])
+
+        return stss
+
+
+class STSSExtraction(nn.Module):
+    """Project the ``kh*kw`` similarity channels of the STSS volume to features."""
+
+    def __init__(
+        self,
+        window: tuple[int, int, int] = (5, 9, 9),
+        chnls: tuple[int, ...] = (256,),
+        norm: _NormKind = "batchnorm",
+    ):
+        super().__init__()
+        self.window = window
+        self.chnls = chnls
+
+        self.conv0 = nn.Sequential(
+            nn.Conv3d(
+                self.window[1] * self.window[2],
+                chnls[0],
+                kernel_size=(1, 1, 1),
+                stride=(1, 1, 1),
+                padding=(0, 0, 0),
+                bias=False,
+            ),
+            _make_norm3d(chnls[0], norm),
+            nn.GELU(),
+        )
+
+    def forward(self, x: Tensor) -> Tensor:
+        b, t, h, w, _, ell, u, v = x.size()
+        x = rearrange(x, "b t h w 1 l u v -> (b l) (u v) t h w", t=t, h=h, w=w)
+        x = self.conv0(x)
+        return x
+
+
+class STSSIntegration(nn.Module):
+    """Fuse the ``L`` temporal-window slices into a single motion feature map."""
+
+    def __init__(
+        self,
+        d_in: int,
+        window: tuple[int, int, int] = (5, 9, 9),
+        chnls: tuple[int, int, int] = (64, 64, 64),
+        norm: _NormKind = "batchnorm",
+        mode: str = "lite",
+    ):
+        super().__init__()
+        self.window = window
+        self.mode = mode
+
+        if mode == "lite":
+            # Single 1x1 Conv3d: L fuse + channel projection, no spatial mixing, no
+            # norm. Replaces the 3-layer 3x3 conv stack so the module contributes
+            # without a deep warm-up path.
+            self.fuse = nn.Sequential(
+                Rearrange("(b l) c t h w -> b (l c) t h w", l=self.window[0]),
+                nn.Conv3d(d_in * self.window[0], chnls[-1], kernel_size=(1, 1, 1), bias=False),
+                nn.GELU(),
+            )
+            return
+
+        self.conv0 = nn.Sequential(
+            nn.Conv3d(d_in, chnls[0], kernel_size=(1, 3, 3), stride=(1, 1, 1), padding=(0, 1, 1), bias=False),
+            _make_norm3d(chnls[0], norm),
+            nn.GELU(),
+        )
+        self.conv1 = nn.Sequential(
+            nn.Conv3d(
+                chnls[0], chnls[1], kernel_size=(1, 3, 3), stride=(1, 1, 1), padding=(0, 1, 1), bias=False
+            ),
+            _make_norm3d(chnls[1], norm),
+            nn.GELU(),
+        )
+        self.conv2_fuse = nn.Sequential(
+            Rearrange("(b l) c t h w -> b (l c) t h w", l=self.window[0]),
+            nn.Conv3d(
+                chnls[1] * self.window[0],
+                chnls[2],
+                kernel_size=(1, 3, 3),
+                stride=(1, 1, 1),
+                padding=(0, 1, 1),
+                bias=False,
+            ),
+            _make_norm3d(chnls[2], norm),
+            nn.GELU(),
+        )
+
+    def forward(self, x: Tensor) -> Tensor:
+        if self.mode == "lite":
+            return self.fuse(x)
+        x = self.conv0(x)
+        x = self.conv1(x)
+        x = self.conv2_fuse(x)
+        return x
+
+
+class STSSEncoder(nn.Module):
+    """One STSS block: LN -> in_proj -> transform -> extract -> integrate -> out_proj."""
+
+    def __init__(
+        self,
+        d_in: int,
+        d_hid: int,
+        d_out: int,
+        window: tuple[int, int, int] = (5, 9, 9),
+        ext_chnls: tuple[int, ...] = (256,),
+        int_chnls: tuple[int, int, int] = (256, 256, 512),
+        corr_func: str = "cosine",
+        norm: _NormKind = "batchnorm",
+        int_mode: str = "lite",
+    ):
+        super().__init__()
+        self.window = window
+        self.ln_pre = nn.LayerNorm(d_in, eps=1e-6)
+        self.in_proj = nn.Linear(d_in, d_hid)
+        self.stss_transformation = STSSTransformation(window=window, corr_func=corr_func)
+        self.stss_extraction = STSSExtraction(window=window, chnls=ext_chnls, norm=norm)
+        self.stss_integration = STSSIntegration(
+            ext_chnls[-1], window=window, chnls=int_chnls, norm=norm, mode=int_mode
+        )
+        self.out_proj = nn.Linear(int_chnls[-1], d_out)
+
+    def forward(self, x: Tensor, grid_sizes: Tensor) -> Tensor:
+        t, h, w = (int(v) for v in grid_sizes[0])
+        x = self.in_proj(self.ln_pre(x))
+        x = self.stss_transformation(x, grid_sizes)
+        x = self.stss_extraction(x)
+        x = self.stss_integration(x)
+        x = self.out_proj(rearrange(x, "b c t h w -> (b t h w) c"))
+        return x
+
+
+class MotionModule(nn.Module):
+    """STSS motion module producing a residual update to vision features.
+
+    Args:
+        d_in: Input feature dimension (must equal the residual target dim).
+        d_hid: Internal correlation/feature dimension (``in_proj`` target).
+        d_out: Output dimension; set equal to ``d_in`` so the residual adds back.
+        window: ``(L, kh, kw)`` space-time correlation window.
+        ext_chnls / int_chnls: channel widths for the extraction / integration convs.
+        corr_func: "cosine" (default), "dotproduct", or "dotproduct_softmax".
+        n_encoders: number of stacked STSS encoders (their outputs are summed).
+        use_layerscale: gate the output with a learnable per-channel LayerScale
+            instead of an ``out_proj`` linear.
+        layerscale_init: initial LayerScale value (used only with ``use_layerscale``).
+        norm: "batchnorm" (RLDX default) / "groupnorm" (distributed-safe) / "syncbn".
+        int_mode: "lite" (single fuse conv) or the full 3x3 conv stack.
+        zero_init_residual: when True, zero-initialize the residual output so the
+            module starts as an exact no-op (warm start from a pretrained
+            checkpoint); the contribution ramps up during training.
+    """
+
+    def __init__(
+        self,
+        d_in: int,
+        d_hid: int,
+        d_out: int,
+        window: tuple[int, int, int] = (5, 9, 9),
+        ext_chnls: tuple[int, ...] = (256,),
+        int_chnls: tuple[int, int, int] = (256, 256, 512),
+        corr_func: str = "cosine",
+        n_encoders: int = 1,
+        use_layerscale: bool = False,
+        layerscale_init: float = 1e-5,
+        norm: _NormKind = "batchnorm",
+        int_mode: str = "lite",
+        zero_init_residual: bool = True,
+    ):
+        super().__init__()
+        self.use_layerscale = use_layerscale
+        self.layerscale_init = layerscale_init
+        self.zero_init_residual = zero_init_residual
+
+        self.stss_encoders = nn.ModuleList(
+            [
+                STSSEncoder(
+                    d_in=d_in if i == 0 else (d_out if self.use_layerscale else d_hid),
+                    d_hid=d_hid,
+                    d_out=d_out if self.use_layerscale else d_hid,
+                    window=window,
+                    ext_chnls=ext_chnls,
+                    int_chnls=int_chnls,
+                    corr_func=corr_func,
+                    norm=norm,
+                    int_mode=int_mode,
+                )
+                for i in range(n_encoders)
+            ]
+        )
+
+        if self.use_layerscale:
+            self.layerscale = nn.Parameter(torch.ones(d_out) * layerscale_init, requires_grad=True)
+        else:
+            self.out_proj = nn.Linear(d_hid, d_out)
+
+        self.initialize_weights()
+
+    def initialize_weights(self) -> None:
+        """Initialize all submodule weights."""
+        for m in self.modules():
+            if isinstance(m, nn.Linear):
+                nn.init.trunc_normal_(m.weight, std=0.02)
+                if m.bias is not None:
+                    nn.init.constant_(m.bias, 0.0)
+            elif isinstance(m, (nn.Conv2d, nn.Conv3d)):
+                nn.init.kaiming_normal_(m.weight, mode="fan_out", nonlinearity="relu")
+                if m.bias is not None:
+                    nn.init.constant_(m.bias, 0.0)
+            elif isinstance(
+                m, (nn.BatchNorm2d, nn.BatchNorm3d, nn.SyncBatchNorm, nn.LayerNorm, nn.GroupNorm)
+            ):
+                nn.init.constant_(m.weight, 1.0)
+                nn.init.constant_(m.bias, 0.0)
+
+        # No-op warm start: gate the residual at zero so a checkpoint loaded into a
+        # policy with this module behaves identically at step 0; the motion
+        # contribution then warms up during training.
+        if self.use_layerscale:
+            init_val = 0.0 if self.zero_init_residual else self.layerscale_init
+            self.layerscale.data.fill_(init_val)
+        elif self.zero_init_residual:
+            nn.init.constant_(self.out_proj.weight, 0.0)
+            if self.out_proj.bias is not None:
+                nn.init.constant_(self.out_proj.bias, 0.0)
+
+    def forward(self, x: Tensor, grid_sizes: Tensor) -> Tensor:
+        """Args:
+            x: ``(sum_i T_i*H_i*W_i, C)`` flattened patch features, order ``(b t h w)``.
+            grid_sizes: ``(B, 3)`` int tensor; each row ``[T, H, W]``.
+        Returns:
+            ``(sum_i T_i*H_i*W_i, d_out)`` residual, same layout as ``x``.
+        """
+        all_same_grid = bool((grid_sizes == grid_sizes[0]).all())
+
+        if all_same_grid:
+            out = x
+            encoder_outputs = []
+            for stss_encoder in self.stss_encoders:
+                out = stss_encoder(out, grid_sizes=grid_sizes)
+                encoder_outputs.append(out)
+            out = torch.stack(encoder_outputs, dim=0).sum(dim=0)
+        else:
+            num_tokens_per_video = grid_sizes.prod(dim=1).tolist()
+            x_splits = x.split(num_tokens_per_video, dim=0)
+
+            processed_videos = []
+            for x_video, grid_size in zip(x_splits, grid_sizes, strict=False):
+                video_out = x_video
+                encoder_outputs = []
+                for stss_encoder in self.stss_encoders:
+                    video_out = stss_encoder(video_out, grid_sizes=grid_size.unsqueeze(0))
+                    encoder_outputs.append(video_out)
+                video_out = torch.stack(encoder_outputs, dim=0).sum(dim=0)
+                processed_videos.append(video_out)
+            out = torch.cat(processed_videos, dim=0)
+
+        out = out * self.layerscale if self.use_layerscale else self.out_proj(out)
+
+        return out

--- a/src/opentau/policies/pi07/rldx_video_encoder.py
+++ b/src/opentau/policies/pi07/rldx_video_encoder.py
@@ -1,0 +1,236 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""RLDX SigLIP video encoder: plain SigLIP + STSS motion module.
+
+``RLDXVideoEncoder`` is a standalone video encoder that runs a stock SigLIP ViT
+on each frame and injects the RLDX-1 space-time self-similarity (STSS) motion
+module (https://github.com/RLWRLD/RLDX-1) as a residual update at a single
+encoder layer. The motion module is the *only* cross-frame mechanism here:
+unlike :class:`~opentau.policies.pi07.video_encoder.SpaceTimeSiglipVideoEncoder`,
+this encoder has **no space-time / temporal attention layers** — the SigLIP
+tower is left exactly as pretrained, and temporal dynamics are captured solely
+by the STSS motion module (see :mod:`opentau.policies.pi07.motion_module`).
+
+It deliberately does not subclass or import the space-time encoder, so the two
+implementations stay fully independent.
+
+Contract (identical I/O to the space-time encoder, so it is a drop-in):
+    forward(video, obs_history_is_pad=None)
+        video: ``(B, T, C, H, W)`` pixel values in ``[0, 1]``, ``1 <= T``.
+        returns: ``(B, num_video_tokens, vlm_hidden_size)`` current-frame tokens.
+
+Notes:
+  - **Adds new learnable parameters** (the motion module). A plain pi05
+    checkpoint loads with ``strict=False``; with ``motion_zero_init=True``
+    (default) the motion residual is zero-gated at init so the policy is
+    byte-identical at step 0 and the motion contribution warms up.
+  - The motion module is registered under ``motion_module.*`` and stays
+    trainable even when the SigLIP tower is frozen by the caller.
+  - Motion runs only when there is a real time axis (``T > 1``); at ``T = 1``
+    the encoder is a plain single-frame SigLIP forward.
+  - ``obs_history_is_pad`` is accepted for API parity but unused: with no
+    temporal attention there are no cross-frame attention scores to mask.
+    Padded history frames only influence the motion residual via the STSS
+    correlation window (matching the RLDX-1 reference, which does not mask them).
+"""
+
+import torch
+from einops import rearrange
+from torch import Tensor, nn
+from transformers.models.siglip.modeling_siglip import SiglipVisionModel
+
+# Import triggers the transformers patch that drops the `/ sqrt(hidden_size)`
+# scaling stock HuggingFace applies after the multi_modal_projector, matching
+# the rest of the OpenTau vision path.
+import opentau.utils.transformers_patch  # noqa: F401
+from opentau.policies.pi07.motion_module import MotionModule
+
+
+class RLDXVideoEncoder(nn.Module):
+    """Plain SigLIP video encoder with an RLDX-1 STSS motion module.
+
+    The caller owns ``vision_tower`` and ``multi_modal_projector`` (constructed
+    by a ``PaliGemmaWithExpertModel`` / ``Gemma3WithExpertModel``); this module
+    holds them by reference (via a list, so their parameters are not
+    re-registered under this module's path) and adds only the motion module's
+    parameters.
+
+    Args:
+        vision_tower: A ``SiglipVisionModel`` (left unmodified — no layer wrapping).
+        multi_modal_projector: SigLIP-hidden -> VLA-hidden projector.
+        max_num_frames: Upper bound on ``T`` accepted by ``forward`` (validation cap).
+        gradient_checkpointing: Wrap each SigLIP layer forward in
+            ``torch.utils.checkpoint`` during training.
+        motion_insert_layer: 0-indexed encoder layer after which the motion
+            residual is injected. ``None`` -> mid-stack (``n_layers // 3``),
+            which is layer 9 for the 27-layer so400m tower (RLDX placement).
+        motion_hidden_dim: Internal correlation/feature width (``in_proj`` target).
+        motion_window: ``(L, kh, kw)`` space-time correlation window; spatial
+            size must fit the patch grid.
+        motion_corr_func: "cosine" / "dotproduct" / "dotproduct_softmax".
+        motion_n_encoders: Number of stacked STSS encoders (outputs summed).
+        motion_norm: "batchnorm" (RLDX default) / "groupnorm" (per-sample, no
+            cross-rank sync — recommended under FSDP/DeepSpeed/multi-rank) / "syncbn".
+        motion_int_mode: "lite" (single fuse conv) or "full" (3x3 conv stack).
+        motion_zero_init: Zero-init the residual so the module starts as a no-op.
+    """
+
+    def __init__(
+        self,
+        vision_tower: SiglipVisionModel,
+        multi_modal_projector: nn.Module,
+        max_num_frames: int,
+        gradient_checkpointing: bool = False,
+        *,
+        motion_insert_layer: int | None = None,
+        motion_hidden_dim: int = 256,
+        motion_window: tuple[int, int, int] = (5, 9, 9),
+        motion_corr_func: str = "cosine",
+        motion_n_encoders: int = 1,
+        motion_norm: str = "batchnorm",
+        motion_int_mode: str = "lite",
+        motion_zero_init: bool = True,
+    ):
+        super().__init__()
+        if max_num_frames < 1:
+            raise ValueError(f"max_num_frames ({max_num_frames}) must be >= 1.")
+
+        self.max_num_frames = max_num_frames
+        self.gradient_checkpointing = gradient_checkpointing
+
+        # Hold references in lists so nn.Module.__setattr__ does not re-register
+        # these caller-owned modules under this encoder's path (would duplicate
+        # ~400M params in state_dict).
+        self._vision_tower_ref: list[SiglipVisionModel] = [vision_tower]
+        self._multi_modal_projector_ref: list[nn.Module] = [multi_modal_projector]
+
+        vision_cfg = vision_tower.config
+        num_patches = (vision_cfg.image_size // vision_cfg.patch_size) ** 2
+        self.num_video_tokens = num_patches
+        self.siglip_hidden_size = vision_cfg.hidden_size
+
+        n_layers = len(vision_tower.vision_model.encoder.layers)
+
+        # Square patch grid (e.g. 16x16 for 224/14). The motion module needs the
+        # spatial grid shape to build the local correlation window.
+        grid = int(round(num_patches**0.5))
+        if grid * grid != num_patches:
+            raise ValueError(f"Motion module requires a square patch grid; got {num_patches} patches.")
+        self.motion_grid_hw = grid
+        if max(motion_window[1], motion_window[2]) > grid:
+            raise ValueError(
+                f"motion_window spatial size {motion_window[1:]} exceeds patch grid {grid}x{grid}."
+            )
+
+        # Default insert layer: mid-stack (n_layers // 3). For the 27-layer
+        # so400m tower this is layer 9, matching the RLDX-1 placement.
+        insert = n_layers // 3 if motion_insert_layer is None else motion_insert_layer
+        if not 0 <= insert < n_layers:
+            raise ValueError(f"motion_insert_layer ({insert}) out of range [0, {n_layers}).")
+        self.motion_insert_layer = insert
+
+        self.motion_module = MotionModule(
+            d_in=self.siglip_hidden_size,
+            d_hid=motion_hidden_dim,
+            d_out=self.siglip_hidden_size,
+            window=motion_window,
+            corr_func=motion_corr_func,
+            n_encoders=motion_n_encoders,
+            norm=motion_norm,
+            int_mode=motion_int_mode,
+            zero_init_residual=motion_zero_init,
+        )
+
+    @property
+    def vision_tower(self) -> SiglipVisionModel:
+        return self._vision_tower_ref[0]
+
+    @property
+    def multi_modal_projector(self) -> nn.Module:
+        return self._multi_modal_projector_ref[0]
+
+    def _apply_motion(self, hidden: Tensor, b: int, t: int) -> Tensor:
+        """Add the STSS motion residual to the per-patch hidden states.
+
+        Args:
+            hidden: ``(B*T, N, D)`` encoder hidden states at the insert layer.
+            b: batch size. t: number of frames.
+        Returns:
+            ``(B*T, N, D)`` hidden states with the motion residual added.
+        """
+        n = hidden.shape[1]
+        gh = self.motion_grid_hw
+        # (B*T, N, D) -> (B*T*N, D) preserving the (b t h w) token order the
+        # motion module expects.
+        flat = rearrange(hidden, "bt n d -> (bt n) d")
+        grid_sizes = torch.tensor([[t, gh, gh]] * b, dtype=torch.long, device=hidden.device)
+        residual = self.motion_module(flat, grid_sizes)  # (B*T*N, D)
+        residual = rearrange(residual, "(bt n) d -> bt n d", n=n)
+        return hidden + residual
+
+    def forward(self, video: Tensor, obs_history_is_pad: Tensor | None = None) -> Tensor:
+        """Encode a video clip and return the current-frame tokens.
+
+        Args:
+            video: ``(B, T, C, H, W)`` pixel values in ``[0, 1]``.
+            obs_history_is_pad: Accepted for API parity; unused (no temporal
+                attention to mask).
+
+        Returns:
+            ``(B, num_video_tokens, vlm_hidden_size)`` current-frame tokens.
+        """
+        if video.ndim != 5:
+            raise ValueError(f"Expected 5D input (B, T, C, H, W); got {tuple(video.shape)}.")
+        b, t, c, h, w = video.shape
+        if t < 1:
+            raise ValueError(f"Expected T >= 1; got {t}.")
+        if t > self.max_num_frames:
+            raise ValueError(
+                f"Expected T <= max_num_frames ({self.max_num_frames}); got {t}. "
+                "Reinstantiate the encoder with a larger max_num_frames."
+            )
+
+        # SigLIP expects pixel values in [-1, 1]; the dataset loader yields [0, 1].
+        video = video * 2.0 - 1.0
+        flat = rearrange(video, "b t c h w -> (b t) c h w")
+        hidden = self.vision_tower.vision_model.embeddings(flat)
+
+        use_ckpt = self.gradient_checkpointing and self.training
+        # Motion runs only with a real time axis (T > 1). It is intentionally NOT
+        # gradient-checkpointed: its BatchNorm3d (default) running stats would be
+        # updated twice under recompute. Memory stays bounded (runs at one layer).
+        run_motion = t > 1
+        for idx, layer in enumerate(self.vision_tower.vision_model.encoder.layers):
+            if use_ckpt:
+                layer_outputs = torch.utils.checkpoint.checkpoint(
+                    layer, hidden, None, False, use_reentrant=False
+                )
+            else:
+                layer_outputs = layer(hidden, None, False)
+            hidden = layer_outputs[0]
+
+            if run_motion and idx == self.motion_insert_layer:
+                hidden = self._apply_motion(hidden, b, t)
+
+        hidden = self.vision_tower.vision_model.post_layernorm(hidden)
+
+        # Drop past-timestep tokens: keep only the current frame (t = T-1).
+        hidden = rearrange(hidden, "(b t) n d -> b t n d", b=b, t=t)
+        current = hidden[:, -1]
+
+        # multi_modal_projector: SigLIP hidden -> VLA hidden. The `/ sqrt(...)`
+        # division is intentionally omitted to match the patched
+        # ``PaliGemmaModel.get_image_features``.
+        return self.multi_modal_projector(current)

--- a/tests/policies/test_pi05.py
+++ b/tests/policies/test_pi05.py
@@ -341,7 +341,7 @@ class TestPI05Integration:
             )
             args1 = tuple(args1)
             result = original_embed_prefix(*args1, **kwargs)
-            prefix_embs, prefix_pad_masks, prefix_att_masks = result
+            prefix_embs, prefix_pad_masks, prefix_att_masks, prefix_segment_ids = result
             captured_variables["prefix_pad_masks"] = prefix_pad_masks.clone()
             return result
 
@@ -497,7 +497,7 @@ class TestPI05Integration:
 
         def capture_embed_prefix_select_action(*args, **kwargs):
             result = original_embed_prefix_select_action(*args, **kwargs)
-            prefix_embs, prefix_pad_masks, prefix_att_masks = result
+            prefix_embs, prefix_pad_masks, prefix_att_masks, prefix_segment_ids = result
             captured_variables_select_action["prefix_pad_masks"] = prefix_pad_masks.clone()
             return result
 
@@ -743,3 +743,154 @@ class TestPI05ExecutionHorizon:
         )
         pad_masks, att_masks = out[1], out[2]
         assert pad_masks.shape[1] == att_masks.shape[1] == cfg.chunk_size
+
+
+class TestPI05ModalityEmbedding:
+    """CPU coverage for the hybrid modality scheme:
+
+    - ``config.use_modality_embedding``: a learnable, modality-indexed embedding
+      added on top of the VLM-prefix token embeddings (layered over RoPE).
+      Zero-initialized, so enabling it on an existing checkpoint is a no-op at
+      step 0 and the per-modality signal is learned from there.
+    - ``config.action_expert_position_gap``: the action expert is instead
+      separated from the prefix by a fixed RoPE position-id gap (no learned
+      embedding for the action modality).
+    """
+
+    HIDDEN = 4
+
+    def _make_prefix_fm(self, *, use_modality_embedding, monkeypatch):
+        """Partial PI05FlowMatching exposing only what ``embed_prefix`` reads on
+        the vision+language path (discrete state, no response, no discrete
+        actions) — no PaliGemma init."""
+        import types
+
+        import torch.nn as nn
+
+        from opentau.policies.pi05.modeling_pi05 import PI05FlowMatching
+
+        mod = "opentau.policies.pi05.modeling_pi05"
+        monkeypatch.setattr(f"{mod}._preferred_dtype", lambda: torch.float32)
+
+        hidden = self.HIDDEN
+        fm = object.__new__(PI05FlowMatching)
+        nn.Module.__init__(fm)
+
+        class _FakePaligemma:
+            def embed_image(self, img):
+                b = img.shape[0]
+                return rearrange(
+                    torch.arange(b * 2 * hidden, dtype=torch.float32), "(b s d) -> b s d", b=b, s=2, d=hidden
+                )
+
+            def embed_language_tokens(self, tokens):
+                return torch.full((*tokens.shape, hidden), 0.5, dtype=torch.float32)
+
+        fm.paligemma_with_expert = _FakePaligemma()
+        fm.config = types.SimpleNamespace(
+            state_type="discrete",
+            predict_response=False,
+            use_modality_embedding=use_modality_embedding,
+        )
+        if use_modality_embedding:
+            fm.modality_embedding = nn.Embedding(fm._NUM_PREFIX_MODALITIES, hidden)
+            nn.init.zeros_(fm.modality_embedding.weight)
+        return fm
+
+    def _prefix_inputs(self, bsize=2, lang_len=3):
+        images = [torch.zeros(bsize, 3, 4, 4)]
+        img_masks = [torch.ones(bsize, dtype=torch.bool)]
+        lang_tokens = torch.zeros(bsize, lang_len, dtype=torch.long)
+        lang_masks = torch.ones(bsize, lang_len, dtype=torch.bool)
+        return images, img_masks, lang_tokens, lang_masks
+
+    def test_embed_prefix_returns_segment_ids(self, monkeypatch):
+        """``embed_prefix`` returns a 4-tuple whose ``segment_ids`` mark each
+        token's modality (vision then language), shape-aligned with pad_masks."""
+        from opentau.policies.pi05.modeling_pi05 import PI05FlowMatching
+
+        fm = self._make_prefix_fm(use_modality_embedding=False, monkeypatch=monkeypatch)
+        embs, pad_masks, att_masks, segment_ids = PI05FlowMatching.embed_prefix(fm, *self._prefix_inputs())
+
+        assert segment_ids.shape == pad_masks.shape
+        # 2 image tokens (vision), then 3 language tokens (language).
+        expected = [fm._MODALITY_VISION] * 2 + [fm._MODALITY_LANGUAGE] * 3
+        for row in segment_ids.tolist():
+            assert row == expected
+
+    def test_zero_init_modality_embedding_is_noop(self, monkeypatch):
+        """Enabling the feature with the default zero-init table must not change
+        the embeddings vs. the feature being off."""
+        from opentau.policies.pi05.modeling_pi05 import PI05FlowMatching
+
+        inputs = self._prefix_inputs()
+        off = self._make_prefix_fm(use_modality_embedding=False, monkeypatch=monkeypatch)
+        on = self._make_prefix_fm(use_modality_embedding=True, monkeypatch=monkeypatch)
+
+        embs_off = PI05FlowMatching.embed_prefix(off, *inputs)[0]
+        embs_on = PI05FlowMatching.embed_prefix(on, *inputs)[0]
+        assert torch.equal(embs_off, embs_on)
+
+    def test_modality_embedding_shifts_each_modality(self, monkeypatch):
+        """With non-zero weights, each token is shifted by exactly its own
+        modality vector on top of the original embedding."""
+        from opentau.policies.pi05.modeling_pi05 import PI05FlowMatching
+
+        inputs = self._prefix_inputs()
+        off = self._make_prefix_fm(use_modality_embedding=False, monkeypatch=monkeypatch)
+        on = self._make_prefix_fm(use_modality_embedding=True, monkeypatch=monkeypatch)
+
+        # Distinct, recognizable vector per modality.
+        with torch.no_grad():
+            for slot in range(on._NUM_PREFIX_MODALITIES):
+                on.modality_embedding.weight[slot] = float(slot + 1)
+
+        embs_off = PI05FlowMatching.embed_prefix(off, *inputs)[0]
+        embs_on, _, _, segment_ids = PI05FlowMatching.embed_prefix(on, *inputs)
+        delta = embs_on - embs_off
+        expected_delta = on.modality_embedding(segment_ids)
+        assert torch.allclose(delta, expected_delta)
+        # Sanity: vision tokens shifted by 1.0, language tokens by 2.0.
+        assert torch.allclose(delta[:, :2], torch.ones_like(delta[:, :2]) * 1.0)
+        assert torch.allclose(delta[:, 2:], torch.ones_like(delta[:, 2:]) * 2.0)
+
+    def _make_position_fm(self, gap):
+        import types
+
+        import torch.nn as nn
+
+        from opentau.policies.pi05.modeling_pi05 import PI05FlowMatching
+
+        fm = object.__new__(PI05FlowMatching)
+        nn.Module.__init__(fm)
+        fm.config = types.SimpleNamespace(action_expert_position_gap=gap)
+        return fm
+
+    def test_action_expert_gap_disabled_is_contiguous(self):
+        """gap=0: action-expert positions continue contiguously after the
+        prefix (``prefix_offset + cumsum(pad) - 1``), unchanged from baseline."""
+        from opentau.policies.pi05.modeling_pi05 import PI05FlowMatching
+
+        fm = self._make_position_fm(gap=0)
+        prefix_offsets = torch.tensor([[10], [7]])
+        suffix_pad_masks = torch.ones(2, 4, dtype=torch.long)
+        pos = PI05FlowMatching._action_expert_position_ids(fm, prefix_offsets, suffix_pad_masks)
+        assert torch.equal(pos, torch.tensor([[10, 11, 12, 13], [7, 8, 9, 10]]))
+
+    def test_action_expert_gap_shifts_positions(self):
+        """gap>0: every action-expert position is pushed forward by exactly the
+        gap, while per-token spacing inside the chunk stays 1."""
+        from opentau.policies.pi05.modeling_pi05 import PI05FlowMatching
+
+        gap = 100
+        fm = self._make_position_fm(gap=gap)
+        prefix_offsets = torch.tensor([[10], [7]])
+        suffix_pad_masks = torch.ones(2, 4, dtype=torch.long)
+
+        baseline = PI05FlowMatching._action_expert_position_ids(
+            self._make_position_fm(gap=0), prefix_offsets, suffix_pad_masks
+        )
+        shifted = PI05FlowMatching._action_expert_position_ids(fm, prefix_offsets, suffix_pad_masks)
+        assert torch.equal(shifted - baseline, torch.full_like(baseline, gap))
+        # Spacing inside the chunk is unchanged (still increments of 1).
+        assert torch.equal(shifted.diff(dim=1), torch.ones(2, 3, dtype=shifted.dtype))


### PR DESCRIPTION
## What this does
Improves video encoder in pi05-mem using specific networks specialized in capturing motion features 

## How it was tested
Run benchmarks in simulations

2 ablations

Batch norm vs Group Norm  - for safe distributed training
Zero init vs RLDX initialization 

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [x] My PR includes policy-related changes.
  - [x] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
