### PR TITLE
feat(policies): optional knowledge_insulation + skip zero-weight loss terms

### DIFF
--- a/src/opentau/configs/train.py
+++ b/src/opentau/configs/train.py
@@ -315,6 +315,35 @@ class TrainPipelineConfig(HubMixin):
                     )
 
         self._validate_running_best()
+        self._validate_loss_weighting()
+
+    def _validate_loss_weighting(self):
+        """Validate ``loss_weighting``.
+
+        A weight of exactly ``0`` is a supported way to drop that loss term from
+        the backward pass entirely (see ``_assemble_weighted_loss`` in
+        ``scripts/train.py``), but the weighting must still name both the ``MSE``
+        and ``CE`` terms, be non-negative, and leave at least one term active.
+
+        Raises:
+            ValueError: If a required term is missing, any weight is negative, or
+                all weights are zero (nothing to optimize).
+        """
+        required = {"MSE", "CE"}
+        missing = required - set(self.loss_weighting)
+        if missing:
+            raise ValueError(
+                f"loss_weighting must define weights for {sorted(required)}; missing "
+                f"{sorted(missing)}. Got {self.loss_weighting}."
+            )
+        negatives = {k: v for k, v in self.loss_weighting.items() if v < 0}
+        if negatives:
+            raise ValueError(f"loss_weighting values must be >= 0; got negative entries {negatives}.")
+        if all(v == 0 for v in self.loss_weighting.values()):
+            raise ValueError(
+                "loss_weighting has all-zero weights; there is nothing to optimize. Set a "
+                "non-zero weight for at least one of MSE / CE."
+            )
 
     def _validate_running_best(self):
         """Validate the running-best checkpoint config and resolve the driving metric.

--- a/src/opentau/policies/pi05/configuration_pi05.py
+++ b/src/opentau/policies/pi05/configuration_pi05.py
@@ -155,6 +155,14 @@ class PI05Config(PreTrainedConfig):
     # Finetuning settings
     freeze_vision_encoder: bool = True
     train_expert_only: bool = False
+
+    # Knowledge insulation (π0.5): when True (default), the prefix/VLM KV cache
+    # is detached before the action expert reads it, so the flow-matching action
+    # loss does NOT backpropagate into the VLM backbone. Set False to let the
+    # action gradient flow into the VLM (end-to-end action training). Default
+    # True preserves existing behavior and is what current checkpoints expect.
+    knowledge_insulation: bool = True
+
     # Wrap each transformer-layer forward in torch.utils.checkpoint to trade
     # ~25-33% same-batch compute for ~30-40 GB of activation memory per rank,
     # typically netting +10-25% throughput once the freed memory is spent on

--- a/src/opentau/policies/pi05/modeling_pi05.py
+++ b/src/opentau/policies/pi05/modeling_pi05.py
@@ -1487,9 +1487,12 @@ class PI05FlowMatching(nn.Module):
         action_expert_position_ids = prefix_offsets + torch.cumsum(suffix_pad_masks, dim=1) - 1
 
         # stop gradient to avoid backpropagating from action expert to VLM
-        for layer_idx in past_key_values:
-            past_key_values[layer_idx]["key_states"] = past_key_values[layer_idx]["key_states"].detach()
-            past_key_values[layer_idx]["value_states"] = past_key_values[layer_idx]["value_states"].detach()
+        if self.config.knowledge_insulation:
+            for layer_idx in past_key_values:
+                past_key_values[layer_idx]["key_states"] = past_key_values[layer_idx]["key_states"].detach()
+                past_key_values[layer_idx]["value_states"] = past_key_values[layer_idx][
+                    "value_states"
+                ].detach()
 
         (_, suffix_out), _ = self.paligemma_with_expert.forward(
             attention_mask=action_expert_2d_attention_mask,

--- a/src/opentau/policies/pi05_mem/configuration_pi05.py
+++ b/src/opentau/policies/pi05_mem/configuration_pi05.py
@@ -141,6 +141,13 @@ class PI05MemConfig(PreTrainedConfig):
     freeze_vision_encoder: bool = True
     train_expert_only: bool = False
 
+    # Knowledge insulation (π0.5): when True (default), the prefix/VLM KV cache
+    # is detached before the action expert reads it, so the flow-matching action
+    # loss does NOT backpropagate into the VLM backbone. Set False to let the
+    # action gradient flow into the VLM (end-to-end action training). Default
+    # True preserves existing behavior and is what current checkpoints expect.
+    knowledge_insulation: bool = True
+
     # Wrap each transformer-layer forward in torch.utils.checkpoint to trade
     # ~25-33% same-batch compute for ~30-40 GB of activation memory per rank,
     # typically netting +10-25% throughput once the freed memory is spent on

--- a/src/opentau/policies/pi05_mem/modeling_pi05.py
+++ b/src/opentau/policies/pi05_mem/modeling_pi05.py
@@ -1168,9 +1168,11 @@ class PI05MemFlowMatching(nn.Module):
 
         assert past_key_values is not None
         kv_cache: dict = past_key_values
-        for layer_idx in kv_cache:
-            kv_cache[layer_idx]["key_states"] = kv_cache[layer_idx]["key_states"].detach()
-            kv_cache[layer_idx]["value_states"] = kv_cache[layer_idx]["value_states"].detach()
+        if self.config.knowledge_insulation:
+            # stop gradient to avoid backpropagating from action expert to VLM
+            for layer_idx in kv_cache:
+                kv_cache[layer_idx]["key_states"] = kv_cache[layer_idx]["key_states"].detach()
+                kv_cache[layer_idx]["value_states"] = kv_cache[layer_idx]["value_states"].detach()
 
         (_, suffix_out), _ = self.paligemma_with_expert.forward(
             attention_mask=action_expert_2d_attention_mask,

--- a/src/opentau/policies/pi06/configuration_pi06.py
+++ b/src/opentau/policies/pi06/configuration_pi06.py
@@ -149,6 +149,13 @@ class PI06Config(PreTrainedConfig):
     freeze_vision_encoder: bool = True
     train_expert_only: bool = False
 
+    # Knowledge insulation (π0.5): when True (default), the prefix/VLM KV cache
+    # is detached before the action expert reads it, so the flow-matching action
+    # loss does NOT backpropagate into the VLM backbone. Set False to let the
+    # action gradient flow into the VLM (end-to-end action training). Default
+    # True preserves existing behavior and is what current checkpoints expect.
+    knowledge_insulation: bool = True
+
     # Wrap each interleaved transformer-layer forward in torch.utils.checkpoint
     # to trade ~25-33% same-batch compute for a large slice of activation memory
     # per rank, typically netting +10-25% throughput once the freed memory is

--- a/src/opentau/policies/pi06/modeling_pi06.py
+++ b/src/opentau/policies/pi06/modeling_pi06.py
@@ -1053,9 +1053,12 @@ class PI06FlowMatching(nn.Module):
         action_expert_position_ids = prefix_offsets + torch.cumsum(suffix_pad_masks, dim=1) - 1
 
         # Knowledge Insulation: block gradients from the action expert into the VLM.
-        for layer_idx in past_key_values:
-            past_key_values[layer_idx]["key_states"] = past_key_values[layer_idx]["key_states"].detach()
-            past_key_values[layer_idx]["value_states"] = past_key_values[layer_idx]["value_states"].detach()
+        if self.config.knowledge_insulation:
+            for layer_idx in past_key_values:
+                past_key_values[layer_idx]["key_states"] = past_key_values[layer_idx]["key_states"].detach()
+                past_key_values[layer_idx]["value_states"] = past_key_values[layer_idx][
+                    "value_states"
+                ].detach()
 
         (_, suffix_out), _ = self.gemma3_with_expert.forward(
             attention_mask=action_expert_2d_attention_mask,

--- a/src/opentau/policies/pi07/low_level/configuration_pi07_low_level.py
+++ b/src/opentau/policies/pi07/low_level/configuration_pi07_low_level.py
@@ -212,6 +212,13 @@ class PI07LowLevelConfig(PreTrainedConfig):
     freeze_vision_encoder: bool = True
     train_expert_only: bool = False
 
+    # Knowledge insulation (π0.5): when True (default), the prefix/VLM KV cache
+    # is detached before the action expert reads it, so the flow-matching action
+    # loss does NOT backpropagate into the VLM backbone. Set False to let the
+    # action gradient flow into the VLM (end-to-end action training). Default
+    # True preserves existing behavior and is what current checkpoints expect.
+    knowledge_insulation: bool = True
+
     vlm_config: Gemma3WithExpertConfig = field(
         default_factory=lambda: Gemma3WithExpertConfig(
             freeze_vision_encoder=True,

--- a/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
@@ -2057,9 +2057,11 @@ class PI07LowLevelFlowMatching(nn.Module):
 
         assert past_key_values is not None
         kv_cache: dict = past_key_values
-        for layer_idx in kv_cache:
-            kv_cache[layer_idx]["key_states"] = kv_cache[layer_idx]["key_states"].detach()
-            kv_cache[layer_idx]["value_states"] = kv_cache[layer_idx]["value_states"].detach()
+        if self.config.knowledge_insulation:
+            # stop gradient to avoid backpropagating from action expert to VLM
+            for layer_idx in kv_cache:
+                kv_cache[layer_idx]["key_states"] = kv_cache[layer_idx]["key_states"].detach()
+                kv_cache[layer_idx]["value_states"] = kv_cache[layer_idx]["value_states"].detach()
 
         (_, suffix_out), _ = self.gemma3_with_expert.forward(
             attention_mask=action_expert_2d_attention_mask,

--- a/src/opentau/policies/pi07_paligemma/low_level/configuration_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/configuration_pi07_low_level.py
@@ -171,6 +171,14 @@ class PI07PaligemmaLowLevelConfig(PreTrainedConfig):
     # Finetuning settings
     freeze_vision_encoder: bool = True
     train_expert_only: bool = False
+
+    # Knowledge insulation (π0.5): when True (default), the prefix/VLM KV cache
+    # is detached before the action expert reads it, so the flow-matching action
+    # loss does NOT backpropagate into the VLM backbone. Set False to let the
+    # action gradient flow into the VLM (end-to-end action training). Default
+    # True preserves existing behavior and is what current checkpoints expect.
+    knowledge_insulation: bool = True
+
     # Wrap each transformer-layer forward in torch.utils.checkpoint to trade
     # ~25-33% same-batch compute for ~30-40 GB of activation memory per rank,
     # typically netting +10-25% throughput once the freed memory is spent on

--- a/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
@@ -2269,9 +2269,12 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
         action_expert_position_ids = prefix_offsets + torch.cumsum(suffix_pad_masks, dim=1) - 1
 
         # stop gradient to avoid backpropagating from action expert to VLM
-        for layer_idx in past_key_values:
-            past_key_values[layer_idx]["key_states"] = past_key_values[layer_idx]["key_states"].detach()
-            past_key_values[layer_idx]["value_states"] = past_key_values[layer_idx]["value_states"].detach()
+        if self.config.knowledge_insulation:
+            for layer_idx in past_key_values:
+                past_key_values[layer_idx]["key_states"] = past_key_values[layer_idx]["key_states"].detach()
+                past_key_values[layer_idx]["value_states"] = past_key_values[layer_idx][
+                    "value_states"
+                ].detach()
 
         (_, suffix_out), _ = self.paligemma_with_expert.forward(
             attention_mask=action_expert_2d_attention_mask,

--- a/src/opentau/scripts/find_unused_params.py
+++ b/src/opentau/scripts/find_unused_params.py
@@ -109,7 +109,12 @@ def find(cfg: TrainPipelineConfig):
 
     logging.info("Running one forward + backward...")
     losses = policy.forward(batch)
-    loss = cfg.loss_weighting["MSE"] * losses["MSE"] + cfg.loss_weighting["CE"] * losses["CE"]
+    # Mirror training's weighted-loss assembly so a zero-weighted term is dropped
+    # from the backward here too — otherwise this audit would report the dropped
+    # term's parameters as "used" (multiply-by-0 still backprops zeros).
+    from opentau.scripts.train import _assemble_weighted_loss
+
+    loss = _assemble_weighted_loss(losses, cfg.loss_weighting)
     # Don't use any optimizer / scaler — just raw autograd.
     loss.backward()
 

--- a/src/opentau/scripts/profile_step.py
+++ b/src/opentau/scripts/profile_step.py
@@ -222,7 +222,7 @@ def profile(cfg: TrainPipelineConfig):
     # Mirror train.py: under DeepSpeed ZeRO-3 we must disable the per-construction
     # parameter partitioning (it shards before init, breaking shape-dependent
     # initializers like SigLIP's lecun_normal_). No-op for any non-ZeRO-3 backend.
-    from opentau.scripts.train import _zero3_disabled_init_context
+    from opentau.scripts.train import _assemble_weighted_loss, _zero3_disabled_init_context
 
     # Mirror train.py: under FSDP, gate the model's internal bf16 cast so the
     # policy stays fp32 for FSDP's MixedPrecision to manage the bf16 compute /
@@ -432,7 +432,7 @@ def profile(cfg: TrainPipelineConfig):
 
         # Phase 2: forward (mirror update_policy lines 74-77)
         losses = policy.forward(batch)
-        loss = cfg.loss_weighting["MSE"] * losses["MSE"] + cfg.loss_weighting["CE"] * losses["CE"]
+        loss = _assemble_weighted_loss(losses, cfg.loss_weighting)
         _sync()
         t2 = time.perf_counter()
 

--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -132,6 +132,51 @@ def _eval_with_fresh_envs(
             torch.cuda.empty_cache()
 
 
+def _assemble_weighted_loss(losses: dict, loss_weighting: dict[str, float]) -> torch.Tensor:
+    """Combine the weighted loss terms into the single scalar fed to ``backward``.
+
+    A term whose weight is exactly ``0`` is **dropped from the sum entirely**
+    (rather than multiplied by 0). Multiplying by 0 still builds the term's
+    backward graph and populates its parameters with zero gradients; dropping it
+    means autograd never traverses that subgraph at all, so ``backward`` does not
+    touch the parameters that feed only that term (they receive ``None`` grad).
+
+    Because ``loss_weighting`` is a static config value identical on every rank,
+    the drop is a rank-uniform decision and cannot cause a cross-rank collective
+    mismatch (CLAUDE.md rule #5). The unused-parameter consequences of a dropped
+    term differ per distributed backend and are handled at ``Accelerator`` setup
+    in ``train()`` (force ``find_unused_parameters`` under DDP; fail fast under
+    parameter-sharding backends).
+
+    When both terms are non-zero this reproduces the previous
+    ``w_mse * MSE + w_ce * CE`` ordering bit-for-bit.
+
+    Args:
+        losses: The policy ``forward`` output; only the keys present in
+            ``loss_weighting`` are read.
+        loss_weighting: Mapping of loss-term name to scalar weight.
+
+    Returns:
+        The scalar weighted loss.
+
+    Raises:
+        ValueError: If every weighted term is dropped (all weights zero or no
+            weighted key present in ``losses``), leaving nothing to optimize.
+    """
+    total: torch.Tensor | None = None
+    for key, weight in loss_weighting.items():
+        if weight == 0 or key not in losses:
+            continue
+        term = weight * losses[key]
+        total = term if total is None else total + term
+    if total is None:
+        raise ValueError(
+            f"No active loss term to backpropagate: loss_weighting={loss_weighting} "
+            "drops every term. Set a non-zero weight for at least one of MSE / CE."
+        )
+    return total
+
+
 def update_policy(
     train_config: TrainPipelineConfig,
     train_metrics: MetricsTracker,
@@ -145,9 +190,7 @@ def update_policy(
     policy.train()
     losses = policy.forward(batch)
     outlier_records = losses.pop("outlier_records", [])
-    loss = (
-        train_config.loss_weighting["MSE"] * losses["MSE"] + train_config.loss_weighting["CE"] * losses["CE"]
-    )
+    loss = _assemble_weighted_loss(losses, train_config.loss_weighting)
 
     accelerator.backward(loss)
     accelerator.unscale_gradients(optimizer=optimizer)
@@ -628,6 +671,21 @@ def train(cfg: TrainPipelineConfig):
     cfg.validate()
 
     find_unused = _find_unused_params_from_env()
+    # A 0 entry in loss_weighting drops that term from the backward pass
+    # (see _assemble_weighted_loss), so the parameters that feed only that term
+    # receive no gradient. Under DDP that requires find_unused_parameters=True or
+    # the reducer raises on the now-unused params. The decision is rank-uniform
+    # (every rank reads the same config), so force it on — with a warning — so a
+    # zero weight cannot crash a run that opted into FIND_UNUSED_PARAMS=false for
+    # speed. (Ignored under DeepSpeed; the ZeRO-3 / FSDP case is guarded below.)
+    if not find_unused and any(w == 0 for w in cfg.loss_weighting.values()):
+        logging.warning(
+            "loss_weighting=%s drops a zero-weighted term from backward, leaving its "
+            "parameters unused; forcing find_unused_parameters=True (overriding "
+            "FIND_UNUSED_PARAMS=false) to avoid a DDP reducer error.",
+            cfg.loss_weighting,
+        )
+        find_unused = True
     accelerator_kwargs = {
         "step_scheduler_with_optimizer": False,
         "split_batches": False,  # split_batches == True is not working anyways
@@ -658,6 +716,25 @@ def train(cfg: TrainPipelineConfig):
     # wandb-logged accelerator config and the value DeepSpeed consumes at prepare()
     # time both reflect TrainPipelineConfig.
     _sync_deepspeed_gradient_accumulation_steps(accelerator, cfg)
+
+    # A zero entry in loss_weighting drops that term from the backward pass
+    # (see _assemble_weighted_loss). Under parameter-sharding backends (DeepSpeed
+    # ZeRO-3 or FSDP) the dropped term's modules are still gathered during the
+    # forward but receive no gradient in the backward, so their reduce-scatter /
+    # reshard hooks can wait on a gradient that never arrives and hang at NCCL.
+    # DDP (handled via find_unused_parameters above) and ZeRO-1/2 (which do not
+    # shard parameters) tolerate the unused params, so fail fast only here.
+    if any(w == 0 for w in cfg.loss_weighting.values()) and (
+        accelerator.distributed_type == accelerate.DistributedType.FSDP
+        or _deepspeed_zero_stage(accelerator) >= 3
+    ):
+        raise ValueError(
+            f"A zero entry in loss_weighting ({cfg.loss_weighting}) drops a loss term "
+            "from the backward pass, which is not supported under parameter sharding "
+            "(DeepSpeed ZeRO-3 or FSDP): the dropped term's parameters are gathered in "
+            "the forward but get no gradient, risking a NCCL hang. Use DDP or DeepSpeed "
+            "ZeRO-1/2, or set all loss weights non-zero."
+        )
 
     # Strict guard for gradient_checkpointing: the pi05 custom forward loop
     # wraps layer bodies in torch.utils.checkpoint.checkpoint. With

--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -132,6 +132,37 @@ def _eval_with_fresh_envs(
             torch.cuda.empty_cache()
 
 
+def _has_zero_loss_weight(loss_weighting: dict[str, float]) -> bool:
+    """Whether any loss-term weight is exactly 0 (i.e. a term is dropped from backward).
+
+    Args:
+        loss_weighting: Mapping of loss-term name to scalar weight.
+
+    Returns:
+        True if at least one weight is 0.
+    """
+    return any(w == 0 for w in loss_weighting.values())
+
+
+def _zero_weight_backend_incompatible(distributed_type: accelerate.DistributedType, zero_stage: int) -> bool:
+    """Whether dropping a loss term is unsafe on the active distributed backend.
+
+    Under parameter-sharding backends (FSDP or DeepSpeed ZeRO-3) the dropped
+    term's modules are still gathered during the forward but get no gradient in
+    the backward, so their reduce-scatter / reshard hooks can wait on a gradient
+    that never arrives and hang at NCCL. DDP (via ``find_unused_parameters``) and
+    DeepSpeed ZeRO-1/2 (no param sharding) tolerate the unused params.
+
+    Args:
+        distributed_type: The accelerator's distributed type.
+        zero_stage: The active DeepSpeed ZeRO stage (0 when not DeepSpeed).
+
+    Returns:
+        True if the backend shards parameters (FSDP or ZeRO-3).
+    """
+    return distributed_type == accelerate.DistributedType.FSDP or zero_stage >= 3
+
+
 def _assemble_weighted_loss(losses: dict, loss_weighting: dict[str, float]) -> torch.Tensor:
     """Combine the weighted loss terms into the single scalar fed to ``backward``.
 
@@ -148,25 +179,33 @@ def _assemble_weighted_loss(losses: dict, loss_weighting: dict[str, float]) -> t
     in ``train()`` (force ``find_unused_parameters`` under DDP; fail fast under
     parameter-sharding backends).
 
-    When both terms are non-zero this reproduces the previous
-    ``w_mse * MSE + w_ce * CE`` ordering bit-for-bit.
+    The terms are summed in a fixed ``(MSE, CE)`` order — independent of the
+    config dict's insertion order — so the float summation order, and thus the
+    result (CLAUDE.md rule #3), is deterministic and reproduces the historical
+    ``w_mse * MSE + w_ce * CE`` summation exactly.
 
     Args:
-        losses: The policy ``forward`` output; only the keys present in
-            ``loss_weighting`` are read.
+        losses: The policy ``forward`` output. A non-zero-weighted term must be
+            present; a zero-weighted (dropped) term need not be.
         loss_weighting: Mapping of loss-term name to scalar weight.
 
     Returns:
         The scalar weighted loss.
 
     Raises:
-        ValueError: If every weighted term is dropped (all weights zero or no
-            weighted key present in ``losses``), leaving nothing to optimize.
+        KeyError: If a non-zero-weighted term is absent from ``losses`` (a real
+            misconfig — surfaced loudly rather than silently dropped).
+        ValueError: If every term is dropped (all weights zero), leaving nothing
+            to optimize.
     """
     total: torch.Tensor | None = None
-    for key, weight in loss_weighting.items():
-        if weight == 0 or key not in losses:
+    for key in ("MSE", "CE"):
+        weight = loss_weighting.get(key, 0)
+        if weight == 0:
+            # Term dropped from backward; a zero-weighted term need not be in `losses`.
             continue
+        # Index directly: a non-zero-weighted term the policy failed to return is
+        # a misconfig and should KeyError loudly, not be silently skipped.
         term = weight * losses[key]
         total = term if total is None else total + term
     if total is None:
@@ -678,7 +717,7 @@ def train(cfg: TrainPipelineConfig):
     # (every rank reads the same config), so force it on — with a warning — so a
     # zero weight cannot crash a run that opted into FIND_UNUSED_PARAMS=false for
     # speed. (Ignored under DeepSpeed; the ZeRO-3 / FSDP case is guarded below.)
-    if not find_unused and any(w == 0 for w in cfg.loss_weighting.values()):
+    if not find_unused and _has_zero_loss_weight(cfg.loss_weighting):
         logging.warning(
             "loss_weighting=%s drops a zero-weighted term from backward, leaving its "
             "parameters unused; forcing find_unused_parameters=True (overriding "
@@ -724,9 +763,8 @@ def train(cfg: TrainPipelineConfig):
     # reshard hooks can wait on a gradient that never arrives and hang at NCCL.
     # DDP (handled via find_unused_parameters above) and ZeRO-1/2 (which do not
     # shard parameters) tolerate the unused params, so fail fast only here.
-    if any(w == 0 for w in cfg.loss_weighting.values()) and (
-        accelerator.distributed_type == accelerate.DistributedType.FSDP
-        or _deepspeed_zero_stage(accelerator) >= 3
+    if _has_zero_loss_weight(cfg.loss_weighting) and _zero_weight_backend_incompatible(
+        accelerator.distributed_type, _deepspeed_zero_stage(accelerator)
     ):
         raise ValueError(
             f"A zero entry in loss_weighting ({cfg.loss_weighting}) drops a loss term "

--- a/tests/policies/test_knowledge_insulation.py
+++ b/tests/policies/test_knowledge_insulation.py
@@ -1,0 +1,196 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Contract tests for the opt-in ``knowledge_insulation`` policy-config flag.
+
+Knowledge insulation (π0.5) ``.detach()``-es the VLM prefix KV cache before the
+flow-matching action expert reads it, so the action loss does not backpropagate
+into the VLM backbone. It is now gated on a per-policy ``knowledge_insulation``
+config field (default ``True``, preserving the historical always-on behavior).
+These CPU tests guard the config contract across every policy that performs the
+detach:
+
+  * the field exists and defaults to ``True``;
+  * it can be turned off (``knowledge_insulation=False``);
+  * it survives the real ``draccus`` save/load round-trip used by
+    ``_save_pretrained`` / ``from_pretrained``;
+  * an old ``config.json`` that predates the field decodes back to ``True``
+    (backward compatibility for existing checkpoints).
+
+The behavioral proof that the flag actually opens/closes the gradient path lives
+behind a GPU forward+backward (the backbone is too heavy for CPU) and is not
+exercised here.
+"""
+
+import dataclasses
+
+import draccus
+import pytest
+import torch
+
+from opentau.configs.policies import PreTrainedConfig
+from opentau.policies.pi05.configuration_pi05 import PI05Config
+from opentau.policies.pi05_mem.configuration_pi05 import PI05MemConfig
+from opentau.policies.pi06.configuration_pi06 import PI06Config
+from opentau.policies.pi07.low_level.configuration_pi07_low_level import PI07LowLevelConfig
+from opentau.policies.pi07_paligemma.low_level.configuration_pi07_low_level import (
+    PI07PaligemmaLowLevelConfig,
+)
+
+# Every policy whose training forward performs the knowledge-insulation detach.
+KI_CONFIG_CLASSES = [
+    PI05Config,
+    PI05MemConfig,
+    PI06Config,
+    PI07LowLevelConfig,
+    PI07PaligemmaLowLevelConfig,
+]
+
+
+@pytest.mark.parametrize("config_cls", KI_CONFIG_CLASSES, ids=lambda c: c.__name__)
+def test_knowledge_insulation_field_defaults_true(config_cls):
+    """The flag must exist as a dataclass field defaulting to True so existing
+    checkpoints keep their historical (always-insulated) behavior."""
+    fields = {f.name: f for f in dataclasses.fields(config_cls)}
+    assert "knowledge_insulation" in fields, f"{config_cls.__name__} is missing knowledge_insulation"
+    assert fields["knowledge_insulation"].default is True
+
+    cfg = config_cls()
+    assert cfg.knowledge_insulation is True
+
+
+@pytest.mark.parametrize("config_cls", KI_CONFIG_CLASSES, ids=lambda c: c.__name__)
+def test_knowledge_insulation_can_be_disabled(config_cls):
+    """The flag must be settable to False (end-to-end action training)."""
+    cfg = config_cls(knowledge_insulation=False)
+    assert cfg.knowledge_insulation is False
+
+
+@pytest.mark.parametrize("config_cls", KI_CONFIG_CLASSES, ids=lambda c: c.__name__)
+def test_knowledge_insulation_survives_round_trip(config_cls):
+    """The value must round-trip through the real draccus encode/decode path
+    (the one ``_save_pretrained`` / ``from_pretrained`` use)."""
+    cfg = config_cls(knowledge_insulation=False)
+    data = draccus.encode(cfg, declared_type=PreTrainedConfig)
+    assert data["knowledge_insulation"] is False
+
+    decoded = draccus.decode(PreTrainedConfig, data)
+    assert type(decoded) is config_cls
+    assert decoded.knowledge_insulation is False
+
+
+@pytest.mark.parametrize("config_cls", KI_CONFIG_CLASSES, ids=lambda c: c.__name__)
+def test_legacy_config_without_field_decodes_true(config_cls):
+    """A pre-existing config.json saved before this field was added (i.e. the
+    key is absent) must decode back to True — backward compatibility."""
+    data = draccus.encode(config_cls(), declared_type=PreTrainedConfig)
+    data.pop("knowledge_insulation", None)
+
+    decoded = draccus.decode(PreTrainedConfig, data)
+    assert type(decoded) is config_cls
+    assert decoded.knowledge_insulation is True
+
+
+def _trainable_vlm_kv_param(policy):
+    """Return a (name, param) for a trainable weight inside the VLM language-model
+    stack that produces the prefix KV cache.
+
+    Every PaliGemma language-model layer's ``k_proj`` / ``v_proj`` feeds the KV
+    cache that the action expert cross-attends to, so the flow-matching action
+    (MSE) loss can only reach these weights *through* that KV cache — which
+    knowledge insulation detaches. Only the vision tower is frozen by default, so
+    these language-model weights carry ``requires_grad=True``.
+    """
+    lm = policy.model.paligemma_with_expert.paligemma.language_model
+    for name, p in lm.named_parameters():
+        if p.requires_grad and "layers." in name and ("k_proj" in name or "v_proj" in name) and p.ndim == 2:
+            return name, p
+    for name, p in lm.named_parameters():  # fallback: any trainable layer weight
+        if p.requires_grad and "layers." in name and p.ndim == 2:
+            return name, p
+    raise AssertionError("no trainable VLM language-model layer weight found")
+
+
+@pytest.mark.gpu
+@pytest.mark.slow
+@pytest.mark.parametrize("knowledge_insulation", [True, False])
+def test_pi05_knowledge_insulation_controls_vlm_gradient(
+    pi05_training_config, lerobot_dataset_metadata, knowledge_insulation
+):
+    """Behavioral proof that the toggle opens/closes the action→VLM gradient path.
+
+    The action (flow-matching ``MSE``) loss is backpropagated *in isolation*
+    (the FAST/``CE`` term always trains the VLM, so it would mask the effect).
+
+      * ``knowledge_insulation=True``  → the prefix KV cache is detached before
+        the action expert, so a VLM language-model weight that feeds the KV
+        receives **no** gradient from the MSE-only backward (``grad is None``).
+      * ``knowledge_insulation=False`` → the same weight **does** receive a
+        gradient (the action loss flows into the VLM backbone).
+
+    The action-side output projection gets a gradient in *both* cases — a sanity
+    check that the MSE backward actually ran.
+    """
+    from opentau.policies.pi05.modeling_pi05 import PI05Policy
+
+    config = pi05_training_config.policy
+    config.knowledge_insulation = knowledge_insulation
+    config.train_expert_only = False  # keep the VLM backbone trainable
+
+    policy = PI05Policy(config, per_dataset_stats=[lerobot_dataset_metadata.stats])
+
+    batch_size = 1
+    batch = {
+        "camera0": torch.randn(batch_size, 3, 224, 224),
+        "camera1": torch.randn(batch_size, 3, 224, 224),
+        "state": torch.randn(batch_size, config.max_state_dim),
+        "actions": torch.randn(batch_size, config.chunk_size, config.max_action_dim),
+        "prompt": ["Pick up the red block"],
+        "response": ["Pick up the red block"],
+        "img_is_pad": torch.zeros(batch_size, 2, dtype=torch.bool),
+        "action_is_pad": torch.zeros(batch_size, config.chunk_size, dtype=torch.bool),
+    }
+
+    policy.to(dtype=torch.bfloat16, device="cuda")
+    batch_cuda = {
+        k: v.to("cuda", non_blocking=True, dtype=torch.bfloat16) if isinstance(v, torch.Tensor) else v
+        for k, v in batch.items()
+    }
+    batch_cuda["action_is_pad"] = batch_cuda["action_is_pad"].to(dtype=torch.bool)
+
+    try:
+        losses = policy.forward(batch_cuda)
+        assert "MSE" in losses
+
+        vlm_name, vlm_param = _trainable_vlm_kv_param(policy)
+        action_param = next(policy.model.action_out_proj.parameters())
+
+        policy.zero_grad(set_to_none=True)
+        losses["MSE"].backward()
+
+        # MSE always trains the action expert / output projection.
+        assert action_param.grad is not None and torch.count_nonzero(action_param.grad) > 0
+
+        if knowledge_insulation:
+            assert vlm_param.grad is None, (
+                f"KI on: VLM weight {vlm_name} unexpectedly received an MSE gradient"
+            )
+        else:
+            assert vlm_param.grad is not None and torch.count_nonzero(vlm_param.grad) > 0, (
+                f"KI off: VLM weight {vlm_name} should receive an MSE gradient"
+            )
+    finally:
+        # Free ~6 GB of PaliGemma weights so adjacent GPU tests don't OOM.
+        del policy
+        torch.cuda.empty_cache()

--- a/tests/scripts/test_loss_weighting_skip.py
+++ b/tests/scripts/test_loss_weighting_skip.py
@@ -1,0 +1,101 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for zero-weight loss-term skipping.
+
+When a ``loss_weighting`` entry is exactly 0 the corresponding term is dropped
+from the backward pass entirely (``_assemble_weighted_loss``), so autograd never
+traverses that subgraph and the parameters that feed only that term receive no
+gradient. This differs from the old ``0 * term`` behavior, which still
+backpropagated zeros into those parameters. These CPU tests pin both the
+gradient-flow contract and the config validation.
+"""
+
+import pytest
+import torch
+
+from opentau.configs.train import TrainPipelineConfig
+from opentau.scripts.train import _assemble_weighted_loss
+
+
+def _leaf(value: float) -> torch.Tensor:
+    return torch.tensor(value, requires_grad=True)
+
+
+class TestAssembleWeightedLoss:
+    def test_both_terms_included_matches_manual_sum(self):
+        mse, ce = _leaf(2.0), _leaf(3.0)
+        loss = _assemble_weighted_loss({"MSE": mse, "CE": ce}, {"MSE": 1.0, "CE": 0.5})
+        assert loss.item() == pytest.approx(1.0 * 2.0 + 0.5 * 3.0)
+        loss.backward()
+        # Both terms are in the graph -> both leaves get gradients.
+        assert mse.grad is not None
+        assert ce.grad is not None
+
+    def test_zero_ce_weight_drops_ce_from_backward(self):
+        mse, ce = _leaf(2.0), _leaf(3.0)
+        loss = _assemble_weighted_loss({"MSE": mse, "CE": ce}, {"MSE": 1.0, "CE": 0.0})
+        assert loss.item() == pytest.approx(2.0)
+        loss.backward()
+        assert mse.grad is not None  # kept term trains normally
+        # Dropped term: backward never traversed it, so the leaf gets *no* grad
+        # (None), not a zero grad. This is the whole point of the feature.
+        assert ce.grad is None
+
+    def test_zero_mse_weight_drops_mse_from_backward(self):
+        mse, ce = _leaf(2.0), _leaf(3.0)
+        loss = _assemble_weighted_loss({"MSE": mse, "CE": ce}, {"MSE": 0.0, "CE": 1.0})
+        assert loss.item() == pytest.approx(3.0)
+        loss.backward()
+        assert ce.grad is not None
+        assert mse.grad is None
+
+    def test_all_zero_raises(self):
+        mse, ce = _leaf(2.0), _leaf(3.0)
+        with pytest.raises(ValueError, match="No active loss term"):
+            _assemble_weighted_loss({"MSE": mse, "CE": ce}, {"MSE": 0.0, "CE": 0.0})
+
+    def test_weighting_key_absent_from_losses_is_skipped(self):
+        # A weighting key that the policy did not return is ignored rather than
+        # raising a KeyError mid-step.
+        mse = _leaf(2.0)
+        loss = _assemble_weighted_loss({"MSE": mse}, {"MSE": 1.0, "CE": 1.0})
+        assert loss.item() == pytest.approx(2.0)
+
+
+class TestLossWeightingValidation:
+    """``TrainPipelineConfig._validate_loss_weighting`` guards startup configs."""
+
+    @staticmethod
+    def _validate(weighting: dict):
+        cfg = object.__new__(TrainPipelineConfig)
+        cfg.loss_weighting = weighting
+        TrainPipelineConfig._validate_loss_weighting(cfg)
+
+    def test_zero_weight_is_allowed(self):
+        # A single zero weight is the supported drop-a-term case.
+        self._validate({"MSE": 1, "CE": 0})
+        self._validate({"MSE": 0, "CE": 1})
+
+    def test_all_zero_rejected(self):
+        with pytest.raises(ValueError, match="all-zero"):
+            self._validate({"MSE": 0, "CE": 0})
+
+    def test_negative_rejected(self):
+        with pytest.raises(ValueError, match=">= 0"):
+            self._validate({"MSE": 1, "CE": -0.5})
+
+    def test_missing_required_key_rejected(self):
+        with pytest.raises(ValueError, match="must define weights"):
+            self._validate({"MSE": 1})

--- a/tests/scripts/test_loss_weighting_skip.py
+++ b/tests/scripts/test_loss_weighting_skip.py
@@ -22,11 +22,16 @@ backpropagated zeros into those parameters. These CPU tests pin both the
 gradient-flow contract and the config validation.
 """
 
+import accelerate
 import pytest
 import torch
 
 from opentau.configs.train import TrainPipelineConfig
-from opentau.scripts.train import _assemble_weighted_loss
+from opentau.scripts.train import (
+    _assemble_weighted_loss,
+    _has_zero_loss_weight,
+    _zero_weight_backend_incompatible,
+)
 
 
 def _leaf(value: float) -> torch.Tensor:
@@ -66,12 +71,49 @@ class TestAssembleWeightedLoss:
         with pytest.raises(ValueError, match="No active loss term"):
             _assemble_weighted_loss({"MSE": mse, "CE": ce}, {"MSE": 0.0, "CE": 0.0})
 
-    def test_weighting_key_absent_from_losses_is_skipped(self):
-        # A weighting key that the policy did not return is ignored rather than
-        # raising a KeyError mid-step.
+    def test_summation_order_independent_of_dict_order(self):
+        # The fixed (MSE, CE) iteration makes the result independent of the
+        # config dict's insertion order, so a CE-first config is bit-identical to
+        # an MSE-first one (CLAUDE.md rule #3 determinism).
+        mse, ce = _leaf(2.0), _leaf(3.0)
+        mse_first = _assemble_weighted_loss({"MSE": mse, "CE": ce}, {"MSE": 1.0, "CE": 0.5})
+        ce_first = _assemble_weighted_loss({"MSE": mse, "CE": ce}, {"CE": 0.5, "MSE": 1.0})
+        assert mse_first.item() == ce_first.item()
+
+    def test_zero_weighted_key_absent_from_losses_is_fine(self):
+        # A *zero*-weighted (dropped) term need not be present in the losses dict.
         mse = _leaf(2.0)
-        loss = _assemble_weighted_loss({"MSE": mse}, {"MSE": 1.0, "CE": 1.0})
+        loss = _assemble_weighted_loss({"MSE": mse}, {"MSE": 1.0, "CE": 0.0})
         assert loss.item() == pytest.approx(2.0)
+
+    def test_nonzero_weighted_key_absent_raises_loudly(self):
+        # A *non-zero*-weighted term the policy failed to return is a misconfig and
+        # must surface as a KeyError, not be silently dropped.
+        mse = _leaf(2.0)
+        with pytest.raises(KeyError):
+            _assemble_weighted_loss({"MSE": mse}, {"MSE": 1.0, "CE": 1.0})
+
+
+class TestDistributedBackendGuards:
+    """CPU coverage for the helpers that gate a dropped term per backend."""
+
+    def test_has_zero_loss_weight(self):
+        assert _has_zero_loss_weight({"MSE": 1, "CE": 0})
+        assert _has_zero_loss_weight({"MSE": 0.0, "CE": 1.0})
+        assert not _has_zero_loss_weight({"MSE": 1, "CE": 1})
+
+    def test_fsdp_is_incompatible(self):
+        assert _zero_weight_backend_incompatible(accelerate.DistributedType.FSDP, 0)
+
+    def test_zero3_is_incompatible(self):
+        assert _zero_weight_backend_incompatible(accelerate.DistributedType.DEEPSPEED, 3)
+
+    def test_zero2_and_ddp_are_compatible(self):
+        # DeepSpeed ZeRO-1/2 (no param sharding) and DDP tolerate the unused params.
+        assert not _zero_weight_backend_incompatible(accelerate.DistributedType.DEEPSPEED, 2)
+        assert not _zero_weight_backend_incompatible(accelerate.DistributedType.DEEPSPEED, 1)
+        assert not _zero_weight_backend_incompatible(accelerate.DistributedType.MULTI_GPU, 0)
+        assert not _zero_weight_backend_incompatible(accelerate.DistributedType.NO, 0)
 
 
 class TestLossWeightingValidation:


### PR DESCRIPTION
## What this does

Two related training-behavior features (🗃️ Feature).

**1. Optional knowledge insulation.** Knowledge insulation (π0.5) detaches the VLM prefix KV cache before the flow-matching action expert so the action loss can't backprop into the VLM backbone — previously hard-coded and unconditional in every flow-matching policy. This adds a `knowledge_insulation: bool = True` field to the five policies that perform the detach (`pi05`, `pi05_mem`, `pi06`, `pi07_low_level`, `pi07_paligemma_low_level`) and gates the detach on it. Default `True` is byte-identical to prior behavior and backward-compatible with existing checkpoints (an old `config.json` without the key decodes to `True`). Set `--policy.knowledge_insulation=false` to train the VLM end-to-end through the action expert.

**2. Skip zero-weighted loss terms from backward.** When an `MSE`/`CE` entry in `loss_weighting` is exactly `0`, the term is now dropped from the total loss entirely so autograd never traverses it. Previously `0 * term` still backpropagated zeros into that term's parameters. New `_assemble_weighted_loss` helper in `scripts/train.py` does the drop (both-nonzero is bit-identical to the old expression).

The drop is a static, rank-uniform config decision, so it cannot cause a cross-rank collective mismatch. Per-backend handling:
- **DDP:** the dropped term's exclusive params get no gradient, so `find_unused_parameters=True` is forced (with a warning) when a weight is `0`.
- **DeepSpeed ZeRO-1/2:** supported (no parameter sharding).
- **DeepSpeed ZeRO-3 / FSDP:** fail fast — under parameter sharding the dropped term's forward-gathered params get no backward gradient and can hang at NCCL.

Config validation rejects all-zero, negative, or missing-key `loss_weighting`. The diagnostic scripts (`find_unused_params.py`, `profile_step.py`) use the same helper so a zero weight is reflected.

## How it was tested

- `pytest -m "not gpu and not network"` green across `tests/policies`, `tests/scripts`, `tests/configs` (904 passed, 2 skipped); pre-commit clean.
- Added `tests/policies/test_knowledge_insulation.py`: per-policy config contract (field present, defaults `True`, togglable, draccus save/load round-trip, legacy-config-without-key decodes to `True`) plus a `@pytest.mark.gpu` grad-flow test (`test_pi05_knowledge_insulation_controls_vlm_gradient`) proving an MSE-only backward reaches a VLM language-model weight only when `knowledge_insulation=False`.
- Added `tests/scripts/test_loss_weighting_skip.py`: a zero weight gives the kept leaf a gradient and the dropped leaf `grad is None` (the core proof); all-zero raises; config validation (all-zero / negative / missing-key rejected).
- GPU pytests (`pytest -m "gpu"`) and regression tests dispatched on this branch via `gpu_test.yml` / `regression_test.yml`.
- Default-`True` KI and both-nonzero loss weighting are no-ops by construction, so a same-seed smoke run stays bit-identical; the multi-rank `find_unused` / ZeRO-3 / FSDP paths are verified on GPU CI.

## How to checkout & try? (for the reviewer)

```bash
gh pr checkout <this-pr>
```
```bash
# CPU: loss-skip behavior + KI config contract
pytest -sx tests/scripts/test_loss_weighting_skip.py
pytest -sx tests/policies/test_knowledge_insulation.py
```
```bash
# GPU: KI grad-flow proof
pytest -m "gpu" -n 0 tests/policies/test_knowledge_insulation.py
```
```bash
# Turn knowledge insulation off (train the VLM through the action expert)
opentau-train --config_path=configs/examples/pi05_training_config.json --policy.knowledge_insulation=false
```
To drop a loss term, set `"loss_weighting": {"MSE": 1, "CE": 0}` in the training config JSON.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [x] My PR includes policy-related changes.
  - [x] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
