### PR TITLE
feat(grpc): optional x-tuner-api-key authentication

### DIFF
--- a/src/opentau/scripts/grpc/auth.py
+++ b/src/opentau/scripts/grpc/auth.py
@@ -27,6 +27,7 @@ stack) so the auth logic can be unit-tested cheaply, CPU-only.
 
 from __future__ import annotations
 
+import hmac
 import logging
 import os
 
@@ -57,9 +58,18 @@ def extract_api_key(metadata) -> str | None:
 
 
 def is_authorized(metadata, expected_key: str) -> bool:
-    """Whether ``metadata`` carries the expected api key."""
+    """Whether ``metadata`` carries the expected api key.
+
+    The comparison uses :func:`hmac.compare_digest` so it runs in constant time
+    with respect to the secret, avoiding leaking key length/prefix information
+    through timing (this guards a public endpoint).
+    """
     provided = extract_api_key(metadata)
-    return provided is not None and provided == expected_key
+    if provided is None:
+        return False
+    # compare_digest needs both operands the same type; bytes is robust to
+    # non-ASCII values that would make the str overload raise TypeError.
+    return hmac.compare_digest(provided.encode("utf-8"), expected_key.encode("utf-8"))
 
 
 class ApiKeyInterceptor(grpc.ServerInterceptor):

--- a/src/opentau/scripts/grpc/auth.py
+++ b/src/opentau/scripts/grpc/auth.py
@@ -1,0 +1,102 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Optional API-key authentication for the robot inference gRPC server.
+
+Authentication is opt-in: it is activated only when the
+``TUNER_INFERENCE_API_KEY`` environment variable is set to a non-empty value.
+When active, every RPC must carry the matching key in the ``x-tuner-api-key``
+metadata header; otherwise the call is rejected with ``UNAUTHENTICATED``.
+When the variable is unset/empty the server runs with no authentication (the
+historical behavior), so this is fully backward compatible.
+
+This module deliberately depends only on ``grpc`` (not torch / the policy
+stack) so the auth logic can be unit-tested cheaply, CPU-only.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import grpc
+
+logger = logging.getLogger(__name__)
+
+API_KEY_HEADER = "x-tuner-api-key"
+API_KEY_ENV = "TUNER_INFERENCE_API_KEY"
+
+
+def extract_api_key(metadata) -> str | None:
+    """Return the ``x-tuner-api-key`` value from gRPC invocation metadata.
+
+    Args:
+        metadata: Iterable of ``(key, value)`` pairs (gRPC invocation
+            metadata), or ``None``.
+
+    Returns:
+        The api key string if present, else ``None``.
+    """
+    if not metadata:
+        return None
+    for key, value in metadata:
+        if key == API_KEY_HEADER:
+            return value
+    return None
+
+
+def is_authorized(metadata, expected_key: str) -> bool:
+    """Whether ``metadata`` carries the expected api key."""
+    provided = extract_api_key(metadata)
+    return provided is not None and provided == expected_key
+
+
+class ApiKeyInterceptor(grpc.ServerInterceptor):
+    """Server interceptor that requires a valid ``x-tuner-api-key`` header.
+
+    RPCs whose metadata is missing the header or carries a wrong key are
+    aborted with ``grpc.StatusCode.UNAUTHENTICATED`` before reaching the
+    servicer.
+    """
+
+    def __init__(self, api_key: str):
+        if not api_key:
+            raise ValueError("api_key must be a non-empty string")
+        self._api_key = api_key
+
+        def _abort(request, context):
+            context.abort(
+                grpc.StatusCode.UNAUTHENTICATED,
+                f"Missing or invalid {API_KEY_HEADER}",
+            )
+
+        self._deny = grpc.unary_unary_rpc_method_handler(_abort)
+
+    def intercept_service(self, continuation, handler_call_details):
+        if is_authorized(handler_call_details.invocation_metadata, self._api_key):
+            return continuation(handler_call_details)
+        return self._deny
+
+
+def interceptor_from_env() -> ApiKeyInterceptor | None:
+    """Build an :class:`ApiKeyInterceptor` from ``TUNER_INFERENCE_API_KEY``.
+
+    Returns:
+        An interceptor when the env var is set to a non-empty (stripped)
+        value, else ``None`` (authentication disabled).
+    """
+    api_key = os.getenv(API_KEY_ENV, "").strip()
+    if not api_key:
+        return None
+    return ApiKeyInterceptor(api_key)

--- a/src/opentau/scripts/grpc/server.py
+++ b/src/opentau/scripts/grpc/server.py
@@ -69,7 +69,7 @@ from opentau.configs.train import TrainPipelineConfig
 from opentau.datasets.lerobot_dataset import BaseDataset
 from opentau.planner.gemini_er_planner import GeminiERPlanner
 from opentau.policies.factory import get_policy_class
-from opentau.scripts.grpc import robot_inference_pb2, robot_inference_pb2_grpc
+from opentau.scripts.grpc import auth, robot_inference_pb2, robot_inference_pb2_grpc
 from opentau.utils.random_utils import set_seed
 from opentau.utils.utils import (
     attempt_torch_compile,
@@ -541,8 +541,18 @@ def serve(cfg: TrainPipelineConfig):
         cfg: Training pipeline configuration including server settings.
     """
     server_cfg = cfg.server
+
+    # Optional API-key auth, activated by the TUNER_INFERENCE_API_KEY env var.
+    # When unset, the server keeps its historical no-auth behavior.
+    interceptors = []
+    auth_interceptor = auth.interceptor_from_env()
+    if auth_interceptor is not None:
+        interceptors.append(auth_interceptor)
+        logger.info("API-key authentication enabled (require %s header)", auth.API_KEY_HEADER)
+
     server = grpc.server(
         futures.ThreadPoolExecutor(max_workers=server_cfg.max_workers),
+        interceptors=interceptors,
         options=[
             ("grpc.max_send_message_length", server_cfg.max_send_message_length),
             ("grpc.max_receive_message_length", server_cfg.max_receive_message_length),

--- a/tests/scripts/test_grpc_auth.py
+++ b/tests/scripts/test_grpc_auth.py
@@ -88,9 +88,7 @@ def _start_echo_server(interceptor):
             response_serializer=lambda b: b,
         ),
     }
-    server.add_generic_rpc_handlers(
-        (grpc.method_handlers_generic_handler("test.Echo", handlers),)
-    )
+    server.add_generic_rpc_handlers((grpc.method_handlers_generic_handler("test.Echo", handlers),))
     port = server.add_insecure_port("[::]:0")
     server.start()
     return server, port

--- a/tests/scripts/test_grpc_auth.py
+++ b/tests/scripts/test_grpc_auth.py
@@ -65,13 +65,25 @@ def _start_echo_server(interceptor):
     def _echo(request, context):
         return request
 
-    handler = grpc.unary_unary_rpc_method_handler(
-        _echo,
-        request_deserializer=lambda b: b,
-        response_serializer=lambda b: b,
-    )
+    def _echo_stream(request_iterator, context):
+        yield from request_iterator
+
+    handlers = {
+        # unary_unary RPC.
+        "Ping": grpc.unary_unary_rpc_method_handler(
+            _echo,
+            request_deserializer=lambda b: b,
+            response_serializer=lambda b: b,
+        ),
+        # stream_stream RPC, mirroring the real server's StreamActionChunks.
+        "PingStream": grpc.stream_stream_rpc_method_handler(
+            _echo_stream,
+            request_deserializer=lambda b: b,
+            response_serializer=lambda b: b,
+        ),
+    }
     server.add_generic_rpc_handlers(
-        (grpc.method_handlers_generic_handler("test.Echo", {"Ping": handler}),)
+        (grpc.method_handlers_generic_handler("test.Echo", handlers),)
     )
     port = server.add_insecure_port("[::]:0")
     server.start()
@@ -84,10 +96,24 @@ def _ping(port, metadata):
         return call(b"hello", metadata=metadata)
 
 
+def _ping_stream(port, metadata):
+    with grpc.insecure_channel(f"localhost:{port}") as channel:
+        call = channel.stream_stream("/test.Echo/PingStream")
+        return list(call(iter([b"hello", b"world"]), metadata=metadata))
+
+
 def test_valid_key_passes_through():
     server, port = _start_echo_server(auth.ApiKeyInterceptor("secret"))
     try:
         assert _ping(port, ((auth.API_KEY_HEADER, "secret"),)) == b"hello"
+    finally:
+        server.stop(None)
+
+
+def test_valid_key_passes_through_streaming():
+    server, port = _start_echo_server(auth.ApiKeyInterceptor("secret"))
+    try:
+        assert _ping_stream(port, ((auth.API_KEY_HEADER, "secret"),)) == [b"hello", b"world"]
     finally:
         server.stop(None)
 
@@ -98,6 +124,19 @@ def test_missing_or_wrong_key_unauthenticated(metadata):
     try:
         with pytest.raises(grpc.RpcError) as exc:
             _ping(port, metadata)
+        assert exc.value.code() == grpc.StatusCode.UNAUTHENTICATED
+    finally:
+        server.stop(None)
+
+
+@pytest.mark.parametrize("metadata", [(), (("x-tuner-api-key", "wrong"),)])
+def test_missing_or_wrong_key_unauthenticated_streaming(metadata):
+    # The deny handler is unary_unary only, but context.abort() fires before the
+    # request stream is read, so it must reject stream_stream RPCs too.
+    server, port = _start_echo_server(auth.ApiKeyInterceptor("secret"))
+    try:
+        with pytest.raises(grpc.RpcError) as exc:
+            _ping_stream(port, metadata)
         assert exc.value.code() == grpc.StatusCode.UNAUTHENTICATED
     finally:
         server.stop(None)

--- a/tests/scripts/test_grpc_auth.py
+++ b/tests/scripts/test_grpc_auth.py
@@ -1,0 +1,103 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the optional API-key interceptor (``auth.py``).
+
+CPU-only, no torch / policy stack: the interceptor is exercised against a
+throwaway in-process gRPC server with a generic echo handler.
+"""
+
+from concurrent import futures
+
+import grpc
+import pytest
+
+from opentau.scripts.grpc import auth
+
+
+def test_extract_api_key():
+    md = (("other", "x"), (auth.API_KEY_HEADER, "secret"))
+    assert auth.extract_api_key(md) == "secret"
+    assert auth.extract_api_key(()) is None
+    assert auth.extract_api_key(None) is None
+
+
+def test_is_authorized():
+    md = ((auth.API_KEY_HEADER, "secret"),)
+    assert auth.is_authorized(md, "secret") is True
+    assert auth.is_authorized(md, "wrong") is False
+    assert auth.is_authorized((), "secret") is False
+
+
+def test_interceptor_from_env(monkeypatch):
+    monkeypatch.delenv(auth.API_KEY_ENV, raising=False)
+    assert auth.interceptor_from_env() is None
+
+    monkeypatch.setenv(auth.API_KEY_ENV, "   ")  # whitespace == unset
+    assert auth.interceptor_from_env() is None
+
+    monkeypatch.setenv(auth.API_KEY_ENV, "k")
+    assert isinstance(auth.interceptor_from_env(), auth.ApiKeyInterceptor)
+
+
+def test_interceptor_requires_non_empty_key():
+    with pytest.raises(ValueError):
+        auth.ApiKeyInterceptor("")
+
+
+def _start_echo_server(interceptor):
+    server = grpc.server(
+        futures.ThreadPoolExecutor(max_workers=1),
+        interceptors=[interceptor],
+    )
+
+    def _echo(request, context):
+        return request
+
+    handler = grpc.unary_unary_rpc_method_handler(
+        _echo,
+        request_deserializer=lambda b: b,
+        response_serializer=lambda b: b,
+    )
+    server.add_generic_rpc_handlers(
+        (grpc.method_handlers_generic_handler("test.Echo", {"Ping": handler}),)
+    )
+    port = server.add_insecure_port("[::]:0")
+    server.start()
+    return server, port
+
+
+def _ping(port, metadata):
+    with grpc.insecure_channel(f"localhost:{port}") as channel:
+        call = channel.unary_unary("/test.Echo/Ping")
+        return call(b"hello", metadata=metadata)
+
+
+def test_valid_key_passes_through():
+    server, port = _start_echo_server(auth.ApiKeyInterceptor("secret"))
+    try:
+        assert _ping(port, ((auth.API_KEY_HEADER, "secret"),)) == b"hello"
+    finally:
+        server.stop(None)
+
+
+@pytest.mark.parametrize("metadata", [(), (("x-tuner-api-key", "wrong"),)])
+def test_missing_or_wrong_key_unauthenticated(metadata):
+    server, port = _start_echo_server(auth.ApiKeyInterceptor("secret"))
+    try:
+        with pytest.raises(grpc.RpcError) as exc:
+            _ping(port, metadata)
+        assert exc.value.code() == grpc.StatusCode.UNAUTHENTICATED
+    finally:
+        server.stop(None)

--- a/tests/scripts/test_grpc_auth.py
+++ b/tests/scripts/test_grpc_auth.py
@@ -23,7 +23,13 @@ from concurrent import futures
 import grpc
 import pytest
 
-from opentau.scripts.grpc import auth
+# Import via the fully-qualified module path with an alias rather than
+# ``from opentau.scripts.grpc import auth``: the local ``opentau.scripts.grpc``
+# package shares its last path component with the third-party ``grpc`` package,
+# and the "from ... import" form makes some static analyzers resolve the bare
+# ``import grpc`` above to the local package (yielding spurious "imported both
+# ways" / "non-callable" findings on ``grpc.server(...)``).
+import opentau.scripts.grpc.auth as auth
 
 
 def test_extract_api_key():


### PR DESCRIPTION
## What this does

Adds **opt-in API-key authentication** for the robot inference gRPC server (🗃️ Feature).

- New module `src/opentau/scripts/grpc/auth.py`: `ApiKeyInterceptor` + `interceptor_from_env()` (grpc-only, no torch / policy stack).
- `server.py`: attaches the interceptor in `serve()` when `TUNER_INFERENCE_API_KEY` is set.
- When active, every RPC must carry `x-tuner-api-key: <key>` in gRPC metadata matching the env var; otherwise the call is rejected with `UNAUTHENTICATED` (the deny handler aborts before the request stream is read, so bidi-streaming `StreamActionChunks` is rejected too).
- When the env var is unset or empty, the server keeps its historical no-auth behavior — fully backward compatible.

**Motivation:** the inference server exposes GPU inference via a public gateway. Without authentication, anyone who knows the endpoint can call the model. This interceptor lets each deployment require a per-service API key without breaking local dev or existing OpenTau users who do not set the env var.

| File | What |
|------|------|
| `src/opentau/scripts/grpc/auth.py` | Interceptor logic (grpc-only, no torch) |
| `src/opentau/scripts/grpc/server.py` | Wire interceptor into `serve()` |
| `tests/scripts/test_grpc_auth.py` | CPU-only unit tests (10 cases) |

## How it was tested

- Added `tests/scripts/test_grpc_auth.py` — 10 CPU-only cases covering key extraction, constant-time comparison (`hmac.compare_digest` over UTF-8 bytes), env-var gating, and an in-process echo server exercising both the `unary_unary` and `stream_stream` paths for valid-key pass-through and missing/wrong-key `UNAUTHENTICATED` denial.
- E2E against a live inference deployment: `HealthCheck` + `GetActionChunk` with a valid `x-tuner-api-key` succeed; a missing or wrong key returns `UNAUTHENTICATED`.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/scripts/test_grpc_auth.py
```

```bash
# Auth disabled (historical behavior) — env var unset:
python src/opentau/scripts/grpc/server.py --config_path=<your_server_config.json>

# Auth enabled — every RPC must send x-tuner-api-key: my-secret-key:
TUNER_INFERENCE_API_KEY=my-secret-key python src/opentau/scripts/grpc/server.py --config_path=<your_server_config.json>
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
