### PR TITLE
chore: bump version to v0.8.0

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,8 +30,8 @@ project = "OpenTau"
 copyright = "2026, Tensor Auto Inc"
 author = "Tensor Auto Inc"
 
-version = "0.7.0"
-release = "0.7.0"
+version = "0.8.0"
+release = "0.8.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ huggingface = "https://huggingface.co/TensorAuto"
 
 [project]
 name = "opentau"
-version = "0.7.0"
+version = "0.8.0"
 description = "OpenTau: Tensor's VLA Training Infrastructure for Real-World Robotics in Pytorch"
 authors = [
     { name = "Shuheng Liu", email = "wish1104@icloud.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -2157,7 +2157,7 @@ wheels = [
 
 [[package]]
 name = "opentau"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
## What this does
Bumps the package version from `0.7.0` to `0.8.0`. (📝 Documentation / chore)

Updated in the three source-of-truth locations:
- `pyproject.toml` (`[project].version`)
- `docs/source/conf.py` (`version` / `release`)
- `uv.lock` (the editable `opentau` package entry)

`src/opentau/__version__.py` reads the version from package metadata via `importlib.metadata`, so it tracks `pyproject.toml` automatically and needs no edit.

## How it was tested
- `uv lock --locked` passes, confirming `uv.lock` is consistent with the bumped `pyproject.toml`.
- `pre-commit run --files pyproject.toml docs/source/conf.py uv.lock` passes (ruff, ruff-format, check-toml, typos, license header, bandit, etc.).
- Verified no stray `0.7.0` references remain in the package (the only other occurrences are the unrelated third-party `annotated-types` and `safetensors` pins in `uv.lock`).

## How to checkout & try? (for the reviewer)
```bash
git checkout worktree-bump-v0.8.0
uv lock --locked            # confirms lock matches pyproject
grep '^version' pyproject.toml docs/source/conf.py
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.
