### PR TITLE
docs(readme): mention cosmos3 policy and link design docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Whether you use the official OpenPi codebase or LeRobot’s reimplementation, yo
 - Dropout in the VLM to reduce overfitting
 - Authentic $\pi_{0.6}$ policy with a Gemma 3 4B backbone, 448×448 vision, and 5-step flow matching
 - Hierarchical $\pi_{0.7}$ policy: high-level planner + low-level controller with a SpaceTime SigLIP video encoder on a Gemma 3 backbone
+- `cosmos3` policy: the $\pi_{0.5}$ flow-matching recipe on a frozen Qwen3-VL-32B (NVIDIA Cosmos3-Super reasoner) backbone with a custom sub-1B action expert
 - A reinforcement learning pipeline described in $\pi^*_{0.6}$
 - And more...
 
@@ -67,6 +68,8 @@ For using the Google Colab notebooks to train and evaluate models, find the cola
 To spin up a $\pi_{0.6}$ training run, start from [configs/examples/pi06_training_config.json](https://github.com/TensorAuto/OpenTau/blob/main/configs/examples/pi06_training_config.json). The policy is selected by setting `"type": "pi06"` and differs from $\pi_{0.5}$ in its Gemma 3 4B backbone, 448×448 image resolution, ~860M-parameter action expert, and 5-step flow-matching default.
 
 $\pi_{0.7}$ splits the model into a high-level planner that proposes subgoals and a low-level controller that executes them. The current implementation pairs a Gemma 3 backbone with a SpaceTime SigLIP video encoder so the controller can attend over temporal context, and the two stages train independently. To train the low-level controller, start from [configs/examples/pi07_low_level_libero.json](https://github.com/TensorAuto/OpenTau/blob/main/configs/examples/pi07_low_level_libero.json) (select via `"type": "pi07_low_level"`); the high-level planner is registered as `"type": "pi07_high_level"`.
+
+`cosmos3` reuses the $\pi_{0.5}$ flow-matching recipe on a frozen Qwen3-VL-32B backbone (NVIDIA's Cosmos3-Super reasoner) paired with a custom sub-1B action expert. Select it with `"type": "cosmos3"` and start from [configs/examples/cosmos3_training_config.json](https://github.com/TensorAuto/OpenTau/blob/main/configs/examples/cosmos3_training_config.json); see the [model documentation](https://opentau.readthedocs.io/en/latest/model.html#cosmos3) for the design adjustments.
 
 ## Training Diagnostics
 


### PR DESCRIPTION
## What this does
Adds a short mention of the new `cosmos3` policy to the README — one feature bullet and one Quick Start paragraph — and links to the model documentation for the full design adjustments rather than repeating them inline. (📝 Documentation)

## How it was tested
Docs-only change. Ran `pre-commit run --files README.md` (trailing-whitespace, end-of-file-fixer, typos, gitleaks) — all passed. Verified the referenced `configs/examples/cosmos3_training_config.json` exists and that the model docs anchor (`model.html#cosmos3`) corresponds to the existing `cosmos3` section in `docs/source/model.rst`.

## How to checkout & try? (for the reviewer)
```bash
git fetch origin worktree-readme-cosmos3 && git checkout worktree-readme-cosmos3
# render/skim the README "Quick Start" section and the feature list
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
