### PR TITLE
feat(robocasa): default eval scene split to pretrain

### DIFF
--- a/src/opentau/envs/configs.py
+++ b/src/opentau/envs/configs.py
@@ -344,7 +344,9 @@ class RoboCasaEnv(EnvConfig):
         visualization_height: Height of visualization frames.
         visualization_width: Width of visualization frames.
         split: RoboCasa dataset split (``None``/``"all"``/``"pretrain"``/
-            ``"target"``). Left ``None`` unless a task-group shortcut sets it.
+            ``"target"``). Defaults to ``"pretrain"`` when left ``None`` — every
+            task-group shortcut and concrete single-task config resolves to the
+            pretrain kitchen-scene distribution; set explicitly to override.
         obj_registries: Object-mesh registries to sample assets from. Defaults to
             ``["lightwheel"]`` (the pack the asset downloader ships by default);
             add ``"objaverse"`` only after downloading that ~30GB pack.

--- a/src/opentau/envs/robocasa.py
+++ b/src/opentau/envs/robocasa.py
@@ -359,6 +359,31 @@ def _resolve_tasks(task: str) -> tuple[list[str], str | None]:
     return names, None
 
 
+def _resolve_split(explicit_split: str | None, group_split: str | None) -> str:
+    r"""Resolve the final RoboCasa kitchen-scene split.
+
+    Precedence: an explicit ``env.split`` wins; otherwise a task-group shortcut's
+    split (from :data:`_TASK_GROUP_SPLITS`) applies; otherwise default to
+    ``"pretrain"``. The default makes concrete / comma-separated single-task
+    configs (which carry no group split) evaluate against the pretrain
+    distribution rather than ``"all"``.
+
+    Args:
+        explicit_split: The split set on ``env.split`` (``None`` if unset).
+        group_split: The split implied by a task-group shortcut (``None`` for a
+            concrete or comma-separated task name).
+
+    Returns:
+        One of ``"all"`` / ``"pretrain"`` / ``"target"`` — a value
+        ``RoboCasaGymEnv`` accepts.
+    """
+    if explicit_split is not None:
+        return explicit_split
+    if group_split is not None:
+        return group_split
+    return "pretrain"
+
+
 def _official_task_horizon(task: str) -> int | None:
     r"""RoboCasa's official per-task horizon (max env steps), read from the dataset
     registry -- e.g. ``OpenCabinet``=1050, ``CloseFridge``=900, ``TurnOnMicrowave``=450.
@@ -535,7 +560,8 @@ class RoboCasaEnv(gym.Env):
             observation_height: Height of observation images.
             visualization_width: Width of visualization frames.
             visualization_height: Height of visualization frames.
-            split: RoboCasa dataset split (``None``/``"all"``/``"pretrain"``/``"target"``).
+            split: RoboCasa dataset split (``None``/``"all"``/``"pretrain"``/``"target"``);
+                ``None`` resolves to ``"pretrain"`` at env construction.
             episode_length: Max steps per episode (``_max_episode_steps``); defaults to 1000.
             obj_registries: Object-mesh registries to sample assets from.
             episode_index: Per-worker index (``0..n_envs-1``) used as the
@@ -632,12 +658,14 @@ class RoboCasaEnv(gym.Env):
             from robocasa.wrappers.gym_wrapper import RoboCasaGymEnv
 
             # RoboCasaGymEnv defaults split="test", which create_env rejects (only
-            # None/"all"/"pretrain"/"target" are valid). Always pass a valid value.
+            # None/"all"/"pretrain"/"target" are valid). create_robocasa_envs resolves
+            # the split for the eval path; default to "pretrain" here too so a direct
+            # RoboCasaEnv(split=None) construction stays valid and consistent.
             self._env = RoboCasaGymEnv(
                 env_name=self.task,
                 camera_widths=self.observation_width,
                 camera_heights=self.observation_height,
-                split=self.split if self.split is not None else "all",
+                split=self.split if self.split is not None else "pretrain",
                 obj_registries=self.obj_registries,
             )
 
@@ -854,8 +882,7 @@ def create_robocasa_envs(
 
     camera_names = _parse_camera_names(camera_name)
     task_names, group_split = _resolve_tasks(str(task))
-    if group_split is not None and split is None:
-        split = group_split
+    split = _resolve_split(split, group_split)
 
     # Shard tasks across accelerator ranks (round-robin), so distributed eval
     # spreads tasks disjointly and per-task video keys stay unique after the

--- a/src/opentau/envs/robocasa.py
+++ b/src/opentau/envs/robocasa.py
@@ -82,10 +82,12 @@ DEFAULT_OBJ_REGISTRIES: tuple[str, ...] = ("lightwheel",)
 # Task-group shortcuts accepted as ``env.task``. A group name expands to the
 # upstream RoboCasa task list and auto-sets the dataset split; individual task
 # names (optionally comma-separated) take precedence and only match exactly.
+# All groups default to the ``pretrain`` split (the kitchen-scene distribution we
+# evaluate against). Pass ``env.split`` explicitly to override for a given group.
 _TASK_GROUP_SPLITS = {
-    "atomic_seen": "target",
-    "composite_seen": "target",
-    "composite_unseen": "target",
+    "atomic_seen": "pretrain",
+    "composite_seen": "pretrain",
+    "composite_unseen": "pretrain",
     "pretrain50": "pretrain",
     "pretrain100": "pretrain",
     "pretrain200": "pretrain",

--- a/tests/envs/test_robocasa.py
+++ b/tests/envs/test_robocasa.py
@@ -51,6 +51,7 @@ from opentau.envs.robocasa import (
     _official_task_horizon,
     _parse_camera_names,
     _resolve_robocasa_assets_root,
+    _resolve_split,
     _resolve_tasks,
     _robocasa_pkg_assets_dir,
     _robocasa_unshadowed,
@@ -221,6 +222,62 @@ def _fake_dataset_registry(atomic: dict, composite: dict):
             sys.modules["robocasa.utils.dataset_registry"] = saved
         else:
             sys.modules.pop("robocasa.utils.dataset_registry", None)
+
+
+@contextlib.contextmanager
+def _fake_task_group_registry(target: dict, pretraining: dict):
+    """Inject a fake ``robocasa.utils.dataset_registry`` exposing ``TARGET_TASKS``
+    / ``PRETRAINING_TASKS`` so ``_resolve_tasks`` can expand group shortcuts
+    without the real sim (mirrors ``_fake_dataset_registry``)."""
+    import sys
+    import types
+
+    mod = types.ModuleType("robocasa.utils.dataset_registry")
+    mod.TARGET_TASKS = target
+    mod.PRETRAINING_TASKS = pretraining
+    saved = sys.modules.get("robocasa.utils.dataset_registry")
+    sys.modules["robocasa.utils.dataset_registry"] = mod
+    try:
+        with patch("opentau.envs.robocasa._import_robocasa_with_version_shim"):
+            yield
+    finally:
+        if saved is not None:
+            sys.modules["robocasa.utils.dataset_registry"] = saved
+        else:
+            sys.modules.pop("robocasa.utils.dataset_registry", None)
+
+
+class TestResolveSplitAndTaskGroups:
+    """Split resolution + task-group → split mapping.
+
+    Pins that every benchmark-group shortcut resolves to the ``pretrain`` split
+    and that concrete single-task configs default to ``pretrain`` too, so an
+    accidental revert of either default fails CI instead of passing silently.
+    """
+
+    _TARGET_GROUPS = ("atomic_seen", "composite_seen", "composite_unseen")
+    _PRETRAIN_GROUPS = ("pretrain50", "pretrain100", "pretrain200", "pretrain300")
+
+    def test_all_task_groups_resolve_to_pretrain_split(self):
+        target = {g: [f"{g}Task"] for g in self._TARGET_GROUPS}
+        pretraining = {g: [f"{g}Task"] for g in self._PRETRAIN_GROUPS}
+        with _fake_task_group_registry(target, pretraining):
+            for group in self._TARGET_GROUPS + self._PRETRAIN_GROUPS:
+                names, split = _resolve_tasks(group)
+                assert names == [f"{group}Task"]
+                assert split == "pretrain", f"{group} must resolve to the pretrain split"
+
+    def test_resolve_split_defaults_unset_to_pretrain(self):
+        # Concrete / comma-separated task names carry no group split -> pretrain.
+        assert _resolve_split(None, None) == "pretrain"
+
+    def test_resolve_split_uses_group_split_when_no_explicit(self):
+        assert _resolve_split(None, "pretrain") == "pretrain"
+        assert _resolve_split(None, "target") == "target"
+
+    def test_resolve_split_explicit_overrides_group_and_default(self):
+        assert _resolve_split("all", None) == "all"
+        assert _resolve_split("target", "pretrain") == "target"
 
 
 class TestOfficialTaskHorizon:


### PR DESCRIPTION
## What this does

RoboCasa eval reads the kitchen-scene `split` (`all` / `pretrain` / `target`)
independently of the task list. This PR makes `pretrain` the default scene
split for **every** eval entry point:

1. **Task-group shortcuts** — `atomic_seen` / `composite_seen` /
   `composite_unseen` previously resolved to the `target` split while the
   `pretrain*` groups resolved to `pretrain`. They now all resolve to
   `pretrain` (`_TASK_GROUP_SPLITS` in `src/opentau/envs/robocasa.py`).

2. **Concrete / comma-separated single-task configs** (e.g. `CloseFridge`) now
   default to `pretrain` too. Previously they carried no group split, left
   `env.split=None`, and `_ensure_env` coerced that to `all` (every kitchen
   scene) at env construction.

Precedence is centralized in a new `_resolve_split(explicit, group)` helper:
**explicit `env.split` > task-group split > `pretrain`**. The `_ensure_env`
`None`→`pretrain` fallback keeps a direct `RoboCasaEnv(split=None)`
construction consistent with the eval path.

**Behavior note (scene distribution):** evaluating a held-out / `target` task
by concrete name now samples `pretrain` scenes by default instead of `all`.
Set `env.split` explicitly (`all` or `target`) to restore the previous
distribution — the explicit override still wins.

🗃️ Feature

## How it was tested

- Added `TestResolveSplitAndTaskGroups` in `tests/envs/test_robocasa.py`,
  pinning all seven group shortcuts to the `pretrain` split (mocking
  `TARGET_TASKS` / `PRETRAINING_TASKS`) plus the single-task default and the
  `explicit > group > pretrain` precedence — so an accidental revert of either
  default fails CI instead of passing silently.
- `pytest -m "not gpu and not network" tests/envs/test_robocasa.py` -> 73 passed.
- `pre-commit run --files src/opentau/envs/robocasa.py src/opentau/envs/configs.py tests/envs/test_robocasa.py` -> clean.
- Env-config / default only; no policy / model / training-loop code is touched,
  so the GPU suite is not required for this change.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/envs/test_robocasa.py::TestResolveSplitAndTaskGroups
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
