### PR TITLE
feat(pi05_mem): interleaved MRoPE as default position embedding

### DIFF
--- a/src/opentau/policies/pi05/paligemma_with_expert.py
+++ b/src/opentau/policies/pi05/paligemma_with_expert.py
@@ -25,6 +25,7 @@ action generation and conditioning.
 import logging
 
 import torch
+from einops import rearrange
 from torch import nn
 from transformers import (
     AutoConfig,
@@ -45,11 +46,25 @@ def _preferred_dtype():
 
 
 def apply_rope(x: torch.Tensor, positions: torch.Tensor, max_wavelength: int = 10_000) -> torch.Tensor:
-    """Applies RoPE positions to the input tensor.
+    """Applies (multimodal) RoPE positions to the input tensor.
+
+    Two position layouts are supported, selected by ``positions.ndim``:
+
+    * **1-D RoPE** — ``positions`` of shape ``[B, L]``: a single scalar
+      position per token (the historical behaviour). Every rotary frequency
+      band is driven by that one position.
+    * **Interleaved MRoPE** — ``positions`` of shape ``[A, B, L]`` (here
+      ``A == 3`` for the temporal / height / width axes): frequency band ``i``
+      is driven by axis ``i % A``, so the three axes are *interleaved* across
+      the full frequency spectrum rather than each owning a contiguous block
+      (the Qwen3-VL "interleaved MRoPE" scheme). When all ``A`` axes carry the
+      same positions this is bit-identical to the 1-D path, so text-style
+      tokens (``t == h == w``) rotate exactly as plain RoPE.
 
     Args:
         x: Input tensor of shape [B, L, H, D].
-        positions: Position tensor of shape [B, L].
+        positions: Position tensor of shape ``[B, L]`` (1-D RoPE) or
+            ``[A, B, L]`` (interleaved MRoPE).
         max_wavelength: Maximum wavelength for RoPE. Defaults to 10_000.
 
     Returns:
@@ -62,7 +77,18 @@ def apply_rope(x: torch.Tensor, positions: torch.Tensor, max_wavelength: int = 1
 
     freq_exponents = (2.0 / x.shape[-1]) * torch.arange(d_half, dtype=torch.float32, device=device)
     timescale = max_wavelength**freq_exponents
-    radians = positions[..., None].to(torch.float32) / timescale[None, None, :].to(torch.float32)
+    if positions.ndim == 2:
+        # 1-D RoPE: [B, L] -> [B, L, d_half]
+        radians = positions[..., None].to(torch.float32) / timescale[None, None, :].to(torch.float32)
+    else:
+        # Interleaved MRoPE: positions [A, B, L]. Assign frequency band i to
+        # axis i % A so every axis spans the full spectrum, then select the
+        # per-band position -> [B, L, d_half].
+        n_axes = positions.shape[0]
+        band_axis = torch.arange(d_half, device=device) % n_axes  # [d_half]
+        pos_per_band = positions.to(torch.float32)[band_axis]  # [d_half, B, L]
+        pos_per_band = rearrange(pos_per_band, "f b l -> b l f")  # [B, L, d_half]
+        radians = pos_per_band / timescale[None, None, :].to(torch.float32)
 
     radians = radians[..., None, :]
 

--- a/src/opentau/policies/pi05_mem/configuration_pi05.py
+++ b/src/opentau/policies/pi05_mem/configuration_pi05.py
@@ -137,6 +137,26 @@ class PI05MemConfig(PreTrainedConfig):
     # Attention utils
     attention_implementation: str = "eager"
 
+    # Rotary position embedding scheme.
+    #   "mrope_interleaved" — interleaved Multimodal RoPE (Qwen3-VL style; the
+    #                        default). The head dim is split into rotary
+    #                        frequency bands and each band is assigned,
+    #                        round-robin, to one of three position axes
+    #                        (temporal, height, width) so every axis spans the
+    #                        full frequency spectrum. Only the per-frame video
+    #                        patch tokens receive true 2-D (height, width)
+    #                        positions; language / state / discrete-action
+    #                        tokens stay text-style (t == h == w), so MRoPE
+    #                        degenerates to ordinary RoPE on the non-video
+    #                        tokens.
+    #   "rope"             — standard 1-D RoPE (a single scalar position per
+    #                        token; the historical scheme). Set this to load /
+    #                        reproduce a checkpoint trained before MRoPE became
+    #                        the default — the two schemes assign different
+    #                        video-token positions, so a checkpoint trained
+    #                        under one must be evaluated under the same one.
+    rope_type: str = "mrope_interleaved"
+
     # Finetuning settings
     freeze_vision_encoder: bool = True
     train_expert_only: bool = False
@@ -260,6 +280,11 @@ class PI05MemConfig(PreTrainedConfig):
         if not isinstance(self.spacetime_layer_stride, int) or self.spacetime_layer_stride < 1:
             raise ValueError(
                 f"`spacetime_layer_stride` must be a positive integer, got {self.spacetime_layer_stride}."
+            )
+
+        if self.rope_type not in ("rope", "mrope_interleaved"):
+            raise ValueError(
+                f"`rope_type` must be one of 'rope'/'mrope_interleaved', got {self.rope_type!r}."
             )
 
         if self.use_motion:

--- a/src/opentau/policies/pi05_mem/modeling_pi05.py
+++ b/src/opentau/policies/pi05_mem/modeling_pi05.py
@@ -41,7 +41,7 @@ from pathlib import Path
 import numpy as np
 import torch
 import torch.nn.functional as F  # noqa: N812
-from einops import rearrange
+from einops import rearrange, reduce, repeat
 from torch import Tensor, nn
 from transformers import AutoProcessor, AutoTokenizer
 
@@ -148,6 +148,99 @@ def make_att_2d_masks(
         att_2d_masks = torch.cat((cross_att_mask, att_2d_masks), dim=2)
 
     return att_2d_masks
+
+
+def build_mrope_prefix_positions(
+    seg_masks: list[Tensor],
+    seg_is_video: list[bool],
+    grid: int,
+) -> Tensor:
+    """Build interleaved-MRoPE (t, h, w) position ids for the prefix.
+
+    The prefix is a concatenation of ordered segments (videos, language,
+    state, optionally discrete actions). Each segment is either a square video
+    patch grid or a run of text-style tokens:
+
+    * **Video segment** (``grid * grid`` row-major patches): all patches share
+      a single temporal index ``t = base`` (the encoder collapses history into
+      one current frame, so there is no per-token time axis), and receive 2-D
+      spatial positions ``h = base + row`` / ``w = base + col``. A present
+      video advances the running cursor by ``grid`` (= ``max(row, col) + 1``),
+      matching Qwen-style "text resumes after the vision block" continuity. A
+      padded (absent) video advances nothing.
+    * **Text segment**: ``t == h == w``, incrementing by 1 per *real* (non-pad)
+      token, so MRoPE degenerates to ordinary 1-D RoPE here.
+
+    The per-sample cursor mirrors the ``cumsum(pad_masks) - 1`` progression of
+    the 1-D path, but a video block consumes ``grid`` position units instead of
+    ``grid * grid``.
+
+    Args:
+        seg_masks: Per-segment bool pad masks, each ``[B, seg_len]``, in prefix
+            order (``True`` = real token).
+        seg_is_video: Parallel list flagging which segments are video grids.
+        grid: Side length of the (square) video patch grid.
+
+    Returns:
+        ``[3, B, L]`` long tensor of (temporal, height, width) positions.
+    """
+    device = seg_masks[0].device
+    bsize = seg_masks[0].shape[0]
+    cur = torch.zeros(bsize, dtype=torch.long, device=device)  # next free scalar position per sample
+
+    # Row-major (h, w) indices for a single video block.
+    patch_idx = torch.arange(grid * grid, device=device)
+    rows = torch.div(patch_idx, grid, rounding_mode="floor")  # [grid*grid]
+    cols = patch_idx % grid  # [grid*grid]
+
+    blocks: list[Tensor] = []  # each [3, B, seg_len]
+    for mask, is_video in zip(seg_masks, seg_is_video, strict=True):
+        seg_len = mask.shape[1]
+        if is_video:
+            present = mask[:, 0].long()  # [B] — 1 where the whole grid is real
+            base = cur[:, None]  # [B, 1]
+            t = base.expand(bsize, seg_len)
+            h = base + rows[None, :]
+            w = base + cols[None, :]
+            blocks.append(torch.stack([t, h, w], dim=0))  # [3, B, seg_len]
+            cur = cur + present * grid
+        else:
+            # Real tokens get cur, cur+1, ...; padded tokens repeat the prior
+            # value (masked out downstream), matching cumsum(pad_masks) - 1.
+            local = torch.cumsum(mask.long(), dim=1) - 1  # [B, seg_len]
+            pos = cur[:, None] + local
+            blocks.append(repeat(pos, "b l -> three b l", three=3))
+            cur = cur + reduce(mask.long(), "b l -> b", "sum")
+
+    return torch.cat(blocks, dim=2)  # [3, B, L]
+
+
+def mrope_suffix_position_ids(
+    prefix_position_ids: Tensor,
+    suffix_pad_masks: Tensor,
+    num_cross_att_tokens: int,
+) -> Tensor:
+    """Text-style interleaved-MRoPE positions for the action-expert suffix.
+
+    The suffix continues from the position right after the prefix region the
+    expert cross-attends to: ``offset = max(prefix positions over the cross
+    region) + 1`` per sample. Suffix tokens are text-style (``t == h == w``),
+    so this is the 1-D ``offset + cumsum(pad) - 1`` progression broadcast to
+    all three axes.
+
+    Args:
+        prefix_position_ids: ``[3, B, L]`` prefix MRoPE positions.
+        suffix_pad_masks: ``[B, Ls]`` bool suffix pad mask.
+        num_cross_att_tokens: Number of leading prefix tokens cached for cross
+            attention (the region the suffix offset continues from).
+
+    Returns:
+        ``[3, B, Ls]`` long tensor of suffix positions.
+    """
+    cross = prefix_position_ids[:, :, :num_cross_att_tokens]  # [3, B, num_cross]
+    offset = reduce(cross, "a b n -> b", "max")[:, None] + 1  # [B, 1]
+    scalar = offset + torch.cumsum(suffix_pad_masks, dim=1) - 1  # [B, Ls]
+    return repeat(scalar, "b l -> three b l", three=3)
 
 
 def resize_with_pad(img: Tensor, width: int, height: int, pad_value: int = -1) -> Tensor:
@@ -924,6 +1017,18 @@ class PI05MemFlowMatching(nn.Module):
                 gradient_checkpointing=config.gradient_checkpointing,
             )
 
+        # Side length of the (square) video patch grid, used by interleaved
+        # MRoPE to give per-frame patches 2-D (height, width) positions. Both
+        # encoders expose ``num_video_tokens`` (a perfect square, e.g. 256 for
+        # a 224/14 grid).
+        num_vid_tokens = self.video_encoder.num_video_tokens
+        self._video_grid = int(round(num_vid_tokens**0.5))
+        if self._video_grid * self._video_grid != num_vid_tokens:
+            raise ValueError(
+                f"Interleaved MRoPE requires a square video patch grid; got "
+                f"{num_vid_tokens} video tokens (not a perfect square)."
+            )
+
         # Per-timestep state projection: each of the T state vectors becomes one token
         self.state_proj = nn.Linear(self.config.max_state_dim, vlm_hidden_size)
 
@@ -975,7 +1080,7 @@ class PI05MemFlowMatching(nn.Module):
         discrete_actions: Tensor | None = None,
         discrete_action_masks: Tensor | None = None,
         obs_history_is_pad: Tensor | None = None,
-    ) -> tuple[Tensor, Tensor, Tensor]:
+    ) -> tuple[Tensor, Tensor, Tensor, Tensor]:
         """Embed videos with the space-time SigLIP video encoder, language
         tokens with the embedding layer, and temporal state via per-timestep
         learned projection.
@@ -993,11 +1098,14 @@ class PI05MemFlowMatching(nn.Module):
                 Used to mask state tokens during training; None during inference.
 
         Returns:
-            (embs, pad_masks, att_masks) tuple.
+            ``(embs, pad_masks, att_masks, position_ids)`` tuple. ``position_ids``
+            is ``[B, L]`` for ``rope_type="rope"`` and ``[3, B, L]`` (interleaved
+            MRoPE; only video tokens get 2-D spatial positions) otherwise.
         """
         embs = []
         pad_masks = []
         att_masks = []
+        seg_is_video: list[bool] = []  # parallel to pad_masks; for MRoPE position ids
         bsize = lang_tokens.shape[0]
 
         for vid, vid_mask in zip(videos, vid_masks, strict=False):
@@ -1009,6 +1117,7 @@ class PI05MemFlowMatching(nn.Module):
 
             embs.append(vid_emb)
             pad_masks.append(vid_mask_expanded)
+            seg_is_video.append(True)
 
             att_masks += [0] * num_vid_embs
 
@@ -1018,6 +1127,7 @@ class PI05MemFlowMatching(nn.Module):
 
         embs.append(lang_emb)
         pad_masks.append(lang_masks)
+        seg_is_video.append(False)
 
         num_lang_embs = lang_emb.shape[1]
         att_masks += [0] * num_lang_embs
@@ -1055,20 +1165,28 @@ class PI05MemFlowMatching(nn.Module):
 
         embs.append(state_emb)
         pad_masks.append(state_mask)
+        seg_is_video.append(False)
         att_masks += [0] * num_state_tokens  # full attention with video and language
 
         if discrete_actions is not None:
             discrete_action_emb = self.paligemma_with_expert.embed_discrete_actions(discrete_actions)
             embs.append(discrete_action_emb.to(dtype=_preferred_dtype()))
             pad_masks.append(discrete_action_masks)
+            seg_is_video.append(False)
             att_masks += [1] * discrete_action_emb.shape[1]
 
         embs = torch.cat(embs, dim=1)
-        pad_masks = torch.cat(pad_masks, dim=1)
-        att_masks = torch.tensor(att_masks, dtype=torch.bool, device=pad_masks.device)
+        pad_masks_cat = torch.cat(pad_masks, dim=1)
+        att_masks = torch.tensor(att_masks, dtype=torch.bool, device=pad_masks_cat.device)
         att_masks = att_masks[None, :].expand(bsize, len(att_masks))
 
-        return embs, pad_masks, att_masks
+        if self.config.rope_type == "mrope_interleaved":
+            position_ids = build_mrope_prefix_positions(pad_masks, seg_is_video, self._video_grid)
+        else:
+            # 1-D RoPE: a single scalar position per real token (historical path).
+            position_ids = torch.cumsum(pad_masks_cat, dim=1) - 1
+
+        return embs, pad_masks_cat, att_masks, position_ids
 
     def embed_suffix(self, noisy_actions: Tensor, timestep: Tensor) -> tuple[Tensor, Tensor, Tensor, Tensor]:
         """Embed noisy_actions, timestep to prepare for Expert Gemma processing."""
@@ -1129,7 +1247,7 @@ class PI05MemFlowMatching(nn.Module):
         return_per_sample: bool = False,
     ) -> dict[str, Tensor | PerSampleLoss]:
         """Do a full training forward pass and compute the loss."""
-        prefix_embs, prefix_pad_masks, prefix_att_masks = self.embed_prefix(
+        prefix_embs, prefix_pad_masks, prefix_att_masks, vlm_position_ids = self.embed_prefix(
             videos,
             vid_masks,
             lang_tokens,
@@ -1141,7 +1259,6 @@ class PI05MemFlowMatching(nn.Module):
         )
 
         vlm_2d_attention_mask = make_att_2d_masks(prefix_pad_masks, prefix_att_masks)
-        vlm_position_ids = torch.cumsum(prefix_pad_masks, dim=1) - 1
 
         num_cross_att_tokens = prefix_embs.shape[1] - self.config.discrete_action_max_length
 
@@ -1181,10 +1298,13 @@ class PI05MemFlowMatching(nn.Module):
             n_cross_att_tokens=num_cross_att_tokens,
             cross_att_pad_masks=prefix_pad_masks[:, :num_cross_att_tokens],
         )
-        prefix_offsets = torch.sum(prefix_pad_masks[:, : -self.config.discrete_action_max_length], dim=-1)[
-            :, None
-        ]
-        action_expert_position_ids = prefix_offsets + torch.cumsum(suffix_pad_masks, dim=1) - 1
+        if self.config.rope_type == "mrope_interleaved":
+            action_expert_position_ids = mrope_suffix_position_ids(
+                vlm_position_ids, suffix_pad_masks, num_cross_att_tokens
+            )
+        else:
+            prefix_offsets = torch.sum(prefix_pad_masks[:, :num_cross_att_tokens], dim=-1)[:, None]
+            action_expert_position_ids = prefix_offsets + torch.cumsum(suffix_pad_masks, dim=1) - 1
 
         assert past_key_values is not None
         kv_cache: dict = past_key_values
@@ -1285,7 +1405,7 @@ class PI05MemFlowMatching(nn.Module):
             actions_shape = (bsize, self.config.chunk_size, self.config.max_action_dim)
             noise = self.sample_noise(actions_shape, device)
 
-        prefix_embs, prefix_pad_masks, prefix_att_masks = self.embed_prefix(
+        prefix_embs, prefix_pad_masks, prefix_att_masks, prefix_position_ids = self.embed_prefix(
             videos,
             vid_masks,
             lang_tokens,
@@ -1294,7 +1414,6 @@ class PI05MemFlowMatching(nn.Module):
             obs_history_is_pad=obs_history_is_pad,
         )
         prefix_att_2d_masks = make_att_2d_masks(prefix_pad_masks, prefix_att_masks)
-        prefix_position_ids = torch.cumsum(prefix_pad_masks, dim=1) - 1
 
         num_cross_att_tokens = prefix_embs.shape[1]
 
@@ -1320,6 +1439,7 @@ class PI05MemFlowMatching(nn.Module):
             masked_time = torch.where(prefix_mask, 0, time)
             v_t = self.denoise_step(
                 prefix_pad_masks,
+                prefix_position_ids,
                 past_key_values,
                 x_t,
                 masked_time,
@@ -1334,6 +1454,7 @@ class PI05MemFlowMatching(nn.Module):
     def denoise_step(
         self,
         prefix_pad_masks: Tensor,
+        prefix_position_ids: Tensor,
         past_key_values: list[dict[str, Tensor]],
         x_t: Tensor,
         time: Tensor,
@@ -1348,8 +1469,13 @@ class PI05MemFlowMatching(nn.Module):
             n_cross_att_tokens=num_cross_att_tokens,
             cross_att_pad_masks=prefix_pad_masks[:, :num_cross_att_tokens],
         )
-        prefix_offsets = torch.sum(prefix_pad_masks, dim=-1)[:, None]
-        action_expert_position_ids = prefix_offsets + torch.cumsum(suffix_pad_masks, dim=1) - 1
+        if self.config.rope_type == "mrope_interleaved":
+            action_expert_position_ids = mrope_suffix_position_ids(
+                prefix_position_ids, suffix_pad_masks, num_cross_att_tokens
+            )
+        else:
+            prefix_offsets = torch.sum(prefix_pad_masks, dim=-1)[:, None]
+            action_expert_position_ids = prefix_offsets + torch.cumsum(suffix_pad_masks, dim=1) - 1
 
         outputs_embeds, _ = self.paligemma_with_expert.forward(
             attention_mask=action_expert_2d_attention_mask,

--- a/src/opentau/policies/pi05_mem/modeling_pi05.py
+++ b/src/opentau/policies/pi05_mem/modeling_pi05.py
@@ -217,19 +217,32 @@ def build_mrope_prefix_positions(
 
 def mrope_suffix_position_ids(
     prefix_position_ids: Tensor,
+    prefix_pad_masks: Tensor,
     suffix_pad_masks: Tensor,
     num_cross_att_tokens: int,
 ) -> Tensor:
     """Text-style interleaved-MRoPE positions for the action-expert suffix.
 
     The suffix continues from the position right after the prefix region the
-    expert cross-attends to: ``offset = max(prefix positions over the cross
-    region) + 1`` per sample. Suffix tokens are text-style (``t == h == w``),
-    so this is the 1-D ``offset + cumsum(pad) - 1`` progression broadcast to
-    all three axes.
+    expert cross-attends to: ``offset = max(real prefix positions over the
+    cross region) + 1`` per sample. Suffix tokens are text-style
+    (``t == h == w``), so this is the 1-D ``offset + cumsum(pad) - 1``
+    progression broadcast to all three axes.
+
+    Only *real* (non-pad) prefix tokens contribute to the offset. This matters
+    because a padded prefix token's position is not "right after the real
+    content": an absent video does not advance the cursor yet its patch block
+    still carries ``h/w = base..base+grid-1`` (see ``build_mrope_prefix_positions``),
+    and a padded text/state token repeats a prior position. Masking padded
+    tokens out of the max makes ``offset`` equal the MRoPE cursor after the
+    cross region (real-token max + 1), so the suffix continues with no position
+    gap. Note this is NOT the 1-D path's token-count ``sum(pad_masks)``: a video
+    block compacts ``grid*grid`` patches into ``grid`` position units, so the
+    two schemes' offsets differ whenever the cross region contains video.
 
     Args:
         prefix_position_ids: ``[3, B, L]`` prefix MRoPE positions.
+        prefix_pad_masks: ``[B, L]`` bool prefix pad mask (``True`` = real).
         suffix_pad_masks: ``[B, Ls]`` bool suffix pad mask.
         num_cross_att_tokens: Number of leading prefix tokens cached for cross
             attention (the region the suffix offset continues from).
@@ -238,7 +251,11 @@ def mrope_suffix_position_ids(
         ``[3, B, Ls]`` long tensor of suffix positions.
     """
     cross = prefix_position_ids[:, :, :num_cross_att_tokens]  # [3, B, num_cross]
-    offset = reduce(cross, "a b n -> b", "max")[:, None] + 1  # [B, 1]
+    cross_pad = prefix_pad_masks[:, :num_cross_att_tokens]  # [B, num_cross]
+    # Exclude padded tokens from the max so absent videos / padded text don't
+    # push the offset past the real content. All-padded cross region -> -1 -> 0.
+    real = torch.where(cross_pad[None], cross, torch.full_like(cross, -1))  # [3, B, num_cross]
+    offset = reduce(real, "a b n -> b", "max")[:, None] + 1  # [B, 1]
     scalar = offset + torch.cumsum(suffix_pad_masks, dim=1) - 1  # [B, Ls]
     return repeat(scalar, "b l -> three b l", three=3)
 
@@ -1300,7 +1317,7 @@ class PI05MemFlowMatching(nn.Module):
         )
         if self.config.rope_type == "mrope_interleaved":
             action_expert_position_ids = mrope_suffix_position_ids(
-                vlm_position_ids, suffix_pad_masks, num_cross_att_tokens
+                vlm_position_ids, prefix_pad_masks, suffix_pad_masks, num_cross_att_tokens
             )
         else:
             prefix_offsets = torch.sum(prefix_pad_masks[:, :num_cross_att_tokens], dim=-1)[:, None]
@@ -1471,7 +1488,7 @@ class PI05MemFlowMatching(nn.Module):
         )
         if self.config.rope_type == "mrope_interleaved":
             action_expert_position_ids = mrope_suffix_position_ids(
-                prefix_position_ids, suffix_pad_masks, num_cross_att_tokens
+                prefix_position_ids, prefix_pad_masks, suffix_pad_masks, num_cross_att_tokens
             )
         else:
             prefix_offsets = torch.sum(prefix_pad_masks, dim=-1)[:, None]

--- a/tests/policies/test_pi05_mem.py
+++ b/tests/policies/test_pi05_mem.py
@@ -846,10 +846,11 @@ class TestInterleavedMRoPE:
         video_mask = torch.ones(1, grid * grid, dtype=torch.bool)
         text_mask = torch.ones(1, 3, dtype=torch.bool)
         prefix_pos = build_mrope_prefix_positions([video_mask, text_mask], [True, False], grid)
+        prefix_pad = torch.ones(1, 7, dtype=torch.bool)
         # max prefix position is 4 -> suffix starts at 5.
         suffix_mask = torch.ones(1, 3, dtype=torch.bool)
 
-        suffix_pos = mrope_suffix_position_ids(prefix_pos, suffix_mask, num_cross_att_tokens=7)
+        suffix_pos = mrope_suffix_position_ids(prefix_pos, prefix_pad, suffix_mask, num_cross_att_tokens=7)
 
         assert suffix_pos.shape == (3, 1, 3)
         for axis in range(3):
@@ -861,9 +862,47 @@ class TestInterleavedMRoPE:
         # Prefix positions 0..6 across 7 tokens; exclude the last 3 from cross.
         prefix_scalar = torch.arange(7).reshape(1, 7)
         prefix_pos = torch.stack([prefix_scalar, prefix_scalar, prefix_scalar], dim=0)
+        prefix_pad = torch.ones(1, 7, dtype=torch.bool)
         suffix_mask = torch.ones(1, 2, dtype=torch.bool)
 
-        suffix_pos = mrope_suffix_position_ids(prefix_pos, suffix_mask, num_cross_att_tokens=4)
+        suffix_pos = mrope_suffix_position_ids(prefix_pos, prefix_pad, suffix_mask, num_cross_att_tokens=4)
 
         # max over first 4 prefix positions (0..3) is 3 -> offset 4 -> [4, 5].
         torch.testing.assert_close(suffix_pos[0, 0], torch.tensor([4, 5]))
+
+    def test_suffix_offset_ignores_padded_video_block(self):
+        """An absent video must not inflate the suffix offset. Its patch block
+        still carries h/w = base..base+grid-1, but those tokens are padded, so
+        the offset must continue right after the real text (no position gap)."""
+        grid = 2  # absent video would otherwise push the max to grid-1 = 1
+        video_mask = torch.zeros(1, grid * grid, dtype=torch.bool)  # absent
+        text_mask = torch.ones(1, 2, dtype=torch.bool)  # 2 real tokens at pos 0,1
+        prefix_pos = build_mrope_prefix_positions([video_mask, text_mask], [True, False], grid)
+        prefix_pad = torch.cat([video_mask, text_mask], dim=1)  # [1, 6]
+        suffix_mask = torch.ones(1, 2, dtype=torch.bool)
+
+        suffix_pos = mrope_suffix_position_ids(
+            prefix_pos, prefix_pad, suffix_mask, num_cross_att_tokens=grid * grid + 2
+        )
+
+        # Real content ends at pos 1 -> offset 2 (NOT base+grid). No gap.
+        torch.testing.assert_close(suffix_pos[0, 0], torch.tensor([2, 3]))
+
+    def test_suffix_offset_is_compacted_cursor_not_token_count(self):
+        """Cross region = present video then absent video. The offset is the
+        MRoPE cursor (`grid`), since a present video compacts grid*grid patches
+        into `grid` position units and the absent video adds nothing — NOT the
+        1-D token count (which would be grid*grid)."""
+        grid = 2
+        present = torch.ones(1, grid * grid, dtype=torch.bool)
+        absent = torch.zeros(1, grid * grid, dtype=torch.bool)
+        prefix_pos = build_mrope_prefix_positions([present, absent], [True, True], grid)
+        prefix_pad = torch.cat([present, absent], dim=1)  # [1, 8]
+        suffix_mask = torch.ones(1, 1, dtype=torch.bool)
+
+        suffix_pos = mrope_suffix_position_ids(
+            prefix_pos, prefix_pad, suffix_mask, num_cross_att_tokens=2 * grid * grid
+        )
+
+        # Compacted cursor == grid (2), not the grid*grid (4) token count.
+        torch.testing.assert_close(suffix_pos[0, 0], torch.tensor([grid]))

--- a/tests/policies/test_pi05_mem.py
+++ b/tests/policies/test_pi05_mem.py
@@ -18,11 +18,14 @@ import numpy as np
 import pytest
 import torch
 
+from opentau.policies.pi05.paligemma_with_expert import apply_rope
 from opentau.policies.pi05_mem.configuration_pi05 import PI05MemConfig
 from opentau.policies.pi05_mem.modeling_pi05 import (
     PI05MemPolicy,
+    build_mrope_prefix_positions,
     create_sinusoidal_pos_embedding,
     make_att_2d_masks,
+    mrope_suffix_position_ids,
     pad_discrete_tokens,
     resize_with_pad,
 )
@@ -84,6 +87,16 @@ class TestPI05MemConfig:
     def test_action_delta_indices(self):
         config = PI05MemConfig(chunk_size=10, n_action_steps=10)
         assert config.action_delta_indices == list(range(10))
+
+    def test_rope_type_default_is_mrope_interleaved(self):
+        assert PI05MemConfig().rope_type == "mrope_interleaved"
+
+    def test_rope_type_accepts_rope(self):
+        assert PI05MemConfig(rope_type="rope").rope_type == "rope"
+
+    def test_rope_type_invalid_raises(self):
+        with pytest.raises(ValueError, match="rope_type"):
+            PI05MemConfig(rope_type="rope2d")
 
 
 class TestHelperFunctions:
@@ -368,7 +381,7 @@ def _make_embed_prefix_stub():
     fm.embed_video = lambda video, obs_history_is_pad=None: torch.zeros(
         video.shape[0], n_video_tokens, hidden, dtype=torch.float32
     )
-    fm.config = types.SimpleNamespace(discrete_action_max_length=2)
+    fm.config = types.SimpleNamespace(discrete_action_max_length=2, rope_type="rope")
     return fm
 
 
@@ -407,7 +420,7 @@ class TestStateMaskCurrentStepAlwaysReal:
         kwargs = _embed_prefix_default_inputs(batch_size=bsize, t_state=t_state)
         kwargs["obs_history_is_pad"] = torch.ones(bsize, t_state, dtype=torch.bool)
 
-        _, pad_masks, _ = PI05MemFlowMatching.embed_prefix(fake, **kwargs)
+        _, pad_masks, _, _ = PI05MemFlowMatching.embed_prefix(fake, **kwargs)
 
         state_slice = _state_slice_indices(prompt_len=3, n_video_tokens=3, t_state=t_state)
         state_mask = pad_masks[:, state_slice]
@@ -464,7 +477,7 @@ class TestStateMaskCurrentStepAlwaysReal:
         kwargs = _embed_prefix_default_inputs(batch_size=bsize, t_state=t_state)
         kwargs["obs_history_is_pad"] = None
 
-        _, pad_masks, _ = PI05MemFlowMatching.embed_prefix(fake, **kwargs)
+        _, pad_masks, _, _ = PI05MemFlowMatching.embed_prefix(fake, **kwargs)
 
         state_slice = _state_slice_indices(prompt_len=3, n_video_tokens=3, t_state=t_state)
         state_mask = pad_masks[:, state_slice]
@@ -488,7 +501,7 @@ class TestStateMaskCurrentStepAlwaysReal:
         kwargs = _embed_prefix_default_inputs(batch_size=bsize, t_state=t_state)
         kwargs["obs_history_is_pad"] = torch.tensor([[True, True, False, False], [True, False, False, False]])
 
-        _, pad_masks, _ = PI05MemFlowMatching.embed_prefix(fake, **kwargs)
+        _, pad_masks, _, _ = PI05MemFlowMatching.embed_prefix(fake, **kwargs)
 
         state_slice = _state_slice_indices(prompt_len=3, n_video_tokens=3, t_state=t_state)
         state_mask = pad_masks[:, state_slice]
@@ -703,3 +716,154 @@ class TestPI05MemExecutionHorizon:
         a_next = PI05MemPolicy.select_action(policy, batch)
         assert calls["n"] == 2
         assert a_next[0, 0].item() == 2000.0
+
+
+def _reference_interleaved_mrope(x, positions, max_wavelength=10_000):
+    """Independent reference for interleaved MRoPE used to pin ``apply_rope``.
+
+    Frequency band ``i`` is driven by axis ``i % A`` (round-robin over the
+    temporal/height/width axes), using the same split-half rotation convention
+    as ``apply_rope``.
+    """
+    d_half = x.shape[-1] // 2
+    x = x.to(torch.float32)
+    freq_exponents = (2.0 / x.shape[-1]) * torch.arange(d_half, dtype=torch.float32)
+    timescale = max_wavelength**freq_exponents
+    n_axes = positions.shape[0]
+    radians = torch.empty(x.shape[0], x.shape[1], d_half, dtype=torch.float32)
+    for i in range(d_half):
+        radians[..., i] = positions[i % n_axes].to(torch.float32) / timescale[i]
+    radians = radians[..., None, :]
+    sin, cos = torch.sin(radians), torch.cos(radians)
+    x1, x2 = x.split(d_half, dim=-1)
+    res = torch.empty_like(x)
+    res[..., :d_half] = x1 * cos - x2 * sin
+    res[..., d_half:] = x2 * cos + x1 * sin
+    return res
+
+
+class TestInterleavedMRoPE:
+    """Unit tests for the interleaved-MRoPE position machinery (rope_type=
+    'mrope_interleaved'). All pure-tensor — no PaliGemma init required."""
+
+    def test_apply_rope_degenerates_to_1d_when_axes_equal(self):
+        """MRoPE with t == h == w must be bit-identical to 1-D RoPE — this is
+        the guarantee that text-style tokens rotate exactly as before, so a
+        'rope' checkpoint's non-video tokens are unchanged."""
+        torch.manual_seed(0)
+        b, length, heads, dim = 2, 5, 3, 8
+        x = torch.randn(b, length, heads, dim)
+        pos_1d = torch.arange(length).expand(b, length)  # [B, L]
+
+        out_1d = apply_rope(x, pos_1d)
+        out_mrope = apply_rope(x, torch.stack([pos_1d, pos_1d, pos_1d], dim=0))  # [3, B, L]
+
+        torch.testing.assert_close(out_1d, out_mrope, rtol=0, atol=0)
+
+    def test_apply_rope_matches_reference_with_distinct_axes(self):
+        """With distinct (t, h, w), ``apply_rope`` must match the independent
+        round-robin reference. dim=12 -> d_half=6 -> every axis owns >=1 band."""
+        torch.manual_seed(1)
+        b, length, heads, dim = 2, 4, 2, 12
+        x = torch.randn(b, length, heads, dim)
+        t = torch.randint(0, 7, (b, length))
+        h = torch.randint(0, 7, (b, length))
+        w = torch.randint(0, 7, (b, length))
+        positions = torch.stack([t, h, w], dim=0)  # [3, B, L]
+
+        torch.testing.assert_close(apply_rope(x, positions), _reference_interleaved_mrope(x, positions))
+
+    def test_apply_rope_unused_axis_does_not_change_output(self):
+        """dim=8 -> d_half=4 -> bands use axes [t, h, w, t]; the w axis still
+        participates (band 2). dim=4 -> d_half=2 -> bands [t, h] only, so w is
+        unused and perturbing it is a no-op."""
+        torch.manual_seed(2)
+        x = torch.randn(1, 1, 1, 4)  # d_half=2 -> only axes t, h are read
+        base = torch.tensor([[3]])
+        pos_a = torch.stack([base, base + 1, base + 5], dim=0)
+        pos_b = torch.stack([base, base + 1, base + 99], dim=0)  # only w differs
+        torch.testing.assert_close(apply_rope(x, pos_a), apply_rope(x, pos_b), rtol=0, atol=0)
+
+    def test_build_prefix_positions_video_then_text(self):
+        """Video block: t=base, h=base+row, w=base+col (row-major). The cursor
+        then advances by ``grid`` (not grid*grid) and text continues 1-D."""
+        grid = 2  # 2x2 = 4 patches
+        video_mask = torch.ones(1, grid * grid, dtype=torch.bool)
+        text_mask = torch.ones(1, 3, dtype=torch.bool)
+
+        pos = build_mrope_prefix_positions([video_mask, text_mask], [True, False], grid)
+
+        assert pos.shape == (3, 1, grid * grid + 3)
+        # Video patches in row-major order: (r, c) = (0,0),(0,1),(1,0),(1,1).
+        torch.testing.assert_close(pos[0, 0], torch.tensor([0, 0, 0, 0, 2, 3, 4]))  # temporal
+        torch.testing.assert_close(pos[1, 0], torch.tensor([0, 0, 1, 1, 2, 3, 4]))  # height
+        torch.testing.assert_close(pos[2, 0], torch.tensor([0, 1, 0, 1, 2, 3, 4]))  # width
+
+    def test_build_prefix_positions_absent_video_does_not_advance(self):
+        """A padded (absent) video must not advance the cursor, so the
+        following text still starts at position 0."""
+        grid = 2
+        video_mask = torch.zeros(1, grid * grid, dtype=torch.bool)  # absent
+        text_mask = torch.ones(1, 3, dtype=torch.bool)
+
+        pos = build_mrope_prefix_positions([video_mask, text_mask], [True, False], grid)
+
+        # Text begins at cursor 0 (video advanced nothing). The video block
+        # still carries h/w spatial structure (masked downstream, not zeroed),
+        # so only the text region is text-style (t == h == w).
+        torch.testing.assert_close(pos[0, 0, -3:], torch.tensor([0, 1, 2]))
+        assert torch.equal(pos[0, :, -3:], pos[1, :, -3:])
+        assert torch.equal(pos[1, :, -3:], pos[2, :, -3:])
+
+    def test_build_prefix_positions_text_padding_advances_by_real_tokens(self):
+        """Padded text tokens repeat the prior position and don't advance the
+        cursor; only real tokens do (mirrors cumsum(pad_masks) - 1)."""
+        text_mask = torch.tensor([[True, False, True]])  # 2 real tokens
+        next_mask = torch.ones(1, 2, dtype=torch.bool)
+
+        pos = build_mrope_prefix_positions([text_mask, next_mask], [False, False], grid=2)
+
+        # local cumsum(mask)-1 = [0, 0, 1]; cursor advances by 2 -> next [2, 3].
+        torch.testing.assert_close(pos[0, 0], torch.tensor([0, 0, 1, 2, 3]))
+
+    def test_build_prefix_positions_per_sample_video_presence(self):
+        """Video presence is per-sample: an absent video for one sample must
+        not advance that sample's cursor while the present one advances by
+        grid."""
+        grid = 2
+        video_mask = torch.tensor([[True] * 4, [False] * 4])  # sample 0 present, 1 absent
+        text_mask = torch.ones(2, 2, dtype=torch.bool)
+
+        pos = build_mrope_prefix_positions([video_mask, text_mask], [True, False], grid)
+
+        # Sample 0: text after grid -> [2, 3]; sample 1: text from 0 -> [0, 1].
+        torch.testing.assert_close(pos[0, :, -2:], torch.tensor([[2, 3], [0, 1]]))
+
+    def test_suffix_positions_continue_from_prefix_max(self):
+        """Suffix offset = max prefix position over the cross region + 1, and
+        the suffix is text-style (t == h == w)."""
+        grid = 2
+        video_mask = torch.ones(1, grid * grid, dtype=torch.bool)
+        text_mask = torch.ones(1, 3, dtype=torch.bool)
+        prefix_pos = build_mrope_prefix_positions([video_mask, text_mask], [True, False], grid)
+        # max prefix position is 4 -> suffix starts at 5.
+        suffix_mask = torch.ones(1, 3, dtype=torch.bool)
+
+        suffix_pos = mrope_suffix_position_ids(prefix_pos, suffix_mask, num_cross_att_tokens=7)
+
+        assert suffix_pos.shape == (3, 1, 3)
+        for axis in range(3):
+            torch.testing.assert_close(suffix_pos[axis, 0], torch.tensor([5, 6, 7]))
+
+    def test_suffix_positions_respect_cross_region_slice(self):
+        """Excluding trailing tokens (e.g. discrete actions) from the cross
+        region lowers the offset to the max over the retained prefix only."""
+        # Prefix positions 0..6 across 7 tokens; exclude the last 3 from cross.
+        prefix_scalar = torch.arange(7).reshape(1, 7)
+        prefix_pos = torch.stack([prefix_scalar, prefix_scalar, prefix_scalar], dim=0)
+        suffix_mask = torch.ones(1, 2, dtype=torch.bool)
+
+        suffix_pos = mrope_suffix_position_ids(prefix_pos, suffix_mask, num_cross_att_tokens=4)
+
+        # max over first 4 prefix positions (0..3) is 3 -> offset 4 -> [4, 5].
+        torch.testing.assert_close(suffix_pos[0, 0], torch.tensor([4, 5]))


### PR DESCRIPTION
## What this does
Adds **interleaved Multimodal RoPE** (Qwen3-VL style) to the `pi05_mem` policy and makes it the **default** position-embedding scheme. (🗃️ Feature)

A new `rope_type` config field gates the behavior:
- `"mrope_interleaved"` (default) — the head dim is split into rotary frequency bands, each assigned round-robin to one of three position axes (temporal / height / width) so every axis spans the full frequency spectrum. Only the per-frame video patch tokens get true 2-D `(height, width)` positions; language / state / discrete-action tokens stay text-style (`t == h == w`), so MRoPE degenerates to ordinary RoPE on the non-video tokens.
- `"rope"` — the legacy 1-D scheme (one scalar position per token).

Implementation:
- `apply_rope` (shared `pi05/paligemma_with_expert.py`) now accepts `[3, B, L]` positions and interleaves bands across axes; the `[B, L]` path is byte-identical to before.
- `modeling_pi05.py` adds `build_mrope_prefix_positions` + `mrope_suffix_position_ids`; `embed_prefix` now returns `position_ids`, and `forward` / `sample_actions` / `denoise_step` branch on `rope_type`.

> ⚠️ Compatibility: because MRoPE is now the default, an existing `pi05_mem` checkpoint loaded without `--policy.rope_type=rope` will apply 2-D positions to video tokens, changing its learned positional behavior. Pin `rope_type=rope` to reproduce/eval pre-MRoPE checkpoints.

## How it was tested
- Added 12 CPU unit tests in `tests/policies/test_pi05_mem.py` (`TestInterleavedMRoPE` + `rope_type` config validation):
  - `apply_rope` degenerates **bit-identically** to 1-D RoPE when `t == h == w` (`atol=0`).
  - `apply_rope` matches an independent round-robin reference with distinct axes; unused-axis perturbation is a no-op.
  - prefix builder `(t, h, w)` layout, cursor advance by `grid`, absent-video / per-sample presence, text padding.
  - suffix offset continues from the prefix cross-region max, respects the cross-region slice.
- Full `tests/policies/test_pi05_mem.py` (59) and shared `tests/policies/test_pi05.py` (15) pass.
- **Not yet run:** GPU two-seed forward/loss determinism smoke (no GPU in dev env). Recommended before training, since MRoPE is now the default forward path.

## How to checkout & try? (for the reviewer)
```bash
pytest -sx "tests/policies/test_pi05_mem.py::TestInterleavedMRoPE"
pytest -sx tests/policies/test_pi05_mem.py tests/policies/test_pi05.py
```
Toggle the scheme on any pi05_mem config: `--policy.rope_type=mrope_interleaved` (default) or `--policy.rope_type=rope`.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [x] My PR includes policy-related changes.
  - [x] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.