### PR TITLE
feat(cosmos3): single-layer reasoner conditioning + backbone truncation

### DIFF
--- a/configs/examples/cosmos3_single_layer_config.json
+++ b/configs/examples/cosmos3_single_layer_config.json
@@ -1,0 +1,105 @@
+{
+    "dataset_mixture": {
+        "datasets": [
+            {
+                "repo_id": "TensorAuto/libero",
+                "episodes": [
+                    0,1,2,3,4,5,6,7,8,9
+                ]
+            }
+        ],
+        "weights": [
+            1.0
+        ],
+        "action_freq": 20.0,
+        "image_resample_strategy": "nearest",
+        "vector_resample_strategy": "nearest"
+    },
+    "policy": {
+        "type": "cosmos3",
+        "n_obs_steps": 1,
+        "normalization_mapping": {
+            "VISUAL": "IDENTITY",
+            "STATE": "MEAN_STD",
+            "ACTION": "MEAN_STD"
+        },
+        "chunk_size": 10,
+        "n_action_steps": 10,
+        "max_state_dim": 32,
+        "max_action_dim": 32,
+        "proj_width": 1024,
+        "num_steps": 10,
+        "attention_implementation": "sdpa",
+        "pretrained_backbone_repo_id": "TensorAuto/cosmos3-reason-32b",
+        "load_pretrained_backbone": true,
+        "image_resize": 224,
+        "freeze_vision_encoder": true,
+        "train_expert_only": true,
+        "gradient_checkpointing": true,
+        "prompt_max_length": 256,
+        "condition_on_layer": 31,
+        "expert_num_hidden_layers": 16,
+        "optimizer_lr": 2.5e-05,
+        "optimizer_betas": [
+            0.9,
+            0.95
+        ],
+        "optimizer_eps": 1e-08,
+        "optimizer_weight_decay": 1e-10,
+        "scheduler_warmup_steps": 1000,
+        "scheduler_decay_steps": 30000,
+        "scheduler_decay_lr": 2.5e-06
+    },
+    "resume": false,
+    "seed": 1000,
+    "resolution": [224, 224],
+    "num_cams": 2,
+    "max_state_dim": 32,
+    "max_action_dim": 32,
+    "action_chunk": 10,
+    "loss_weighting": {"MSE": 1, "CE": 0},
+    "num_workers": 4,
+    "batch_size": 2,
+    "gradient_accumulation_steps": 1,
+    "dataloader_batch_size": 2,
+    "prefetch_factor": 8,
+    "steps": 40,
+    "log_freq": 5,
+    "save_checkpoint": true,
+    "save_freq": 40,
+    "val_freq": 10,
+    "use_policy_training_preset": false,
+    "trace_nans": false,
+    "optimizer": {
+        "type": "adamw",
+        "lr": 2.5e-05,
+        "weight_decay": 1e-10,
+        "grad_clip_norm": 10.0,
+        "betas": [
+            0.9,
+            0.95
+        ],
+        "eps": 1e-08
+    },
+    "scheduler": {
+        "type": "cosine_decay_with_warmup",
+        "num_warmup_steps": 1000,
+        "num_decay_steps": 30000,
+        "peak_lr": 2.5e-05,
+        "decay_lr": 2.5e-06
+    },
+    "wandb": {
+        "enable": false,
+        "entity": "wyautox-autox",
+        "project": "cosmos3",
+        "run_id": null,
+        "name": null,
+        "notes": "cosmos3 single-layer conditioning (expert reads backbone layer 31; backbone truncated to its first 32 layers; 16-layer expert)",
+        "tags": [],
+        "group": null,
+        "job_type": null,
+        "mode": null,
+        "on_resume": "fork",
+        "disable_artifact": false
+    }
+}

--- a/src/opentau/policies/cosmos3/configuration_cosmos3.py
+++ b/src/opentau/policies/cosmos3/configuration_cosmos3.py
@@ -87,8 +87,26 @@ class Cosmos3Config(PreTrainedConfig):
         dropout: Dropout probability inside the expert. Defaults to 0.1.
         expert_hidden_size: Action-expert hidden width. Defaults to 1024.
         expert_intermediate_size: Action-expert SwiGLU MLP width. Defaults to 2048.
-        expert_num_hidden_layers: Action-expert depth. MUST equal the backbone text
-            tower depth (64 for Qwen3-VL-32B). Defaults to 64.
+        condition_on_layer: Which backbone (reasoner) layer the action expert
+            cross-attends to. ``None`` (default) keeps the per-layer correspondence
+            -- expert layer ``i`` reads backbone layer ``i`` -- which requires
+            ``expert_num_hidden_layers == backbone depth``. When set to an int ``k``
+            (0-indexed; Python-style negatives allowed, e.g. ``-1`` = last layer),
+            **every** expert layer cross-attends to backbone layer ``k`` instead. In
+            this single-layer regime two things follow: (1) the expert depth is freed
+            from the backbone depth (``expert_num_hidden_layers`` may be anything >= 1,
+            e.g. a shallower/cheaper expert), and (2) the frozen backbone is truncated
+            to its first ``k + 1`` layers at load time -- the deeper layers are never
+            allocated or run, a large VRAM + forward-compute saving on the 32B reasoner.
+            The selected layer's KV is bit-identical whether or not the backbone is
+            truncated (deepstack vision features are injected only into the earliest
+            layers, so layer ``k``'s output depends only on layers ``0..k``). Defaults
+            to ``None``.
+        expert_num_hidden_layers: Action-expert depth. With ``condition_on_layer=None``
+            this MUST equal the backbone text tower depth (64 for Qwen3-VL-32B) so each
+            expert layer reads the matching backbone KV layer; with a single
+            ``condition_on_layer`` selected the constraint is dropped and any depth >= 1
+            is allowed. Defaults to 64.
         expert_num_attention_heads: Action-expert query heads. Free (multiple of
             ``expert_num_key_value_heads``). Defaults to 16.
         expert_num_key_value_heads: Action-expert KV heads. MUST equal the backbone
@@ -140,6 +158,13 @@ class Cosmos3Config(PreTrainedConfig):
     train_expert_only: bool = True
     gradient_checkpointing: bool = False
     dropout: float = 0.1
+
+    # --- Backbone-layer conditioning ---
+    # None: per-layer correspondence (expert layer i reads backbone layer i).
+    # int k: every expert layer reads backbone layer k (and the backbone is truncated
+    # to its first k+1 layers; see the docstring). Resolved/range-checked against the
+    # real backbone depth at model-build time in ``Qwen3VLWithExpertModel``.
+    condition_on_layer: int | None = None
 
     # --- Action-expert sizing (see module docstring for the hard constraints) ---
     expert_hidden_size: int = 1024

--- a/src/opentau/policies/cosmos3/modeling_cosmos3.py
+++ b/src/opentau/policies/cosmos3/modeling_cosmos3.py
@@ -150,6 +150,7 @@ class Cosmos3FlowMatching(nn.Module):
             load_pretrained_backbone_repo=(
                 config.pretrained_backbone_repo_id if config.load_pretrained_backbone else None
             ),
+            condition_on_layer=config.condition_on_layer,
         )
 
         expert_hidden = config.expert_hidden_size

--- a/src/opentau/policies/cosmos3/qwen3vl_with_expert.py
+++ b/src/opentau/policies/cosmos3/qwen3vl_with_expert.py
@@ -37,14 +37,30 @@ Hard cross-attention constraints (validated at build time)
 ----------------------------------------------------------
 The expert's per-layer keys/values are concatenated with the backbone's cached KV,
 so the expert's ``num_key_value_heads`` and ``head_dim`` **must** equal the backbone
-text tower's (8 / 128 for Qwen3-VL-32B), and the expert must have the same number of
-layers (64) as the backbone so layer ``i`` of the expert reads layer ``i`` of the
-cache. The expert's *query* head count is free (any multiple of the KV head count)
-because the backbone's queries are never consumed here. The shared MRoPE ``(cos, sin)``
-are produced by the backbone's ``rotary_emb`` and reused by the expert, which is why
-``expert_head_dim`` must match.
+text tower's (8 / 128 for Qwen3-VL-32B). The expert's *query* head count is free (any
+multiple of the KV head count) because the backbone's queries are never consumed here.
+The shared MRoPE ``(cos, sin)`` are produced by the backbone's ``rotary_emb`` and
+reused by the expert, which is why ``expert_head_dim`` must match.
+
+Which backbone layer the expert reads (``condition_on_layer``)
+--------------------------------------------------------------
+By default (``condition_on_layer=None``) the expert mirrors the backbone one-for-one:
+expert layer ``i`` reads the cached KV of backbone layer ``i``, so the expert must have
+the same number of layers (64) as the backbone. Setting ``condition_on_layer=k`` flips
+this to **single-layer conditioning**: every expert layer cross-attends to the cached
+KV of backbone layer ``k`` only. Two consequences follow and are both handled here:
+
+* The layer-count equality is dropped -- the expert may be any depth >= 1 (a shallower,
+  cheaper expert all reading the one rich layer).
+* The frozen backbone is **truncated** to its first ``k + 1`` text layers at build time
+  (``text_config.num_hidden_layers`` is lowered before the backbone is constructed /
+  loaded), so layers ``k+1..N-1`` are never allocated or run. The selected layer's KV is
+  bit-identical with or without truncation: Qwen3-VL injects deepstack vision features
+  only into the earliest layers (after layer ``j`` for ``j < len(features)``), so the
+  output of layer ``k`` -- and hence its KV -- depends only on layers ``0..k``.
 """
 
+import copy
 from contextlib import nullcontext
 
 import torch
@@ -261,8 +277,11 @@ class Qwen3ExpertDecoderLayer(nn.Module):
 class Qwen3ActionExpert(nn.Module):
     """The trainable flow-matching action expert: a stack of AdaRMS Qwen3 decoder layers.
 
-    Operates on action-token embeddings (the suffix). Each layer ``i`` cross-attends to
-    the frozen backbone's cached KV for layer ``i`` plus the action chunk itself.
+    Operates on action-token embeddings (the suffix). Layer ``i`` cross-attends to
+    ``cached_kv[i]`` plus the action chunk itself. The expert is mode-agnostic: the
+    caller (``Qwen3VLWithExpertModel.run_expert``) hands it a ``cached_kv`` list whose
+    length equals the expert depth -- the per-layer backbone cache in the default regime,
+    or the single selected layer's KV broadcast to every position in single-layer mode.
     """
 
     def __init__(
@@ -339,13 +358,20 @@ class Qwen3VLWithExpertModel(nn.Module):
         train_expert_only: bool = True,
         gradient_checkpointing: bool = False,
         load_pretrained_backbone_repo: str | None = None,
+        condition_on_layer: int | None = None,
     ):
         super().__init__()
         self.freeze_vision_encoder = freeze_vision_encoder
         self.train_expert_only = train_expert_only
 
+        # Deepcopy so the layer-count / attn-impl mutations below stay local and never
+        # corrupt the caller's config object (e.g. a shared tiny config across tests).
+        qwen3vl_config = copy.deepcopy(qwen3vl_config)
         text_cfg = qwen3vl_config.text_config
-        # Hard cross-attention constraints (see module docstring).
+        backbone_depth = text_cfg.num_hidden_layers
+
+        # Hard cross-attention constraints (see module docstring): head geometry must
+        # match regardless of which backbone layer(s) the expert reads.
         if expert_head_dim != text_cfg.head_dim:
             raise ValueError(
                 f"expert_head_dim ({expert_head_dim}) must equal the backbone head_dim ({text_cfg.head_dim})."
@@ -355,20 +381,49 @@ class Qwen3VLWithExpertModel(nn.Module):
                 f"expert_num_key_value_heads ({expert_num_key_value_heads}) must equal the backbone "
                 f"num_key_value_heads ({text_cfg.num_key_value_heads})."
             )
-        if expert_num_hidden_layers != text_cfg.num_hidden_layers:
-            raise ValueError(
-                f"expert_num_hidden_layers ({expert_num_hidden_layers}) must equal the backbone "
-                f"num_hidden_layers ({text_cfg.num_hidden_layers}) so each expert layer reads the matching "
-                "backbone KV cache layer."
-            )
-        self.num_layers = text_cfg.num_hidden_layers
 
-        qwen3vl_config.text_config._attn_implementation = attention_implementation
+        # Resolve which backbone layer the expert conditions on (Python-style negatives).
+        if condition_on_layer is None:
+            self.condition_on_layer = None
+        else:
+            resolved = condition_on_layer + backbone_depth if condition_on_layer < 0 else condition_on_layer
+            if not 0 <= resolved < backbone_depth:
+                raise ValueError(
+                    f"condition_on_layer ({condition_on_layer}) is out of range for a backbone with "
+                    f"{backbone_depth} layers; expected an index in [-{backbone_depth}, {backbone_depth - 1}]."
+                )
+            self.condition_on_layer = resolved
+
+        if self.condition_on_layer is None:
+            # Per-layer correspondence: expert layer i reads backbone layer i, so the
+            # depths must match and the full backbone is run.
+            if expert_num_hidden_layers != backbone_depth:
+                raise ValueError(
+                    f"expert_num_hidden_layers ({expert_num_hidden_layers}) must equal the backbone "
+                    f"num_hidden_layers ({backbone_depth}) so each expert layer reads the matching backbone "
+                    "KV cache layer. (Set condition_on_layer=k to read a single layer with a free expert depth.)"
+                )
+            self.num_layers = backbone_depth
+        else:
+            # Single-layer conditioning: expert depth is free, and the backbone only needs
+            # its first condition_on_layer+1 layers -- truncate so the deeper layers are
+            # never allocated or run (the selected layer's KV is unchanged; see docstring).
+            self.num_layers = self.condition_on_layer + 1
+            text_cfg.num_hidden_layers = self.num_layers
+
+        text_cfg._attn_implementation = attention_implementation
         if load_pretrained_backbone_repo is not None:
+            from_pretrained_kwargs = {
+                "dtype": torch.bfloat16,
+                "attn_implementation": attention_implementation,
+            }
+            if self.condition_on_layer is not None:
+                # Honor the truncated layer count when loading; the dropped layers'
+                # checkpoint tensors are skipped (logged as unused), so they are never
+                # materialized -- this is the VRAM saving.
+                from_pretrained_kwargs["config"] = qwen3vl_config
             self.backbone = Qwen3VLForConditionalGeneration.from_pretrained(
-                load_pretrained_backbone_repo,
-                dtype=torch.bfloat16,
-                attn_implementation=attention_implementation,
+                load_pretrained_backbone_repo, **from_pretrained_kwargs
             )
         else:
             self.backbone = Qwen3VLForConditionalGeneration(qwen3vl_config)
@@ -440,9 +495,12 @@ class Qwen3VLWithExpertModel(nn.Module):
         pixel_values: Tensor | None,
         image_grid_thw: Tensor | None,
     ) -> list[tuple[Tensor, Tensor]]:
-        """Run the backbone over the observation prefix; return the per-layer (K, V) cache.
+        """Run the backbone over the observation prefix; return its per-layer (K, V) cache.
 
         Each entry is ``(key, value)`` of shape ``(B, num_kv_heads, S_prefix, head_dim)``.
+        The list has ``self.num_layers`` entries -- the full backbone depth in the default
+        regime, or the truncated ``condition_on_layer + 1`` entries in single-layer mode
+        (the selected layer being the last). ``run_expert`` maps it onto the expert layers.
 
         When ``train_expert_only`` (the default), the backbone is fully frozen: the forward
         runs under ``no_grad`` and the cached KV is ``.detach()``'d, so the expert reads it
@@ -479,4 +537,10 @@ class Qwen3VLWithExpertModel(nn.Module):
         attn_mask: Tensor,
         adarms_cond: Tensor,
     ) -> Tensor:
+        if self.condition_on_layer is not None:
+            # Single-layer conditioning: broadcast the one selected backbone layer's KV
+            # to every expert layer. run_prefix truncated the backbone to
+            # condition_on_layer+1 layers, so the selection is the last cached entry.
+            selected_kv = cached_kv[self.condition_on_layer]
+            cached_kv = [selected_kv] * len(self.expert.layers)
         return self.expert(action_embs, cached_kv, cos, sin, attn_mask, adarms_cond)

--- a/tests/policies/test_cosmos3_cpu.py
+++ b/tests/policies/test_cosmos3_cpu.py
@@ -42,14 +42,14 @@ MAX_ACTION_DIM = 8
 MAX_STATE_DIM = 8
 
 
-def _tiny_qwen3vl_config() -> Qwen3VLConfig:
+def _tiny_qwen3vl_config(num_hidden_layers: int = 2) -> Qwen3VLConfig:
     """A minimally-sized Qwen3-VL config (head_dim/kv-heads/layers must match the expert)."""
     return Qwen3VLConfig(
         text_config={
             "model_type": "qwen3_vl_text",
             "hidden_size": 64,
             "intermediate_size": 128,
-            "num_hidden_layers": 2,
+            "num_hidden_layers": num_hidden_layers,
             "num_attention_heads": 4,
             "num_key_value_heads": 2,
             "head_dim": 16,
@@ -103,9 +103,11 @@ def _tiny_cosmos3_config(**overrides) -> Cosmos3Config:
     return Cosmos3Config(**kwargs)
 
 
-def _build_model() -> Cosmos3FlowMatching:
+def _build_model(qwen3vl_num_layers: int = 2, **overrides) -> Cosmos3FlowMatching:
     torch.manual_seed(0)
-    return Cosmos3FlowMatching(_tiny_cosmos3_config(), qwen3vl_config=_tiny_qwen3vl_config())
+    return Cosmos3FlowMatching(
+        _tiny_cosmos3_config(**overrides), qwen3vl_config=_tiny_qwen3vl_config(qwen3vl_num_layers)
+    )
 
 
 def _text_batch(bsize: int = 2, n_text: int = 6):
@@ -252,6 +254,149 @@ def test_cosmos3_sample_actions_shape():
         state=state,
         action_prefix=action_prefix,
         delay=delay,
+    )
+    assert actions.shape == (bsize, CHUNK, MAX_ACTION_DIM)
+    assert torch.isfinite(actions).all()
+
+
+# ---- single-layer conditioning (condition_on_layer) ----
+
+
+def test_cosmos3_single_layer_forward_and_grads():
+    """condition_on_layer=k: forward is finite, the backbone is truncated to k+1 layers,
+    and only the expert receives gradients (the truncated backbone stays frozen)."""
+    model = _build_model(condition_on_layer=0)
+    we = model.qwen3vl_with_expert
+    assert we.condition_on_layer == 0
+    assert we.num_layers == 1
+    assert len(we.backbone.model.language_model.layers) == 1  # deeper layers never allocated
+
+    input_ids, attention_mask, state, actions = _text_batch()
+    out = model(
+        input_ids=input_ids,
+        attention_mask=attention_mask,
+        pixel_values=None,
+        image_grid_thw=None,
+        state=state,
+        actions=actions,
+        noise=torch.randn_like(actions),
+        time=torch.rand(actions.shape[0]),
+    )
+    assert torch.isfinite(out["MSE"])
+    out["MSE"].backward()
+    assert any(p.grad is not None for p in we.expert.parameters())
+    assert all(p.grad is None for p in we.backbone.parameters())
+
+
+def test_cosmos3_single_layer_allows_shallower_expert():
+    """In single-layer mode the expert depth is free (need not equal the backbone depth)."""
+    model = _build_model(qwen3vl_num_layers=2, condition_on_layer=1, expert_num_hidden_layers=5)
+    assert len(model.qwen3vl_with_expert.expert.layers) == 5
+    assert model.qwen3vl_with_expert.num_layers == 2  # condition_on_layer=1 -> first 2 layers
+    input_ids, attention_mask, state, actions = _text_batch()
+    out = model(
+        input_ids=input_ids,
+        attention_mask=attention_mask,
+        pixel_values=None,
+        image_grid_thw=None,
+        state=state,
+        actions=actions,
+        noise=torch.randn_like(actions),
+        time=torch.rand(actions.shape[0]),
+    )
+    assert torch.isfinite(out["MSE"])
+
+
+def test_cosmos3_single_layer_negative_index():
+    """Negative condition_on_layer indexes from the end (Python-style)."""
+    model = _build_model(qwen3vl_num_layers=2, condition_on_layer=-1, expert_num_hidden_layers=3)
+    assert model.qwen3vl_with_expert.condition_on_layer == 1  # -1 -> last of 2 layers
+    assert model.qwen3vl_with_expert.num_layers == 2
+
+
+def test_cosmos3_single_layer_out_of_range_raises():
+    with pytest.raises(ValueError):
+        _build_model(qwen3vl_num_layers=2, condition_on_layer=2)  # valid indices are 0, 1
+    with pytest.raises(ValueError):
+        _build_model(qwen3vl_num_layers=2, condition_on_layer=-3)
+
+
+def test_cosmos3_default_mode_requires_matching_depth():
+    """With condition_on_layer=None the expert depth must still equal the backbone depth."""
+    with pytest.raises(ValueError):
+        _build_model(qwen3vl_num_layers=2, expert_num_hidden_layers=3)  # 3 != 2
+
+
+def test_cosmos3_single_layer_truncation_kv_matches_full_backbone():
+    """Truncating the backbone to k+1 layers yields the *same* KV at the selected layer as
+    the full backbone: deepstack vision features are injected only into the earliest layers,
+    so layer k's output (and its cached KV) depends only on layers 0..k."""
+    k = 2  # backbone depth 4 -> truncate to 3 layers (layer 3 dropped)
+    full = _build_model(qwen3vl_num_layers=4, expert_num_hidden_layers=4)  # condition_on_layer=None
+    trunc = _build_model(qwen3vl_num_layers=4, condition_on_layer=k, expert_num_hidden_layers=4)
+    # Pin the shared backbone weights so the comparison isolates truncation, not init RNG.
+    trunc.qwen3vl_with_expert.backbone.load_state_dict(
+        full.qwen3vl_with_expert.backbone.state_dict(), strict=False
+    )
+
+    input_ids, attention_mask, pixel_values, image_grid_thw = _image_inputs()
+
+    def cached(model):
+        pos, _ = model.qwen3vl_with_expert.get_rope_index(
+            input_ids=input_ids, image_grid_thw=image_grid_thw, attention_mask=attention_mask
+        )
+        return model.qwen3vl_with_expert.run_prefix(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=pos,
+            pixel_values=pixel_values,
+            image_grid_thw=image_grid_thw,
+        )
+
+    full_kv = cached(full)
+    trunc_kv = cached(trunc)
+    assert len(full_kv) == 4 and len(trunc_kv) == k + 1
+    fk, fv = full_kv[k]
+    tk, tv = trunc_kv[k]  # the selected layer is the last truncated entry
+    assert torch.equal(fk, tk)
+    assert torch.equal(fv, tv)
+
+
+def test_cosmos3_single_layer_deterministic():
+    """Two seeded single-layer forwards produce bit-identical loss (CLAUDE.md rule 3)."""
+    losses = []
+    for _ in range(2):
+        model = _build_model(qwen3vl_num_layers=2, condition_on_layer=0, expert_num_hidden_layers=3)
+        input_ids, attention_mask, state, actions = _text_batch()
+        torch.manual_seed(1234)
+        noise = torch.randn_like(actions)
+        time = torch.rand(actions.shape[0])
+        out = model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            pixel_values=None,
+            image_grid_thw=None,
+            state=state,
+            actions=actions,
+            noise=noise,
+            time=time,
+        )
+        losses.append(out["MSE"].item())
+    assert losses[0] == losses[1], f"non-deterministic loss: {losses}"
+
+
+def test_cosmos3_single_layer_sample_actions_shape():
+    model = _build_model(qwen3vl_num_layers=2, condition_on_layer=0, expert_num_hidden_layers=3)
+    input_ids, attention_mask, state, _ = _text_batch()
+    bsize = input_ids.shape[0]
+    actions = model.sample_actions(
+        input_ids=input_ids,
+        attention_mask=attention_mask,
+        pixel_values=None,
+        image_grid_thw=None,
+        state=state,
+        action_prefix=torch.zeros(bsize, CHUNK, MAX_ACTION_DIM),
+        delay=torch.tensor(0, dtype=torch.long),
     )
     assert actions.shape == (bsize, CHUNK, MAX_ACTION_DIM)
     assert torch.isfinite(actions).all()

--- a/tests/policies/test_cosmos3_gpu.py
+++ b/tests/policies/test_cosmos3_gpu.py
@@ -92,9 +92,11 @@ def _tiny_config(**overrides) -> Cosmos3Config:
     return Cosmos3Config(**kwargs)
 
 
-def _build(device):
+def _build(device, qwen3vl_num_layers=2, **overrides):
     torch.manual_seed(0)
-    model = Cosmos3FlowMatching(_tiny_config(), qwen3vl_config=_tiny_qwen3vl_config())
+    qcfg = _tiny_qwen3vl_config()
+    qcfg.text_config.num_hidden_layers = qwen3vl_num_layers
+    model = Cosmos3FlowMatching(_tiny_config(**overrides), qwen3vl_config=qcfg)
     return model.to(device=device, dtype=torch.bfloat16)
 
 
@@ -131,6 +133,33 @@ def test_cosmos3_gpu_forward_backward():
     backbone = model.qwen3vl_with_expert.backbone
     assert any(p.grad is not None and torch.isfinite(p.grad).all() for p in expert.parameters())
     assert all(p.grad is None for p in backbone.parameters())
+
+
+@pytest.mark.gpu
+def test_cosmos3_gpu_single_layer_forward_backward():
+    """bf16 single-layer conditioning on CUDA: backbone truncated to k+1 layers, a shallower
+    expert reads the one selected layer, finite loss, expert grads flow, backbone frozen."""
+    device = "cuda"
+    model = _build(device, qwen3vl_num_layers=4, condition_on_layer=2, expert_num_hidden_layers=8)
+    we = model.qwen3vl_with_expert
+    assert we.condition_on_layer == 2 and we.num_layers == 3
+    assert len(we.backbone.model.language_model.layers) == 3  # layer 3 never allocated
+    assert len(we.expert.layers) == 8  # expert depth decoupled from backbone depth
+    iid, am, st, act, noise, time = _batch(device)
+    out = model(
+        input_ids=iid,
+        attention_mask=am,
+        pixel_values=None,
+        image_grid_thw=None,
+        state=st,
+        actions=act,
+        noise=noise,
+        time=time,
+    )
+    assert torch.isfinite(out["MSE"])
+    out["MSE"].backward()
+    assert any(p.grad is not None and torch.isfinite(p.grad).all() for p in we.expert.parameters())
+    assert all(p.grad is None for p in we.backbone.parameters())
 
 
 @pytest.mark.gpu


### PR DESCRIPTION
## What this does
Adds a `condition_on_layer` option to the **cosmos3** policy (🗃️ Feature), letting users pick a single Qwen3-VL reasoner layer for the action expert to condition on, instead of the default per-layer correspondence.

- **`condition_on_layer=None` (default, unchanged):** expert layer `i` cross-attends to the matching backbone layer `i`'s KV cache, which requires `expert_num_hidden_layers == backbone depth` (64 for Qwen3-VL-32B).
- **`condition_on_layer=k`:** *every* expert layer cross-attends to backbone layer `k` only. Two things follow:
  1. **Expert depth is decoupled from the backbone depth** — the layer-count equality constraint is dropped, so the expert can be any depth `>= 1` (e.g. a shallower, cheaper expert all reading the one selected layer).
  2. **The frozen backbone is truncated to its first `k + 1` text layers at load time** — the deeper layers are never allocated or run, a large VRAM + forward-compute saving on the 32B reasoner. Negative indices (Python-style, e.g. `-1` = last layer) are supported and the index is range-checked against the real backbone depth at build time.

The selected layer's KV is **bit-identical with or without truncation**: Qwen3-VL injects deepstack vision features only into the earliest layers (after layer `j` for `j < len(features)`), so the output of layer `k` — and hence its cached KV — depends only on layers `0..k`. Truncation is therefore a pure compute/memory optimization, not a change in numerics.

Implementation lives in `policies/cosmos3/qwen3vl_with_expert.py` (resolution, validation, truncation via `text_config.num_hidden_layers`, and KV broadcast in `run_expert`); the field is added to `Cosmos3Config` and threaded through `modeling_cosmos3.py`. An example config (`configs/examples/cosmos3_single_layer_config.json`) demonstrates a 16-layer expert reading backbone layer 31.

## How it was tested
- **CPU suite** (`pytest -m "not gpu and not network"` on `tests/policies/test_cosmos3_cpu.py`): **19 passed** (11 existing + 8 new). New tests cover: single-layer forward/backward with only-expert gradients, backbone truncated to `k+1` layers, a shallower expert decoupled from backbone depth, negative indexing, out-of-range error, the default-mode depth guard still firing, two-seed bit-identical determinism (CLAUDE.md rule 3), and a **KV truncation-equivalence** test asserting the selected layer's cached KV is bit-identical (`torch.equal`) between the full and truncated backbone (validates the deepstack-injection reasoning above).
- **GPU suite on an 8×A100-80GB node** (`pytest -m "gpu" -n 0` on `tests/policies/test_cosmos3_gpu.py`): **3 passed**, including a new `test_cosmos3_gpu_single_layer_forward_backward` exercising the bf16 truncation + shallower-expert path on real A100 hardware.
- **Real load-path smoke on A100:** saved a small real Qwen3-VL checkpoint to disk and loaded it through the cosmos3 code path with `condition_on_layer=2` — the backbone allocated only 3 of 4 text layers (the deep layer's checkpoint tensors were skipped, confirming the `from_pretrained(config=truncated)` VRAM saving on a real sharded checkpoint), a 6-layer expert worked, and the bf16 forward produced a finite loss.
- `pre-commit run --all-files`-equivalent hooks pass on all changed files. Nightly `regression_test.yml` covers end-to-end regression on the AWS runner.

## How to checkout & try? (for the reviewer)
```bash
pytest -sx tests/policies/test_cosmos3_cpu.py -k single_layer
```
```bash
# on a CUDA box (e.g. the 8xA100 node)
pytest -m "gpu" -n 0 tests/policies/test_cosmos3_gpu.py
```
```bash
# single-layer training config (frozen Qwen3-VL-32B truncated to layer 31, 16-layer expert)
opentau-train --config_path=configs/examples/cosmos3_single_layer_config.json
# or override on top of the default cosmos3 config:
opentau-train --config_path=configs/examples/cosmos3_training_config.json --policy.condition_on_layer=31 --policy.expert_num_hidden_layers=16
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [x] My PR includes policy-related changes.
  - [x] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
