### PR TITLE
fix(robocasa): promote multi-env Sync eval to Async for correct renders

### DIFF
--- a/src/opentau/configs/default.py
+++ b/src/opentau/configs/default.py
@@ -568,7 +568,11 @@ class EvalConfig:
             Only used for environments that are not already vectorized.
             Defaults to 16.
         use_async_envs: Whether to use asynchronous environments (multiprocessing).
-            Defaults to True.
+            Defaults to True. RoboCasa eval *requires* the async backend for any
+            multi-env (batch_size > 1) build: its per-env EGL/GL offscreen render
+            contexts cross-contaminate in a single process, so SyncVectorEnv feeds
+            the policy the wrong env's pixels (issue #449). A multi-env RoboCasa
+            Sync build is therefore auto-promoted to async; LIBERO is unaffected.
         max_episodes_rendered: Maximum number of episodes to render as videos.
             Defaults to 16.
         grid_size: Grid dimensions for video summary (rows, cols). If None, will

--- a/src/opentau/envs/robocasa.py
+++ b/src/opentau/envs/robocasa.py
@@ -823,6 +823,48 @@ def _make_env_fns(
     return [partial(_make_env, i) for i in range(n_envs)]
 
 
+# Escape hatch: force the (broken) single-process SyncVectorEnv path even for
+# n_envs > 1. Renders WILL be wrong (see _maybe_promote_sync_to_async); only for
+# callers that knowingly do not depend on observation correctness.
+ALLOW_ROBOCASA_SYNC_ENV = "OPENTAU_ALLOW_ROBOCASA_SYNC"
+
+
+def _maybe_promote_sync_to_async(
+    env_cls: Callable[..., gym.vector.VectorEnv], n_envs: int
+) -> Callable[..., gym.vector.VectorEnv]:
+    r"""Promote a multi-env ``SyncVectorEnv`` build to ``AsyncVectorEnv`` for RoboCasa.
+
+    Each RoboCasa sub-env renders its cameras through its own MuJoCo *offscreen*
+    EGL/GL context. With more than one sub-env in a single process
+    (``SyncVectorEnv``) those contexts cross-contaminate: ``sim.render()`` for one
+    env can return *another* env's framebuffer, so the policy is fed observations
+    that do not match the scene it is acting in — which tanks success and makes it
+    non-reproducible. Scene *geometry* is unaffected (it is pinned by each env's own
+    seeded RNG; verified bit-identical across Sync/Async), so the corruption is
+    purely in the rendered pixels. ``AsyncVectorEnv`` (spawn) puts each env in its
+    own process with its own context and renders correctly. This is an upstream
+    robosuite/mujoco limitation, not something fixable in the wrapper, so a
+    multi-env Sync build is transparently promoted to Async. See issue #449.
+
+    Single-env Sync (one context, no contamination) is left as-is, as is anything
+    that is already Async. ``OPENTAU_ALLOW_ROBOCASA_SYNC=1`` forces the original
+    (broken-render) Sync path for callers that knowingly do not need correct
+    observations (e.g. a dataset-independent CPU smoke test).
+    """
+    if os.environ.get(ALLOW_ROBOCASA_SYNC_ENV) == "1":
+        return env_cls
+    is_sync = isinstance(env_cls, type) and issubclass(env_cls, gym.vector.SyncVectorEnv)
+    if is_sync and n_envs > 1:
+        acc_print(
+            f"[opentau] RoboCasa eval requested SyncVectorEnv with n_envs={n_envs} (>1): its "
+            "per-env EGL/GL offscreen render contexts cross-contaminate in one process and "
+            "corrupt observations (issue #449). Promoting to AsyncVectorEnv (spawn) so each env "
+            f"renders correctly. Set {ALLOW_ROBOCASA_SYNC_ENV}=1 to keep Sync (renders will be wrong)."
+        )
+        return partial(gym.vector.AsyncVectorEnv, context="spawn")
+    return env_cls
+
+
 # main API entry point
 def create_robocasa_envs(
     task: str,
@@ -856,6 +898,10 @@ def create_robocasa_envs(
         raise ValueError("env_cls must be a callable that wraps a list of environment factory callables.")
     if not isinstance(n_envs, int) or n_envs <= 0:
         raise ValueError(f"n_envs must be a positive int; got {n_envs}.")
+
+    # A multi-env single-process Sync build corrupts RoboCasa's per-env renders
+    # (issue #449); transparently run it on the process-isolated Async backend.
+    env_cls = _maybe_promote_sync_to_async(env_cls, n_envs)
 
     # Relocate RoboCasa assets out of the (ephemeral) uv venv and make the packs the
     # requested registries need available. Resolve + export the root, then run the download

--- a/tests/envs/test_robocasa.py
+++ b/tests/envs/test_robocasa.py
@@ -26,6 +26,7 @@ Real sim rollouts are validated separately on a CUDA box.
 import contextlib
 import json
 import os
+from functools import partial
 from pathlib import Path
 from unittest.mock import Mock, patch
 
@@ -39,6 +40,7 @@ from opentau.envs.configs import EnvConfig, RoboCasaEnv
 from opentau.envs.factory import make_env_config, make_envs
 from opentau.envs.robocasa import (
     ACTION_DIM,
+    ALLOW_ROBOCASA_SYNC_ENV,
     OBS_STATE_DIM,
     ROBOCASA_ASSETS_ROOT_ENV,
     _default_camera_name_mapping,
@@ -46,6 +48,7 @@ from opentau.envs.robocasa import (
     _ensure_robocasa_assets,
     _import_robocasa_with_version_shim,
     _internal_robocasa_pkg_dir,
+    _maybe_promote_sync_to_async,
     _maybe_relink_robocasa_assets,
     _needed_asset_packs,
     _official_task_horizon,
@@ -529,6 +532,76 @@ class TestMakeEnvsDispatch:
         import gymnasium as gym
 
         assert kwargs["env_cls"] is gym.vector.SyncVectorEnv
+
+
+class TestSyncToAsyncPromotion:
+    """RoboCasa multi-env Sync builds are promoted to Async (issue #449).
+
+    A single-process ``SyncVectorEnv`` cross-contaminates each sub-env's MuJoCo
+    *offscreen* EGL/GL render context, so ``sim.render()`` can return the wrong
+    env's framebuffer and the policy is fed observations that don't match the scene
+    it is acting in (scene geometry itself is unaffected — it is pinned by each
+    env's seeded RNG). The builder transparently promotes a multi-env Sync build to
+    ``AsyncVectorEnv`` (spawn). Single-env Sync (one context) and already-Async
+    builds are left untouched, and an env-var escape hatch forces the Sync path.
+    """
+
+    def test_multi_env_sync_is_promoted_to_async_spawn(self, monkeypatch):
+        import gymnasium as gym
+
+        monkeypatch.delenv(ALLOW_ROBOCASA_SYNC_ENV, raising=False)
+        out = _maybe_promote_sync_to_async(gym.vector.SyncVectorEnv, n_envs=4)
+        assert isinstance(out, partial)
+        assert out.func is gym.vector.AsyncVectorEnv
+        assert out.keywords == {"context": "spawn"}
+
+    def test_single_env_sync_is_left_as_sync(self, monkeypatch):
+        import gymnasium as gym
+
+        monkeypatch.delenv(ALLOW_ROBOCASA_SYNC_ENV, raising=False)
+        # One env -> one render context -> no contamination -> keep Sync.
+        assert _maybe_promote_sync_to_async(gym.vector.SyncVectorEnv, n_envs=1) is gym.vector.SyncVectorEnv
+
+    def test_async_build_is_unchanged(self, monkeypatch):
+        import gymnasium as gym
+
+        monkeypatch.delenv(ALLOW_ROBOCASA_SYNC_ENV, raising=False)
+        async_cls = partial(gym.vector.AsyncVectorEnv, context="spawn")
+        assert _maybe_promote_sync_to_async(async_cls, n_envs=8) is async_cls
+
+    def test_escape_hatch_keeps_sync(self, monkeypatch):
+        import gymnasium as gym
+
+        monkeypatch.setenv(ALLOW_ROBOCASA_SYNC_ENV, "1")
+        # Override -> keep the (broken-render) Sync path even for n_envs > 1.
+        assert _maybe_promote_sync_to_async(gym.vector.SyncVectorEnv, n_envs=4) is gym.vector.SyncVectorEnv
+
+    def test_non_vectorenv_callable_untouched(self, monkeypatch):
+        # A mocked env_cls (as the other tests use) is not a SyncVectorEnv subclass,
+        # so it passes through unchanged regardless of n_envs.
+        monkeypatch.delenv(ALLOW_ROBOCASA_SYNC_ENV, raising=False)
+        sentinel = Mock()
+        assert _maybe_promote_sync_to_async(sentinel, n_envs=8) is sentinel
+
+    def test_create_robocasa_envs_promotes_multi_env_sync(self, monkeypatch):
+        # End-to-end: a real SyncVectorEnv + n_envs>1 through create_robocasa_envs
+        # builds via AsyncVectorEnv. Patch AsyncVectorEnv so no sim import / spawn.
+        import gymnasium as gym
+
+        monkeypatch.delenv(ALLOW_ROBOCASA_SYNC_ENV, raising=False)
+        async_sentinel = Mock(name="async_vec")
+        async_cls = Mock(return_value=async_sentinel)
+        monkeypatch.setattr(gym.vector, "AsyncVectorEnv", async_cls)
+        with patch("opentau.envs.robocasa.get_proc_accelerator", return_value=None):
+            out = create_robocasa_envs(
+                task="A",
+                n_envs=4,
+                env_cls=gym.vector.SyncVectorEnv,
+                episode_length=900,
+                auto_download_assets=False,
+            )
+        assert out["A"][0] is async_sentinel
+        assert async_cls.call_args.kwargs.get("context") == "spawn"
 
 
 def _fake_robocasa_assets(monkeypatch, tmp_path: Path) -> tuple[Path, list[dict]]:


### PR DESCRIPTION
## What this does

Fixes #449 (🐛 Bug).

RoboCasa eval under `SyncVectorEnv` (`eval.use_async_envs: false`) with
`batch_size > 1` produces **substantially lower and non-reproducible** success
than `AsyncVectorEnv` on identical task / split / seeds / weights.

The issue hypothesized a global-RNG scene-generation leak. A policy-free
diagnostic (hashing scene geometry and rendered pixels separately, per env-slot,
across both backends) shows that is **not** the cause:

- **Scene geometry is bit-identical** across Sync and Async for every seed — it is
  pinned by each env's own seeded per-env RNG (robosuite's `self.rng`, an
  independent PCG64 stream), so RNG is exonerated.
- **Rendered observations are corrupted under Sync**: different-scene sub-envs
  return the *same* image (their render hashes collide) and are non-reproducible
  across runs, while Async renders are per-env-distinct and reproducible.

Root cause: with N RoboCasa sub-envs in one process, their MuJoCo **offscreen
EGL/GL render contexts cross-contaminate**, so `sim.render()` returns another
env's framebuffer and the policy acts on observations that do not match its
scene. This is an upstream robosuite/mujoco limitation; `AsyncVectorEnv`'s
one-process-per-env isolation renders each env correctly.

Fix: `create_robocasa_envs` now transparently promotes a multi-env Sync build to
`AsyncVectorEnv` (spawn) with a warning (`_maybe_promote_sync_to_async`).
Single-env Sync (one context, no contamination) is untouched, and
`OPENTAU_ALLOW_ROBOCASA_SYNC=1` forces the original path. `use_async_envs`
already defaults to `True`. This is intentionally an auto-promote rather than a
hard error, because the in-training eval call site is not wrapped in try/except
and a raise would abort training runs.

**LIBERO is unaffected** — it loads fixed precomputed `init_states` indexed by a
deterministic slot (`episode_index`) with static BDDL scenes, so there is no
per-reset procedural rendering churn and Sync == Async there.

## How it was tested

- GPU diagnostic (policy-free) on an A100: for a fixed seed range, hashed each
  sub-env's scene geometry (`sim.model` body/geom pos/size/quat + `qpos0`) and
  first rendered frame, under `SyncVectorEnv` vs `AsyncVectorEnv`, twice each.
  Result: scene hashes match **8/8** across both backends; under Sync the render
  hashes **collide across different-scene slots** and are **0/8 reproducible**;
  under Async renders are per-env-distinct and reproducible. This pinpoints
  render-context contamination and rules out RNG.
- Added `TestSyncToAsyncPromotion` (6 CPU tests) in `tests/envs/test_robocasa.py`:
  multi-env Sync is promoted to spawn Async, single-env Sync is kept, an
  already-Async build is unchanged, the escape-hatch env var keeps Sync, a
  non-`VectorEnv` callable passes through, and the promotion fires end-to-end
  through `create_robocasa_envs`.
- `pytest -m "not gpu and not network" tests/envs/test_robocasa.py` → 79 passed.
  `pre-commit run --all` clean on the changed files.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/envs/test_robocasa.py::TestSyncToAsyncPromotion
```

With this change, a RoboCasa eval requested with `eval.use_async_envs=false` and
`eval.batch_size>1` logs a warning and runs on the (correct) async backend; set
`OPENTAU_ALLOW_ROBOCASA_SYNC=1` to keep the old Sync path.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.
