### PR TITLE
chore: bump version to 0.9.0

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,8 +30,8 @@ project = "OpenTau"
 copyright = "2026, Tensor Auto Inc"
 author = "Tensor Auto Inc"
 
-version = "0.8.0"
-release = "0.8.0"
+version = "0.9.0"
+release = "0.9.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ huggingface = "https://huggingface.co/TensorAuto"
 
 [project]
 name = "opentau"
-version = "0.8.0"
+version = "0.9.0"
 description = "OpenTau: Tensor's VLA Training Infrastructure for Real-World Robotics in Pytorch"
 authors = [
     { name = "Shuheng Liu", email = "wish1104@icloud.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -2157,7 +2157,7 @@ wheels = [
 
 [[package]]
 name = "opentau"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
## What this does
Bumps the package version from 0.8.0 to 0.9.0 (📝 Documentation / release chore):
- `pyproject.toml`: `version = "0.9.0"`
- `docs/source/conf.py`: Sphinx `version` / `release` set to `0.9.0`
- `uv.lock`: regenerated via `uv lock` (only the `opentau` entry changed)

## How it was tested
- `uv lock` resolves cleanly (274 packages) with only `opentau v0.8.0 -> v0.9.0` updated.
- `pre-commit run` on the changed files: all hooks pass.

## How to checkout & try? (for the reviewer)
```bash
git fetch origin worktree-bump-v0.9.0 && git checkout worktree-bump-v0.9.0
uv sync --extra dev
python -c "import opentau; print(opentau.__version__)"  # 0.9.0
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).