### PR TITLE
feat(datasets): per-task prompt substitution from a config-time pool

### DIFF
--- a/configs/examples/prompt_substitutions_example.json
+++ b/configs/examples/prompt_substitutions_example.json
@@ -1,0 +1,26 @@
+{
+    "put the white mug on the left plate and put the yellow and white mug on the right plate": [
+        "place the white mug on the left plate and the yellow-and-white mug on the right plate",
+        "set the white mug onto the left plate, then set the yellow and white mug onto the right plate"
+    ],
+    "put the white mug on the plate and put the chocolate pudding to the right of the plate": [
+        "place the white mug on the plate and the chocolate pudding to the plate's right",
+        "put the white mug onto the plate, then place the pudding just right of it"
+    ],
+    "put the yellow and white mug in the microwave and close it": [
+        "place the yellow and white mug inside the microwave and shut the door",
+        "put the yellow-and-white mug into the microwave, then close the microwave"
+    ],
+    "turn on the stove and put the moka pot on it": [
+        "switch the stove on and set the moka pot on the burner",
+        "turn the stove on, then place the moka pot on top of it"
+    ],
+    "put both the alphabet soup and the cream cheese box in the basket": [
+        "place the alphabet soup can and the cream cheese box into the basket",
+        "move the alphabet soup and the cream cheese into the basket"
+    ],
+    "put both the alphabet soup and the tomato sauce in the basket": [
+        "place the alphabet soup and the tomato sauce into the basket",
+        "move both the soup can and the tomato sauce can to the basket"
+    ]
+}

--- a/docs/source/tutorials/datasets.rst
+++ b/docs/source/tutorials/datasets.rst
@@ -64,6 +64,63 @@ For example:
         ...
     }
 
+Randomizing task prompts with a substitution pool
+--------------------------------------------------
+
+A per-dataset ``prompt_substitutions`` mapping randomly swaps the on-disk task
+prompt at fetch time — e.g. paraphrase augmentation for prompt robustness. Each
+key must exactly match an on-disk task string (``meta/tasks.*``); a matching
+sample's prompt is **always** replaced by a uniform random draw from that key's
+list, so include the original string in the list if it should still appear.
+Unmapped tasks pass through unchanged, and keys that match no on-disk task
+string raise at dataset init (typo protection).
+
+.. code-block:: javascript
+
+    {
+        "dataset_mixture": {
+            "datasets": [
+                {
+                    "repo_id": "TensorAuto/libero",
+                    "prompt_substitutions": {
+                        "put both the alphabet soup and the tomato sauce in the basket": [
+                            "place the alphabet soup and the tomato sauce into the basket",
+                            "move both the soup can and the tomato sauce can to the basket"
+                        ]
+                    }
+                }
+            ]
+        },
+        ...
+    }
+
+Large pools can live in their own file and be inlined with a ``$ref`` include
+(resolved relative to the referencing config file — see
+`configs/examples/prompt_substitutions_example.json <https://github.com/TensorAuto/OpenTau/blob/main/configs/examples/prompt_substitutions_example.json>`_):
+
+.. code-block:: javascript
+
+    {
+        "repo_id": "TensorAuto/libero",
+        "prompt_substitutions": {"$ref": "prompt_substitutions_example.json"}
+    }
+
+Sibling keys next to ``"$ref"`` deep-merge over the loaded fragment, so a
+config can extend or override individual task entries in place.
+
+Notes:
+
+- Substitution applies to the **training split only** by default; the
+  validation split keeps the on-disk prompts. Set the mixture-level
+  ``"val_enable_prompt_substitution": true`` to also randomize validation
+  prompts (with always-replace semantics the original prompt never appears in
+  training, so this makes val loss match the training prompt distribution).
+- ``response``/memory CE targets are **not** rewritten — substitutes must be
+  semantic paraphrases of the original task.
+- Like every per-dataset field, ``prompt_substitutions`` has no CLI override
+  path; set it in the JSON config.
+- VQA datasets build their own prompts and reject this field.
+
 Computing max token length for dataset mixture
 ----------------------------------------------
 

--- a/src/opentau/configs/default.py
+++ b/src/opentau/configs/default.py
@@ -104,11 +104,29 @@ class DatasetConfig:
             check (a warning is logged); ``False`` forces the check on for this
             dataset even if the mixture default is ``True``. Does not affect
             the record-time check inside ``add_episode``.
+        prompt_substitutions: Optional mapping from an on-disk task string
+            (exact match against ``meta/tasks.*``) to a non-empty list of
+            substitute prompts. At fetch time a matching sample's task is
+            ALWAYS replaced by a uniform random draw from its list (include
+            the original in the list if it should still appear); unmapped
+            tasks pass through unchanged. Applies to the train split only
+            unless ``DatasetMixtureConfig.val_enable_prompt_substitution`` is
+            set. Keys that match no on-disk task string raise at dataset
+            init. ``response``/memory CE targets are NOT rewritten, so
+            substitutes must be semantic paraphrases of the original task.
+            Only settable for LeRobot datasets (``repo_id``), not VQA
+            entries. Like every per-dataset field it has no CLI override
+            path — set it in the JSON config; an external fragment can be
+            inlined with ``{"$ref": "path/to/fragment.json"}`` (see
+            ``opentau/configs/refs.py``). Draws use the default torch RNG
+            (see the ``DatasetMixtureConfig`` note). Defaults to None.
 
     Raises:
-        ValueError: If both or neither of `repo_id` and `vqa` are set, or
-            if `data_features_name_mapping` is provided.
-            is provided.
+        ValueError: If both or neither of ``repo_id`` and ``vqa`` are set, if
+            ``tolerance_s`` or ``val_split_ratio`` is out of range, or if
+            ``prompt_substitutions`` is set on a VQA entry, maps a task
+            literally named ``"$ref"``, or contains an empty or non-string
+            substitute list.
     """
 
     repo_id: str | None = None
@@ -125,6 +143,18 @@ class DatasetConfig:
 
     # optional standard data format mapping for the dataset if mapping is not already in standard_data_format_mapping.py
     data_features_name_mapping: dict[str, str] | None = None
+
+    # Optional per-dataset prompt substitution. Maps an on-disk task string
+    # (exact match against meta/tasks.*) to a non-empty list of substitute
+    # prompts; at fetch time a matching sample's task is ALWAYS replaced by a
+    # uniform random draw from the list (include the original in the list if
+    # it should still appear). Unmapped tasks pass through unchanged. Train
+    # split only unless `DatasetMixtureConfig.val_enable_prompt_substitution`
+    # is set. Config-file-only (per-dataset fields have no CLI override path);
+    # an external fragment can be inlined with `{"$ref": "fragment.json"}`.
+    # Note: `response`/memory CE targets are NOT rewritten — substitutes must
+    # be semantic paraphrases of the original task.
+    prompt_substitutions: dict[str, list[str]] | None = None
 
     # Optional overrides for the metadata fields read from `meta/info.json`.
     # `None` means "do not override". Any string value (including "") is
@@ -163,6 +193,35 @@ class DatasetConfig:
                 f"`DatasetConfig.val_split_ratio` must be in [0, 1] (or None to inherit), "
                 f"got {self.val_split_ratio} for {self.repo_id or self.vqa}."
             )
+
+        if self.prompt_substitutions is not None:
+            if self.vqa is not None:
+                raise ValueError(
+                    f"`DatasetConfig.prompt_substitutions` only applies to LeRobot datasets "
+                    f"(`repo_id`); VQA dataset {self.vqa!r} builds its own prompt."
+                )
+            for task, subs in self.prompt_substitutions.items():
+                if not isinstance(task, str):
+                    raise ValueError(
+                        f"`prompt_substitutions` keys must be on-disk task strings, got "
+                        f"{task!r} for {self.repo_id}."
+                    )
+                if task == "$ref":
+                    raise ValueError(
+                        "`prompt_substitutions` cannot map a task literally named '$ref': the "
+                        "config loader treats any JSON object containing a '$ref' key as a file "
+                        "include directive (see opentau/configs/refs.py)."
+                    )
+                if not isinstance(subs, list) or len(subs) == 0:
+                    raise ValueError(
+                        f"`prompt_substitutions[{task!r}]` must be a non-empty list of strings, "
+                        f"got {subs!r} for {self.repo_id}."
+                    )
+                if not all(isinstance(s, str) for s in subs):
+                    raise ValueError(
+                        f"`prompt_substitutions[{task!r}]` contains non-string entries: "
+                        f"{subs!r} for {self.repo_id}."
+                    )
 
         # If data_features_name_mapping is provided, upsert it into the global
         # DATA_FEATURES_NAME_MAPPING. Register under the plain repo_id (back-compat
@@ -261,6 +320,13 @@ class DatasetMixtureConfig:
             aren't polluted by training-time augmentation. Subgoal *frame*
             sampling (end-of-segment vs. uniform in the next 4s) stays active
             either way; only the masking logic is gated.
+        val_enable_prompt_substitution: Whether the per-dataset
+            ``DatasetConfig.prompt_substitutions`` swaps also fire on the
+            validation split. Defaults to ``False`` — validation evaluates on
+            the on-disk prompts. Flip to ``True`` when val loss should match
+            the training prompt distribution (with always-replace semantics
+            the original prompt never appears in training unless listed among
+            its own substitutes).
         require_non_empty_robot_type: If True, every dataset in the mixture
             must have a non-empty ``robot_type`` after the optional
             ``DatasetConfig.robot_type`` override has been applied. Defaults to
@@ -350,6 +416,9 @@ class DatasetMixtureConfig:
     # Default keeps validation deterministic-ish (no masking); subgoal frame
     # selection stays random either way.
     val_enable_optional_key_dropout: bool = False
+    # Whether per-dataset `DatasetConfig.prompt_substitutions` swaps also fire
+    # on the validation split. Default keeps validation on the on-disk prompts.
+    val_enable_prompt_substitution: bool = False
 
     # When True, require every dataset in the mixture to have a non-empty
     # robot_type / control_mode after `DatasetConfig.{robot_type,control_mode}`

--- a/src/opentau/configs/default.py
+++ b/src/opentau/configs/default.py
@@ -106,7 +106,7 @@ class DatasetConfig:
             the record-time check inside ``add_episode``.
         prompt_substitutions: Optional mapping from an on-disk task string
             (exact match against ``meta/tasks.*``) to a non-empty list of
-            substitute prompts. At fetch time a matching sample's task is
+            non-empty substitute prompts. At fetch time a matching sample's task is
             ALWAYS replaced by a uniform random draw from its list (include
             the original in the list if it should still appear); unmapped
             tasks pass through unchanged. Applies to the train split only
@@ -125,8 +125,8 @@ class DatasetConfig:
         ValueError: If both or neither of ``repo_id`` and ``vqa`` are set, if
             ``tolerance_s`` or ``val_split_ratio`` is out of range, or if
             ``prompt_substitutions`` is set on a VQA entry, maps a task
-            literally named ``"$ref"``, or contains an empty or non-string
-            substitute list.
+            literally named ``"$ref"``, has a non-string key, or contains an
+            empty substitute list or empty/non-string entries.
     """
 
     repo_id: str | None = None
@@ -217,10 +217,11 @@ class DatasetConfig:
                         f"`prompt_substitutions[{task!r}]` must be a non-empty list of strings, "
                         f"got {subs!r} for {self.repo_id}."
                     )
-                if not all(isinstance(s, str) for s in subs):
+                if not all(isinstance(s, str) and s for s in subs):
                     raise ValueError(
-                        f"`prompt_substitutions[{task!r}]` contains non-string entries: "
-                        f"{subs!r} for {self.repo_id}."
+                        f"`prompt_substitutions[{task!r}]` contains empty or non-string entries: "
+                        f"{subs!r} for {self.repo_id}. With always-replace semantics an empty "
+                        f"substitute would silently train matching samples on an empty prompt."
                     )
 
         # If data_features_name_mapping is provided, upsert it into the global

--- a/src/opentau/datasets/factory.py
+++ b/src/opentau/datasets/factory.py
@@ -272,6 +272,7 @@ def make_dataset(
             vector_resample_strategy=train_cfg.dataset_mixture.vector_resample_strategy,
             return_advantage_input=return_advantage_input,
             skip_timestamp_check=effective_skip,
+            prompt_substitutions=cfg.prompt_substitutions,
         )
     else:
         raise ValueError("Exactly one of `cfg.vqa` and `cfg.repo_id` should be provided.")
@@ -316,12 +317,14 @@ def make_dataset(
 
         # Subset wraps the same underlying dataset by reference, so the
         # training and validation halves would share every instance attribute
-        # — including the optional-key dropout flag. Give the val subset its
-        # own shallow copy whose only divergent attribute is the dropout
-        # toggle. See ``BaseDataset.shallow_copy_with_dropout`` for the
-        # contract on what stays shared.
+        # — including the optional-key dropout and prompt-substitution flags.
+        # Give the val subset its own shallow copy whose only divergent
+        # attributes are those toggles. See
+        # ``BaseDataset.shallow_copy_with_dropout`` for the contract on what
+        # stays shared.
         val_dataset.dataset = dataset.shallow_copy_with_dropout(  # type: ignore[attr-defined]
             enable_dropout=train_cfg.dataset_mixture.val_enable_optional_key_dropout,
+            enable_prompt_substitution=train_cfg.dataset_mixture.val_enable_prompt_substitution,
         )
         return train_dataset, val_dataset  # type: ignore[return-value]
 

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -788,21 +788,32 @@ class BaseDataset(torch.utils.data.Dataset):
         # is set). Subgoal *frame* selection (end-of-segment vs. uniform window)
         # stays random either way — this flag only gates masking/zero-fill.
         self.enable_optional_key_dropout = True
+        # Whether per-task prompt substitution (`LeRobotDataset`'s
+        # `prompt_substitutions`) fires. `make_dataset` flips this off on the
+        # validation subset (unless `val_enable_prompt_substitution` is set).
+        # Defined here rather than on `LeRobotDataset` because
+        # `shallow_copy_with_dropout` manages it for every subclass; VQA
+        # datasets simply never read it.
+        self.enable_prompt_substitution = True
 
-    def shallow_copy_with_dropout(self, *, enable_dropout: bool) -> "BaseDataset":
-        """Return a shallow copy that only diverges in ``enable_optional_key_dropout``.
+    def shallow_copy_with_dropout(
+        self, *, enable_dropout: bool, enable_prompt_substitution: bool = False
+    ) -> "BaseDataset":
+        """Return a shallow copy that only diverges in the augmentation toggles.
 
         Used by :func:`opentau.datasets.factory.make_dataset` to give the
-        validation subset its own dataset instance so dropout can be toggled
-        independently of the training subset. The copy shares ``meta``,
-        ``hf_dataset``, ``episode_data_index``, cached segment tables, and
-        every other instance attribute by reference — only
-        ``enable_optional_key_dropout`` diverges. If a future refactor adds an
-        instance attribute that needs to diverge between train and val, it
+        validation subset its own dataset instance so optional-key dropout and
+        prompt substitution can be toggled independently of the training
+        subset. The copy shares ``meta``, ``hf_dataset``,
+        ``episode_data_index``, cached segment tables, and every other
+        instance attribute by reference — only ``enable_optional_key_dropout``
+        and ``enable_prompt_substitution`` diverge. If a future refactor adds
+        an instance attribute that needs to diverge between train and val, it
         must be set here too.
         """
         clone = copy.copy(self)
         clone.enable_optional_key_dropout = enable_dropout
+        clone.enable_prompt_substitution = enable_prompt_substitution
         return clone
 
     @abstractmethod
@@ -1330,6 +1341,7 @@ class LeRobotDataset(BaseDataset):
         standardize: bool = True,
         return_advantage_input: bool = False,
         skip_timestamp_check: bool = False,
+        prompt_substitutions: dict[str, list[str]] | None = None,
     ):
         """Initialize LeRobotDataset.
 
@@ -1462,6 +1474,13 @@ class LeRobotDataset(BaseDataset):
                 ``delta_timestamps`` lookups may sample unintended frames. Defaults
                 to False. Does not affect the record-time check inside
                 ``add_episode``.
+            prompt_substitutions (dict[str, list[str]] | None, optional): Mapping from
+                an on-disk task string (exact match against ``meta.tasks``) to a
+                non-empty list of substitute prompts. During ``__getitem__`` a matching
+                sample's task is ALWAYS replaced by a uniform random draw from its list
+                (gated by ``self.enable_prompt_substitution``); unmapped tasks pass
+                through unchanged. Keys matching no on-disk task string raise a
+                ``ValueError`` at init. Defaults to None.
         """
         super().__init__(cfg)
         self.cfg = cfg
@@ -1525,6 +1544,44 @@ class LeRobotDataset(BaseDataset):
         self.meta = LeRobotDatasetMetadata(
             self.repo_id, self.root, revision, force_cache_sync=force_cache_sync
         )
+
+        # Resolve config-time prompt substitutions once against the on-disk
+        # task table. Kept off `meta` (shared by reference with the val split
+        # and the v3.0 metadata cache) and keyed by task_index so the
+        # `__getitem__` hot path is a single int lookup.
+        self._prompt_substitutions_by_index: dict[int, list[str]] = {}
+        if prompt_substitutions:
+            for task, subs in prompt_substitutions.items():
+                # Guards direct constructions that bypass `DatasetConfig.__post_init__`;
+                # an empty list would crash cryptically in `torch.randint` at fetch time.
+                if not isinstance(task, str):
+                    raise ValueError(
+                        f"`prompt_substitutions` keys must be on-disk task strings, got "
+                        f"{task!r} for dataset {self.repo_id!r}."
+                    )
+                if not isinstance(subs, list) or not subs or not all(isinstance(s, str) for s in subs):
+                    raise ValueError(
+                        f"`prompt_substitutions[{task!r}]` for dataset {self.repo_id!r} must be "
+                        f"a non-empty list of strings, got {subs!r}."
+                    )
+            on_disk_tasks = set(self.meta.tasks.values())
+            unknown = [t for t in prompt_substitutions if t not in on_disk_tasks]
+            if unknown:
+                near_misses = {u: [t for t in on_disk_tasks if t.strip() == u.strip()] for u in unknown}
+                raise ValueError(
+                    f"`prompt_substitutions` for dataset {self.repo_id!r} contains keys matching "
+                    f"no on-disk task string (exact match, {len(self.meta.tasks)} tasks on disk): "
+                    f"{[repr(u) for u in unknown]}. Whitespace near-misses: {near_misses}. "
+                    f"Check for typos/trailing whitespace in the config."
+                )
+            # A v2.x tasks.jsonl may map the same task string to several
+            # task_index values (`task_to_task_index` inverts last-wins), so
+            # key the map from every index whose string matches — a single
+            # reverse lookup would leave earlier duplicate indices unswapped.
+            for task_idx, task in self.meta.tasks.items():
+                subs = prompt_substitutions.get(task)
+                if subs is not None:
+                    self._prompt_substitutions_by_index[task_idx] = list(subs)
 
         # Overlay setup: when info.json declares a `videos.source_repo`, all video
         # reads are routed to that upstream repo. Fetch its info.json once (for
@@ -2362,6 +2419,24 @@ class LeRobotDataset(BaseDataset):
     def __len__(self):
         return self.num_frames
 
+    def _resolve_task(self, task_idx: int) -> str:
+        """Decode ``task_idx`` to its prompt string, applying config-time
+        prompt substitution.
+
+        A task with an entry in ``prompt_substitutions`` is ALWAYS replaced by
+        a uniform random draw from its substitute list (gated by
+        ``self.enable_prompt_substitution``, which the factory flips off on
+        the validation split); unmapped tasks pass through unchanged. No RNG
+        is consumed on the pass-through path, so configs without substitutions
+        keep a bit-identical RNG stream.
+        """
+        task = self.meta.tasks[task_idx]
+        if self.enable_prompt_substitution and self._prompt_substitutions_by_index:
+            substitutes = self._prompt_substitutions_by_index.get(task_idx)
+            if substitutes is not None:
+                task = substitutes[torch.randint(len(substitutes), ()).item()]
+        return task
+
     @retry_random_on_failure
     def __getitem__(self, idx) -> dict:
         item = self.hf_dataset[idx]
@@ -2397,9 +2472,9 @@ class LeRobotDataset(BaseDataset):
             for cam in image_keys:
                 item[cam] = self.image_transforms(item[cam])
 
-        # Add task as a string
-        task_idx = item["task_index"].item()
-        item["task"] = self.meta.tasks[task_idx]
+        # Add task as a string, applying optional config-time prompt
+        # substitution (see `_resolve_task`).
+        item["task"] = self._resolve_task(item["task_index"].item())
 
         # Squeeze the temporal dimension for features with a single delta timestamp
         for feature, mean in self.delta_timestamps_params[0].items():
@@ -3023,6 +3098,10 @@ class LeRobotDataset(BaseDataset):
         obj.image_transforms = None
         obj.delta_timestamps_params = obj.compute_delta_params(None, None, None, None)
         obj.episode_data_index = None
+        # `create` bypasses __init__, but `__getitem__` unconditionally routes
+        # the task string through `_resolve_task`, which reads these.
+        obj.enable_prompt_substitution = True
+        obj._prompt_substitutions_by_index = {}
         obj.video_backend = video_backend if video_backend is not None else get_safe_default_codec()
         obj.image_resample_strategy = image_resample_strategy
         obj.vector_resample_strategy = vector_resample_strategy

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -1476,7 +1476,7 @@ class LeRobotDataset(BaseDataset):
                 ``add_episode``.
             prompt_substitutions (dict[str, list[str]] | None, optional): Mapping from
                 an on-disk task string (exact match against ``meta.tasks``) to a
-                non-empty list of substitute prompts. During ``__getitem__`` a matching
+                non-empty list of non-empty substitute prompts. During ``__getitem__`` a matching
                 sample's task is ALWAYS replaced by a uniform random draw from its list
                 (gated by ``self.enable_prompt_substitution``); unmapped tasks pass
                 through unchanged. Keys matching no on-disk task string raise a
@@ -1559,10 +1559,10 @@ class LeRobotDataset(BaseDataset):
                         f"`prompt_substitutions` keys must be on-disk task strings, got "
                         f"{task!r} for dataset {self.repo_id!r}."
                     )
-                if not isinstance(subs, list) or not subs or not all(isinstance(s, str) for s in subs):
+                if not isinstance(subs, list) or not subs or not all(isinstance(s, str) and s for s in subs):
                     raise ValueError(
                         f"`prompt_substitutions[{task!r}]` for dataset {self.repo_id!r} must be "
-                        f"a non-empty list of strings, got {subs!r}."
+                        f"a non-empty list of non-empty strings, got {subs!r}."
                     )
             on_disk_tasks = set(self.meta.tasks.values())
             unknown = [t for t in prompt_substitutions if t not in on_disk_tasks]

--- a/tests/configs/test_default.py
+++ b/tests/configs/test_default.py
@@ -436,8 +436,11 @@ class TestPromptSubstitutionsConfig:
         with pytest.raises(ValueError, match="only applies to LeRobot datasets"):
             DatasetConfig(vqa="clevr", prompt_substitutions={"do x": ["y"]})
 
-    @pytest.mark.parametrize("bad_subs", [[], "not-a-list", ["ok", 3]])
+    @pytest.mark.parametrize("bad_subs", [[], "not-a-list", ["ok", 3], ["ok", ""]])
     def test_invalid_substitute_list_raises(self, bad_subs):
+        """Empty strings are rejected too: with always-replace semantics an
+        empty substitute would silently train matching samples on an empty
+        prompt."""
         with pytest.raises(ValueError, match="prompt_substitutions"):
             DatasetConfig(repo_id="repo1", prompt_substitutions={"do x": bad_subs})
 

--- a/tests/configs/test_default.py
+++ b/tests/configs/test_default.py
@@ -418,3 +418,93 @@ class TestPretrainedConfigCodec:
 
         assert isinstance(loaded.vlm_config, Gemma3WithExpertConfig)
         assert loaded.vlm_config.gemma3_config.text_config.hidden_size == 2560
+
+
+class TestPromptSubstitutionsConfig:
+    """`DatasetConfig.prompt_substitutions` validation and (de)serialization."""
+
+    def test_defaults(self):
+        assert DatasetConfig(repo_id="repo1").prompt_substitutions is None
+        assert DatasetMixtureConfig().val_enable_prompt_substitution is False
+
+    def test_valid_mapping_accepted(self):
+        subs = {"do x": ["do X", "perform x"]}
+        cfg = DatasetConfig(repo_id="repo1", prompt_substitutions=subs)
+        assert cfg.prompt_substitutions == subs
+
+    def test_rejected_on_vqa_entry(self):
+        with pytest.raises(ValueError, match="only applies to LeRobot datasets"):
+            DatasetConfig(vqa="clevr", prompt_substitutions={"do x": ["y"]})
+
+    @pytest.mark.parametrize("bad_subs", [[], "not-a-list", ["ok", 3]])
+    def test_invalid_substitute_list_raises(self, bad_subs):
+        with pytest.raises(ValueError, match="prompt_substitutions"):
+            DatasetConfig(repo_id="repo1", prompt_substitutions={"do x": bad_subs})
+
+    def test_non_string_key_rejected(self):
+        with pytest.raises(ValueError, match="keys must be on-disk task strings"):
+            DatasetConfig(repo_id="repo1", prompt_substitutions={0: ["do x"]})
+
+    def test_literal_ref_key_rejected(self):
+        """A task literally named ``$ref`` would be swallowed by the config
+        loader's include mechanism before it ever reached the dataset."""
+        with pytest.raises(ValueError, match=r"\$ref"):
+            DatasetConfig(repo_id="repo1", prompt_substitutions={"$ref": ["x"]})
+
+    def test_draccus_json_round_trip(self, tmp_path):
+        """Arbitrary punctuation/unicode task keys survive encode -> JSON file
+        -> decode, as exercised by checkpoint save/resume."""
+        subs = {"put the mug, gently, on the plate — now!": ["placez la tasse 杯子", "option: $2 (b)"]}
+        cfg = DatasetConfig(repo_id="repo1", prompt_substitutions=subs)
+
+        encoded = draccus.encode(cfg)
+        assert encoded["prompt_substitutions"] == subs
+
+        path = tmp_path / "dataset_config.json"
+        with draccus.config_type("json"), open(path, "w") as f:
+            draccus.dump(cfg, f)
+        with open(path) as f:
+            reloaded = draccus.decode(DatasetConfig, json.load(f))
+        assert reloaded.prompt_substitutions == subs
+
+    def test_ref_fragment_inlines_mapping(self, tmp_path):
+        """A `{"$ref": "fragment.json"}` at the field position inlines the
+        fragment's mapping (the parser resolves refs before draccus decode)."""
+        from opentau.configs.refs import resolve_refs
+
+        fragment = {"do x": ["do X", "perform x"]}
+        (tmp_path / "subs.json").write_text(json.dumps(fragment))
+        cfg_path = tmp_path / "dataset.json"
+        cfg_path.write_text(json.dumps({"repo_id": "repo1", "prompt_substitutions": {"$ref": "subs.json"}}))
+
+        cfg = draccus.decode(DatasetConfig, resolve_refs(cfg_path))
+        assert cfg.prompt_substitutions == fragment
+
+    def test_ref_fragment_sibling_keys_deep_merge(self, tmp_path):
+        from opentau.configs.refs import resolve_refs
+
+        (tmp_path / "subs.json").write_text(json.dumps({"do x": ["do X"]}))
+        cfg_path = tmp_path / "dataset.json"
+        cfg_path.write_text(
+            json.dumps(
+                {
+                    "repo_id": "repo1",
+                    "prompt_substitutions": {"$ref": "subs.json", "do y": ["do Y"]},
+                }
+            )
+        )
+
+        cfg = draccus.decode(DatasetConfig, resolve_refs(cfg_path))
+        assert cfg.prompt_substitutions == {"do x": ["do X"], "do y": ["do Y"]}
+
+    def test_example_fragment_is_valid(self):
+        """The shipped example fragment decodes into a valid DatasetConfig."""
+        example = Path(__file__).parents[2] / "configs" / "examples" / "prompt_substitutions_example.json"
+        with open(example) as f:
+            subs = json.load(f)
+
+        cfg = DatasetConfig(repo_id="TensorAuto/libero", prompt_substitutions=subs)
+        assert cfg.prompt_substitutions
+        for task, sub_list in cfg.prompt_substitutions.items():
+            assert isinstance(task, str)
+            assert sub_list and all(isinstance(s, str) for s in sub_list)

--- a/tests/datasets/test_prompt_substitution.py
+++ b/tests/datasets/test_prompt_substitution.py
@@ -1,0 +1,189 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for config-time per-task prompt substitution.
+
+Covers the ``_resolve_task`` unit behavior (always-swap, pass-through,
+zero-RNG guarantee, determinism), the train/val gating through
+``shallow_copy_with_dropout``, and the ``LeRobotDataset.__init__``
+validation + end-to-end ``__getitem__`` integration via the dataset
+fixtures.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import opentau.datasets.lerobot_dataset as _ld
+
+
+def _make_dataset(substitutions_by_index: dict[int, list[str]], enable: bool = True):
+    """Minimal LeRobotDataset carrying just the attrs ``_resolve_task`` reads."""
+    ds = _ld.LeRobotDataset.__new__(_ld.LeRobotDataset)
+    ds.enable_prompt_substitution = enable
+    ds._prompt_substitutions_by_index = substitutions_by_index
+    ds.meta = SimpleNamespace(tasks={0: "task zero", 1: "task one"})
+    return ds
+
+
+class TestResolveTask:
+    def test_mapped_task_always_swaps(self):
+        ds = _make_dataset({0: ["swapped"]})
+        assert all(ds._resolve_task(0) == "swapped" for _ in range(20))
+
+    def test_uniform_draws_cover_all_substitutes(self):
+        """Every substitute appears; the original never does unless listed."""
+        ds = _make_dataset({0: ["sub a", "sub b"]})
+        torch.manual_seed(0)
+        drawn = {ds._resolve_task(0) for _ in range(100)}
+        assert drawn == {"sub a", "sub b"}
+
+    def test_original_reappears_only_when_listed(self):
+        ds = _make_dataset({0: ["task zero", "sub a"]})
+        torch.manual_seed(0)
+        drawn = {ds._resolve_task(0) for _ in range(100)}
+        assert drawn == {"task zero", "sub a"}
+
+    def test_unmapped_task_passes_through(self):
+        ds = _make_dataset({0: ["swapped"]})
+        assert ds._resolve_task(1) == "task one"
+
+    @pytest.mark.parametrize(
+        "substitutions, enable, task_idx",
+        [
+            ({}, True, 0),  # feature off (no mapping configured)
+            ({0: ["swapped"]}, False, 0),  # gated off (val split)
+            ({0: ["swapped"]}, True, 1),  # mapping present, this task misses
+        ],
+    )
+    def test_no_rng_consumed_on_pass_through(self, substitutions, enable, task_idx):
+        """Pins the determinism guarantee: pass-through paths must not touch
+        the torch RNG stream, so configs without substitutions stay
+        bit-identical to pre-feature runs."""
+        ds = _make_dataset(substitutions, enable=enable)
+        torch.manual_seed(0)
+        state_before = torch.random.get_rng_state()
+        ds._resolve_task(task_idx)
+        assert torch.equal(state_before, torch.random.get_rng_state())
+
+    def test_hit_is_deterministic_under_seed(self):
+        ds = _make_dataset({0: ["sub a", "sub b", "sub c"]})
+        torch.manual_seed(0)
+        first = [ds._resolve_task(0) for _ in range(50)]
+        torch.manual_seed(0)
+        second = [ds._resolve_task(0) for _ in range(50)]
+        assert first == second
+
+
+class TestValGating:
+    def test_val_clone_keeps_on_disk_prompt(self):
+        ds = _make_dataset({0: ["swapped"]})
+        clone = ds.shallow_copy_with_dropout(enable_dropout=False)
+        assert clone._resolve_task(0) == "task zero"
+        # The training instance is unaffected by the clone.
+        assert ds._resolve_task(0) == "swapped"
+
+    def test_val_opt_in_reenables_substitution(self):
+        ds = _make_dataset({0: ["swapped"]})
+        clone = ds.shallow_copy_with_dropout(enable_dropout=False, enable_prompt_substitution=True)
+        assert clone._resolve_task(0) == "swapped"
+
+
+class TestInitValidationAndGetItem:
+    """Through the real ``__init__`` / ``__getitem__`` via the dataset
+    fixtures (tasks are ``"Perform action {i}."``)."""
+
+    def test_unknown_key_raises_with_near_miss(self, tmp_path, lerobot_dataset_factory):
+        with pytest.raises(ValueError) as excinfo:
+            lerobot_dataset_factory(
+                root=tmp_path,
+                total_tasks=1,
+                prompt_substitutions={"Perform action 0.\n": ["anything"]},
+            )
+        msg = str(excinfo.value)
+        assert "prompt_substitutions" in msg
+        assert "Perform action 0.\\n" in msg  # repr() makes the whitespace visible
+        assert "Whitespace near-misses" in msg
+        assert "Perform action 0." in msg
+
+    def test_empty_substitute_list_raises_at_init(self, tmp_path, lerobot_dataset_factory):
+        """Direct constructions bypass DatasetConfig.__post_init__; init must
+        still reject an empty list before it can crash `torch.randint`."""
+        with pytest.raises(ValueError, match="non-empty list of strings"):
+            lerobot_dataset_factory(
+                root=tmp_path,
+                total_tasks=1,
+                prompt_substitutions={"Perform action 0.": []},
+            )
+
+    def test_non_string_key_raises_designed_error(self, tmp_path, lerobot_dataset_factory):
+        """A non-string key (e.g. keyed by task_index by mistake) must hit the
+        designed ValueError, not an AttributeError inside the near-miss
+        diagnostics."""
+        with pytest.raises(ValueError, match="keys must be on-disk task strings"):
+            lerobot_dataset_factory(
+                root=tmp_path,
+                total_tasks=1,
+                prompt_substitutions={0: ["anything"]},
+            )
+
+    def test_duplicate_task_strings_map_every_index(self, tmp_path, lerobot_dataset_factory):
+        """A v2.x tasks.jsonl may map the same string to several task_index
+        values (`task_to_task_index` inverts last-wins); every duplicate index
+        must substitute, not just the last one."""
+        tasks = {
+            0: {"task_index": 0, "task": "dup task"},
+            1: {"task_index": 1, "task": "dup task"},
+        }
+        ds = lerobot_dataset_factory(
+            root=tmp_path,
+            tasks=tasks,
+            standardize=False,
+            prompt_substitutions={"dup task": ["swapped"]},
+        )
+        assert set(ds._prompt_substitutions_by_index) == {0, 1}
+        assert ds._resolve_task(0) == "swapped"
+        assert ds._resolve_task(1) == "swapped"
+
+    @staticmethod
+    def _stub_video_decode(monkeypatch):
+        """The fixture declares video features but ships no mp4s; return
+        zero frames so the real ``__getitem__`` can run end-to-end."""
+
+        def _fake_query_videos(self, query_ts, ep_idx):
+            return {key: torch.zeros((3, 8, 8)) for key in query_ts}
+
+        monkeypatch.setattr(_ld.LeRobotDataset, "_query_videos", _fake_query_videos)
+
+    def test_getitem_swaps_mapped_task(self, tmp_path, lerobot_dataset_factory, monkeypatch):
+        self._stub_video_decode(monkeypatch)
+        ds = lerobot_dataset_factory(
+            root=tmp_path,
+            total_tasks=1,
+            standardize=False,
+            prompt_substitutions={"Perform action 0.": ["Do the thing."]},
+        )
+        assert ds[0]["task"] == "Do the thing."
+
+    def test_getitem_val_clone_keeps_on_disk_prompt(self, tmp_path, lerobot_dataset_factory, monkeypatch):
+        self._stub_video_decode(monkeypatch)
+        ds = lerobot_dataset_factory(
+            root=tmp_path,
+            total_tasks=1,
+            standardize=False,
+            prompt_substitutions={"Perform action 0.": ["Do the thing."]},
+        )
+        clone = ds.shallow_copy_with_dropout(enable_dropout=False)
+        assert clone[0]["task"] == "Perform action 0."
+        assert ds[0]["task"] == "Do the thing."

--- a/tests/datasets/test_prompt_substitution.py
+++ b/tests/datasets/test_prompt_substitution.py
@@ -117,14 +117,17 @@ class TestInitValidationAndGetItem:
         assert "Whitespace near-misses" in msg
         assert "Perform action 0." in msg
 
-    def test_empty_substitute_list_raises_at_init(self, tmp_path, lerobot_dataset_factory):
+    @pytest.mark.parametrize("bad_subs", [[], ["ok", ""]])
+    def test_invalid_substitute_list_raises_at_init(self, tmp_path, lerobot_dataset_factory, bad_subs):
         """Direct constructions bypass DatasetConfig.__post_init__; init must
-        still reject an empty list before it can crash `torch.randint`."""
-        with pytest.raises(ValueError, match="non-empty list of strings"):
+        still reject an empty list (would crash `torch.randint` at fetch time)
+        and empty-string substitutes (would silently train matching samples on
+        an empty prompt)."""
+        with pytest.raises(ValueError, match="non-empty list of non-empty strings"):
             lerobot_dataset_factory(
                 root=tmp_path,
                 total_tasks=1,
-                prompt_substitutions={"Perform action 0.": []},
+                prompt_substitutions={"Perform action 0.": bad_subs},
             )
 
     def test_non_string_key_raises_designed_error(self, tmp_path, lerobot_dataset_factory):


### PR DESCRIPTION
## What this does

Adds config-time **per-task prompt substitution** (🗃️ Feature): a new per-dataset field `DatasetConfig.prompt_substitutions: dict[str, list[str]] | None` maps an on-disk task string (exact match against `meta/tasks.*`) to a pool of substitute prompts. At fetch time, a matching sample's task is **always** replaced by a uniform random draw from its list (include the original in the list if it should still appear); unmapped tasks pass through unchanged. Useful for paraphrase augmentation / prompt-robustness training.

Design points:

- **Single choke point.** The swap happens in a new `LeRobotDataset._resolve_task` helper at the one place `__getitem__` decodes `task_index` into the string that becomes `batch["prompt"]`, upstream of `_to_standard_data_format`, so every policy sees it uniformly. `meta.tasks` / `task_to_task_index` are never mutated (they're shared by reference with the val split, the v3.0 metadata cache, and dataset-writing paths).
- **Train-only by default.** The val split keeps on-disk prompts via the existing `shallow_copy_with_dropout` mechanism (extended with an `enable_prompt_substitution` toggle). A new mixture-level `val_enable_prompt_substitution: bool = False` opts validation in, mirroring `val_enable_optional_key_dropout`.
- **Determinism-safe.** The draw uses the default per-worker-seeded torch RNG (same discipline as the existing optional-key dropout rolls), and the pass-through path consumes **zero** RNG — configs without substitutions keep a bit-identical RNG stream. No RNG is consumed at construction time either, so the train/val `random_split` is unperturbed.
- **Fail-fast validation.** Mapping keys that match no on-disk task string raise at dataset init with a `repr()`-based whitespace near-miss hint (catches the classic invisible trailing `"\n"`). Non-string keys, empty/non-string substitute lists, a literal `"$ref"` key, and use on VQA entries (which build their own prompts) are all rejected at config time. Duplicate task strings in a v2.x `tasks.jsonl` (last-wins reverse index) are handled by resolving the map over every matching `task_index`.
- **`$ref`-friendly.** Large pools can live in their own JSON fragment and be inlined with `{"$ref": "fragment.json"}` — resolved by the existing include mechanism before draccus decode, zero extra code. A runnable example fragment is shipped at `configs/examples/prompt_substitutions_example.json` (built from real `TensorAuto/libero` episode 0-9 task strings), and the feature is documented in `docs/source/tutorials/datasets.rst`.

Example:

```json
{
    "repo_id": "TensorAuto/libero",
    "prompt_substitutions": {"$ref": "prompt_substitutions_example.json"}
}
```

## How it was tested

- Added `tests/datasets/test_prompt_substitution.py`: always-swap, uniform coverage, original-only-when-listed, pass-through, **zero-RNG-consumed** guarantee (RNG state bit-compared around a pass-through fetch), seeded determinism, val-clone gating (incl. opt-in re-enable), init validation (unknown key with near-miss, empty list, non-string key), duplicate-task-index resolution, and end-to-end `__getitem__` swap/gating through the dataset fixtures.
- Extended `tests/configs/test_default.py`: field defaults, VQA rejection, invalid substitute lists, non-string keys, literal `"$ref"` key, draccus JSON round-trip (unicode/punctuation keys, as exercised by checkpoint save/resume), `$ref` fragment inlining + sibling-key deep-merge, and validity of the shipped example fragment.
- `pre-commit run` clean; `pytest -m "not gpu and not network" tests/datasets tests/configs -n auto` green (674 tests); full CPU suite green apart from pre-existing sim-env import failures that fail identically on `main` in an env without the `libero` extra.
- **Determinism check (CPU, local)**: hashed 25 real dataloader batches from `configs/examples/pi05_training_config.json`. Feature-off on this branch is **byte-identical** to the pre-change code (digest compared against a stashed baseline) and repeatable across same-seed runs; feature-on (via the `$ref` example fragment) is self-deterministic across same-seed runs, train batches contain only substitutes, and val batches keep the on-disk prompts.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/datasets/test_prompt_substitution.py
pytest -sx tests/configs/test_default.py -k PromptSubstitutions
```

Or see it in real batches: add the snippet below to the dataset entry of `configs/examples/pi05_training_config.json` and print `batch["prompt"]` for a few training batches — prompts come from the substitute pool, while validation batches keep the on-disk strings.

```json
"prompt_substitutions": {"$ref": "prompt_substitutions_example.json"}
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
