### PR TITLE
fix(configs): escape bare % in field comments that crash draccus --help

### DIFF
--- a/src/opentau/optim/optimizers.py
+++ b/src/opentau/optim/optimizers.py
@@ -62,7 +62,7 @@ class AdamConfig(OptimizerConfig):
     # Use the fused Adam CUDA kernel when running on GPU. Falls back to the
     # default foreach path on CPU-only hosts (see build()). Typically faster
     # than foreach once models get large enough that launch overhead matters;
-    # exact speedup is workload-dependent (e.g. ~60% on pi05's ~3.4B params
+    # exact speedup is workload-dependent (e.g. ~60%% on pi05's ~3.4B params
     # on A100, smaller for smaller models). No math change; same state_dict
     # layout.
     fused: bool = True

--- a/src/opentau/policies/pi0/configuration_pi0.py
+++ b/src/opentau/policies/pi0/configuration_pi0.py
@@ -138,8 +138,8 @@ class PI0Config(PreTrainedConfig):
     train_state_proj: bool = True
 
     # Wrap each transformer-layer forward in torch.utils.checkpoint to trade
-    # ~25-33% same-batch compute for ~30-40 GB of activation memory per rank,
-    # typically netting +10-25% throughput once the freed memory is spent on
+    # ~25-33%% same-batch compute for ~30-40 GB of activation memory per rank,
+    # typically netting +10-25%% throughput once the freed memory is spent on
     # a larger per-rank batch. Only supported with distributed_type=MULTI_GPU
     # (DDP), NO (single process), or DeepSpeed ZeRO-1/2 — src/opentau/scripts/
     # train.py raises if the accelerator's distributed_type is anything else

--- a/src/opentau/policies/pi05/configuration_pi05.py
+++ b/src/opentau/policies/pi05/configuration_pi05.py
@@ -164,8 +164,8 @@ class PI05Config(PreTrainedConfig):
     knowledge_insulation: bool = True
 
     # Wrap each transformer-layer forward in torch.utils.checkpoint to trade
-    # ~25-33% same-batch compute for ~30-40 GB of activation memory per rank,
-    # typically netting +10-25% throughput once the freed memory is spent on
+    # ~25-33%% same-batch compute for ~30-40 GB of activation memory per rank,
+    # typically netting +10-25%% throughput once the freed memory is spent on
     # a larger per-rank batch. Only supported with distributed_type=MULTI_GPU
     # (DDP), NO (single process), or DeepSpeed ZeRO-1/2 — src/opentau/scripts/
     # train.py raises if the accelerator's distributed_type is anything else

--- a/src/opentau/policies/pi05_mem/configuration_pi05.py
+++ b/src/opentau/policies/pi05_mem/configuration_pi05.py
@@ -169,8 +169,8 @@ class PI05MemConfig(PreTrainedConfig):
     knowledge_insulation: bool = True
 
     # Wrap each transformer-layer forward in torch.utils.checkpoint to trade
-    # ~25-33% same-batch compute for ~30-40 GB of activation memory per rank,
-    # typically netting +10-25% throughput once the freed memory is spent on
+    # ~25-33%% same-batch compute for ~30-40 GB of activation memory per rank,
+    # typically netting +10-25%% throughput once the freed memory is spent on
     # a larger per-rank batch. Only supported with distributed_type=MULTI_GPU
     # (DDP), NO (single process), or DeepSpeed ZeRO-1/2 — src/opentau/scripts/
     # train.py raises if the accelerator's distributed_type is anything else

--- a/src/opentau/policies/pi06/configuration_pi06.py
+++ b/src/opentau/policies/pi06/configuration_pi06.py
@@ -157,8 +157,8 @@ class PI06Config(PreTrainedConfig):
     knowledge_insulation: bool = True
 
     # Wrap each interleaved transformer-layer forward in torch.utils.checkpoint
-    # to trade ~25-33% same-batch compute for a large slice of activation memory
-    # per rank, typically netting +10-25% throughput once the freed memory is
+    # to trade ~25-33%% same-batch compute for a large slice of activation memory
+    # per rank, typically netting +10-25%% throughput once the freed memory is
     # spent on a larger per-rank batch. Only supported with distributed_type=
     # MULTI_GPU (DDP), NO (single process), or DeepSpeed ZeRO-1/2 — src/opentau/
     # scripts/train.py raises if the accelerator's distributed_type is anything

--- a/src/opentau/policies/pi07_paligemma/low_level/configuration_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/configuration_pi07_low_level.py
@@ -192,8 +192,8 @@ class PI07PaligemmaLowLevelConfig(PreTrainedConfig):
     knowledge_insulation: bool = True
 
     # Wrap each transformer-layer forward in torch.utils.checkpoint to trade
-    # ~25-33% same-batch compute for ~30-40 GB of activation memory per rank,
-    # typically netting +10-25% throughput once the freed memory is spent on
+    # ~25-33%% same-batch compute for ~30-40 GB of activation memory per rank,
+    # typically netting +10-25%% throughput once the freed memory is spent on
     # a larger per-rank batch. Only supported with distributed_type=MULTI_GPU
     # (DDP), NO (single process), or DeepSpeed ZeRO-1/2 — src/opentau/scripts/
     # train.py raises if the accelerator's distributed_type is anything else

--- a/tests/configs/test_train.py
+++ b/tests/configs/test_train.py
@@ -17,6 +17,7 @@ import os
 from pathlib import Path
 from unittest.mock import patch
 
+import draccus
 import pytest
 from draccus.utils import ParsingError
 
@@ -460,3 +461,23 @@ def test_running_best_validate_integration(dataset_mixture_config, policy_config
     )
     with pytest.raises(ValueError, match="running_best_count"):
         cfg.validate()
+
+
+def test_help_generation_does_not_raise(capsys):
+    """`--help` over the full TrainPipelineConfig tree must render, not crash.
+
+    Draccus turns dataclass field comments into argparse help strings, and
+    argparse %-formats those strings to substitute ``%(default)s`` — so a bare
+    ``%`` in any field comment anywhere in the config tree (policies, optim,
+    envs, ...) raises ``TypeError: not enough arguments for format string``.
+    Literal percent signs in field comments must be escaped as ``%%``.
+    """
+    with pytest.raises(SystemExit) as exc_info:
+        draccus.parse(TrainPipelineConfig, args=["--help"])
+    assert exc_info.value.code == 0
+    out = capsys.readouterr().out
+    # Sanity-check the help actually rendered the nested policy/optim groups.
+    assert "--policy.gradient_checkpointing" in out
+    assert "--optimizer.fused" in out
+    # An un-rendered %% means the string skipped argparse's %-formatting.
+    assert "%%" not in out

--- a/tests/configs/test_train.py
+++ b/tests/configs/test_train.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
 import json
 import os
 from pathlib import Path
@@ -481,3 +482,32 @@ def test_help_generation_does_not_raise(capsys):
     assert "--optimizer.fused" in out
     # An un-rendered %% means the string skipped argparse's %-formatting.
     assert "%%" not in out
+
+
+@pytest.mark.parametrize(
+    "config_module, config_cls",
+    [
+        ("opentau.policies.pi0.configuration_pi0", "PI0Config"),
+        ("opentau.policies.pi05.configuration_pi05", "PI05Config"),
+        ("opentau.policies.pi05_mem.configuration_pi05", "PI05MemConfig"),
+        ("opentau.policies.pi06.configuration_pi06", "PI06Config"),
+        (
+            "opentau.policies.pi07_paligemma.low_level.configuration_pi07_low_level",
+            "PI07PaligemmaLowLevelConfig",
+        ),
+        ("opentau.optim.optimizers", "AdamConfig"),
+    ],
+)
+def test_policy_config_help_generation_does_not_raise(config_module: str, config_cls: str, capsys):
+    """`--help` over each policy/optim config class must render, not crash.
+
+    Complements ``test_help_generation_does_not_raise``: the full
+    TrainPipelineConfig help only renders the policy choices registered at
+    import time (e.g. pi06 is not on that import chain), so each config class
+    whose field comments contain escaped percent signs is exercised directly.
+    """
+    cls = getattr(importlib.import_module(config_module), config_cls)
+    with pytest.raises(SystemExit) as exc_info:
+        draccus.parse(cls, args=["--help"])
+    assert exc_info.value.code == 0
+    assert "%%" not in capsys.readouterr().out


### PR DESCRIPTION
## What this does
Fixes a crash where any draccus `--help` over `TrainPipelineConfig` (e.g. `train.py --help` under `accelerate launch`, or `opentau-train ... --help`) dies with `TypeError: not enough arguments for format string` raised from argparse's `_expand_help`.

Root cause: draccus turns dataclass field comments into argparse help strings and appends `(default: %(default)s)`; argparse then `%`-formats the whole string against a params dict. Any bare `%` in a field comment is therefore parsed as a printf placeholder. The offenders were the `gradient_checkpointing` field comments (`~25-33%`, `+10-25%`) in the pi0 / pi05 / pi05_mem / pi06 / pi07_paligemma configs and the `AdamConfig.fused` comment (`~60%`).

Fix: escape the literal percent signs as `%%` in those comments (argparse renders `%%` back to a literal `%` in the help output). A sweep of all field comments under `src/opentau/configs/`, `src/opentau/optim/`, and every `configuration_*.py` confirmed these 6 files are the complete set. The `~25-33%` occurrences in the pi07 `configuration_*.py` class docstrings are left untouched: draccus only uses class docstrings as argparse group descriptions, which are not `%`-formatted.

Note on the checklist: although `configuration_*.py` / `optim/` files are touched, the edits are `#` comments only — the Python AST of every changed source module is bit-identical before/after — so there is no policy/optimizer behavior change and the policy checkbox is intentionally left unchecked.

## How it was tested
- Added `test_help_generation_does_not_raise` in `tests/configs/test_train.py`: asserts `draccus.parse(TrainPipelineConfig, args=["--help"])` exits with `SystemExit(0)`, that the nested `--policy.gradient_checkpointing` / `--optimizer.fused` groups actually rendered, and that no un-rendered `%%` leaked into the output. Runs in ~0.3s.
- Verified the original repro now exits 0 and the escaped text renders as a literal `%` (e.g. "trade ~25-33% same-batch") in the help output.
- Verified every changed source module is AST-identical to `main` (comment-only change).
- `pre-commit run` on all changed files: clean.
- `pytest tests/configs tests/optim tests/policies -m "not gpu and not network" -n auto`: 771 passed, 2 skipped.

## How to checkout & try? (for the reviewer)
```bash
pytest -sx tests/configs/test_train.py::test_help_generation_does_not_raise
```
Or reproduce the original crash directly (crashes on `main`, prints full help here):
```bash
python -c "import draccus; from opentau.configs.train import TrainPipelineConfig; draccus.parse(TrainPipelineConfig, args=['--help'])"
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
