### PR TITLE
feat(datasets): standard mistake/success roles in feature name mapping

### DIFF
--- a/src/opentau/configs/default.py
+++ b/src/opentau/configs/default.py
@@ -85,10 +85,11 @@ class DatasetConfig:
             ``mistake``, or a success-polarity column (e.g. DROID's
             ``is_episode_successful``) to ``success`` — polarity is expressed
             by which role you map, so no inversion flag is needed. When both
-            resolve, ``mistake`` wins (it is segment-grained). The ``success``
-            role also drives the value-function return bins; it may name a
-            per-frame column or a per-episode key in the episodes metadata.
-            Defaults to None.
+            resolve, ``mistake`` wins (it is segment-grained). ``mistake``
+            must name a per-frame column; for an episode-level outcome map
+            ``success`` instead, which resolves from a per-frame column or a
+            per-episode key in the episodes metadata and also drives the
+            value-function return bins. Defaults to None.
         robot_type: Optional override for the dataset's ``robot_type`` metadata
             field. When provided (including the empty string), takes precedence
             over the value loaded from ``meta/info.json``. ``None`` (default)

--- a/src/opentau/configs/default.py
+++ b/src/opentau/configs/default.py
@@ -76,8 +76,19 @@ class DatasetConfig:
         video_backend: Video codec backend to use. Defaults to a safe default codec.
         stats: Dictionary of statistics for normalization, keyed by feature name.
             Each value is a dictionary with 'mean' and 'std' arrays. Defaults to None.
-        data_features_name_mapping: Optional mapping from dataset feature names to
-            standard feature names. Defaults to None.
+        data_features_name_mapping: Optional mapping from standard feature
+            names (``camera0``/``camera1``/..., ``state``, ``actions``,
+            ``prompt``, ``response``, ``mistake``, ``success``) to this
+            dataset's own column names. The ``mistake`` and ``success`` roles
+            feed the optional ``mistake`` metadata key: map a
+            mistake-polarity column (True/1 = something went wrong) to
+            ``mistake``, or a success-polarity column (e.g. DROID's
+            ``is_episode_successful``) to ``success`` — polarity is expressed
+            by which role you map, so no inversion flag is needed. When both
+            resolve, ``mistake`` wins (it is segment-grained). The ``success``
+            role also drives the value-function return bins; it may name a
+            per-frame column or a per-episode key in the episodes metadata.
+            Defaults to None.
         robot_type: Optional override for the dataset's ``robot_type`` metadata
             field. When provided (including the empty string), takes precedence
             over the value loaded from ``meta/info.json``. ``None`` (default)

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -243,6 +243,10 @@ _DOWNLOAD_MAX_WORKERS = 16
 # instances within a single process (e.g., train + val constructed for the same repo).
 _CONTROL_MODE_WARNED: set[str] = set()
 
+# Datasets already warned about a within-episode-varying `success` role column
+# (one warning per repo_id per process; train/val splits instantiate twice).
+_SUCCESS_ROLE_WARNED: set[str] = set()
+
 # ``skip_timestamp_check`` is a mixture-wide decision (with optional per-dataset
 # override) that produces an identical warning for every dataset in the mixture.
 # For a 392-dataset pretraining run on 8 ranks, the naive per-dataset emission
@@ -1635,6 +1639,31 @@ class LeRobotDataset(BaseDataset):
                 self.repo_id,
             )
 
+        # The `success` role expects an episode-constant column: it feeds the
+        # value-function return bins and the derived `mistake` metadata, both
+        # episode-level outcomes. A genuinely per-frame column (e.g. a
+        # terminal-only success marker) would silently yield per-frame
+        # outcomes, so where the episodes metadata carries per-episode
+        # min/max aggregates (v3.0 layouts), prove constancy at load time.
+        success_col = DATA_FEATURES_NAME_MAPPING.get(self._get_feature_mapping_key(), {}).get("success")
+        if (
+            success_col is not None
+            and self.meta.episodes is not None
+            and self.repo_id not in _SUCCESS_ROLE_WARNED
+        ):
+            varying, checked = self._count_success_role_varying_episodes(self.meta.episodes, success_col)
+            if varying:
+                _SUCCESS_ROLE_WARNED.add(self.repo_id)
+                logging.warning(
+                    "Dataset %r: column %r mapped to the `success` role varies within %d/%d episodes. "
+                    "The role expects an episode-constant outcome; value-function return bins and the "
+                    "derived `mistake` metadata will follow whichever frame is sampled.",
+                    self.repo_id,
+                    success_col,
+                    varying,
+                    checked,
+                )
+
         # Resolve the effective episode set: `(episodes or all) - excluded`,
         # with `excluded_episodes` taking precedence (see
         # `resolve_selected_episodes`). Done before the stats block below so the
@@ -2474,6 +2503,36 @@ class LeRobotDataset(BaseDataset):
         if value is not None:
             return bool(np.asarray(value).reshape(-1)[0])
         return None
+
+    @staticmethod
+    def _count_success_role_varying_episodes(episodes, success_col: str) -> tuple[int, int]:
+        """Count episodes whose mapped ``success`` column varies within the episode.
+
+        Best-effort constancy proof for the ``success`` role: relies on the
+        v3.0 flattened per-episode aggregates ``stats/<col>/min`` /
+        ``stats/<col>/max`` in the episodes metadata. Episodes without those
+        keys are skipped (v2.x layouts carry no flattened aggregates), so a
+        zero ``checked`` count means "nothing provable", not "all constant".
+
+        Args:
+            episodes: Per-episode metadata rows — a mapping keyed by episode
+                index or an iterable of row dicts.
+            success_col: Dataset-specific column name mapped to ``success``.
+
+        Returns:
+            ``(varying, checked)`` episode counts.
+        """
+        lo_key, hi_key = f"stats/{success_col}/min", f"stats/{success_col}/max"
+        varying = checked = 0
+        rows = episodes.values() if hasattr(episodes, "values") else episodes
+        for row in rows:
+            lo, hi = row.get(lo_key), row.get(hi_key)
+            if lo is None or hi is None:
+                continue
+            checked += 1
+            if float(np.asarray(lo).reshape(-1)[0]) != float(np.asarray(hi).reshape(-1)[0]):
+                varying += 1
+        return varying, checked
 
     def _attach_mistake_raw(self, item: dict, episodes_info: dict) -> bool | None:
         """Attach ``mistake_raw`` from the standard ``mistake``/``success`` roles.

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -933,7 +933,14 @@ class BaseDataset(torch.utils.data.Dataset):
         img_is_pad = self._standardize_images(item, standard_item, self.num_cams)
 
         for new_key, key in name_map.items():
-            if "camera" in new_key:
+            # Cameras were standardized above. `mistake`/`success` are
+            # optional-metadata roles: they may name a per-episode-only column
+            # (absent from `item`), and copying them here would leak a raw,
+            # per-dataset key into the sample schema — default collation
+            # across a mixture requires every dataset to emit the same keys.
+            # They are resolved in `__getitem__` (`_attach_mistake_raw`) and
+            # emitted uniformly by `_emit_optional_keys` instead.
+            if "camera" in new_key or new_key in ("mistake", "success"):
                 continue
             standard_item[new_key] = item[key]
 

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -2583,10 +2583,14 @@ class LeRobotDataset(BaseDataset):
         The mistake-polarity column (mapped via the ``mistake`` role in
         ``data_features_name_mapping``, defaulting to the literal ``mistake``
         column written by ``annotate_mistakes.py`` / ``attach_metadata.py``)
-        wins when present — it is segment-grained. Otherwise a resolved
-        ``success`` role (see :meth:`_resolve_episode_success`) is inverted
-        into an episode-constant ``mistake_raw``. With neither source no key
-        is attached, and ``_emit_optional_keys`` pads the field.
+        wins when present — it is segment-grained and deliberately resolved
+        as a frame column only: an episode-level mistake signal is just the
+        inverse of ``success``, so episode-metadata sources belong on the
+        ``success`` role (which gets the full frame -> episode-metadata ->
+        episodes-stats chain). Otherwise a resolved ``success`` role (see
+        :meth:`_resolve_episode_success`) is inverted into an
+        episode-constant ``mistake_raw``. With neither source no key is
+        attached, and ``_emit_optional_keys`` pads the field.
 
         Returns the resolved ``success`` value (or None) so ``__getitem__``
         can reuse it for the value-function return bins without re-resolving

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -1643,15 +1643,19 @@ class LeRobotDataset(BaseDataset):
         # value-function return bins and the derived `mistake` metadata, both
         # episode-level outcomes. A genuinely per-frame column (e.g. a
         # terminal-only success marker) would silently yield per-frame
-        # outcomes, so where the episodes metadata carries per-episode
-        # min/max aggregates (v3.0 layouts), prove constancy at load time.
+        # outcomes, so where genuinely per-episode min/max aggregates exist
+        # (v2.1+ `episodes_stats`; the v2.0 backward-compatible path only
+        # replicates the global aggregate), prove constancy at load time.
         success_col = DATA_FEATURES_NAME_MAPPING.get(self._get_feature_mapping_key(), {}).get("success")
         if (
             success_col is not None
-            and self.meta.episodes is not None
+            and self.meta._version >= packaging.version.parse("v2.1")
+            and getattr(self.meta, "episodes_stats", None)
             and self.repo_id not in _SUCCESS_ROLE_WARNED
         ):
-            varying, checked = self._count_success_role_varying_episodes(self.meta.episodes, success_col)
+            varying, checked = self._count_success_role_varying_episodes(
+                self.meta.episodes_stats, success_col
+            )
             if varying:
                 _SUCCESS_ROLE_WARNED.add(self.repo_id)
                 logging.warning(
@@ -2467,7 +2471,12 @@ class LeRobotDataset(BaseDataset):
         return task
 
     @staticmethod
-    def _resolve_episode_success(item: dict, episodes_info: dict, name_map: dict[str, str]) -> bool | None:
+    def _resolve_episode_success(
+        item: dict,
+        episodes_info: dict,
+        name_map: dict[str, str],
+        episode_stats: dict[str, dict] | None = None,
+    ) -> bool | None:
         """Resolve the standard ``success`` role for the current sample.
 
         ``success`` is the success-polarity counterpart of the ``mistake``
@@ -2479,12 +2488,22 @@ class LeRobotDataset(BaseDataset):
            ``is_episode_successful``), read from ``item`` first and from the
            per-episode ``meta.episodes`` entry second — so one mapping entry
            covers both storage layouts;
-        2. the mapped column's v3.0 flattened aggregate
-           ``stats/<col>/mean`` in ``meta.episodes`` (thresholded at 0.5 —
-           the role expects an episode-constant signal, not a
-           terminal-frame-only marker);
+        2. the mapped column's per-episode ``mean`` aggregate in
+           ``episode_stats`` (one ``meta.episodes_stats`` entry, nested
+           ``{col: {"mean": ...}}``), thresholded at 0.5 — the role expects
+           an episode-constant signal, not a terminal-frame-only marker;
         3. the OpenTau per-episode convention key ``success`` in
            ``meta.episodes`` (written by e.g. RECAP-style annotation).
+
+        Args:
+            item: Raw frame dict from ``hf_dataset``.
+            episodes_info: This episode's ``meta.episodes`` record.
+            name_map: Standard-role -> dataset-column mapping.
+            episode_stats: This episode's ``meta.episodes_stats`` entry, or
+                None. Callers must pass only genuinely per-episode stats —
+                the v2.0 backward-compatible path replicates the *global*
+                aggregate per episode, which would resolve every episode to
+                the same outcome.
 
         Returns None when no source is available, so callers can distinguish
         "labeled as failed" from "unlabeled".
@@ -2496,7 +2515,7 @@ class LeRobotDataset(BaseDataset):
                 value = episodes_info.get(col)
             if value is not None:
                 return bool(np.asarray(value).reshape(-1)[0])
-            stat = episodes_info.get(f"stats/{col}/mean")
+            stat = (episode_stats or {}).get(col, {}).get("mean")
             if stat is not None:
                 return float(np.asarray(stat).reshape(-1)[0]) >= 0.5
         value = episodes_info.get("success")
@@ -2505,28 +2524,33 @@ class LeRobotDataset(BaseDataset):
         return None
 
     @staticmethod
-    def _count_success_role_varying_episodes(episodes, success_col: str) -> tuple[int, int]:
+    def _count_success_role_varying_episodes(episodes_stats, success_col: str) -> tuple[int, int]:
         """Count episodes whose mapped ``success`` column varies within the episode.
 
-        Best-effort constancy proof for the ``success`` role: relies on the
-        v3.0 flattened per-episode aggregates ``stats/<col>/min`` /
-        ``stats/<col>/max`` in the episodes metadata. Episodes without those
-        keys are skipped (v2.x layouts carry no flattened aggregates), so a
-        zero ``checked`` count means "nothing provable", not "all constant".
+        Best-effort constancy proof for the ``success`` role: compares the
+        per-episode ``min``/``max`` aggregates in ``meta.episodes_stats``
+        (nested ``{episode_index: {col: {"min": ..., "max": ...}}}``, the
+        shape emitted by ``load_episodes_stats`` / ``load_episodes_stats_v30``).
+        Episodes without aggregates for the column are skipped, so a zero
+        ``checked`` count means "nothing provable", not "all constant".
+        Callers must pass only genuinely per-episode stats — the v2.0
+        backward-compatible path replicates the *global* aggregate per
+        episode, whose min/max spread would be misread as within-episode
+        variation.
 
         Args:
-            episodes: Per-episode metadata rows — a mapping keyed by episode
-                index or an iterable of row dicts.
+            episodes_stats: Per-episode stats — a mapping keyed by episode
+                index or an iterable of per-episode stats dicts.
             success_col: Dataset-specific column name mapped to ``success``.
 
         Returns:
             ``(varying, checked)`` episode counts.
         """
-        lo_key, hi_key = f"stats/{success_col}/min", f"stats/{success_col}/max"
         varying = checked = 0
-        rows = episodes.values() if hasattr(episodes, "values") else episodes
+        rows = episodes_stats.values() if hasattr(episodes_stats, "values") else episodes_stats
         for row in rows:
-            lo, hi = row.get(lo_key), row.get(hi_key)
+            entry = row.get(success_col) or {}
+            lo, hi = entry.get("min"), entry.get("max")
             if lo is None or hi is None:
                 continue
             checked += 1
@@ -2534,7 +2558,19 @@ class LeRobotDataset(BaseDataset):
                 varying += 1
         return varying, checked
 
-    def _attach_mistake_raw(self, item: dict, episodes_info: dict) -> bool | None:
+    def _episode_stats_for(self, ep_idx: int) -> dict[str, dict] | None:
+        """This episode's ``meta.episodes_stats`` entry, if genuinely per-episode.
+
+        Returns None for pre-v2.1 datasets: their backward-compatible
+        ``episodes_stats`` replicate the global aggregate per episode, which
+        must not be mistaken for an episode-level signal.
+        """
+        if self.meta._version < packaging.version.parse("v2.1"):
+            return None
+        episodes_stats = getattr(self.meta, "episodes_stats", None)
+        return episodes_stats.get(ep_idx) if episodes_stats else None
+
+    def _attach_mistake_raw(self, item: dict, episodes_info: dict, ep_idx: int) -> bool | None:
         """Attach ``mistake_raw`` from the standard ``mistake``/``success`` roles.
 
         The mistake-polarity column (mapped via the ``mistake`` role in
@@ -2550,7 +2586,9 @@ class LeRobotDataset(BaseDataset):
         after ``_to_standard_data_format`` has dropped the raw columns.
         """
         name_map = DATA_FEATURES_NAME_MAPPING.get(self._get_feature_mapping_key(), {})
-        success = self._resolve_episode_success(item, episodes_info, name_map)
+        success = self._resolve_episode_success(
+            item, episodes_info, name_map, episode_stats=self._episode_stats_for(ep_idx)
+        )
         mistake_col = name_map.get("mistake", "mistake")
         if mistake_col in item:
             item["mistake_raw"] = int(item[mistake_col])
@@ -2626,7 +2664,7 @@ class LeRobotDataset(BaseDataset):
             item["frame_index"] = frame_in_ep
             if "memory" in item:
                 item["memory_raw"] = str(item["memory"])
-            success = self._attach_mistake_raw(item, episodes_info)
+            success = self._attach_mistake_raw(item, episodes_info, ep_idx)
             item["next_memory_raw"] = self._lookup_next_memory(ep_idx, frame_in_ep)
             quality = self.meta.episodes[ep_idx].get("quality")
             if quality is not None:

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -2437,6 +2437,68 @@ class LeRobotDataset(BaseDataset):
                 task = substitutes[torch.randint(len(substitutes), ()).item()]
         return task
 
+    @staticmethod
+    def _resolve_episode_success(item: dict, episodes_info: dict, name_map: dict[str, str]) -> bool | None:
+        """Resolve the standard ``success`` role for the current sample.
+
+        ``success`` is the success-polarity counterpart of the ``mistake``
+        role: True means the episode succeeded. Resolution chain (first hit
+        wins):
+
+        1. the frame column mapped to ``success`` in
+           ``data_features_name_mapping`` (e.g. DROID's episode-constant
+           ``is_episode_successful``), read from ``item`` first and from the
+           per-episode ``meta.episodes`` entry second — so one mapping entry
+           covers both storage layouts;
+        2. the mapped column's v3.0 flattened aggregate
+           ``stats/<col>/mean`` in ``meta.episodes`` (thresholded at 0.5 —
+           the role expects an episode-constant signal, not a
+           terminal-frame-only marker);
+        3. the OpenTau per-episode convention key ``success`` in
+           ``meta.episodes`` (written by e.g. RECAP-style annotation).
+
+        Returns None when no source is available, so callers can distinguish
+        "labeled as failed" from "unlabeled".
+        """
+        col = name_map.get("success")
+        if col is not None:
+            value = item.get(col)
+            if value is None:
+                value = episodes_info.get(col)
+            if value is not None:
+                return bool(np.asarray(value).reshape(-1)[0])
+            stat = episodes_info.get(f"stats/{col}/mean")
+            if stat is not None:
+                return float(np.asarray(stat).reshape(-1)[0]) >= 0.5
+        value = episodes_info.get("success")
+        if value is not None:
+            return bool(np.asarray(value).reshape(-1)[0])
+        return None
+
+    def _attach_mistake_raw(self, item: dict, episodes_info: dict) -> bool | None:
+        """Attach ``mistake_raw`` from the standard ``mistake``/``success`` roles.
+
+        The mistake-polarity column (mapped via the ``mistake`` role in
+        ``data_features_name_mapping``, defaulting to the literal ``mistake``
+        column written by ``annotate_mistakes.py`` / ``attach_metadata.py``)
+        wins when present — it is segment-grained. Otherwise a resolved
+        ``success`` role (see :meth:`_resolve_episode_success`) is inverted
+        into an episode-constant ``mistake_raw``. With neither source no key
+        is attached, and ``_emit_optional_keys`` pads the field.
+
+        Returns the resolved ``success`` value (or None) so ``__getitem__``
+        can reuse it for the value-function return bins without re-resolving
+        after ``_to_standard_data_format`` has dropped the raw columns.
+        """
+        name_map = DATA_FEATURES_NAME_MAPPING.get(self._get_feature_mapping_key(), {})
+        success = self._resolve_episode_success(item, episodes_info, name_map)
+        mistake_col = name_map.get("mistake", "mistake")
+        if mistake_col in item:
+            item["mistake_raw"] = int(item[mistake_col])
+        elif success is not None:
+            item["mistake_raw"] = int(not success)
+        return success
+
     @retry_random_on_failure
     def __getitem__(self, idx) -> dict:
         item = self.hf_dataset[idx]
@@ -2505,8 +2567,7 @@ class LeRobotDataset(BaseDataset):
             item["frame_index"] = frame_in_ep
             if "memory" in item:
                 item["memory_raw"] = str(item["memory"])
-            if "mistake" in item:
-                item["mistake_raw"] = int(item["mistake"])
+            success = self._attach_mistake_raw(item, episodes_info)
             item["next_memory_raw"] = self._lookup_next_memory(ep_idx, frame_in_ep)
             quality = self.meta.episodes[ep_idx].get("quality")
             if quality is not None:
@@ -2522,7 +2583,9 @@ class LeRobotDataset(BaseDataset):
             else:
                 item["advantage"] = torch.tensor(0.0, dtype=torch.bfloat16)
 
-            success = episodes_info.get("success", True)
+            # Resolved by `_attach_mistake_raw` before the raw columns were
+            # dropped; unlabeled episodes count as successful for return bins.
+            success = success if success is not None else True
 
             # only add the below fields to item when training or evaluating the value fns
             if isinstance(self.cfg.policy, ValueConfig):

--- a/src/opentau/datasets/standard_data_format_mapping.py
+++ b/src/opentau/datasets/standard_data_format_mapping.py
@@ -51,9 +51,10 @@ Constants:
           annotate_mistakes.py / attach_metadata.py
         - "success": Success-polarity signal (True = episode succeeded), e.g.
           DROID's "is_episode_successful". Resolved from the frame column or
-          the per-episode metadata (including the v3.0 "stats/<col>/mean"
-          aggregate) and inverted into "mistake" when no mistake column
-          exists; also drives the value-function return bins
+          the per-episode metadata (including the per-episode "mean"
+          aggregate in episodes_stats, v2.1+) and inverted into "mistake"
+          when no mistake column exists; also drives the value-function
+          return bins
 
 Example:
     Access feature name mapping for a dataset:

--- a/src/opentau/datasets/standard_data_format_mapping.py
+++ b/src/opentau/datasets/standard_data_format_mapping.py
@@ -47,7 +47,8 @@ Constants:
         - "prompt": Task descriptions or prompts
         - "response": Expected responses or labels
         - "mistake": Mistake-polarity signal (True/1 = something went wrong);
-          defaults to the literal "mistake" column written by
+          must name a per-frame column (episode-level outcomes belong on
+          "success"); defaults to the literal "mistake" column written by
           annotate_mistakes.py / attach_metadata.py
         - "success": Success-polarity signal (True = episode succeeded), e.g.
           DROID's "is_episode_successful". Resolved from the frame column or

--- a/src/opentau/datasets/standard_data_format_mapping.py
+++ b/src/opentau/datasets/standard_data_format_mapping.py
@@ -46,6 +46,14 @@ Constants:
         - "actions": Action outputs
         - "prompt": Task descriptions or prompts
         - "response": Expected responses or labels
+        - "mistake": Mistake-polarity signal (True/1 = something went wrong);
+          defaults to the literal "mistake" column written by
+          annotate_mistakes.py / attach_metadata.py
+        - "success": Success-polarity signal (True = episode succeeded), e.g.
+          DROID's "is_episode_successful". Resolved from the frame column or
+          the per-episode metadata (including the v3.0 "stats/<col>/mean"
+          aggregate) and inverted into "mistake" when no mistake column
+          exists; also drives the value-function return bins
 
 Example:
     Access feature name mapping for a dataset:

--- a/tests/datasets/test_success_role.py
+++ b/tests/datasets/test_success_role.py
@@ -23,6 +23,7 @@ mistake-polarity column taking precedence over an inverted ``success`` role).
 
 from __future__ import annotations
 
+import pytest
 import torch
 
 from opentau.datasets.lerobot_dataset import LeRobotDataset
@@ -31,6 +32,13 @@ from opentau.datasets.standard_data_format_mapping import DATA_FEATURES_NAME_MAP
 resolve = LeRobotDataset._resolve_episode_success
 
 _TEST_MAPPING_KEY = "_tests/success_role_dummy"
+
+
+@pytest.fixture(autouse=True)
+def _clean_mapping_registration():
+    """Remove the test's mapping key from the process-global registry."""
+    yield
+    DATA_FEATURES_NAME_MAPPING.pop(_TEST_MAPPING_KEY, None)
 
 
 def _make_ds(mapping: dict[str, str]) -> LeRobotDataset:
@@ -125,3 +133,29 @@ class TestAttachMistakeRaw:
         item = {}
         assert ds._attach_mistake_raw(item, {}) is None
         assert "mistake_raw" not in item
+
+
+class TestCountSuccessRoleVaryingEpisodes:
+    count = staticmethod(LeRobotDataset._count_success_role_varying_episodes)
+
+    def test_constant_episodes_count_zero(self):
+        eps = {
+            0: {"stats/ok/min": [1.0], "stats/ok/max": [1.0]},
+            1: {"stats/ok/min": [0.0], "stats/ok/max": [0.0]},
+        }
+        assert self.count(eps, "ok") == (0, 2)
+
+    def test_varying_episode_detected(self):
+        eps = {
+            0: {"stats/ok/min": [0.0], "stats/ok/max": [1.0]},
+            1: {"stats/ok/min": [1.0], "stats/ok/max": [1.0]},
+        }
+        assert self.count(eps, "ok") == (1, 2)
+
+    def test_missing_aggregates_are_skipped_not_flagged(self):
+        eps = {0: {"length": 10}, 1: {"stats/ok/min": [1.0], "stats/ok/max": [1.0]}}
+        assert self.count(eps, "ok") == (0, 1)
+
+    def test_accepts_iterable_of_rows(self):
+        rows = [{"stats/ok/min": [0.0], "stats/ok/max": [1.0]}]
+        assert self.count(rows, "ok") == (1, 1)

--- a/tests/datasets/test_success_role.py
+++ b/tests/datasets/test_success_role.py
@@ -1,0 +1,127 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the standard ``mistake`` / ``success`` feature-mapping roles.
+
+Covers ``LeRobotDataset._resolve_episode_success`` (the resolution chain for
+success-polarity signals: mapped frame column -> mapped episode-metadata key
+-> v3.0 flattened stats aggregate -> legacy per-episode ``success`` key) and
+``LeRobotDataset._attach_mistake_raw`` (deriving ``mistake_raw`` with the
+mistake-polarity column taking precedence over an inverted ``success`` role).
+"""
+
+from __future__ import annotations
+
+import torch
+
+from opentau.datasets.lerobot_dataset import LeRobotDataset
+from opentau.datasets.standard_data_format_mapping import DATA_FEATURES_NAME_MAPPING
+
+resolve = LeRobotDataset._resolve_episode_success
+
+_TEST_MAPPING_KEY = "_tests/success_role_dummy"
+
+
+def _make_ds(mapping: dict[str, str]) -> LeRobotDataset:
+    """Minimal LeRobotDataset carrying just what _attach_mistake_raw reads."""
+    DATA_FEATURES_NAME_MAPPING[_TEST_MAPPING_KEY] = mapping
+    ds = object.__new__(LeRobotDataset)
+    ds.repo_id = _TEST_MAPPING_KEY
+    ds.control_mode = None
+    return ds
+
+
+class TestResolveEpisodeSuccess:
+    def test_mapped_frame_column_bool_tensor(self):
+        nm = {"success": "is_episode_successful"}
+        assert resolve({"is_episode_successful": torch.tensor(True)}, {}, nm) is True
+        assert resolve({"is_episode_successful": torch.tensor([False])}, {}, nm) is False
+
+    def test_mapped_frame_column_plain_int(self):
+        nm = {"success": "task_success"}
+        assert resolve({"task_success": 1}, {}, nm) is True
+        assert resolve({"task_success": 0}, {}, nm) is False
+
+    def test_mapped_episode_meta_key(self):
+        nm = {"success": "is_episode_successful"}
+        assert resolve({}, {"is_episode_successful": True}, nm) is True
+        assert resolve({}, {"is_episode_successful": 0}, nm) is False
+
+    def test_mapped_stats_mean_fallback(self):
+        nm = {"success": "is_episode_successful"}
+        assert resolve({}, {"stats/is_episode_successful/mean": [1.0]}, nm) is True
+        assert resolve({}, {"stats/is_episode_successful/mean": [0.0]}, nm) is False
+
+    def test_frame_column_beats_episode_meta_and_stats(self):
+        nm = {"success": "flag"}
+        info = {"flag": True, "stats/flag/mean": [1.0]}
+        assert resolve({"flag": torch.tensor(False)}, info, nm) is False
+
+    def test_legacy_success_key_without_mapping(self):
+        assert resolve({}, {"success": False}, {}) is False
+        assert resolve({}, {"success": True}, {}) is True
+
+    def test_mapped_role_beats_legacy_success_key(self):
+        nm = {"success": "flag"}
+        assert resolve({"flag": torch.tensor(False)}, {"success": True}, nm) is False
+
+    def test_mapped_but_absent_falls_back_to_legacy_key(self):
+        nm = {"success": "absent_col"}
+        assert resolve({}, {"success": False}, nm) is False
+
+    def test_none_when_unlabeled(self):
+        assert resolve({}, {}, {}) is None
+        assert resolve({}, {}, {"success": "absent_col"}) is None
+
+
+class TestAttachMistakeRaw:
+    def test_success_column_inverts_to_mistake(self):
+        ds = _make_ds({"success": "is_episode_successful"})
+        item = {"is_episode_successful": torch.tensor(False)}
+        assert ds._attach_mistake_raw(item, {}) is False
+        assert item["mistake_raw"] == 1
+
+        item = {"is_episode_successful": torch.tensor(True)}
+        assert ds._attach_mistake_raw(item, {}) is True
+        assert item["mistake_raw"] == 0
+
+    def test_mapped_mistake_column(self):
+        ds = _make_ds({"mistake": "is_mistake"})
+        item = {"is_mistake": torch.tensor(1)}
+        ds._attach_mistake_raw(item, {})
+        assert item["mistake_raw"] == 1
+
+    def test_mistake_column_wins_over_success_role(self):
+        ds = _make_ds({"success": "ok_flag", "mistake": "seg_mistake"})
+        item = {"seg_mistake": torch.tensor(1), "ok_flag": torch.tensor(True)}
+        assert ds._attach_mistake_raw(item, {}) is True
+        assert item["mistake_raw"] == 1
+
+    def test_literal_mistake_column_needs_no_mapping(self):
+        ds = _make_ds({})
+        item = {"mistake": torch.tensor(1)}
+        ds._attach_mistake_raw(item, {})
+        assert item["mistake_raw"] == 1
+
+    def test_stats_aggregate_derives_mistake(self):
+        ds = _make_ds({"success": "is_episode_successful"})
+        item = {}
+        assert ds._attach_mistake_raw(item, {"stats/is_episode_successful/mean": [0.0]}) is False
+        assert item["mistake_raw"] == 1
+
+    def test_unlabeled_attaches_nothing(self):
+        ds = _make_ds({})
+        item = {}
+        assert ds._attach_mistake_raw(item, {}) is None
+        assert "mistake_raw" not in item

--- a/tests/datasets/test_success_role.py
+++ b/tests/datasets/test_success_role.py
@@ -16,18 +16,28 @@
 
 Covers ``LeRobotDataset._resolve_episode_success`` (the resolution chain for
 success-polarity signals: mapped frame column -> mapped episode-metadata key
--> v3.0 flattened stats aggregate -> legacy per-episode ``success`` key) and
-``LeRobotDataset._attach_mistake_raw`` (deriving ``mistake_raw`` with the
-mistake-polarity column taking precedence over an inverted ``success`` role).
+-> per-episode ``episodes_stats`` mean aggregate -> legacy per-episode
+``success`` key), ``LeRobotDataset._attach_mistake_raw`` (deriving
+``mistake_raw`` with the mistake-polarity column taking precedence over an
+inverted ``success`` role), and the episode-constancy counting over
+``episodes_stats``. The stats-shaped tests go through the real
+``load_episodes_v30`` / ``load_episodes_stats_v30`` loaders so the helpers are
+exercised against loader-emitted structures, not hand-built dicts.
 """
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
+import numpy as np
+import packaging.version
+import pyarrow as pa
 import pytest
 import torch
 
 from opentau.datasets.lerobot_dataset import LeRobotDataset
 from opentau.datasets.standard_data_format_mapping import DATA_FEATURES_NAME_MAPPING
+from opentau.datasets.utils import load_episodes_stats_v30, load_episodes_v30
 
 resolve = LeRobotDataset._resolve_episode_success
 
@@ -41,13 +51,38 @@ def _clean_mapping_registration():
     DATA_FEATURES_NAME_MAPPING.pop(_TEST_MAPPING_KEY, None)
 
 
-def _make_ds(mapping: dict[str, str]) -> LeRobotDataset:
+def _make_ds(
+    mapping: dict[str, str],
+    episodes_stats: dict | None = None,
+    version: str = "v3.0",
+) -> LeRobotDataset:
     """Minimal LeRobotDataset carrying just what _attach_mistake_raw reads."""
     DATA_FEATURES_NAME_MAPPING[_TEST_MAPPING_KEY] = mapping
     ds = object.__new__(LeRobotDataset)
     ds.repo_id = _TEST_MAPPING_KEY
     ds.control_mode = None
+    ds.meta = SimpleNamespace(_version=packaging.version.parse(version), episodes_stats=episodes_stats or {})
     return ds
+
+
+def _v30_episodes_table(success_stats: list[tuple[float, float, float]]) -> pa.Table:
+    """Build a v3.0 episodes-metadata Arrow table with flattened stats columns.
+
+    ``success_stats`` holds one ``(min, max, mean)`` triple per episode for a
+    column named ``ok`` — the same flattened ``stats/{feature}/{stat}`` layout
+    ``_read_v30_episodes_arrow`` produces from the metadata shards.
+    """
+    n = len(success_stats)
+    return pa.table(
+        {
+            "episode_index": pa.array(range(n), type=pa.int64()),
+            "length": pa.array([10] * n, type=pa.int64()),
+            "tasks": pa.array([["task"]] * n, type=pa.list_(pa.string())),
+            "stats/ok/min": pa.array([[lo] for lo, _, _ in success_stats], type=pa.list_(pa.float64())),
+            "stats/ok/max": pa.array([[hi] for _, hi, _ in success_stats], type=pa.list_(pa.float64())),
+            "stats/ok/mean": pa.array([[mu] for _, _, mu in success_stats], type=pa.list_(pa.float64())),
+        }
+    )
 
 
 class TestResolveEpisodeSuccess:
@@ -66,15 +101,17 @@ class TestResolveEpisodeSuccess:
         assert resolve({}, {"is_episode_successful": True}, nm) is True
         assert resolve({}, {"is_episode_successful": 0}, nm) is False
 
-    def test_mapped_stats_mean_fallback(self):
-        nm = {"success": "is_episode_successful"}
-        assert resolve({}, {"stats/is_episode_successful/mean": [1.0]}, nm) is True
-        assert resolve({}, {"stats/is_episode_successful/mean": [0.0]}, nm) is False
+    def test_episode_stats_mean_fallback_uses_loader_shape(self):
+        nm = {"success": "ok"}
+        stats = load_episodes_stats_v30(None, episodes_table=_v30_episodes_table([(1, 1, 1), (0, 0, 0)]))
+        assert resolve({}, {}, nm, episode_stats=stats[0]) is True
+        assert resolve({}, {}, nm, episode_stats=stats[1]) is False
 
     def test_frame_column_beats_episode_meta_and_stats(self):
         nm = {"success": "flag"}
-        info = {"flag": True, "stats/flag/mean": [1.0]}
-        assert resolve({"flag": torch.tensor(False)}, info, nm) is False
+        info = {"flag": True}
+        stats = {"flag": {"mean": np.array([1.0])}}
+        assert resolve({"flag": torch.tensor(False)}, info, nm, episode_stats=stats) is False
 
     def test_legacy_success_key_without_mapping(self):
         assert resolve({}, {"success": False}, {}) is False
@@ -93,69 +130,94 @@ class TestResolveEpisodeSuccess:
         assert resolve({}, {}, {"success": "absent_col"}) is None
 
 
+class TestEpisodeStatsFor:
+    def test_returns_entry_for_v21_plus(self):
+        stats = {0: {"ok": {"mean": np.array([1.0])}}}
+        ds = _make_ds({}, episodes_stats=stats, version="v3.0")
+        assert ds._episode_stats_for(0) is stats[0]
+        assert ds._episode_stats_for(99) is None
+
+    def test_v20_backward_compatible_stats_are_ignored(self):
+        # v2.0 episodes_stats replicate the *global* aggregate per episode —
+        # not an episode-level signal, so the lookup must return None.
+        stats = {0: {"ok": {"mean": np.array([0.5])}}}
+        ds = _make_ds({}, episodes_stats=stats, version="v2.0")
+        assert ds._episode_stats_for(0) is None
+
+
 class TestAttachMistakeRaw:
     def test_success_column_inverts_to_mistake(self):
         ds = _make_ds({"success": "is_episode_successful"})
         item = {"is_episode_successful": torch.tensor(False)}
-        assert ds._attach_mistake_raw(item, {}) is False
+        assert ds._attach_mistake_raw(item, {}, 0) is False
         assert item["mistake_raw"] == 1
 
         item = {"is_episode_successful": torch.tensor(True)}
-        assert ds._attach_mistake_raw(item, {}) is True
+        assert ds._attach_mistake_raw(item, {}, 0) is True
         assert item["mistake_raw"] == 0
 
     def test_mapped_mistake_column(self):
         ds = _make_ds({"mistake": "is_mistake"})
         item = {"is_mistake": torch.tensor(1)}
-        ds._attach_mistake_raw(item, {})
+        ds._attach_mistake_raw(item, {}, 0)
         assert item["mistake_raw"] == 1
 
     def test_mistake_column_wins_over_success_role(self):
         ds = _make_ds({"success": "ok_flag", "mistake": "seg_mistake"})
         item = {"seg_mistake": torch.tensor(1), "ok_flag": torch.tensor(True)}
-        assert ds._attach_mistake_raw(item, {}) is True
+        assert ds._attach_mistake_raw(item, {}, 0) is True
         assert item["mistake_raw"] == 1
 
     def test_literal_mistake_column_needs_no_mapping(self):
         ds = _make_ds({})
         item = {"mistake": torch.tensor(1)}
-        ds._attach_mistake_raw(item, {})
+        ds._attach_mistake_raw(item, {}, 0)
         assert item["mistake_raw"] == 1
 
-    def test_stats_aggregate_derives_mistake(self):
-        ds = _make_ds({"success": "is_episode_successful"})
+    def test_episode_stats_aggregate_derives_mistake(self):
+        stats = load_episodes_stats_v30(None, episodes_table=_v30_episodes_table([(0, 0, 0)]))
+        ds = _make_ds({"success": "ok"}, episodes_stats=stats)
         item = {}
-        assert ds._attach_mistake_raw(item, {"stats/is_episode_successful/mean": [0.0]}) is False
+        assert ds._attach_mistake_raw(item, {}, 0) is False
         assert item["mistake_raw"] == 1
+
+    def test_v20_stats_do_not_derive_mistake(self):
+        stats = {0: {"ok": {"mean": np.array([0.0])}}}
+        ds = _make_ds({"success": "ok"}, episodes_stats=stats, version="v2.0")
+        item = {}
+        assert ds._attach_mistake_raw(item, {}, 0) is None
+        assert "mistake_raw" not in item
 
     def test_unlabeled_attaches_nothing(self):
         ds = _make_ds({})
         item = {}
-        assert ds._attach_mistake_raw(item, {}) is None
+        assert ds._attach_mistake_raw(item, {}, 0) is None
         assert "mistake_raw" not in item
 
 
 class TestCountSuccessRoleVaryingEpisodes:
     count = staticmethod(LeRobotDataset._count_success_role_varying_episodes)
 
+    def _loader_stats(self, triples):
+        return load_episodes_stats_v30(None, episodes_table=_v30_episodes_table(triples))
+
     def test_constant_episodes_count_zero(self):
-        eps = {
-            0: {"stats/ok/min": [1.0], "stats/ok/max": [1.0]},
-            1: {"stats/ok/min": [0.0], "stats/ok/max": [0.0]},
-        }
-        assert self.count(eps, "ok") == (0, 2)
+        stats = self._loader_stats([(1, 1, 1), (0, 0, 0)])
+        assert self.count(stats, "ok") == (0, 2)
 
     def test_varying_episode_detected(self):
-        eps = {
-            0: {"stats/ok/min": [0.0], "stats/ok/max": [1.0]},
-            1: {"stats/ok/min": [1.0], "stats/ok/max": [1.0]},
-        }
-        assert self.count(eps, "ok") == (1, 2)
+        stats = self._loader_stats([(0, 1, 0.5), (1, 1, 1)])
+        assert self.count(stats, "ok") == (1, 2)
 
-    def test_missing_aggregates_are_skipped_not_flagged(self):
-        eps = {0: {"length": 10}, 1: {"stats/ok/min": [1.0], "stats/ok/max": [1.0]}}
-        assert self.count(eps, "ok") == (0, 1)
+    def test_missing_column_is_skipped_not_flagged(self):
+        stats = self._loader_stats([(1, 1, 1)])
+        assert self.count(stats, "other_col") == (0, 0)
 
-    def test_accepts_iterable_of_rows(self):
-        rows = [{"stats/ok/min": [0.0], "stats/ok/max": [1.0]}]
-        assert self.count(rows, "ok") == (1, 1)
+    def test_episodes_metadata_records_have_no_stats(self):
+        # `load_episodes_v30` strips every `stats/*` column from the episode
+        # records; the count must run on `episodes_stats`, not `episodes`.
+        table = _v30_episodes_table([(0, 1, 0.5)])
+        episodes = load_episodes_v30(None, episodes_table=table)
+        assert not any(k.startswith("stats/") for k in episodes[0])
+        stats = load_episodes_stats_v30(None, episodes_table=table)
+        assert self.count(stats, "ok") == (1, 1)

--- a/tests/datasets/test_success_role.py
+++ b/tests/datasets/test_success_role.py
@@ -34,21 +34,24 @@ import packaging.version
 import pyarrow as pa
 import pytest
 import torch
+from torch.utils.data import default_collate
 
-from opentau.datasets.lerobot_dataset import LeRobotDataset
+from opentau.datasets.lerobot_dataset import BaseDataset, LeRobotDataset
 from opentau.datasets.standard_data_format_mapping import DATA_FEATURES_NAME_MAPPING
 from opentau.datasets.utils import load_episodes_stats_v30, load_episodes_v30
 
 resolve = LeRobotDataset._resolve_episode_success
 
 _TEST_MAPPING_KEY = "_tests/success_role_dummy"
+_SCHEMA_KEYS = ["_tests/success_role_schema_a", "_tests/success_role_schema_b"]
 
 
 @pytest.fixture(autouse=True)
 def _clean_mapping_registration():
-    """Remove the test's mapping key from the process-global registry."""
+    """Remove the test's mapping keys from the process-global registry."""
     yield
-    DATA_FEATURES_NAME_MAPPING.pop(_TEST_MAPPING_KEY, None)
+    for key in (_TEST_MAPPING_KEY, *_SCHEMA_KEYS):
+        DATA_FEATURES_NAME_MAPPING.pop(key, None)
 
 
 def _make_ds(
@@ -221,3 +224,98 @@ class TestCountSuccessRoleVaryingEpisodes:
         assert not any(k.startswith("stats/") for k in episodes[0])
         stats = load_episodes_stats_v30(None, episodes_table=table)
         assert self.count(stats, "ok") == (1, 1)
+
+
+class _SchemaDummy(BaseDataset):
+    """Concrete BaseDataset that bypasses __init__ so `_to_standard_data_format`
+    can run end-to-end against a registered name mapping (mirrors the harness
+    in test_optional_keys.py)."""
+
+    def __init__(self, mapping_key: str):
+        torch.utils.data.Dataset.__init__(self)
+        self._mapping_key = mapping_key
+        self.resolution = (8, 8)
+        self.num_cams = 1
+        self.max_state_dim = 7
+        self.max_action_dim = 7
+        self.action_chunk = 1
+        self.n_obs_history = None
+        self.history_state_drop_prob = 0.0
+        self.subgoal_drop_prob = 0.0
+        self.subgoal_end_of_segment_prob = 0.0
+        self.response_drop_prob = 0.0
+        self.metadata_drop_all_prob = 0.0
+        self.metadata_drop_each_prob = 0.0
+        self.emit_fps = False
+        self._action_freq = None
+        self.enable_optional_key_dropout = True
+        self.meta = SimpleNamespace(info={}, fps=30)
+
+    def _get_feature_mapping_key(self) -> str:
+        return self._mapping_key
+
+
+def _schema_dummy(key: str, mapping: dict[str, str]) -> _SchemaDummy:
+    DATA_FEATURES_NAME_MAPPING[key] = {
+        "camera0": "camera0",
+        "state": "state",
+        "actions": "actions",
+        "prompt": "prompt",
+        "response": "response",
+        **mapping,
+    }
+    return _SchemaDummy(key)
+
+
+def _schema_raw_item(ds: _SchemaDummy, **extra) -> dict:
+    h, w = ds.resolution
+    return {
+        "camera0": torch.full((3, h, w), 0.5, dtype=torch.float32),
+        "state": torch.zeros(ds.max_state_dim, dtype=torch.float32),
+        "actions": torch.zeros((ds.action_chunk, ds.max_action_dim), dtype=torch.float32),
+        "actions_is_pad": torch.zeros(ds.action_chunk, dtype=torch.bool),
+        "prompt": "do the thing",
+        "response": "ok",
+        **extra,
+    }
+
+
+class TestStandardDataFormatSchema:
+    """The `mistake`/`success` roles must not leak through the generic copy
+    loop of `_to_standard_data_format` — a raw per-dataset key breaks default
+    collation across a mixture, and a per-episode-only column would KeyError."""
+
+    def test_mapped_success_role_not_copied_into_schema(self):
+        ds = _schema_dummy(_SCHEMA_KEYS[0], {"success": "is_episode_successful"})
+        out = ds._to_standard_data_format(
+            _schema_raw_item(ds, is_episode_successful=torch.tensor(False), mistake_raw=1)
+        )
+        assert "success" not in out
+        assert "is_episode_successful" not in out
+        assert out["mistake"].item() is True
+        assert out["mistake_is_pad"].item() is False
+
+    def test_schema_matches_dataset_without_success_role_and_collates(self):
+        ds_a = _schema_dummy(_SCHEMA_KEYS[0], {"success": "is_episode_successful"})
+        ds_b = _schema_dummy(_SCHEMA_KEYS[1], {})
+        out_a = ds_a._to_standard_data_format(
+            _schema_raw_item(ds_a, is_episode_successful=torch.tensor(True), mistake_raw=0)
+        )
+        out_b = ds_b._to_standard_data_format(_schema_raw_item(ds_b))
+        assert set(out_a) == set(out_b)
+        batch = default_collate([out_a, out_b])
+        assert batch["mistake_is_pad"].tolist() == [False, True]
+
+    def test_episode_only_success_column_does_not_keyerror(self):
+        # The mapped column may exist only in the episode metadata — the copy
+        # loop must not require it as a frame column.
+        ds = _schema_dummy(_SCHEMA_KEYS[0], {"success": "episode_only_col"})
+        out = ds._to_standard_data_format(_schema_raw_item(ds))
+        assert "success" not in out
+        assert out["mistake_is_pad"].item() is True
+
+    def test_mapped_mistake_role_not_required_as_frame_column(self):
+        ds = _schema_dummy(_SCHEMA_KEYS[0], {"mistake": "seg_mistake"})
+        out = ds._to_standard_data_format(_schema_raw_item(ds))
+        assert "seg_mistake" not in out
+        assert out["mistake_is_pad"].item() is True


### PR DESCRIPTION
## What this does

Generalizes how per-dataset success/failure marks reach the training pipeline. (🗃️ Feature)

Many datasets ship a teleoperator success/failure mark under a dataset-specific column name — e.g. DROID 1.0.1 carries a per-frame `is_episode_successful` bool (17.6% of its 95,658 episodes are marked as failed attempts). Today the loader only picks up a column literally named `mistake` (the one written by `annotate_mistakes.py` / `attach_metadata.py`), so:

- those signals are silently dropped — every sample emits `mistake_is_pad=True`, and the pi07 `Mistake:` metadata conditioning never sees them;
- the value-function path hardcodes `episodes_info.get("success", True)`, so all failed episodes of such datasets count as successes for return-bin computation.

This PR promotes `mistake` and `success` to standard roles in the existing `data_features_name_mapping` mechanism instead of adding new config surface:

- Map a **mistake-polarity** column (True/1 = something went wrong) to `mistake`, or a **success-polarity** column to `success`. Polarity is expressed by which role you map, so the mapping stays a plain `str -> str` dict — no inversion flags.
- Resolution order in `__getitem__`: the mapped `mistake` column wins when present (it is segment-grained; the literal `mistake` fallback keeps existing annotated datasets working with zero config). Otherwise the `success` role is resolved — frame column first, then the per-episode metadata key, then the v3.0 flattened `stats/<col>/mean` aggregate — and inverted into `mistake_raw`. With neither source, behavior is unchanged (field padded).
- The same resolved value now feeds the value-function return bins, replacing the hardcoded default (unlabeled episodes still default to success).

With this, wiring e.g. DROID's flag is one config line:

```json
"data_features_name_mapping": { "success": "is_episode_successful", ... }
```

## How it was tested

- Added `tests/datasets/test_success_role.py`: the full resolution chain of `_resolve_episode_success` (mapped frame column as bool tensor / plain int, per-episode metadata key, the per-episode `episodes_stats` mean fallback with 0.5 threshold, legacy `success` key, precedence, unlabeled → `None`), `_attach_mistake_raw` (success inversion, mapped mistake column, mistake-beats-success precedence, literal-column fallback without mapping, unlabeled attaches nothing), the v2.0 backward-compatible-stats gating, the init-time episode-constancy warning inputs, and schema-level tests through `_to_standard_data_format` (no raw role keys leak; `default_collate` works across a success-mapped and an unmapped dataset; per-episode-only columns don't KeyError). Stats-shaped tests run against real `load_episodes_v30` / `load_episodes_stats_v30` loader output.
- `uv run pytest tests/datasets/ -m "not gpu and not network" -n auto` → 562 passed, 7 skipped (includes the pre-existing `test_optional_keys.py` coverage of the downstream `mistake`/`mistake_is_pad` emission).
- `uv run pytest tests/scripts/test_attach_metadata.py tests/scripts/test_annotate_mistakes.py -m "not gpu and not network"` → 40 passed (the producers of the literal `mistake` column, exercising the unchanged fallback path end-to-end).
- Verified against DROID 1.0.1 metadata (local copy) that the mapped role resolves the intended signal: `stats/is_episode_successful/mean` is episode-constant (min == max on all 95,658 episodes) and flags 16,794 failures.
- `pre-commit run` on all changed files → clean.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/datasets/test_success_role.py
```

Or on a dataset with a success-polarity column (e.g. a DROID sample), add the role to the dataset entry in the training config and check a fetched batch:

```json
"data_features_name_mapping": { "success": "is_episode_successful", ... }
```

Batches from failed episodes now come out with `mistake=True, mistake_is_pad=False` instead of the field being padded away.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
