### PR TITLE
fix(datasets): per-instance feature-name mapping resolution

### DIFF
--- a/src/opentau/configs/default.py
+++ b/src/opentau/configs/default.py
@@ -42,10 +42,12 @@ draccus.decode.register(np.ndarray, np.asarray)
 # For encoding to yaml
 draccus.encode.register(np.ndarray, lambda x: x.tolist())
 
-# DATA_FEATURES_NAME_MAPPING keys registered by a config entry this process.
-# Distinguishes a genuine mixture-entry collision (warn) from a single entry
-# overriding a built-in default mapping (legitimate, silent).
-_CONFIG_REGISTERED_MAPPING_KEYS: set[str] = set()
+# Registry keys some config entry RESOLVES through (its effective key) this
+# process. Distinguishes a genuine mixture-entry collision (warn: an earlier
+# entry's registry consumers would silently see the new columns) from the
+# silent-by-design overwrites: a single entry overriding a built-in default,
+# and the plain repo_id back-compat slot in the joint/ee pattern.
+_CONFIG_EFFECTIVE_MAPPING_KEYS: set[str] = set()
 
 
 @dataclass
@@ -271,30 +273,32 @@ class DatasetConfig:
                 effective = feature_mapping_key(self.repo_id, self.control_mode)
                 keys = list(dict.fromkeys([self.repo_id, effective]))
             for key in keys:
-                # Warn only on an entry-vs-entry conflict: the key must be the
-                # effective (composite-or-plain) key this entry's datasets
-                # resolve, AND the previous registration must come from
-                # another config entry. Overwriting the plain repo_id
-                # back-compat slot from a different control mode, or
-                # overriding a *built-in* default mapping, is by design and
-                # stays silent.
+                # Warn only when overwriting a key some earlier config entry
+                # RESOLVES through (its effective key) with a different
+                # mapping — that entry's registry consumers would silently
+                # see this entry's columns. Both the effective write and the
+                # plain-repo_id back-compat write are checked (a plain-key
+                # entry's effective registration can be clobbered by a later
+                # composite-key entry's back-compat write). Overwriting an
+                # un-tracked key — a built-in default, or the back-compat
+                # slot in the joint/ee pattern — stays silent by design.
                 previous = DATA_FEATURES_NAME_MAPPING.get(key)
                 if (
-                    key == effective
-                    and key in _CONFIG_REGISTERED_MAPPING_KEYS
+                    key in _CONFIG_EFFECTIVE_MAPPING_KEYS
                     and previous is not None
                     and previous != self.data_features_name_mapping
                 ):
                     warnings.warn(
                         f"data_features_name_mapping: registry key {key!r} is being overwritten "
-                        "with a different mapping (two mixture entries share this "
-                        "repo_id/control_mode). Each dataset instance still uses its own entry's "
+                        "with a different mapping (another mixture entry resolves its mapping "
+                        "via this key). Each dataset instance still uses its own entry's "
                         "mapping, but registry consumers (annotation scripts, direct "
                         "constructions) will see only the last one registered.",
                         stacklevel=2,
                     )
                 DATA_FEATURES_NAME_MAPPING[key] = self.data_features_name_mapping
-                _CONFIG_REGISTERED_MAPPING_KEYS.add(key)
+            if effective is not None:
+                _CONFIG_EFFECTIVE_MAPPING_KEYS.add(effective)
 
 
 @dataclass

--- a/src/opentau/configs/default.py
+++ b/src/opentau/configs/default.py
@@ -42,6 +42,11 @@ draccus.decode.register(np.ndarray, np.asarray)
 # For encoding to yaml
 draccus.encode.register(np.ndarray, lambda x: x.tolist())
 
+# DATA_FEATURES_NAME_MAPPING keys registered by a config entry this process.
+# Distinguishes a genuine mixture-entry collision (warn) from a single entry
+# overriding a built-in default mapping (legitimate, silent).
+_CONFIG_REGISTERED_MAPPING_KEYS: set[str] = set()
+
 
 @dataclass
 class DatasetConfig:
@@ -266,11 +271,20 @@ class DatasetConfig:
                 effective = feature_mapping_key(self.repo_id, self.control_mode)
                 keys = list(dict.fromkeys([self.repo_id, effective]))
             for key in keys:
-                # Only the effective (composite-or-plain) key is what this
-                # entry's datasets resolve; overwriting the plain repo_id
-                # back-compat slot from a different control mode is by design.
+                # Warn only on an entry-vs-entry conflict: the key must be the
+                # effective (composite-or-plain) key this entry's datasets
+                # resolve, AND the previous registration must come from
+                # another config entry. Overwriting the plain repo_id
+                # back-compat slot from a different control mode, or
+                # overriding a *built-in* default mapping, is by design and
+                # stays silent.
                 previous = DATA_FEATURES_NAME_MAPPING.get(key)
-                if key == effective and previous is not None and previous != self.data_features_name_mapping:
+                if (
+                    key == effective
+                    and key in _CONFIG_REGISTERED_MAPPING_KEYS
+                    and previous is not None
+                    and previous != self.data_features_name_mapping
+                ):
                     warnings.warn(
                         f"data_features_name_mapping: registry key {key!r} is being overwritten "
                         "with a different mapping (two mixture entries share this "
@@ -280,6 +294,7 @@ class DatasetConfig:
                         stacklevel=2,
                     )
                 DATA_FEATURES_NAME_MAPPING[key] = self.data_features_name_mapping
+                _CONFIG_REGISTERED_MAPPING_KEYS.add(key)
 
 
 @dataclass

--- a/src/opentau/configs/default.py
+++ b/src/opentau/configs/default.py
@@ -89,7 +89,13 @@ class DatasetConfig:
             must name a per-frame column; for an episode-level outcome map
             ``success`` instead, which resolves from a per-frame column or a
             per-episode key in the episodes metadata and also drives the
-            value-function return bins. Defaults to None.
+            value-function return bins.
+            Two mixture entries may share a ``repo_id`` and ``control_mode``
+            while declaring different mappings (e.g. two camera views of one
+            repo): each dataset instance resolves its own entry's mapping.
+            The global registry keeps only the last registration for
+            annotation-script consumers — a warning fires when entries
+            disagree. Defaults to None.
         robot_type: Optional override for the dataset's ``robot_type`` metadata
             field. When provided (including the empty string), takes precedence
             over the value loaded from ``meta/info.json``. ``None`` (default)
@@ -243,17 +249,37 @@ class DatasetConfig:
         # two entries that share a repo_id but use different action columns
         # (e.g. control_mode="joint" -> action_joint vs control_mode="ee" ->
         # action_ee) coexist instead of the second silently clobbering the first.
+        # Dataset instances resolve their own entry's mapping per-instance
+        # (BaseDataset._get_name_map), so a same-key clobber here no longer
+        # affects training reads — but the registry stays the source for
+        # annotation scripts and direct constructions, so warn when two
+        # entries disagree on the same key.
         if self.data_features_name_mapping is not None:
             from opentau.datasets.standard_data_format_mapping import (
                 DATA_FEATURES_NAME_MAPPING,
                 feature_mapping_key,
             )
 
-            DATA_FEATURES_NAME_MAPPING[self.repo_id] = self.data_features_name_mapping
+            keys = []
+            effective = None
             if self.repo_id is not None:
-                key = feature_mapping_key(self.repo_id, self.control_mode)
-                if key != self.repo_id:
-                    DATA_FEATURES_NAME_MAPPING[key] = self.data_features_name_mapping
+                effective = feature_mapping_key(self.repo_id, self.control_mode)
+                keys = list(dict.fromkeys([self.repo_id, effective]))
+            for key in keys:
+                # Only the effective (composite-or-plain) key is what this
+                # entry's datasets resolve; overwriting the plain repo_id
+                # back-compat slot from a different control mode is by design.
+                previous = DATA_FEATURES_NAME_MAPPING.get(key)
+                if key == effective and previous is not None and previous != self.data_features_name_mapping:
+                    warnings.warn(
+                        f"data_features_name_mapping: registry key {key!r} is being overwritten "
+                        "with a different mapping (two mixture entries share this "
+                        "repo_id/control_mode). Each dataset instance still uses its own entry's "
+                        "mapping, but registry consumers (annotation scripts, direct "
+                        "constructions) will see only the last one registered.",
+                        stacklevel=2,
+                    )
+                DATA_FEATURES_NAME_MAPPING[key] = self.data_features_name_mapping
 
 
 @dataclass

--- a/src/opentau/datasets/dataset_mixture.py
+++ b/src/opentau/datasets/dataset_mixture.py
@@ -265,9 +265,23 @@ class DatasetMixtureMetadata:
         metadatas: List[DatasetMetadata],
         dataset_weights: List[float],
         dataset_names: List[str] | None = None,
+        name_maps: List[dict[str, str] | None] | None = None,
     ):
         self.cfg = cfg
         self._dataset_weights = list(dataset_weights)
+
+        # Per-entry feature-name mappings (aligned with `metadatas`). When an
+        # entry is None, resolution falls back to the global registry — which
+        # is ambiguous when two entries share a repo_id and control_mode, so
+        # WeightedDatasetMixture passes each dataset's own instance mapping.
+        if name_maps is None:
+            name_maps = [None] * len(metadatas)
+
+        def _entry_name_map(m: DatasetMetadata, own: dict[str, str] | None) -> dict[str, str]:
+            if own is not None:
+                return own
+            key = feature_mapping_key(m.repo_id, getattr(m, "info", {}).get("control_mode"))
+            return DATA_FEATURES_NAME_MAPPING[key if key in DATA_FEATURES_NAME_MAPPING else m.repo_id]
 
         # Snapshot raw state / action dims BEFORE `_to_standard_data_format`
         # pads the standardized stats. Used to surface incompatible-dim
@@ -275,9 +289,8 @@ class DatasetMixtureMetadata:
         # but with mismatched proprio / action widths). Done up front because
         # the standardize loop below clobbers `metadata.stats`.
         raw_dims: list[tuple[int, int]] = []
-        for m in metadatas:
-            key = feature_mapping_key(m.repo_id, getattr(m, "info", {}).get("control_mode"))
-            name_map = DATA_FEATURES_NAME_MAPPING[key if key in DATA_FEATURES_NAME_MAPPING else m.repo_id]
+        for m, own_map in zip(metadatas, name_maps, strict=True):
+            name_map = _entry_name_map(m, own_map)
             raw_dims.append(
                 (
                     int(m.stats[name_map["state"]]["mean"].shape[-1]),
@@ -286,9 +299,12 @@ class DatasetMixtureMetadata:
             )
 
         # convert each metadata stats to the standard data format
-        for metadata in metadatas:
+        for metadata, own_map in zip(metadatas, name_maps, strict=True):
             metadata.stats = self._to_standard_data_format(
-                metadata.repo_id, metadata.stats, getattr(metadata, "info", {}).get("control_mode")
+                metadata.repo_id,
+                metadata.stats,
+                getattr(metadata, "info", {}).get("control_mode"),
+                name_map=own_map,
             )
 
         # Per-dataset stats kept for diagnostic / back-compat consumers
@@ -475,7 +491,11 @@ class DatasetMixtureMetadata:
         return agg["actions"]
 
     def _to_standard_data_format(
-        self, repo_id: str, stats: dict[str, dict[str, np.ndarray]], control_mode: str | None = None
+        self,
+        repo_id: str,
+        stats: dict[str, dict[str, np.ndarray]],
+        control_mode: str | None = None,
+        name_map: dict[str, str] | None = None,
     ) -> dict[str, dict[str, np.ndarray]]:
         """Convert statistics to the standard data format.
 
@@ -489,6 +509,9 @@ class DatasetMixtureMetadata:
                 feature-name mapping, so dual-split entries (joint vs ee) pick
                 their own action column. ``None`` falls back to the plain
                 ``repo_id`` entry.
+            name_map: This entry's own feature-name mapping. When provided it
+                wins over the registry lookup — the registry is ambiguous when
+                two mixture entries share a ``repo_id`` and ``control_mode``.
 
         Returns:
             Statistics dictionary with standard feature names and padded vectors.
@@ -497,9 +520,13 @@ class DatasetMixtureMetadata:
             KeyError: If a required feature is missing from stats or if required
                 statistics (mean, std, min, max) are missing.
         """
-        key = feature_mapping_key(repo_id, control_mode)
-        name_map = DATA_FEATURES_NAME_MAPPING[key if key in DATA_FEATURES_NAME_MAPPING else repo_id]
-        features_without_stats = ["prompt", "response", "advantage"]
+        if name_map is None:
+            key = feature_mapping_key(repo_id, control_mode)
+            name_map = DATA_FEATURES_NAME_MAPPING[key if key in DATA_FEATURES_NAME_MAPPING else repo_id]
+        # `mistake`/`success` are optional-metadata roles, not normalization
+        # features — their columns may have stats on disk, but they must not
+        # enter the standardized stats schema.
+        features_without_stats = ["prompt", "response", "advantage", "mistake", "success"]
 
         standard_stats = {}
         for new_key, key in name_map.items():
@@ -736,11 +763,22 @@ class WeightedDatasetMixture:
         # `DatasetMixtureMetadata` clobbers `metadata.stats` via
         # `_to_standard_data_format`; this must run before any downstream
         # consumer that reads the raw per-feature stats.
+        # Thread each dataset's instance mapping through so colliding entries
+        # (same repo_id + control_mode, different mappings) standardize their
+        # stats against their own columns. `random_split` wrappers hold the
+        # real dataset one level deeper, same as the `.meta` lookup above.
+        def _instance_name_map(ds) -> dict[str, str] | None:
+            own = getattr(ds, "_data_features_name_mapping", None)
+            if own is None and hasattr(ds, "dataset"):
+                own = getattr(ds.dataset, "_data_features_name_mapping", None)
+            return own
+
         self.meta = DatasetMixtureMetadata(
             cfg,
             [ds.meta for ds in datasets],
             dataset_weights,
             dataset_names=self.dataset_names,
+            name_maps=[_instance_name_map(ds) for ds in datasets],
         )
 
         # Wrap every underlying dataset so __getitem__ injects

--- a/src/opentau/datasets/factory.py
+++ b/src/opentau/datasets/factory.py
@@ -140,11 +140,21 @@ def resolve_delta_timestamps(
 
     if dataset_cfg.repo_id is None:
         raise ValueError("dataset_cfg.repo_id must not be None when resolving delta timestamps.")
-    # Runs before `_apply_metadata_overrides`, so prefer the config's control_mode
-    # override, falling back to the on-disk value, to resolve dual-split columns.
-    control_mode = dataset_cfg.control_mode if dataset_cfg.control_mode is not None else ds_meta.control_mode
-    mkey = feature_mapping_key(dataset_cfg.repo_id, control_mode)
-    name_map = DATA_FEATURES_NAME_MAPPING[mkey if mkey in DATA_FEATURES_NAME_MAPPING else dataset_cfg.repo_id]
+    if dataset_cfg.data_features_name_mapping is not None:
+        # This entry's own mapping — the registry may hold another entry's
+        # mapping when two entries share a repo_id and control_mode (see
+        # BaseDataset._get_name_map for the fetch-time counterpart).
+        name_map = dataset_cfg.data_features_name_mapping
+    else:
+        # Runs before `_apply_metadata_overrides`, so prefer the config's control_mode
+        # override, falling back to the on-disk value, to resolve dual-split columns.
+        control_mode = (
+            dataset_cfg.control_mode if dataset_cfg.control_mode is not None else ds_meta.control_mode
+        )
+        mkey = feature_mapping_key(dataset_cfg.repo_id, control_mode)
+        name_map = DATA_FEATURES_NAME_MAPPING[
+            mkey if mkey in DATA_FEATURES_NAME_MAPPING else dataset_cfg.repo_id
+        ]
     reverse_name_map = {v: k for k, v in name_map.items()}
     for key in ds_meta.features:
         if key not in reverse_name_map:
@@ -273,6 +283,7 @@ def make_dataset(
             return_advantage_input=return_advantage_input,
             skip_timestamp_check=effective_skip,
             prompt_substitutions=cfg.prompt_substitutions,
+            data_features_name_mapping=cfg.data_features_name_mapping,
         )
     else:
         raise ValueError("Exactly one of `cfg.vqa` and `cfg.repo_id` should be provided.")

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -760,6 +760,36 @@ class BaseDataset(torch.utils.data.Dataset):
             ...         return "my-dataset"
     """
 
+    # Per-instance feature-name mapping. When set (LeRobotDataset receives it
+    # from the mixture entry's `data_features_name_mapping`), it wins over the
+    # process-global DATA_FEATURES_NAME_MAPPING registry — two mixture entries
+    # sharing a repo_id and control_mode would otherwise clobber each other's
+    # registry entry (last-wins) and silently read the same columns.
+    _data_features_name_mapping: dict[str, str] | None = None
+
+    def _get_name_map(self, strict: bool = True) -> dict[str, str]:
+        """Resolve this dataset's feature-name mapping.
+
+        The per-instance mapping (set from the config entry) takes precedence;
+        the global ``DATA_FEATURES_NAME_MAPPING`` registry is the fallback for
+        built-in defaults and direct constructions.
+
+        Args:
+            strict: When True, a dataset with neither a per-instance mapping
+                nor a registry entry raises ``KeyError`` (standardization
+                cannot proceed without a mapping). When False, returns an
+                empty dict instead — for optional-role lookups.
+
+        Returns:
+            Mapping from standard feature names to dataset-specific names.
+        """
+        if self._data_features_name_mapping is not None:
+            return self._data_features_name_mapping
+        key = self._get_feature_mapping_key()
+        if strict:
+            return DATA_FEATURES_NAME_MAPPING[key]
+        return DATA_FEATURES_NAME_MAPPING.get(key, {})
+
     def __init__(self, cfg: TrainPipelineConfig):
         super().__init__()
         # Standard Data Format parameters
@@ -881,7 +911,7 @@ class BaseDataset(torch.utils.data.Dataset):
         Returns:
             List of boolean values indicating which camera slots are padded.
         """
-        name_map = DATA_FEATURES_NAME_MAPPING[self._get_feature_mapping_key()]
+        name_map = self._get_name_map()
         image_is_pad = []
         for cam_idx in range(n_cams):
             std_key = f"camera{cam_idx}"
@@ -927,7 +957,7 @@ class BaseDataset(torch.utils.data.Dataset):
         Returns:
             Dictionary with standardized feature names and formats.
         """
-        name_map = DATA_FEATURES_NAME_MAPPING[self._get_feature_mapping_key()]
+        name_map = self._get_name_map()
 
         standard_item = {}
         img_is_pad = self._standardize_images(item, standard_item, self.num_cams)
@@ -1353,6 +1383,7 @@ class LeRobotDataset(BaseDataset):
         return_advantage_input: bool = False,
         skip_timestamp_check: bool = False,
         prompt_substitutions: dict[str, list[str]] | None = None,
+        data_features_name_mapping: dict[str, str] | None = None,
     ):
         """Initialize LeRobotDataset.
 
@@ -1492,10 +1523,20 @@ class LeRobotDataset(BaseDataset):
                 (gated by ``self.enable_prompt_substitution``); unmapped tasks pass
                 through unchanged. Keys matching no on-disk task string raise a
                 ``ValueError`` at init. Defaults to None.
+            data_features_name_mapping (dict[str, str] | None, optional): This
+                instance's standard-role -> dataset-column mapping. When set it
+                wins over the process-global ``DATA_FEATURES_NAME_MAPPING``
+                registry (see :meth:`BaseDataset._get_name_map`), so two
+                mixture entries sharing a ``repo_id`` and ``control_mode`` can
+                declare different mappings (e.g. two camera views of the same
+                repo) without clobbering each other. ``None`` (default) falls
+                back to the registry.
         """
         super().__init__(cfg)
         self.cfg = cfg
         self.repo_id = repo_id
+        if data_features_name_mapping is not None:
+            self._data_features_name_mapping = dict(data_features_name_mapping)
         self.root = Path(root) if root else HF_OPENTAU_HOME / repo_id
         self.image_transforms = image_transforms
         self.delta_timestamps_params = self.compute_delta_params(
@@ -1653,7 +1694,7 @@ class LeRobotDataset(BaseDataset):
         # outcomes, so where genuinely per-episode min/max aggregates exist
         # (v2.1+ `episodes_stats`; the v2.0 backward-compatible path only
         # replicates the global aggregate), prove constancy at load time.
-        success_col = DATA_FEATURES_NAME_MAPPING.get(self._get_feature_mapping_key(), {}).get("success")
+        success_col = self._get_name_map(strict=False).get("success")
         if (
             success_col is not None
             and self.meta._version >= packaging.version.parse("v2.1")
@@ -2418,7 +2459,7 @@ class LeRobotDataset(BaseDataset):
         # old ordering threw away 75% of decodes.
         if self.enable_optional_key_dropout and bool(torch.rand(()) < self.subgoal_drop_prob):
             return {}
-        name_map = DATA_FEATURES_NAME_MAPPING[self._get_feature_mapping_key()]
+        name_map = self._get_name_map()
         at_end = bool(torch.rand(()) < self.subgoal_end_of_segment_prob)
         subgoal_frame = self._sample_subgoal_frame(ep_idx, frame_in_ep, at_end_of_segment=at_end)
         ts = subgoal_frame / self.fps
@@ -2596,7 +2637,7 @@ class LeRobotDataset(BaseDataset):
         can reuse it for the value-function return bins without re-resolving
         after ``_to_standard_data_format`` has dropped the raw columns.
         """
-        name_map = DATA_FEATURES_NAME_MAPPING.get(self._get_feature_mapping_key(), {})
+        name_map = self._get_name_map(strict=False)
         success = self._resolve_episode_success(
             item, episodes_info, name_map, episode_stats=self._episode_stats_for(ep_idx)
         )

--- a/src/opentau/scripts/diagnose_norm_distribution.py
+++ b/src/opentau/scripts/diagnose_norm_distribution.py
@@ -326,7 +326,9 @@ def _build_tasks(args: Args) -> tuple[list[dict], dict, list[str]]:
     cols, dims = [], []
     max_s = max_a = 1
     for dc, m in zip(kept_cfgs, metadatas, strict=True):
-        nm = resolve_feature_mapping(dc.repo_id, m.info.get("control_mode"))
+        # Mirror training: the entry's own mapping wins over the registry
+        # (which is ambiguous when entries share a repo_id and control_mode).
+        nm = dc.data_features_name_mapping or resolve_feature_mapping(dc.repo_id, m.info.get("control_mode"))
         scol, acol = nm.get("state"), nm.get("actions")
         sdim = int(np.asarray(m.stats[scol]["mean"]).shape[-1]) if scol in m.stats else 0
         adim = int(np.asarray(m.stats[acol]["mean"]).shape[-1]) if acol in m.stats else 0
@@ -338,7 +340,13 @@ def _build_tasks(args: Args) -> tuple[list[dict], dict, list[str]]:
         max_state_dim=max_s, max_action_dim=max_a, num_cams=0, resolution=(224, 224), dataset_mixture=mix_cfg
     )
     names = WeightedDatasetMixture._make_dataset_names(cfg_shim, metadatas)
-    mm = DatasetMixtureMetadata(cfg_shim, metadatas, kept_w, dataset_names=names)
+    mm = DatasetMixtureMetadata(
+        cfg_shim,
+        metadatas,
+        kept_w,
+        dataset_names=names,
+        name_maps=[dc.data_features_name_mapping for dc in kept_cfgs],
+    )
     logger.info("%d (robot_type, control_mode) heads over %d datasets", len(mm.norm_keys), len(names))
 
     # Per-head meta stats, sliced to each head's native dim.

--- a/tests/datasets/test_name_mapping_collision.py
+++ b/tests/datasets/test_name_mapping_collision.py
@@ -33,7 +33,7 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 
-from opentau.configs.default import _CONFIG_REGISTERED_MAPPING_KEYS, DatasetConfig
+from opentau.configs.default import _CONFIG_EFFECTIVE_MAPPING_KEYS, DatasetConfig
 from opentau.datasets.dataset_mixture import DatasetMixtureMetadata
 from opentau.datasets.factory import make_dataset, resolve_delta_timestamps
 from opentau.datasets.lerobot_dataset import LeRobotDataset
@@ -54,7 +54,7 @@ def _clean_mapping_registration():
     yield
     for key in _TEST_KEYS:
         DATA_FEATURES_NAME_MAPPING.pop(key, None)
-        _CONFIG_REGISTERED_MAPPING_KEYS.discard(key)
+        _CONFIG_EFFECTIVE_MAPPING_KEYS.discard(key)
 
 
 def _make_ds(instance_mapping: dict[str, str] | None) -> LeRobotDataset:
@@ -170,6 +170,38 @@ class TestConfigRegistrationWarning:
                 data_features_name_mapping={"camera0": "config_cam"},
             )
         assert DATA_FEATURES_NAME_MAPPING["_tests/collision_repo"]["camera0"] == "config_cam"
+
+    def test_explicit_then_missing_control_mode_does_not_warn(self):
+        """A plain-key entry after a composite-key entry only overwrites the
+        back-compat slot — the composite entry's effective key is intact."""
+        DatasetConfig(
+            repo_id="_tests/collision_repo",
+            control_mode="joint",
+            data_features_name_mapping={"camera0": "exterior_1_left"},
+        )
+        import warnings as _warnings
+
+        with _warnings.catch_warnings():
+            _warnings.simplefilter("error")
+            DatasetConfig(
+                repo_id="_tests/collision_repo",
+                data_features_name_mapping={"camera0": "exterior_2_left"},
+            )
+        assert DATA_FEATURES_NAME_MAPPING["_tests/collision_repo::joint"]["camera0"] == "exterior_1_left"
+
+    def test_missing_then_explicit_control_mode_warns(self):
+        """A composite-key entry's back-compat write clobbers the plain key a
+        prior entry RESOLVES through — that must warn."""
+        DatasetConfig(
+            repo_id="_tests/collision_repo",
+            data_features_name_mapping={"camera0": "exterior_1_left"},
+        )
+        with pytest.warns(UserWarning, match="overwritten with a different mapping"):
+            DatasetConfig(
+                repo_id="_tests/collision_repo",
+                control_mode="joint",
+                data_features_name_mapping={"camera0": "exterior_2_left"},
+            )
 
 
 def _colliding_configs() -> tuple[DatasetConfig, DatasetConfig]:

--- a/tests/datasets/test_name_mapping_collision.py
+++ b/tests/datasets/test_name_mapping_collision.py
@@ -33,7 +33,7 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 
-from opentau.configs.default import DatasetConfig
+from opentau.configs.default import _CONFIG_REGISTERED_MAPPING_KEYS, DatasetConfig
 from opentau.datasets.dataset_mixture import DatasetMixtureMetadata
 from opentau.datasets.factory import make_dataset, resolve_delta_timestamps
 from opentau.datasets.lerobot_dataset import LeRobotDataset
@@ -50,10 +50,11 @@ _TEST_KEYS = [
 
 @pytest.fixture(autouse=True)
 def _clean_mapping_registration():
-    """Remove this module's keys from the process-global registry."""
+    """Remove this module's keys from the process-global registries."""
     yield
     for key in _TEST_KEYS:
         DATA_FEATURES_NAME_MAPPING.pop(key, None)
+        _CONFIG_REGISTERED_MAPPING_KEYS.discard(key)
 
 
 def _make_ds(instance_mapping: dict[str, str] | None) -> LeRobotDataset:
@@ -155,6 +156,20 @@ class TestConfigRegistrationWarning:
                 control_mode="ee",
                 data_features_name_mapping={"actions": "action_ee"},
             )
+
+    def test_overriding_builtin_default_does_not_warn(self):
+        """A single entry overriding a built-in registry default (a key never
+        registered by a config entry) is legitimate and stays silent."""
+        DATA_FEATURES_NAME_MAPPING["_tests/collision_repo"] = {"camera0": "builtin_cam"}
+        import warnings as _warnings
+
+        with _warnings.catch_warnings():
+            _warnings.simplefilter("error")
+            DatasetConfig(
+                repo_id="_tests/collision_repo",
+                data_features_name_mapping={"camera0": "config_cam"},
+            )
+        assert DATA_FEATURES_NAME_MAPPING["_tests/collision_repo"]["camera0"] == "config_cam"
 
 
 def _colliding_configs() -> tuple[DatasetConfig, DatasetConfig]:

--- a/tests/datasets/test_name_mapping_collision.py
+++ b/tests/datasets/test_name_mapping_collision.py
@@ -1,0 +1,265 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for per-instance feature-name mapping resolution.
+
+Two mixture entries sharing a ``repo_id`` and ``control_mode`` while declaring
+different ``data_features_name_mapping`` values (e.g. two camera views of the
+same repo) used to clobber each other in the process-global
+``DATA_FEATURES_NAME_MAPPING`` registry (last-wins), so both dataset instances
+silently read the last entry's columns. Covers ``BaseDataset._get_name_map``
+(per-instance mapping wins, registry fallback, strict behavior), the
+end-to-end collision repro through the real ``LeRobotDataset`` constructor,
+and the config-time warning when conflicting registrations share a key.
+"""
+
+from __future__ import annotations
+
+import copy
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from opentau.configs.default import DatasetConfig
+from opentau.datasets.dataset_mixture import DatasetMixtureMetadata
+from opentau.datasets.factory import make_dataset, resolve_delta_timestamps
+from opentau.datasets.lerobot_dataset import LeRobotDataset
+from opentau.datasets.standard_data_format_mapping import DATA_FEATURES_NAME_MAPPING
+
+_TEST_KEYS = [
+    "_tests/name_mapping_dummy",
+    "_tests/name_mapping_dummy::joint",
+    "_tests/collision_repo",
+    "_tests/collision_repo::joint",
+    "_tests/collision_repo::ee",
+]
+
+
+@pytest.fixture(autouse=True)
+def _clean_mapping_registration():
+    """Remove this module's keys from the process-global registry."""
+    yield
+    for key in _TEST_KEYS:
+        DATA_FEATURES_NAME_MAPPING.pop(key, None)
+
+
+def _make_ds(instance_mapping: dict[str, str] | None) -> LeRobotDataset:
+    ds = object.__new__(LeRobotDataset)
+    ds.repo_id = "_tests/name_mapping_dummy"
+    ds.control_mode = None
+    if instance_mapping is not None:
+        ds._data_features_name_mapping = instance_mapping
+    return ds
+
+
+class TestGetNameMap:
+    def test_instance_mapping_wins_over_registry(self):
+        DATA_FEATURES_NAME_MAPPING["_tests/name_mapping_dummy"] = {"camera0": "registry_cam"}
+        ds = _make_ds({"camera0": "instance_cam"})
+        assert ds._get_name_map()["camera0"] == "instance_cam"
+
+    def test_registry_fallback_when_no_instance_mapping(self):
+        DATA_FEATURES_NAME_MAPPING["_tests/name_mapping_dummy"] = {"camera0": "registry_cam"}
+        ds = _make_ds(None)
+        assert ds._get_name_map()["camera0"] == "registry_cam"
+
+    def test_strict_raises_without_any_mapping(self):
+        ds = _make_ds(None)
+        with pytest.raises(KeyError):
+            ds._get_name_map()
+
+    def test_non_strict_returns_empty_without_any_mapping(self):
+        ds = _make_ds(None)
+        assert ds._get_name_map(strict=False) == {}
+
+
+class TestSameRepoEntriesKeepOwnMappings:
+    def test_two_instances_resolve_their_own_camera(self, tmp_path, lerobot_dataset_factory):
+        """The collision repro: same repo_id, same (absent) control mode,
+        different camera0 — each instance must read its own column."""
+        map_a = {"camera0": "exterior_1_left", "state": "observation.state", "actions": "action"}
+        map_b = {"camera0": "exterior_2_left", "state": "observation.state", "actions": "action"}
+        ds_a = lerobot_dataset_factory(
+            root=tmp_path / "a", standardize=False, data_features_name_mapping=map_a
+        )
+        ds_b = lerobot_dataset_factory(
+            root=tmp_path / "b", standardize=False, data_features_name_mapping=map_b
+        )
+        assert ds_a._get_name_map()["camera0"] == "exterior_1_left"
+        assert ds_b._get_name_map()["camera0"] == "exterior_2_left"
+
+    def test_val_clone_shares_the_instance_mapping(self, tmp_path, lerobot_dataset_factory):
+        mapping = {"camera0": "exterior_1_left", "state": "observation.state", "actions": "action"}
+        ds = lerobot_dataset_factory(root=tmp_path, standardize=False, data_features_name_mapping=mapping)
+        clone = ds.shallow_copy_with_dropout(enable_dropout=False)
+        assert clone._get_name_map()["camera0"] == "exterior_1_left"
+
+
+class TestConfigRegistrationWarning:
+    def test_conflicting_same_key_registration_warns(self):
+        DatasetConfig(
+            repo_id="_tests/collision_repo",
+            control_mode="joint",
+            data_features_name_mapping={"camera0": "exterior_1_left"},
+        )
+        with pytest.warns(UserWarning, match="overwritten with a different mapping"):
+            DatasetConfig(
+                repo_id="_tests/collision_repo",
+                control_mode="joint",
+                data_features_name_mapping={"camera0": "exterior_2_left"},
+            )
+        # Registry keeps the last registration (documented last-wins).
+        assert DATA_FEATURES_NAME_MAPPING["_tests/collision_repo::joint"]["camera0"] == "exterior_2_left"
+
+    def test_identical_registration_does_not_warn(self):
+        mapping = {"camera0": "exterior_1_left"}
+        DatasetConfig(
+            repo_id="_tests/collision_repo", control_mode="joint", data_features_name_mapping=mapping
+        )
+        import warnings as _warnings
+
+        with _warnings.catch_warnings():
+            _warnings.simplefilter("error")
+            DatasetConfig(
+                repo_id="_tests/collision_repo",
+                control_mode="joint",
+                data_features_name_mapping=dict(mapping),
+            )
+
+    def test_different_control_modes_do_not_warn(self):
+        """The joint/ee pattern: plain repo_id fallback overwrite is by design."""
+        DatasetConfig(
+            repo_id="_tests/collision_repo",
+            control_mode="joint",
+            data_features_name_mapping={"actions": "action_joint"},
+        )
+        import warnings as _warnings
+
+        with _warnings.catch_warnings():
+            _warnings.simplefilter("error")
+            DatasetConfig(
+                repo_id="_tests/collision_repo",
+                control_mode="ee",
+                data_features_name_mapping={"actions": "action_ee"},
+            )
+
+
+def _colliding_configs() -> tuple[DatasetConfig, DatasetConfig]:
+    """Two mixture entries, same repo_id + control_mode, different camera0."""
+    cfg_a = DatasetConfig(
+        repo_id="_tests/collision_repo",
+        control_mode="joint",
+        data_features_name_mapping={
+            "camera0": "exterior_1_left",
+            "state": "observation.state",
+            "actions": "action",
+        },
+    )
+    with pytest.warns(UserWarning, match="overwritten with a different mapping"):
+        cfg_b = DatasetConfig(
+            repo_id="_tests/collision_repo",
+            control_mode="joint",
+            data_features_name_mapping={
+                "camera0": "exterior_2_left",
+                "state": "observation.state",
+                "actions": "action",
+            },
+        )
+    return cfg_a, cfg_b
+
+
+class TestResolveDeltaTimestampsPerEntryMap:
+    def test_colliding_entries_get_own_camera_deltas(self):
+        """resolve_delta_timestamps runs in the same make_dataset path — it
+        must use the entry's own mapping, not the (clobbered) registry."""
+        cfg_a, cfg_b = _colliding_configs()
+        train_cfg = SimpleNamespace(
+            dataset_mixture=SimpleNamespace(action_freq=15.0, n_obs_history=None), policy=None
+        )
+        meta = SimpleNamespace(
+            features={"exterior_1_left": {}, "exterior_2_left": {}, "observation.state": {}, "action": {}},
+            fps=15,
+            control_mode="joint",
+        )
+        dt_a, _, _, _ = resolve_delta_timestamps(train_cfg, cfg_a, meta)
+        dt_b, _, _, _ = resolve_delta_timestamps(train_cfg, cfg_b, meta)
+        assert "exterior_1_left" in dt_a and "exterior_2_left" not in dt_a
+        assert "exterior_2_left" in dt_b and "exterior_1_left" not in dt_b
+
+
+class TestMixtureMetadataPerEntryMaps:
+    @staticmethod
+    def _entry_meta(base, cam_col: str, cam_mean: float):
+        stats = copy.deepcopy({k: v for k, v in base.stats.items() if k != "camera0"})
+        cam_stats = copy.deepcopy(base.stats["camera0"])
+        cam_stats["mean"] = np.full_like(cam_stats["mean"], cam_mean)
+        stats[cam_col] = cam_stats
+        return SimpleNamespace(repo_id="_tests/collision_repo", info=dict(base.info), stats=stats)
+
+    def test_colliding_entries_standardize_own_camera_stats(
+        self, train_pipeline_config, lerobot_dataset_metadata
+    ):
+        m_a = self._entry_meta(lerobot_dataset_metadata, "exterior_1_left", 0.25)
+        m_b = self._entry_meta(lerobot_dataset_metadata, "exterior_2_left", 0.75)
+        maps = [
+            {"camera0": "exterior_1_left", "state": "state", "actions": "actions"},
+            {"camera0": "exterior_2_left", "state": "state", "actions": "actions"},
+        ]
+        mm = DatasetMixtureMetadata(
+            train_pipeline_config, [m_a, m_b], [0.5, 0.5], dataset_names=["a", "b"], name_maps=maps
+        )
+        assert float(np.asarray(mm.per_dataset_stats[0]["camera0"]["mean"]).reshape(-1)[0]) == 0.25
+        assert float(np.asarray(mm.per_dataset_stats[1]["camera0"]["mean"]).reshape(-1)[0]) == 0.75
+
+    def test_success_role_column_excluded_from_stats_schema(
+        self, train_pipeline_config, lerobot_dataset_metadata
+    ):
+        m = self._entry_meta(lerobot_dataset_metadata, "exterior_1_left", 0.5)
+        m.stats["is_episode_successful"] = {
+            "min": np.array([0.0]),
+            "max": np.array([1.0]),
+            "mean": np.array([0.8]),
+            "std": np.array([0.4]),
+            "count": np.array([150]),
+        }
+        maps = [
+            {
+                "camera0": "exterior_1_left",
+                "state": "state",
+                "actions": "actions",
+                "success": "is_episode_successful",
+            }
+        ]
+        mm = DatasetMixtureMetadata(train_pipeline_config, [m], [1.0], dataset_names=["a"], name_maps=maps)
+        assert "success" not in mm.per_dataset_stats[0]
+        assert "is_episode_successful" not in mm.per_dataset_stats[0]
+
+
+class TestMakeDatasetThreadsInstanceMapping:
+    def test_each_entry_constructor_receives_own_mapping(self, train_pipeline_config):
+        """make_dataset must hand each colliding entry its own mapping."""
+        cfg_a, cfg_b = _colliding_configs()
+        with (
+            patch("opentau.datasets.factory.LeRobotDatasetMetadata") as mock_meta_cls,
+            patch("opentau.datasets.factory.LeRobotDataset") as mock_ds_cls,
+        ):
+            mock_meta_cls.return_value = MagicMock(features=[])
+            mock_ds_cls.return_value = MagicMock(meta=MagicMock(info={}, stats={}, camera_keys=[]))
+            make_dataset(cfg_a, train_pipeline_config)
+            make_dataset(cfg_b, train_pipeline_config)
+        first, second = mock_ds_cls.call_args_list
+        assert first.kwargs["data_features_name_mapping"]["camera0"] == "exterior_1_left"
+        assert second.kwargs["data_features_name_mapping"]["camera0"] == "exterior_2_left"


### PR DESCRIPTION
## What this does

Fixes a silent feature-name-mapping collision between mixture entries. (🐛 Bug)

Two `dataset_mixture` entries that share both `repo_id` and `control_mode` but declare different `data_features_name_mapping` values — the natural pattern for training two camera views of the same repo, e.g. two `lerobot/droid_1.0.1` entries with `camera0 -> observation.images.exterior_1_left` vs `...exterior_2_left` — silently clobber each other today:

- `DatasetConfig.__post_init__` registers each mapping into the process-global `DATA_FEATURES_NAME_MAPPING` last-wins, and the composite `repo_id::control_mode` key only disambiguates entries with *different* control modes.
- At fetch time the datasets resolve their mapping from that registry, so **both instances read the last entry's columns** — the first entry's camera view never loads, and the mixture trains two identical copies of one view.

The fix stores the mapping per dataset instance and prefers it over the registry:

- `BaseDataset._get_name_map(strict=...)` resolves the per-instance mapping first, falling back to the registry (built-in defaults, annotation scripts, direct constructions keep working unchanged). All fetch-time lookups (`_to_standard_data_format`, `_load_subgoal_frames`, the `mistake`/`success` role resolution from #457) go through it.
- `resolve_delta_timestamps` prefers the entry's own mapping too, so each colliding entry's camera column gets its own temporal-window config.
- `DatasetMixtureMetadata` accepts per-entry `name_maps` (threaded from `WeightedDatasetMixture`, with the same one-level-deep unwrap as the `.meta` lookup for `random_split` wrappers), so normalization stats standardize against each entry's own columns; the `mistake`/`success` roles are excluded from the stats schema.
- `make_dataset` threads `cfg.data_features_name_mapping` into the `LeRobotDataset` constructor; the val-split clone shares it (shallow copy).
- Config registration still upserts the registry for its remaining consumers, but now **warns** when an entry overwrites the same *effective* key with a different mapping. The plain-`repo_id` fallback overwrite in the legitimate joint/ee dual-control-mode pattern stays silent — that one is by design.

No checked-in example config uses the colliding pattern (verified by scanning `configs/**/*.json`), so this only affects user configs.

## How it was tested

- Added `tests/datasets/test_name_mapping_collision.py`:
  - `_get_name_map`: instance mapping wins over the registry, registry fallback, strict `KeyError` vs non-strict empty-dict behavior.
  - The collision repro through the real constructor: two datasets, same `repo_id`, different `data_features_name_mapping` — each resolves its own `camera0`; the val-split clone shares the instance mapping.
  - Config-time warning: fires on a conflicting same-key registration (registry stays last-wins), silent for identical re-registration and for the joint/ee different-control-mode pattern.
  - `resolve_delta_timestamps`: each colliding entry's camera column gets its own deltas; `DatasetMixtureMetadata`: colliding entries standardize their own camera stats, and a mapped `success` column stays out of the stats schema; `make_dataset`: the constructor receives each entry's own mapping.
- `uv run pytest tests/datasets/ tests/configs/ -m "not gpu and not network" -n auto` → 722 passed, 7 skipped (includes the pre-existing `test_feature_mapping_dual_split.py` coverage of the joint/ee registry pattern).
- `pre-commit run` on all changed files → clean.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/datasets/test_name_mapping_collision.py
```

Or reproduce the pre-fix behavior on any config with two same-repo entries mapping different `camera0` columns: before this change both datasets return the same `_get_name_map()["camera0"]`; after it, each returns its own.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
