### PR TITLE
fix(policies): attribute outliers to per-entry dataset name, not source key

### DIFF
--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -1020,7 +1020,11 @@ class BaseDataset(torch.utils.data.Dataset):
         # Provenance fields (part of the standard data format). `source` is the
         # dataset's identity (repo_id for LeRobotDataset, the dataset key for
         # VQA), so a sample's origin survives into the training batch — useful
-        # for debugging which dataset/frame produced an outlier. `episode_index`
+        # for debugging which dataset/frame produced an outlier. NOTE: two
+        # mixture entries sharing a repo_id and control_mode emit an identical
+        # `source`; per-entry attribution (e.g. the outlier-debug pipeline)
+        # must use the mixture-level `dataset_repo_id` that `_TaggedDataset`
+        # injects at the wrapping layer instead. `episode_index`
         # / `frame_index` are plain ints (default-collate to a (B,) int64
         # tensor); VQA / missing values emit the sentinel -1 so a heterogeneous
         # LeRobot+VQA batch stays schema-aligned under default collation.

--- a/src/opentau/policies/outlier_utils.py
+++ b/src/opentau/policies/outlier_utils.py
@@ -41,7 +41,10 @@ class OutlierRecord(TypedDict):
     ``value`` is the largest ``|normalized value|`` seen for this
     ``(source, key, dim)`` in the batch; ``source`` / ``episode`` / ``frame`` are
     the provenance of that worst sample (``None`` when the batch lacks the
-    field). Only plain Python scalars are stored so the list survives the
+    field). ``source`` is the mixture-level per-entry dataset name
+    (``dataset_repo_id``, unique across colliding mixture entries) when the
+    batch carries one, else the sample-level ``source`` feature-mapping key.
+    Only plain Python scalars are stored so the list survives the
     ``gather_object`` round-trip used to ship records to rank 0.
     """
 
@@ -104,8 +107,11 @@ def detect_state_action_outliers(batch: dict[str, Tensor], threshold: float | No
     A normalized value far from unit scale almost always means bad normalization
     stats (e.g. near-zero std on a constant dim) or corrupt data. This finds the
     offending dims so the training loop can warn about them, recording the
-    ``source`` / ``episode_index`` / ``frame_index`` (when present in the batch)
-    to trace a poorly-normalized dim back to the dataset/frame to inspect.
+    dataset identity / ``episode_index`` / ``frame_index`` (when present in the
+    batch) to trace a poorly-normalized dim back to the dataset/frame to
+    inspect. The dataset identity is ``dataset_repo_id`` (the mixture-level
+    per-entry name, unique even for colliding entries that share a repo_id and
+    control_mode) when present, else the sample-level ``source`` key.
 
     Pure and collective-free: it reads ``batch`` without mutating it, fires no
     collective, and does NO cross-step dedup or logging — so the ``forward``
@@ -153,7 +159,15 @@ def detect_state_action_outliers(batch: dict[str, Tensor], threshold: float | No
     if not bool(torch.cat([viol.flatten() for _, viol in per_key.values()]).any()):
         return []
 
-    src = batch.get("source")
+    # Prefer the mixture-level per-entry name (`dataset_repo_id`, injected by
+    # `_TaggedDataset`, unique per mixture entry) over the sample-level
+    # `source` feature-mapping key: two mixture entries sharing a repo_id and
+    # control_mode emit an identical `source`, which would merge their records
+    # into one (source, key, dim) offender and make the outlier unattributable
+    # to the specific entry/view.
+    src = batch.get("dataset_repo_id")
+    if src is None:
+        src = batch.get("source")
     ep = batch.get("episode_index")
     fr = batch.get("frame_index")
 

--- a/tests/policies/test_outlier_detection.py
+++ b/tests/policies/test_outlier_detection.py
@@ -159,3 +159,39 @@ class TestDetectStateActionOutliers:
         dim2 = [r for r in records if r["key"] == "state" and r["dim"] == 2]
         assert len(dim2) == 1
         assert dim2[0]["value"] == pytest.approx(88.0)
+
+    # -- per-entry attribution: dataset_repo_id wins over the shared source key --
+
+    def test_colliding_entries_distinguished_by_dataset_repo_id(self):
+        # Two mixture entries sharing a repo_id + control_mode (e.g. two camera
+        # views of lerobot/droid_1.0.1) emit an IDENTICAL sample-level `source`
+        # (the feature-mapping key), but `_TaggedDataset` injects the
+        # deduplicated per-entry name as `dataset_repo_id`. The detector must
+        # key records on the latter so the two entries' offenders stay
+        # distinguishable (`(source, key, dim)` merge keys differ).
+        batch = {
+            "state": torch.zeros(2, 8),
+            "source": ["lerobot/droid_1.0.1", "lerobot/droid_1.0.1"],
+            "dataset_repo_id": ["lerobot/droid_1.0.1#0", "lerobot/droid_1.0.1#1"],
+        }
+        batch["state"][0, 2] = 40.0  # entry #0 offends on dim 2
+        batch["state"][1, 2] = 88.0  # entry #1 offends on the SAME dim
+        records = detect_state_action_outliers(batch, 10.0)
+        dim2 = {r["source"]: r for r in records if r["key"] == "state" and r["dim"] == 2}
+        # Same-source merging would collapse these to one record; per-entry
+        # names keep one record per entry, each with its own worst value.
+        assert set(dim2) == {"lerobot/droid_1.0.1#0", "lerobot/droid_1.0.1#1"}
+        assert dim2["lerobot/droid_1.0.1#0"]["value"] == pytest.approx(40.0)
+        assert dim2["lerobot/droid_1.0.1#1"]["value"] == pytest.approx(88.0)
+
+    def test_source_fallback_without_dataset_repo_id(self):
+        # Batches that never went through the mixture wrapper (direct dataset
+        # use, VQA-only paths) carry no `dataset_repo_id`; `source` is used.
+        batch = {
+            "state": torch.zeros(2, 8),
+            "source": ["dsA", "dsB"],
+        }
+        batch["state"][1, 3] = 50.0
+        records = detect_state_action_outliers(batch, 10.0)
+        assert len(records) == 1
+        assert records[0]["source"] == "dsB"


### PR DESCRIPTION
## What this does
Follow-up to #458 (flagged in its review). Since #458, two `dataset_mixture` entries sharing a `repo_id` and `control_mode` (e.g. two `lerobot/droid_1.0.1` entries with different `camera0` views) are first-class — but both emit an identical sample-level `source` (the feature-mapping key set in `BaseDataset._to_standard_data_format`). The outlier-debug pipeline (`log_outlier_records_distributed` in `scripts/train.py`) merges records per `(source, key, dim)`, so offenders from the two entries collapsed into one record and an outlier could not be attributed to the specific entry/view.

Fix (the less invasive of the two options flagged in the review): `detect_state_action_outliers` now prefers `batch["dataset_repo_id"]` — the mixture-level deduplicated per-entry name (`repo_id#N` from `WeightedDatasetMixture._make_dataset_names`) that `_TaggedDataset` injects for every mixture dataset, VQA included — and falls back to `source` when absent (direct dataset use, VQA-only paths). Since the record's `source` field is what both the merge key and the warning message use, this single change fixes attribution end to end; the merge logic in `train.py` is untouched, and per-sample `dataset_index` provenance was never affected. The sample-level `source` has exactly one consumer (this pipeline), so no other call sites need alignment. Also adds a note at the provenance comment in `lerobot_dataset.py` pointing per-entry attribution at `dataset_repo_id`.

## How it was tested
- Added `test_colliding_entries_distinguished_by_dataset_repo_id` in `tests/policies/test_outlier_detection.py`: a batch with identical `source` values but distinct `lerobot/droid_1.0.1#0` / `#1` per-entry names produces two distinguishable records with per-entry worst values (previously they merged into one `(source, key, dim)` offender).
- Added `test_source_fallback_without_dataset_repo_id` covering the non-mixture path (no `dataset_repo_id` in the batch → `source` is used, preserving existing behavior).
- `pre-commit run` clean on all changed files.
- `pytest -m "not gpu and not network" -n auto tests/policies tests/scripts tests/datasets` → 1464 passed, 9 skipped.

## How to checkout & try? (for the reviewer)
```bash
git checkout claude/eloquent-montalcini-d87f5d
pytest -sx tests/policies/test_outlier_detection.py
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
