### PR TITLE
fix(datasets): restore T dim for n_obs_history=1 camera queries

### DIFF
--- a/src/opentau/configs/default.py
+++ b/src/opentau/configs/default.py
@@ -339,9 +339,12 @@ class DatasetMixtureConfig:
             returns shape ``(T, max_state_dim)``. When ``None``, the default
             single-step behavior is preserved with rank-3 camera tensors
             ``(C, H, W)`` and rank-1 state tensors ``(max_state_dim,)``.
-            Note that ``n_obs_history=1`` produces rank-4/rank-2 tensors with
-            a leading singleton dimension, so downstream consumers must handle
-            both rank conventions. Defaults to ``None``. The temporal stride
+            Note that ``n_obs_history=1`` produces rank-4 camera tensors
+            ``(1, C, H, W)`` with a leading singleton dimension, while state
+            collapses to rank-1 ``(max_state_dim,)`` (the length-1
+            delta-timestamps query is squeezed like the ``None`` case), so
+            downstream consumers must rank-normalize state themselves.
+            Defaults to ``None``. The temporal stride
             between sampled observations is read from the policy config's
             ``history_interval`` attribute (defaults to 1 when the policy
             doesn't define one), so observations are sampled at timesteps

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -924,8 +924,16 @@ class BaseDataset(torch.utils.data.Dataset):
                     standard_item[std_key] = torch.zeros((3, *self.resolution))
                 image_is_pad.append(True)
             elif self.n_obs_history is not None:
+                img = item[key]
+                # n_obs_history == 1 produces a length-1 delta-timestamps
+                # query, which the fetch paths collapse to (C, H, W) —
+                # `_query_videos` for video keys, the single-delta squeeze in
+                # `__getitem__` for image columns. Restore the temporal dim so
+                # the (T, C, H, W) contract holds for T == 1.
+                if self.n_obs_history == 1 and img.ndim == 3:
+                    img = rearrange(img, "c h w -> 1 c h w")
                 standard_item[std_key] = self.resize_with_pad(
-                    item[key], self.resolution[1], self.resolution[0], pad_value=0
+                    img, self.resolution[1], self.resolution[0], pad_value=0
                 )
                 # Per-frame temporal padding info (from clamped episode boundaries) is
                 # tracked by obs_history_is_pad on the state side. Camera _is_pad only

--- a/tests/datasets/test_obs_history.py
+++ b/tests/datasets/test_obs_history.py
@@ -326,6 +326,103 @@ def test_obs_history_is_pad_fallback_shape(lerobot_dataset_factory, info_factory
 
 
 # ---------------------------------------------------------------------------
+# Integration tests: video datasets with observation history
+# ---------------------------------------------------------------------------
+
+
+def _make_video_dataset_with_history(
+    lerobot_dataset_factory, tmp_path, monkeypatch, n_obs_history, frame_hw=(48, 64)
+):
+    """Create a LeRobotDataset with video cameras and observation history.
+
+    The fixture datasets declare video features but ship no mp4s, so
+    ``decode_video_frames`` is patched to synthesize ``(len(ts), 3, H, W)``
+    frames. Patching at the decode level (rather than ``_query_videos``)
+    keeps the real single-timestamp squeeze in ``_query_videos`` in play —
+    that squeeze is what makes ``n_obs_history=1`` regress to (C, H, W).
+    """
+    from opentau.datasets.lerobot_dataset import LeRobotDataset
+
+    monkeypatch.setitem(
+        DATA_FEATURES_NAME_MAPPING,
+        DUMMY_REPO_ID,
+        {
+            "camera0": "laptop",
+            "camera1": "phone",
+            "state": "state",
+            "actions": "action",
+            "prompt": "task",
+            "response": "response",
+        },
+    )
+
+    h, w = frame_hw
+
+    def _fake_decode(video_path, timestamps, tolerance_s, backend=None):
+        return torch.rand(len(timestamps), 3, h, w)
+
+    monkeypatch.setattr("opentau.datasets.lerobot_dataset.decode_video_frames", _fake_decode)
+
+    dataset = lerobot_dataset_factory(
+        root=tmp_path / f"obs_hist_video_{n_obs_history}",
+        repo_id=DUMMY_REPO_ID,
+        total_episodes=3,
+        total_frames=150,
+        total_tasks=1,
+    )
+
+    dataset.cfg.dataset_mixture.n_obs_history = n_obs_history
+    dataset.n_obs_history = n_obs_history
+    dataset.cfg.policy = DummyPolicyConfig(chunk_size=dataset.cfg.action_chunk)
+    # Disable the random-index retry wrapper so a failure surfaces at the
+    # queried index instead of being silently replaced by a random sample.
+    dataset._total_rand_attempts = 0
+
+    dt_info = resolve_delta_timestamps(dataset.cfg, dataset.cfg.dataset_mixture.datasets[0], dataset.meta)
+    dataset.delta_timestamps_params = LeRobotDataset.compute_delta_params(*dt_info)
+
+    return dataset
+
+
+@pytest.mark.parametrize("n_obs_history", [1, 3])
+def test_video_history_camera_shapes(lerobot_dataset_factory, tmp_path, monkeypatch, n_obs_history):
+    """Camera tensors keep the (T, 3, H, W) contract for any n_obs_history.
+
+    Regression test for n_obs_history=1 with video datasets: the length-1
+    delta-timestamps query is squeezed to (C, H, W) upstream, which used to
+    fail the (T, 3, H, W) shape assert in ``_standardize_images`` on every
+    sample fetch.
+    """
+    dataset = _make_video_dataset_with_history(
+        lerobot_dataset_factory, tmp_path, monkeypatch, n_obs_history=n_obs_history
+    )
+    item = dataset[25]
+    expected = (n_obs_history, 3, *dataset.cfg.resolution)
+    assert item["camera0"].shape == expected
+    assert item["camera1"].shape == expected
+    assert item["img_is_pad"].shape == (dataset.cfg.num_cams,)
+    assert not item["img_is_pad"].any()
+    assert item["obs_history_is_pad"].shape == (n_obs_history,)
+    # Deliberate asymmetry pinned: cameras keep the T=1 singleton, but state
+    # follows the generic length-1 delta squeeze and stays rank-1 — policies
+    # rank-normalize (B, D) -> (B, 1, D) themselves (see the n_obs_history
+    # docstring in configs/default.py).
+    if n_obs_history == 1:
+        assert item["state"].shape == (dataset.cfg.max_state_dim,)
+    else:
+        assert item["state"].shape == (n_obs_history, dataset.cfg.max_state_dim)
+
+
+def test_video_history_t1_batch_collates(lerobot_dataset_factory, tmp_path, monkeypatch):
+    """n_obs_history=1 items collate into a (B, 1, 3, H, W) camera batch."""
+    dataset = _make_video_dataset_with_history(
+        lerobot_dataset_factory, tmp_path, monkeypatch, n_obs_history=1
+    )
+    batch = torch.utils.data.default_collate([dataset[25], dataset[26]])
+    assert batch["camera0"].shape == (2, 1, 3, *dataset.cfg.resolution)
+
+
+# ---------------------------------------------------------------------------
 # Batched resize_with_pad tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What this does
Fixes a crash where setting `dataset_mixture.n_obs_history: 1` with any camera-bearing dataset failed every sample fetch. (🐛 Bug)

With `n_obs_history: 1`, `resolve_delta_timestamps` gives cameras a length-1 delta-timestamps list, and both fetch paths then collapse the temporal dim: `_query_videos` squeezes single-timestamp video queries to `(C, H, W)`, and the generic single-delta squeeze in `__getitem__` does the same for image-dtype columns. `_standardize_images` then asserts `(T, 3, H, W)` whenever `n_obs_history` is set, so `_assert_image_in_unit_range` raised on every item (`Expected image camera0 to have shape (T, 3, H, W) ... Got shape torch.Size([3, 224, 224])`) and the retry wrapper exhausted all attempts per sample.

The fix restores the missing T dim in `_standardize_images` when `self.n_obs_history == 1` and the camera tensor is 3-D — the only case the upstream squeeze can produce. The upstream squeezes are deliberately left alone:

- subgoal loading (`_load_subgoal_frames`) relies on `_query_videos` returning `(C, H, W)` for its single-frame queries;
- `state` intentionally stays rank-1 `(max_state_dim,)` at `n_obs_history=1` via the generic single-delta squeeze — the history-consuming policies already rank-normalize state `(B, D) -> (B, 1, D)` and video `(B, C, H, W) -> (B, 1, C, H, W)` themselves.

The `n_obs_history` docstring in `configs/default.py` claimed `n_obs_history=1` produces rank-4/rank-2 tensors with a leading singleton; it now spells out the actual shipped contract (rank-4 cameras, rank-1 state).

Padded (absent) camera slots already emitted `(n_obs_history, 3, H, W)` zeros, so present and absent slots now collate consistently at T=1. The `n_obs_history=None` and `n_obs_history>1` paths are byte-identical to before.

## How it was tested
- Added a video-dataset observation-history section to `tests/datasets/test_obs_history.py`:
  - `test_video_history_camera_shapes` (parametrized over `n_obs_history in {1, 3}`) — patches `decode_video_frames` at the module level so the real `_query_videos` squeeze stays in play, maps both dummy cameras, and asserts the `(T, 3, H, W)` camera contract, `img_is_pad`, `obs_history_is_pad`, and the deliberate rank-1 state shape at T=1.
  - `test_video_history_t1_batch_collates` — asserts two T=1 items collate to a `(B, 1, 3, H, W)` camera batch.
  - The helper disables the random-index retry wrapper (`_total_rand_attempts = 0`) so failures surface at the queried index.
- Red/green verified: with the `_standardize_images` hunk reverted, the `n_obs_history=1` case fails with exactly the reported assertion while `n_obs_history=3` passes; with the fix, all pass.
- `pytest -m "not gpu and not network" -n auto`: 2029 passed, 13 skipped, 1 pre-existing environmental failure (`test_libero2torch` needs LIBERO assets not present locally; unrelated to this change).
- Full `tests/datasets/` (603 passed) and `tests/configs/` (147 passed) directories green; `pre-commit run` clean.

## How to checkout & try? (for the reviewer)
```bash
pytest -sx tests/datasets/test_obs_history.py
```
Or reproduce the original crash by checking out `main`, cherry-picking only the test hunk, and running:
```bash
pytest -sx "tests/datasets/test_obs_history.py::test_video_history_camera_shapes[1]"
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
