### PR TITLE
feat(policies): add cosmos3_nano policy on the Cosmos3-Nano 8B reasoner

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Whether you use the official OpenPi codebase or LeRobot’s reimplementation, yo
 - Dropout in the VLM to reduce overfitting
 - Authentic $\pi_{0.6}$ policy with a Gemma 3 4B backbone, 448×448 vision, and 5-step flow matching
 - Hierarchical $\pi_{0.7}$ policy: high-level planner + low-level controller with a SpaceTime SigLIP video encoder on a Gemma 3 backbone
-- `cosmos3` policy: the $\pi_{0.5}$ flow-matching recipe on a frozen Qwen3-VL-32B (NVIDIA Cosmos3-Super reasoner) backbone with a custom sub-1B action expert
+- `cosmos3` policy: the $\pi_{0.5}$ flow-matching recipe on a frozen Qwen3-VL-32B (NVIDIA Cosmos3-Super reasoner) backbone with a custom sub-1B action expert — plus a `cosmos3_nano` sibling on the smaller Qwen3-VL-8B (Cosmos3-Nano reasoner) backbone
 - A reinforcement learning pipeline described in $\pi^*_{0.6}$
 - And more...
 
@@ -69,7 +69,7 @@ To spin up a $\pi_{0.6}$ training run, start from [configs/examples/pi06_trainin
 
 $\pi_{0.7}$ splits the model into a high-level planner that proposes subgoals and a low-level controller that executes them. The current implementation pairs a Gemma 3 backbone with a SpaceTime SigLIP video encoder so the controller can attend over temporal context, and the two stages train independently. To train the low-level controller, start from [configs/examples/pi07_low_level_libero.json](https://github.com/TensorAuto/OpenTau/blob/main/configs/examples/pi07_low_level_libero.json) (select via `"type": "pi07_low_level"`); the high-level planner is registered as `"type": "pi07_high_level"`.
 
-`cosmos3` reuses the $\pi_{0.5}$ flow-matching recipe on a frozen Qwen3-VL-32B backbone (NVIDIA's Cosmos3-Super reasoner) paired with a custom sub-1B action expert. Select it with `"type": "cosmos3"` and start from [configs/examples/cosmos3_training_config.json](https://github.com/TensorAuto/OpenTau/blob/main/configs/examples/cosmos3_training_config.json); see the [model documentation](https://opentau.readthedocs.io/en/latest/model.html#cosmos3) for the design adjustments.
+`cosmos3` reuses the $\pi_{0.5}$ flow-matching recipe on a frozen Qwen3-VL-32B backbone (NVIDIA's Cosmos3-Super reasoner) paired with a custom sub-1B action expert. Select it with `"type": "cosmos3"` and start from [configs/examples/cosmos3_training_config.json](https://github.com/TensorAuto/OpenTau/blob/main/configs/examples/cosmos3_training_config.json); see the [model documentation](https://opentau.readthedocs.io/en/latest/model.html#cosmos3) for the design adjustments. `cosmos3_nano` is the same architecture on the smaller frozen Qwen3-VL-8B backbone (the Cosmos3-Nano reasoner, which keeps the identical 8-KV-head × 128-head-dim interface the expert reads) — select it with `"type": "cosmos3_nano"` and start from [configs/examples/cosmos3_nano_training_config.json](https://github.com/TensorAuto/OpenTau/blob/main/configs/examples/cosmos3_nano_training_config.json).
 
 ## Training Diagnostics
 

--- a/configs/examples/cosmos3_nano_training_config.json
+++ b/configs/examples/cosmos3_nano_training_config.json
@@ -1,0 +1,104 @@
+{
+    "dataset_mixture": {
+        "datasets": [
+            {
+                "repo_id": "TensorAuto/libero",
+                "episodes": [
+                    0,1,2,3,4,5,6,7,8,9
+                ]
+            }
+        ],
+        "weights": [
+            1.0
+        ],
+        "action_freq": 20.0,
+        "image_resample_strategy": "nearest",
+        "vector_resample_strategy": "nearest"
+    },
+    "policy": {
+        "type": "cosmos3_nano",
+        "n_obs_steps": 1,
+        "normalization_mapping": {
+            "VISUAL": "IDENTITY",
+            "STATE": "MEAN_STD",
+            "ACTION": "MEAN_STD"
+        },
+        "chunk_size": 10,
+        "n_action_steps": 10,
+        "max_state_dim": 32,
+        "max_action_dim": 32,
+        "proj_width": 1024,
+        "num_steps": 10,
+        "attention_implementation": "sdpa",
+        "pretrained_backbone_repo_id": "TensorAuto/cosmos3-reason-8b",
+        "load_pretrained_backbone": true,
+        "image_resize": 224,
+        "freeze_vision_encoder": true,
+        "train_expert_only": true,
+        "gradient_checkpointing": true,
+        "prompt_max_length": 256,
+        "expert_num_hidden_layers": 36,
+        "optimizer_lr": 2.5e-05,
+        "optimizer_betas": [
+            0.9,
+            0.95
+        ],
+        "optimizer_eps": 1e-08,
+        "optimizer_weight_decay": 1e-10,
+        "scheduler_warmup_steps": 1000,
+        "scheduler_decay_steps": 30000,
+        "scheduler_decay_lr": 2.5e-06
+    },
+    "resume": false,
+    "seed": 1000,
+    "resolution": [224, 224],
+    "num_cams": 2,
+    "max_state_dim": 32,
+    "max_action_dim": 32,
+    "action_chunk": 10,
+    "loss_weighting": {"MSE": 1, "CE": 0},
+    "num_workers": 4,
+    "batch_size": 2,
+    "gradient_accumulation_steps": 1,
+    "dataloader_batch_size": 2,
+    "prefetch_factor": 8,
+    "steps": 40,
+    "log_freq": 5,
+    "save_checkpoint": true,
+    "save_freq": 40,
+    "val_freq": 10,
+    "use_policy_training_preset": false,
+    "trace_nans": false,
+    "optimizer": {
+        "type": "adamw",
+        "lr": 2.5e-05,
+        "weight_decay": 1e-10,
+        "grad_clip_norm": 10.0,
+        "betas": [
+            0.9,
+            0.95
+        ],
+        "eps": 1e-08
+    },
+    "scheduler": {
+        "type": "cosine_decay_with_warmup",
+        "num_warmup_steps": 1000,
+        "num_decay_steps": 30000,
+        "peak_lr": 2.5e-05,
+        "decay_lr": 2.5e-06
+    },
+    "wandb": {
+        "enable": false,
+        "entity": "wyautox-autox",
+        "project": "cosmos3_nano",
+        "run_id": null,
+        "name": null,
+        "notes": "cosmos3_nano training run (frozen Qwen3-VL-8B backbone + flow-matching action expert)",
+        "tags": [],
+        "group": null,
+        "job_type": null,
+        "mode": null,
+        "on_resume": "fork",
+        "disable_artifact": false
+    }
+}

--- a/docs/source/model.rst
+++ b/docs/source/model.rst
@@ -281,6 +281,17 @@ prefix and the trainable action expert to the flow-matching velocity head
      x_t += dt*v_t, then unnormalize -> executed action chunk.
 
 
+cosmos3_nano
+------------
+- cosmos3_nano is the cosmos3 recipe on the smaller **frozen Qwen3-VL-8B backbone** — the reasoning tower of NVIDIA `Cosmos3-Nano <https://huggingface.co/nvidia/Cosmos3-Nano>`_, extracted by the same ``src/opentau/scripts/extract_cosmos3_reasoner.py`` (the script reads the reasoner geometry from the snapshot's root ``config.json``, so it handles both family members). All modeling code is shared with cosmos3; the package only carries the nano defaults.
+- The Nano reasoner keeps the exact KV interface the action expert cross-attends to — the same **8 KV heads × head_dim 128** as the 32B tower — so the expert architecture and every hard constraint carry over unchanged. The only geometry change is the backbone depth: **36 layers** instead of 64, which the default ``expert_num_hidden_layers=36`` mirrors (per-layer conditioning). With the inherited expert widths the trainable expert + projections total ~0.51B parameters. ``condition_on_layer`` works exactly as in cosmos3 (range ``[-36, 35]``).
+- The extracted reasoner backbone is published at `TensorAuto/cosmos3-reason-8b <https://huggingface.co/TensorAuto/cosmos3-reason-8b>`_ (**private** — the default ``pretrained_backbone_repo_id``; the training environment needs an HF token with TensorAuto org read access, picked up from the ambient ``HF_TOKEN`` / ``~/.cache/huggingface/token``), ~17.5 GB in bf16 — it fits comfortably on a single 24–32 GB GPU for inference, where the 32B backbone needs an 80 GB-class card. To reproduce or re-host it, run the extraction script on the ungated ``nvidia/Cosmos3-Nano``.
+- See the implementation in `src/opentau/policies/cosmos3_nano/modeling_cosmos3_nano.py <https://github.com/TensorAuto/OpenTau/blob/main/src/opentau/policies/cosmos3_nano/modeling_cosmos3_nano.py>`_.
+- To spin up a training run, start from `configs/examples/cosmos3_nano_training_config.json <https://github.com/TensorAuto/OpenTau/blob/main/configs/examples/cosmos3_nano_training_config.json>`_.
+- Config selector: ``--policy.type=cosmos3_nano``.
+- Disclaimer: as with cosmos3, only the reasoner *backbone* is published — no trained cosmos3_nano *policy* checkpoint exists yet; the action expert is randomly initialized and produced by training.
+
+
 value
 -----
 - The value model is a vision-language model used to predict the value of the current state. It is used to train VLA policies with the RECAP framework.

--- a/src/opentau/__init__.py
+++ b/src/opentau/__init__.py
@@ -170,6 +170,7 @@ available_policies = [
     "pi07_high_level",
     "pi07_low_level",
     "cosmos3",
+    "cosmos3_nano",
     "value",
 ]
 

--- a/src/opentau/policies/__init__.py
+++ b/src/opentau/policies/__init__.py
@@ -20,6 +20,7 @@ such as PI0, PI05, and Value policy.
 """
 
 from .cosmos3.configuration_cosmos3 import Cosmos3Config as Cosmos3Config
+from .cosmos3_nano.configuration_cosmos3_nano import Cosmos3NanoConfig as Cosmos3NanoConfig
 from .pi0.configuration_pi0 import PI0Config as PI0Config
 from .pi05.configuration_pi05 import PI05Config as PI05Config
 from .pi05.configuration_pi05 import PI05ContinuousStateConfig as PI05ContinuousStateConfig

--- a/src/opentau/policies/cosmos3_nano/__init__.py
+++ b/src/opentau/policies/cosmos3_nano/__init__.py
@@ -1,0 +1,28 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""cosmos3_nano: the cosmos3 flow-matching VLA policy on the smaller Cosmos3-Nano reasoner.
+
+cosmos3_nano is architecturally identical to ``policies/cosmos3`` — a frozen Qwen3-VL
+backbone encodes images + language once (prefix) and a trainable sub-1B Qwen3-style
+flow-matching action expert cross-attends to its per-layer key/value cache to denoise a
+continuous action chunk — but swaps the 32B backbone (the Cosmos3-Super reasoning tower)
+for the **Qwen3-VL-8B reasoning tower of NVIDIA Cosmos3-Nano**, extracted into a
+standalone checkpoint by ``opentau.scripts.extract_cosmos3_reasoner``.
+
+The Nano reasoner keeps the exact KV interface the expert consumes (8 key/value heads x
+head_dim 128 — identical to the 32B tower), so the only geometry change is the backbone
+depth: 36 layers instead of 64. All modeling code is imported from
+``policies/cosmos3``; this package only carries the nano defaults.
+"""

--- a/src/opentau/policies/cosmos3_nano/configuration_cosmos3_nano.py
+++ b/src/opentau/policies/cosmos3_nano/configuration_cosmos3_nano.py
@@ -1,0 +1,69 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Configuration for the cosmos3_nano policy.
+
+cosmos3_nano is the cosmos3 recipe (see ``configuration_cosmos3.py``) with the frozen
+Qwen3-VL-32B backbone (the Cosmos3-Super reasoning tower) swapped for a **frozen
+Qwen3-VL-8B** — the reasoning tower of NVIDIA ``Cosmos3-Nano``, extracted into a
+standalone checkpoint by ``opentau.scripts.extract_cosmos3_reasoner`` and published as
+``TensorAuto/cosmos3-reason-8b`` (**private** — like the 32B extraction, the training
+environment needs an HF token with read access to the TensorAuto org;
+``from_pretrained`` picks up the ambient ``HF_TOKEN`` / ``~/.cache/huggingface/token``).
+
+The Nano tower is byte-for-byte the Qwen3-VL-8B geometry: hidden 4096, **36 layers**,
+32 attention heads, and — decisive for the action expert's cross-attention — the same
+8 key/value heads x head_dim 128 as the 32B tower. The expert's hard KV-concat
+constraints therefore carry over unchanged, and the only default that must move is
+``expert_num_hidden_layers`` (36, matching the backbone depth for the default per-layer
+correspondence). With the inherited expert widths (hidden 1024, 16 query heads,
+intermediate 2048) the trainable expert + projections total ~0.51B parameters.
+
+``condition_on_layer`` works exactly as in cosmos3 (valid range [-36, 35]); every other
+field, constraint, and preset is inherited from ``Cosmos3Config``.
+"""
+
+from dataclasses import dataclass
+
+from opentau.configs.policies import PreTrainedConfig
+from opentau.policies.cosmos3.configuration_cosmos3 import Cosmos3Config
+
+
+@PreTrainedConfig.register_subclass("cosmos3_nano")
+@dataclass
+class Cosmos3NanoConfig(Cosmos3Config):
+    """Configuration class for the cosmos3_nano policy.
+
+    Identical to :class:`Cosmos3Config` except for the two nano defaults below; see the
+    cosmos3 docstrings for the meaning of every field and the hard expert/backbone
+    geometry constraints (re-validated against the loaded backbone at model-build time).
+
+    Args:
+        pretrained_backbone_repo_id: HF repo id (or local path) for the Qwen3-VL-8B
+            backbone weights — the Cosmos3-Nano reasoning tower extracted by
+            ``opentau.scripts.extract_cosmos3_reasoner`` (run once on the ungated
+            ``nvidia/Cosmos3-Nano``). Defaults to ``TensorAuto/cosmos3-reason-8b``,
+            the published extraction (**private** — needs an HF token with TensorAuto
+            org read access). Re-run the extraction script to reproduce or re-host it.
+        expert_num_hidden_layers: Action-expert depth. With ``condition_on_layer=None``
+            this MUST equal the backbone text tower depth (36 for Qwen3-VL-8B); with a
+            single ``condition_on_layer`` selected, any depth >= 1 is allowed.
+            Defaults to 36.
+    """
+
+    # --- Backbone (Qwen3-VL-8B reasoning tower extracted from NVIDIA Cosmos3-Nano) ---
+    pretrained_backbone_repo_id: str = "TensorAuto/cosmos3-reason-8b"
+
+    # --- Action-expert sizing (must match the 36-layer Nano tower; see module docstring) ---
+    expert_num_hidden_layers: int = 36

--- a/src/opentau/policies/cosmos3_nano/modeling_cosmos3_nano.py
+++ b/src/opentau/policies/cosmos3_nano/modeling_cosmos3_nano.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""cosmos3_nano: the cosmos3 flow-matching VLA policy on a frozen Qwen3-VL-8B reasoner.
+
+Architecturally identical to ``policies/cosmos3/modeling_cosmos3.py`` — the model,
+prefix/suffix pipeline, flow-matching loss, and sampler are all inherited unchanged.
+The Cosmos3-Nano reasoner keeps the exact KV interface the expert cross-attention
+consumes (8 KV heads x head_dim 128), so the only difference is the backbone
+checkpoint (``TensorAuto/cosmos3-reason-8b``) and depth (36 layers), both carried by
+:class:`Cosmos3NanoConfig`.
+"""
+
+from opentau.policies.cosmos3.modeling_cosmos3 import Cosmos3Policy
+from opentau.policies.cosmos3_nano.configuration_cosmos3_nano import Cosmos3NanoConfig
+
+
+class Cosmos3NanoPolicy(Cosmos3Policy):
+    """OpenTau wrapper for cosmos3_nano — ``Cosmos3Policy`` with the Nano backbone defaults."""
+
+    config_class = Cosmos3NanoConfig
+    name = "cosmos3_nano"

--- a/src/opentau/policies/factory.py
+++ b/src/opentau/policies/factory.py
@@ -34,6 +34,7 @@ from opentau.configs.types import FeatureType
 from opentau.datasets.lerobot_dataset import LeRobotDatasetMetadata
 from opentau.datasets.utils import dataset_to_policy_features
 from opentau.policies.cosmos3.configuration_cosmos3 import Cosmos3Config
+from opentau.policies.cosmos3_nano.configuration_cosmos3_nano import Cosmos3NanoConfig
 from opentau.policies.pi0.configuration_pi0 import PI0Config
 from opentau.policies.pi05.configuration_pi05 import PI05Config
 from opentau.policies.pi05_mem.configuration_pi05 import PI05MemConfig
@@ -120,6 +121,10 @@ def get_policy_class(name: str) -> type[PreTrainedPolicy]:
         from opentau.policies.cosmos3.modeling_cosmos3 import Cosmos3Policy
 
         return Cosmos3Policy
+    elif name == "cosmos3_nano":
+        from opentau.policies.cosmos3_nano.modeling_cosmos3_nano import Cosmos3NanoPolicy
+
+        return Cosmos3NanoPolicy
     elif name == "value":
         from opentau.policies.value.modeling_value import ValueFunction
 
@@ -167,6 +172,8 @@ def make_policy_config(policy_type: str, **kwargs) -> PreTrainedConfig:
         return PI07LowLevelConfig(**kwargs)
     elif policy_type == "cosmos3":
         return Cosmos3Config(**kwargs)
+    elif policy_type == "cosmos3_nano":
+        return Cosmos3NanoConfig(**kwargs)
     elif policy_type == "value":
         return ValueConfig(**kwargs)
     else:

--- a/src/opentau/scripts/extract_cosmos3_reasoner.py
+++ b/src/opentau/scripts/extract_cosmos3_reasoner.py
@@ -109,7 +109,7 @@ def _is_reasoner_key(key: str) -> bool:
 
 
 def _remap_transformer_key(key: str) -> str | None:
-    """Map a Cosmos3-Super ``transformer/`` key to its Qwen3-VL name, or None to drop it."""
+    """Map a Cosmos3 omni ``transformer/`` key to its Qwen3-VL name, or None to drop it."""
     if not _is_reasoner_key(key):
         return None
     if key == "embed_tokens.weight":

--- a/src/opentau/scripts/extract_cosmos3_reasoner.py
+++ b/src/opentau/scripts/extract_cosmos3_reasoner.py
@@ -13,16 +13,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Extract the **reasoning tower** of NVIDIA ``Cosmos3-Super`` into a standalone
-Qwen3-VL-32B checkpoint for the cosmos3 policy backbone.
+"""Extract the **reasoning tower** of an NVIDIA ``Cosmos3`` omni model (``Cosmos3-Super``
+or ``Cosmos3-Nano``) into a standalone Qwen3-VL checkpoint for the cosmos3 /
+cosmos3_nano policy backbones.
 
-``nvidia/Cosmos3-Super`` (HF: ``cosmos3_omni`` / diffusers ``Cosmos3OmniTransformer``,
-~64.6B params, ungated) is an interleaved Mixture-of-Transformers: every one of its 64
-layers has **shared attention** plus **two MLPs** -- ``mlp`` (the autoregressive
-**reasoner / text** path) and ``mlp_moe_gen`` (the diffusion **generation** path) -- plus
-audio/action/video generation modules. Its text config is byte-for-byte Qwen3-VL-32B
-(hidden 5120, 64 layers, 64 heads, 8 KV, head_dim 128, intermediate 25600,
-mrope_section [24,20,20]), and its ``vision_encoder/`` is a stock ``Qwen3VLVisionModel``.
+The Cosmos3 omni models (HF: ``cosmos3_omni`` / diffusers ``Cosmos3OmniTransformer``,
+ungated) are interleaved Mixture-of-Transformers: every layer computes one joint
+attention over both token streams but carries **separate per-path weights** -- the
+autoregressive **reasoner / text** path (``mlp``, ``self_attn.to_*``) and the diffusion
+**generation** path (``mlp_moe_gen``, ``self_attn.add_*``/``*_moe_gen``) -- plus
+audio/action/video generation modules. The reasoner geometry is byte-for-byte the
+matching stock Qwen3-VL size -- Qwen3-VL-32B for Super (~64.6B total; hidden 5120, 64
+layers, 64 heads, 8 KV, head_dim 128, intermediate 25600), Qwen3-VL-8B for Nano
+(~15.75B total; hidden 4096, 36 layers, 32 heads, same 8 KV / head_dim 128) -- and the
+``vision_encoder/`` is a stock ``Qwen3VLVisionModel`` in both. The geometry is read from
+the snapshot's root ``config.json`` (``text_config`` / ``vision_config``), so the same
+script extracts every family member.
 
 This script keeps only the reasoner tower and drops the generation tower, producing a
 standard ``Qwen3VLForConditionalGeneration`` checkpoint:
@@ -46,19 +52,22 @@ standard ``Qwen3VLForConditionalGeneration`` checkpoint:
 
 Usage::
 
-    # one-time, on a box with the (ungated) Cosmos3-Super download + enough RAM/disk
-    huggingface-cli download nvidia/Cosmos3-Super --include "transformer/*" "vision_encoder/*" \
-        "text_tokenizer/*" "tokenizer_config.json" "preprocessor_config.json" \
-        "video_preprocessor_config.json"
+    # one-time, on a box with the (ungated) Cosmos3 download + enough RAM/disk
+    huggingface-cli download nvidia/Cosmos3-Nano --include "config.json" "transformer/*" \
+        "vision_encoder/*" "text_tokenizer/*" "tokenizer_config.json" \
+        "preprocessor_config.json" "video_preprocessor_config.json"
     python -m opentau.scripts.extract_cosmos3_reasoner \
         --cosmos3-path <hf-snapshot-dir> --out-dir <reasoner-checkpoint-dir>
 
-The resulting directory is a normal Qwen3-VL-32B checkpoint; point the cosmos3 policy at it
-via ``--policy.pretrained_backbone_repo_id=<reasoner-checkpoint-dir>``.
+(Same for ``nvidia/Cosmos3-Super``; the root ``config.json`` must be part of the
+download since it carries the reasoner geometry.) The resulting directory is a normal
+Qwen3-VL checkpoint; point the cosmos3 / cosmos3_nano policy at it via
+``--policy.pretrained_backbone_repo_id=<reasoner-checkpoint-dir>``.
 """
 
 import argparse
 import glob
+import json
 import os
 import re
 import shutil
@@ -131,50 +140,57 @@ def _iter_safetensors(folder: str):
                 yield key, f.get_tensor(key)
 
 
-def _qwen3vl_32b_config() -> Qwen3VLConfig:
+def _qwen3vl_config_from_snapshot(cosmos3_path: str) -> Qwen3VLConfig:
+    """Build the reasoner's ``Qwen3VLConfig`` from the snapshot's root ``config.json``.
+
+    The Cosmos3 omni root config carries the reasoner's ``text_config`` /
+    ``vision_config`` verbatim (byte-for-byte the matching stock Qwen3-VL size:
+    32B for Super, 8B for Nano) plus the Qwen3-VL special token ids. Reading the
+    geometry from the source instead of hardcoding one size lets this script extract
+    every family member -- and keeps source fields the old hardcoded config silently
+    defaulted (e.g. ``max_position_embeddings`` 262144, vs the transformers default
+    128000 that ``TensorAuto/cosmos3-reason-32b`` shipped with; harmless at our
+    prompt lengths, but source-verbatim is the safer default going forward).
+    """
+    cfg_path = os.path.join(cosmos3_path, "config.json")
+    if not os.path.exists(cfg_path):
+        raise FileNotFoundError(
+            f'{cfg_path} not found -- add "config.json" to the snapshot download includes; '
+            "the root Cosmos3 config carries the reasoner text/vision geometry."
+        )
+    with open(cfg_path) as f:
+        src = json.load(f)
+    for key in (
+        "text_config",
+        "vision_config",
+        "image_token_id",
+        "video_token_id",
+        "vision_start_token_id",
+        "vision_end_token_id",
+    ):
+        if key not in src:
+            raise KeyError(f"'{key}' missing from {cfg_path} -- not a Cosmos3 omni root config?")
     return Qwen3VLConfig(
-        text_config={
-            "model_type": "qwen3_vl_text",
-            "hidden_size": 5120,
-            "intermediate_size": 25600,
-            "num_hidden_layers": 64,
-            "num_attention_heads": 64,
-            "num_key_value_heads": 8,
-            "head_dim": 128,
-            "vocab_size": 151936,
-            "rms_norm_eps": 1e-6,
-            "rope_theta": 5_000_000,
-            "rope_scaling": {
-                "mrope_interleaved": True,
-                "mrope_section": [24, 20, 20],
-                "rope_type": "default",
-            },
-        },
-        vision_config={
-            "model_type": "qwen3_vl",
-            "hidden_size": 1152,
-            "intermediate_size": 4304,
-            "num_heads": 16,
-            "depth": 27,
-            "patch_size": 16,
-            "temporal_patch_size": 2,
-            "spatial_merge_size": 2,
-            "out_hidden_size": 5120,
-            "deepstack_visual_indexes": [8, 16, 24],
-            "num_position_embeddings": 2304,
-            "in_channels": 3,
-        },
-        image_token_id=151655,
-        video_token_id=151656,
-        vision_start_token_id=151652,
-        vision_end_token_id=151653,
-        tie_word_embeddings=False,
+        text_config=src["text_config"],
+        vision_config=src["vision_config"],
+        image_token_id=src["image_token_id"],
+        video_token_id=src["video_token_id"],
+        vision_start_token_id=src["vision_start_token_id"],
+        vision_end_token_id=src["vision_end_token_id"],
+        tie_word_embeddings=src.get("tie_word_embeddings", False),
         dtype="bfloat16",
     )
 
 
 def extract(cosmos3_path: str, out_dir: str, verify: bool = True) -> None:
-    """Build a Qwen3-VL-32B reasoner checkpoint from a Cosmos3-Super snapshot."""
+    """Build a standalone Qwen3-VL reasoner checkpoint from a Cosmos3 omni snapshot."""
+    # Derive the reasoner geometry first so a missing/bad root config.json fails fast,
+    # before the long tensor-loading pass over the multi-GB snapshot.
+    config = _qwen3vl_config_from_snapshot(cosmos3_path)
+    n_layers = config.text_config.num_hidden_layers
+    hidden = config.text_config.hidden_size
+    print(f"reasoner geometry from root config.json: {n_layers} layers, hidden {hidden}")
+
     transformer_dir = os.path.join(cosmos3_path, "transformer")
     vision_dir = os.path.join(cosmos3_path, "vision_encoder")
     state_dict: dict[str, torch.Tensor] = {}
@@ -195,7 +211,6 @@ def extract(cosmos3_path: str, out_dir: str, verify: bool = True) -> None:
         n_vis += 1
     print(f"vision_encoder/: mapped {n_vis} tensors -> model.visual.*")
 
-    config = _qwen3vl_32b_config()
     os.makedirs(out_dir, exist_ok=True)
 
     # Instantiate on meta (no real storage), then assign the loaded bf16 tensors directly.
@@ -252,13 +267,17 @@ def extract(cosmos3_path: str, out_dir: str, verify: bool = True) -> None:
     if os.path.isdir(tok_dir):
         for f in os.listdir(tok_dir):
             shutil.copy2(os.path.join(tok_dir, f), os.path.join(out_dir, f))
-    print(f"✓ wrote Qwen3-VL-32B reasoner checkpoint to {out_dir}")
+    print(f"✓ wrote Qwen3-VL reasoner checkpoint ({n_layers} layers, hidden {hidden}) to {out_dir}")
 
 
 def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("--cosmos3-path", required=True, help="Local snapshot dir of nvidia/Cosmos3-Super.")
-    ap.add_argument("--out-dir", required=True, help="Output dir for the extracted Qwen3-VL-32B reasoner.")
+    ap.add_argument(
+        "--cosmos3-path",
+        required=True,
+        help="Local snapshot dir of nvidia/Cosmos3-Super or nvidia/Cosmos3-Nano (must include the root config.json).",
+    )
+    ap.add_argument("--out-dir", required=True, help="Output dir for the extracted Qwen3-VL reasoner.")
     ap.add_argument("--no-verify", action="store_true", help="Skip the meta-device key-set verification.")
     args = ap.parse_args()
     extract(args.cosmos3_path, args.out_dir, verify=not args.no_verify)

--- a/tests/policies/test_cosmos3_nano_cpu.py
+++ b/tests/policies/test_cosmos3_nano_cpu.py
@@ -1,0 +1,282 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU smoke tests for the cosmos3_nano policy.
+
+cosmos3_nano shares all modeling code with cosmos3 -- see ``test_cosmos3_cpu.py`` for the
+full architectural coverage (masks, single-layer conditioning, freezing, per-sample loss,
+prompt truncation, etc.). These tests lock the nano-specific surface only: factory/draccus
+registration, the nano defaults (the Qwen3-VL-8B tower geometry), inheritance of the
+config validators, a tiny end-to-end forward + determinism smoke through the
+``Cosmos3NanoConfig`` / ``Cosmos3NanoPolicy`` plumbing, and the sub-1B expert parameter
+budget at nano depth.
+"""
+
+import dataclasses
+from pathlib import Path
+
+import pytest
+import torch
+from transformers import Qwen3VLConfig
+
+from opentau.policies.cosmos3.configuration_cosmos3 import Cosmos3Config
+from opentau.policies.cosmos3.modeling_cosmos3 import Cosmos3FlowMatching, Cosmos3Policy
+from opentau.policies.cosmos3_nano.configuration_cosmos3_nano import Cosmos3NanoConfig
+from opentau.policies.cosmos3_nano.modeling_cosmos3_nano import Cosmos3NanoPolicy
+
+# Small vision/text special-token ids that fit inside the tiny vocab below.
+IMAGE_TOKEN_ID = 10
+VIDEO_TOKEN_ID = 11
+VISION_START_ID = 12
+VISION_END_ID = 13
+VOCAB = 200
+
+CHUNK = 4
+STATE_DIM = 5
+MAX_ACTION_DIM = 8
+MAX_STATE_DIM = 8
+
+
+def _tiny_qwen3vl_config(num_hidden_layers: int = 2) -> Qwen3VLConfig:
+    """A minimally-sized Qwen3-VL config (head_dim/kv-heads/layers must match the expert)."""
+    return Qwen3VLConfig(
+        text_config={
+            "model_type": "qwen3_vl_text",
+            "hidden_size": 64,
+            "intermediate_size": 128,
+            "num_hidden_layers": num_hidden_layers,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+            "head_dim": 16,
+            "vocab_size": VOCAB,
+            "rms_norm_eps": 1e-6,
+            "rope_theta": 5_000_000,
+            "rope_scaling": {"mrope_interleaved": True, "mrope_section": [4, 2, 2], "rope_type": "default"},
+        },
+        vision_config={
+            "model_type": "qwen3_vl",
+            "hidden_size": 32,
+            "intermediate_size": 64,
+            "num_heads": 2,
+            "depth": 4,
+            "patch_size": 16,
+            "temporal_patch_size": 2,
+            "spatial_merge_size": 2,
+            "out_hidden_size": 64,
+            "deepstack_visual_indexes": [1, 2],
+            "num_position_embeddings": 256,
+            "in_channels": 3,
+        },
+        image_token_id=IMAGE_TOKEN_ID,
+        video_token_id=VIDEO_TOKEN_ID,
+        vision_start_token_id=VISION_START_ID,
+        vision_end_token_id=VISION_END_ID,
+        tie_word_embeddings=False,
+    )
+
+
+def _tiny_nano_config(**overrides) -> Cosmos3NanoConfig:
+    kwargs = {
+        "chunk_size": CHUNK,
+        "n_action_steps": CHUNK,
+        "max_action_dim": MAX_ACTION_DIM,
+        "max_state_dim": MAX_STATE_DIM,
+        "proj_width": 16,
+        "num_steps": 3,
+        "attention_implementation": "eager",
+        "load_pretrained_backbone": False,
+        "dropout": 0.0,
+        "expert_hidden_size": 32,
+        "expert_intermediate_size": 64,
+        "expert_num_hidden_layers": 2,
+        "expert_num_attention_heads": 4,
+        "expert_num_key_value_heads": 2,
+        "expert_head_dim": 16,
+        "expert_adarms_cond_dim": 16,
+    }
+    kwargs.update(overrides)
+    return Cosmos3NanoConfig(**kwargs)
+
+
+def _text_batch(bsize: int = 2, n_text: int = 6):
+    input_ids = torch.randint(20, VOCAB, (bsize, n_text))
+    attention_mask = torch.ones(bsize, n_text, dtype=torch.long)
+    state = torch.randn(bsize, STATE_DIM)
+    state = torch.nn.functional.pad(state, (0, MAX_STATE_DIM - STATE_DIM))
+    actions = torch.randn(bsize, CHUNK, MAX_ACTION_DIM)
+    return input_ids, attention_mask, state, actions
+
+
+def test_cosmos3_nano_factory_registration():
+    from opentau.policies.factory import get_policy_class, make_policy_config
+
+    cfg = make_policy_config("cosmos3_nano")
+    assert isinstance(cfg, Cosmos3NanoConfig)
+    assert cfg.type == "cosmos3_nano"
+
+    policy_cls = get_policy_class("cosmos3_nano")
+    assert policy_cls is Cosmos3NanoPolicy
+    assert policy_cls.name == "cosmos3_nano"
+    assert policy_cls.config_class is Cosmos3NanoConfig
+    # nano is a strict specialization of cosmos3 (all modeling code is shared).
+    assert issubclass(Cosmos3NanoPolicy, Cosmos3Policy)
+    assert issubclass(Cosmos3NanoConfig, Cosmos3Config)
+
+
+def test_cosmos3_nano_defaults_only_two_fields_differ():
+    """nano == cosmos3 defaults except the backbone repo and the expert depth.
+
+    The Nano reasoner keeps the exact KV interface the expert consumes (8 KV heads x
+    head_dim 128 -- identical to the 32B tower), so no other default may drift; a third
+    differing field means an unintended change to one of the packages.
+    """
+    nano, base = Cosmos3NanoConfig(), Cosmos3Config()
+    # Field-name sets must match exactly, else the per-field loop below would silently
+    # skip a field declared only on Cosmos3NanoConfig.
+    assert {f.name for f in dataclasses.fields(Cosmos3NanoConfig)} == {
+        f.name for f in dataclasses.fields(Cosmos3Config)
+    }, "cosmos3_nano must not add new config fields silently -- extend this test if intentional"
+    overridden = {"pretrained_backbone_repo_id", "expert_num_hidden_layers"}
+    for f in dataclasses.fields(Cosmos3Config):
+        if f.name in overridden:
+            continue
+        assert getattr(nano, f.name) == getattr(base, f.name), f"unexpected nano override: {f.name}"
+
+    assert nano.pretrained_backbone_repo_id == "TensorAuto/cosmos3-reason-8b"
+    assert nano.expert_num_hidden_layers == 36  # Qwen3-VL-8B text-tower depth
+    assert nano.expert_num_key_value_heads == 8
+    assert nano.expert_head_dim == 128
+
+
+def test_cosmos3_nano_config_validation_inherited():
+    with pytest.raises(ValueError):
+        Cosmos3NanoConfig(attention_implementation="flash_cuda")
+    with pytest.raises(ValueError):
+        Cosmos3NanoConfig(n_action_steps=100, chunk_size=50)
+    with pytest.raises(ValueError):
+        # query heads not a multiple of kv heads
+        Cosmos3NanoConfig(expert_num_attention_heads=15, expert_num_key_value_heads=8)
+
+
+def test_cosmos3_nano_inner_forward_and_determinism():
+    """Tiny forward through the nano config plumbing: loss-dict compat + bit-identical repeats."""
+    torch.manual_seed(0)
+    model = Cosmos3FlowMatching(_tiny_nano_config(), qwen3vl_config=_tiny_qwen3vl_config())
+    input_ids, attention_mask, state, actions = _text_batch()
+    noise = torch.randn_like(actions)
+    time = torch.rand(actions.shape[0])
+
+    losses = []
+    for _ in range(2):
+        out = model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            pixel_values=None,
+            image_grid_thw=None,
+            state=state,
+            actions=actions,
+            noise=noise,
+            time=time,
+        )
+        assert set(out.keys()) == {"MSE", "CE"}
+        assert out["CE"].item() == 0.0
+        assert torch.isfinite(out["MSE"])
+        losses.append(out["MSE"].item())
+    assert losses[0] == losses[1], f"non-deterministic loss: {losses}"
+
+
+def test_cosmos3_nano_default_depth_exercises_build_validator():
+    """The nano default expert depth (36) must build against a 36-layer backbone via the
+    build-time depth-equality validator, and be rejected against any other depth."""
+    torch.manual_seed(0)
+    default_depth = Cosmos3NanoConfig().expert_num_hidden_layers
+    cfg = _tiny_nano_config(expert_num_hidden_layers=default_depth)
+    model = Cosmos3FlowMatching(cfg, qwen3vl_config=_tiny_qwen3vl_config(num_hidden_layers=default_depth))
+    assert len(model.qwen3vl_with_expert.expert.layers) == 36
+    with pytest.raises(ValueError, match="expert_num_hidden_layers"):
+        Cosmos3FlowMatching(cfg, qwen3vl_config=_tiny_qwen3vl_config(num_hidden_layers=2))
+
+
+def test_cosmos3_nano_example_config_parses():
+    """The shipped example config must parse into a TrainPipelineConfig with a
+    Cosmos3NanoConfig policy (a typo'd policy field would crash draccus here, offline,
+    rather than at training launch)."""
+    import draccus
+
+    from opentau.configs.train import TrainPipelineConfig
+
+    path = Path(__file__).resolve().parents[2] / "configs" / "examples" / "cosmos3_nano_training_config.json"
+    cfg = draccus.parse(TrainPipelineConfig, config_path=str(path), args=[])
+    assert isinstance(cfg.policy, Cosmos3NanoConfig)
+    assert cfg.policy.type == "cosmos3_nano"
+    assert cfg.policy.pretrained_backbone_repo_id == "TensorAuto/cosmos3-reason-8b"
+    assert cfg.policy.expert_num_hidden_layers == 36
+    assert cfg.batch_size == cfg.dataloader_batch_size * cfg.gradient_accumulation_steps
+
+
+def test_cosmos3_nano_policy_wrapper_builds():
+    """``Cosmos3NanoPolicy`` constructs offline with a tiny config and inherits the wrapper."""
+    policy = Cosmos3NanoPolicy(_tiny_nano_config(), qwen3vl_config=_tiny_qwen3vl_config())
+    assert policy.processor is None  # load_pretrained_backbone=False
+    assert isinstance(policy.model, Cosmos3FlowMatching)
+    assert isinstance(policy.config, Cosmos3NanoConfig)
+    policy.reset()
+    assert len(policy._action_queue) == 0
+
+
+def test_cosmos3_nano_expert_under_1b_params():
+    """The default (real) nano expert + projections must be < 1B trainable params.
+
+    Same arithmetic as ``test_cosmos3_expert_under_1b_params``; at the nano depth (36
+    layers vs 64) the default widths land around ~0.51B, so also pin a tighter bound to
+    catch an accidental depth/width bump.
+    """
+    cfg = Cosmos3NanoConfig()  # real defaults; head geometry from Qwen3-VL-8B
+    h = cfg.expert_hidden_size
+    inter = cfg.expert_intermediate_size
+    hq, hkv, hd = cfg.expert_num_attention_heads, cfg.expert_num_key_value_heads, cfg.expert_head_dim
+    c = cfg.expert_adarms_cond_dim
+    per_layer = (
+        h * (hq * hd)  # q_proj
+        + 2 * h * (hkv * hd)  # k_proj + v_proj
+        + (hq * hd) * h  # o_proj
+        + 2 * hd  # q_norm + k_norm
+        + 3 * h * inter  # gated MLP
+        + 2 * (c * 3 * h + 3 * h)  # two AdaRMS dense (weight + bias)
+    )
+    total = per_layer * cfg.expert_num_hidden_layers + (c * 3 * h + 3 * h)  # + final norm
+    assert total < 1_000_000_000, f"expert has {total:,} params (>= 1B)"
+    assert total < 600_000_000, f"nano expert unexpectedly large: {total:,} params"
+
+    # Pin the analytic formula to the actual module: a 2-layer expert at the real
+    # widths must count exactly per_layer*2 + final norm, so module drift (a new
+    # sublayer, a bias change) fails this test instead of silently invalidating the
+    # budget arithmetic above.
+    from opentau.policies.cosmos3.qwen3vl_with_expert import Qwen3ActionExpert
+
+    expert = Qwen3ActionExpert(
+        num_hidden_layers=2,
+        hidden_size=h,
+        intermediate_size=inter,
+        num_attention_heads=hq,
+        num_key_value_heads=hkv,
+        head_dim=hd,
+        adarms_cond_dim=c,
+        rms_norm_eps=cfg.expert_rms_norm_eps,
+        dropout=0.0,
+        attention_implementation="eager",
+    )
+    actual = sum(p.numel() for p in expert.parameters())
+    expected = per_layer * 2 + (c * 3 * h + 3 * h)
+    assert actual == expected, f"analytic formula drifted from Qwen3ActionExpert: {actual:,} != {expected:,}"

--- a/tests/policies/test_cosmos3_nano_gpu.py
+++ b/tests/policies/test_cosmos3_nano_gpu.py
@@ -1,0 +1,159 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""GPU smoke tests for the cosmos3_nano policy.
+
+cosmos3_nano shares all modeling code with cosmos3 (``test_cosmos3_gpu.py`` covers the
+architecture on CUDA, including single-layer conditioning); these run the inner
+``Cosmos3FlowMatching`` built from a ``Cosmos3NanoConfig`` on CUDA in bf16 with a tiny
+random ``qwen3_vl`` config (no 8B download), locking the nano config plumbing on GPU:
+bf16 forward + backward with the frozen-backbone / trainable-expert split, and
+bit-identical loss determinism. The full 8B (``TensorAuto/cosmos3-reason-8b``) load +
+memory-fit is exercised separately as a manual smoke on the target hardware.
+"""
+
+import pytest
+import torch
+from transformers import Qwen3VLConfig
+
+from opentau.policies.cosmos3.modeling_cosmos3 import Cosmos3FlowMatching
+from opentau.policies.cosmos3_nano.configuration_cosmos3_nano import Cosmos3NanoConfig
+
+CHUNK = 4
+MAX_ADIM, MAX_SDIM = 8, 8
+
+
+def _tiny_qwen3vl_config() -> Qwen3VLConfig:
+    return Qwen3VLConfig(
+        text_config={
+            "model_type": "qwen3_vl_text",
+            "hidden_size": 64,
+            "intermediate_size": 128,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+            "head_dim": 16,
+            "vocab_size": 200,
+            "rms_norm_eps": 1e-6,
+            "rope_theta": 5_000_000,
+            "rope_scaling": {"mrope_interleaved": True, "mrope_section": [4, 2, 2], "rope_type": "default"},
+        },
+        vision_config={
+            "model_type": "qwen3_vl",
+            "hidden_size": 32,
+            "intermediate_size": 64,
+            "num_heads": 2,
+            "depth": 4,
+            "patch_size": 16,
+            "temporal_patch_size": 2,
+            "spatial_merge_size": 2,
+            "out_hidden_size": 64,
+            "deepstack_visual_indexes": [1, 2],
+            "num_position_embeddings": 256,
+            "in_channels": 3,
+        },
+        image_token_id=10,
+        video_token_id=11,
+        vision_start_token_id=12,
+        vision_end_token_id=13,
+        tie_word_embeddings=False,
+    )
+
+
+def _tiny_config(**overrides) -> Cosmos3NanoConfig:
+    kwargs = {
+        "chunk_size": CHUNK,
+        "n_action_steps": CHUNK,
+        "max_action_dim": MAX_ADIM,
+        "max_state_dim": MAX_SDIM,
+        "proj_width": 16,
+        "num_steps": 3,
+        "attention_implementation": "eager",
+        "load_pretrained_backbone": False,
+        "dropout": 0.0,
+        "expert_hidden_size": 32,
+        "expert_intermediate_size": 64,
+        "expert_num_hidden_layers": 2,
+        "expert_num_attention_heads": 4,
+        "expert_num_key_value_heads": 2,
+        "expert_head_dim": 16,
+        "expert_adarms_cond_dim": 16,
+    }
+    kwargs.update(overrides)
+    return Cosmos3NanoConfig(**kwargs)
+
+
+def _build(device, **overrides):
+    torch.manual_seed(0)
+    model = Cosmos3FlowMatching(_tiny_config(**overrides), qwen3vl_config=_tiny_qwen3vl_config())
+    return model.to(device=device, dtype=torch.bfloat16)
+
+
+def _batch(device, seed=0):
+    g = torch.Generator(device="cpu").manual_seed(seed)
+    input_ids = torch.randint(20, 200, (2, 6), generator=g).to(device)
+    attention_mask = torch.ones(2, 6, dtype=torch.long, device=device)
+    state = torch.randn(2, MAX_SDIM, generator=g).to(device)
+    actions = torch.randn(2, CHUNK, MAX_ADIM, generator=g).to(device)
+    noise = torch.randn(2, CHUNK, MAX_ADIM, generator=g).to(device)
+    time = torch.rand(2, generator=g).to(device)
+    return input_ids, attention_mask, state, actions, noise, time
+
+
+@pytest.mark.gpu
+def test_cosmos3_nano_gpu_forward_backward():
+    """bf16 forward + backward on CUDA via Cosmos3NanoConfig: finite loss, expert grads
+    flow, backbone frozen."""
+    device = "cuda"
+    model = _build(device)
+    iid, am, st, act, noise, time = _batch(device)
+    out = model(
+        input_ids=iid,
+        attention_mask=am,
+        pixel_values=None,
+        image_grid_thw=None,
+        state=st,
+        actions=act,
+        noise=noise,
+        time=time,
+    )
+    assert torch.isfinite(out["MSE"])
+    out["MSE"].backward()
+    expert = model.qwen3vl_with_expert.expert
+    backbone = model.qwen3vl_with_expert.backbone
+    assert any(p.grad is not None and torch.isfinite(p.grad).all() for p in expert.parameters())
+    assert all(p.grad is None for p in backbone.parameters())
+
+
+@pytest.mark.gpu
+def test_cosmos3_nano_gpu_determinism():
+    """Two eval forwards with identical inputs give a bit-identical loss on GPU."""
+    device = "cuda"
+    losses = []
+    for _ in range(2):
+        model = _build(device).eval()
+        iid, am, st, act, noise, time = _batch(device, seed=3)
+        with torch.no_grad():
+            out = model(
+                input_ids=iid,
+                attention_mask=am,
+                pixel_values=None,
+                image_grid_thw=None,
+                state=st,
+                actions=act,
+                noise=noise,
+                time=time,
+            )
+        losses.append(out["MSE"].item())
+    assert losses[0] == losses[1], f"non-deterministic loss on GPU: {losses}"

--- a/tests/scripts/test_extract_cosmos3_reasoner.py
+++ b/tests/scripts/test_extract_cosmos3_reasoner.py
@@ -1,0 +1,113 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Offline tests for the config-derivation half of ``extract_cosmos3_reasoner``.
+
+The tensor-remapping half is exercised end-to-end when extracting a real snapshot;
+these lock ``_qwen3vl_config_from_snapshot`` — the only pure function with real
+failure modes: a missing root ``config.json`` (e.g. a snapshot downloaded with the
+pre-parametrization include list), a non-omni config, and both released family
+geometries (Nano = Qwen3-VL-8B, Super = Qwen3-VL-32B)."""
+
+import json
+
+import pytest
+
+from opentau.scripts.extract_cosmos3_reasoner import _qwen3vl_config_from_snapshot
+
+
+def _root_config(hidden: int, layers: int, heads: int, inter: int) -> dict:
+    """A minimal Cosmos3 omni root config carrying the reasoner geometry."""
+    return {
+        "architectures": ["Cosmos3ForConditionalGeneration"],
+        "model_type": "cosmos3_omni",
+        "text_config": {
+            "model_type": "qwen3_vl_text",
+            "hidden_size": hidden,
+            "intermediate_size": inter,
+            "num_hidden_layers": layers,
+            "num_attention_heads": heads,
+            "num_key_value_heads": 8,
+            "head_dim": 128,
+            "vocab_size": 151936,
+            "rms_norm_eps": 1e-6,
+            "rope_theta": 5_000_000,
+            "rope_scaling": {
+                "mrope_interleaved": True,
+                "mrope_section": [24, 20, 20],
+                "rope_type": "default",
+            },
+            "max_position_embeddings": 262144,
+        },
+        "vision_config": {
+            "model_type": "qwen3_vl",
+            "hidden_size": 1152,
+            "intermediate_size": 4304,
+            "num_heads": 16,
+            "depth": 27,
+            "patch_size": 16,
+            "temporal_patch_size": 2,
+            "spatial_merge_size": 2,
+            "out_hidden_size": hidden,
+            "deepstack_visual_indexes": [8, 16, 24],
+            "num_position_embeddings": 2304,
+            "in_channels": 3,
+        },
+        "image_token_id": 151655,
+        "video_token_id": 151656,
+        "vision_start_token_id": 151652,
+        "vision_end_token_id": 151653,
+        "tie_word_embeddings": False,
+    }
+
+
+@pytest.mark.parametrize(
+    "hidden,layers,heads,inter",
+    [
+        (4096, 36, 32, 12288),  # Cosmos3-Nano reasoner == Qwen3-VL-8B
+        (5120, 64, 64, 25600),  # Cosmos3-Super reasoner == Qwen3-VL-32B
+    ],
+)
+def test_geometry_derived_from_root_config(tmp_path, hidden, layers, heads, inter):
+    (tmp_path / "config.json").write_text(json.dumps(_root_config(hidden, layers, heads, inter)))
+    cfg = _qwen3vl_config_from_snapshot(str(tmp_path))
+    t, v = cfg.text_config, cfg.vision_config
+    assert (t.hidden_size, t.num_hidden_layers, t.num_attention_heads, t.intermediate_size) == (
+        hidden,
+        layers,
+        heads,
+        inter,
+    )
+    # Family constants the expert cross-attention depends on, taken verbatim.
+    assert (t.num_key_value_heads, t.head_dim) == (8, 128)
+    assert t.max_position_embeddings == 262144
+    assert (v.out_hidden_size, v.depth) == (hidden, 27)
+    assert cfg.image_token_id == 151655
+    assert cfg.tie_word_embeddings is False
+
+
+def test_missing_root_config_fails_fast(tmp_path):
+    """A snapshot without the root config.json (e.g. downloaded with the old include
+    list) must fail immediately with an actionable message, not mid-extraction."""
+    with pytest.raises(FileNotFoundError, match="config.json"):
+        _qwen3vl_config_from_snapshot(str(tmp_path))
+
+
+@pytest.mark.parametrize("missing", ["text_config", "vision_config", "image_token_id"])
+def test_non_omni_root_config_raises_diagnostic_keyerror(tmp_path, missing):
+    root = _root_config(4096, 36, 32, 12288)
+    del root[missing]
+    (tmp_path / "config.json").write_text(json.dumps(root))
+    with pytest.raises(KeyError, match=missing):
+        _qwen3vl_config_from_snapshot(str(tmp_path))

--- a/tests/test_available.py
+++ b/tests/test_available.py
@@ -18,6 +18,7 @@
 
 import opentau
 from opentau.policies.cosmos3.modeling_cosmos3 import Cosmos3Policy
+from opentau.policies.cosmos3_nano.modeling_cosmos3_nano import Cosmos3NanoPolicy
 from opentau.policies.pi0.modeling_pi0 import PI0Policy
 from opentau.policies.pi05.modeling_pi05 import PI05Policy
 from opentau.policies.pi05_mem.modeling_pi05 import PI05MemPolicy
@@ -45,6 +46,7 @@ def test_available_policies():
         PI07HighLevelPlannerPolicy,
         PI07LowLevelPolicy,
         Cosmos3Policy,
+        Cosmos3NanoPolicy,
     ]
     policies = [pol_cls.name for pol_cls in policy_classes]
     assert set(policies) == set(opentau.available_policies), policies


### PR DESCRIPTION
## What this does
Adds a **`cosmos3_nano`** policy (🗃️ Feature) — a sibling of `cosmos3` on the smaller **frozen Qwen3-VL-8B backbone** (the reasoning tower of NVIDIA [Cosmos3-Nano](https://huggingface.co/nvidia/Cosmos3-Nano)), published as `TensorAuto/cosmos3-reason-8b` (~17.5 GB bf16, private).

Because the Nano reasoner keeps the exact KV interface the action expert cross-attends to (8 KV heads × head_dim 128 — identical to the 32B tower; independently verified against the published configs, where Nano's `text_config` is byte-for-byte Qwen3-VL-8B), all modeling code is shared with `cosmos3`. The new package only carries the nano defaults:

- `src/opentau/policies/cosmos3_nano/` — `Cosmos3NanoConfig(Cosmos3Config)` overriding exactly two defaults (`pretrained_backbone_repo_id="TensorAuto/cosmos3-reason-8b"`, `expert_num_hidden_layers=36` = the Qwen3-VL-8B depth) and `Cosmos3NanoPolicy(Cosmos3Policy)` overriding only `name`/`config_class`. With the inherited expert widths the trainable expert + projections total ~0.51B params.
- `src/opentau/scripts/extract_cosmos3_reasoner.py` — parametrized: the reasoner geometry is now derived from the source snapshot's root `config.json` (fail-fast, before the tensor-loading pass) instead of a hardcoded 32B config, so the same script extracts both Super and Nano. Note: a re-extraction now carries the source-verbatim `max_position_embeddings=262144` (the published 32b extraction shipped with the transformers default 128000 — harmless at our prompt lengths; documented in the function docstring).
- `configs/examples/cosmos3_nano_training_config.json` — smoke training config (steps 40, batch 2).
- Registration: `factory.py`, `policies/__init__.py`, `available_policies`.
- Docs: README + `docs/source/model.rst` section.
- The `TensorAuto/cosmos3-reason-8b` checkpoint was produced with the parametrized script from the ungated `nvidia/Cosmos3-Nano` and uploaded (private, mirroring the 32b repo layout). Extraction verification: exact key-set match against `Qwen3VLForConditionalGeneration`, bit-identical spot checks of remapped tensors vs the source shards (text first/last layer + vision first/mid/last), no generation-tower keys leaked, processor loads, prefix KV geometry (36 layers × 8 KV × 128), and a sane greedy generation.

## How it was tested
- Added `tests/policies/test_cosmos3_nano_cpu.py` (registration, defaults-drift guard incl. field-set equality, inherited validators, tiny forward + bit-identical determinism, wrapper build, analytic sub-1B param budget pinned to the actual `Qwen3ActionExpert` module, draccus parse of the shipped example config, build-time depth-validator exercise at the real 36-layer default).
- Added `tests/policies/test_cosmos3_nano_gpu.py` (bf16 CUDA forward/backward with frozen-backbone/trainable-expert split, bit-identical determinism) and `tests/scripts/test_extract_cosmos3_reasoner.py` (geometry derivation for both family members, fail-fast on missing root config, diagnostic KeyError on non-omni configs).
- Full CPU suite: `pytest -m "not gpu and not network" -n auto tests/policies/ tests/test_available.py tests/scripts/test_extract_cosmos3_reasoner.py` — green (628+ passed).
- GPU pytests on the GPU dev box: `pytest -m gpu -n 0 tests/policies/test_cosmos3_nano_gpu.py tests/policies/test_cosmos3_gpu.py` — 5/5 passed.
- Determinism (CLAUDE.md rule 3), on the GPU dev box with the real `TensorAuto/cosmos3-reason-8b` backbone: ran `configs/examples/cosmos3_nano_training_config.json` (40 steps, seed 1000) twice — the per-step train-loss/grad-norm/validation series is bit-identical across the two runs.
- `pre-commit run --all-files` — clean.

## How to checkout & try? (for the reviewer)
```bash
pytest -sx tests/policies/test_cosmos3_nano_cpu.py
```
```bash
pytest -sx tests/scripts/test_extract_cosmos3_reasoner.py
```
On a GPU box with an HF token that has TensorAuto read access (the 8B backbone fits a single 24–32 GB GPU):
```bash
accelerate launch --num_processes=1 src/opentau/scripts/train.py \
    --config_path=configs/examples/cosmos3_nano_training_config.json --save_checkpoint=false
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [x] My PR includes policy-related changes.
  - [x] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
