### PR TITLE
fix(policies): keep current frame when history-drop augmentation fires

### DIFF
--- a/src/opentau/policies/pi05_mem/modeling_pi05.py
+++ b/src/opentau/policies/pi05_mem/modeling_pi05.py
@@ -881,7 +881,10 @@ class PI05MemPolicy(PreTrainedPolicy):
             obs_history_is_pad: Optional bool tensor (B, T) indicating which
                 temporal frames are padded. Padded frames are zeroed out before
                 encoding so the video encoder does not see clamped/repeated
-                content.
+                content. The current frame (t = T-1) is never zeroed, even
+                when flagged: the dataset's ``history_state_drop_prob``
+                augmentation marks ``obs_history_is_pad`` all-True while
+                keeping the current step.
 
         Returns:
             A tuple of (videos, vid_masks) lists.
@@ -912,8 +915,15 @@ class PI05MemPolicy(PreTrainedPolicy):
                 vid = vid.unsqueeze(1)  # (B, C, H, W) -> (B, 1, C, H, W)
 
             if obs_history_is_pad is not None:
-                frame_mask = (~obs_history_is_pad)[:, :, None, None, None]  # (B, T, 1, 1, 1)
-                vid = vid * frame_mask
+                frame_keep = ~obs_history_is_pad  # (B, T) — `~` allocates a fresh tensor
+                # The current frame (t = T-1) is ALWAYS kept even when the
+                # dataset's history_state_drop_prob augmentation marks
+                # obs_history_is_pad all-True — the augmentation drops the
+                # *history* but keeps the current step, mirroring the state
+                # path's `state_mask[:, -1] = True` in embed_prefix. The fresh
+                # `~` tensor keeps the in-place write off the caller's mask.
+                frame_keep[:, -1] = True
+                vid = vid * frame_keep[:, :, None, None, None]  # (B, T, 1, 1, 1)
 
             if self.config.resize_imgs_with_padding is not None:
                 b, t_frames = vid.shape[:2]

--- a/src/opentau/policies/pi05_mem/rldx_video_encoder.py
+++ b/src/opentau/policies/pi05_mem/rldx_video_encoder.py
@@ -173,8 +173,11 @@ class RLDXVideoEncoder(nn.Module):
                 (start-of-episode zero) frames. When given, padded frames are
                 replaced by the nearest real frame before the STSS correlation,
                 so they contribute "no motion" instead of spurious motion against
-                a blank frame. This mirrors the space-time encoder, which masks
-                exactly these frames out of temporal attention.
+                a blank frame. The current frame (t = T-1) is treated as real
+                even when flagged (the ``history_state_drop_prob`` augmentation
+                marks the whole mask True while keeping the current frame).
+                This mirrors the space-time encoder, which masks exactly these
+                frames out of temporal attention.
         Returns:
             ``(B*T, N, D)`` hidden states with the motion residual added.
         """
@@ -189,11 +192,17 @@ class RLDXVideoEncoder(nn.Module):
         # would otherwise read as motion. Padded frames are dropped after the
         # encoder anyway; this only protects the current frame's residual.
         if obs_history_is_pad is not None:
-            real = ~obs_history_is_pad  # (b, t)
+            real = ~obs_history_is_pad  # (b, t) — `~` allocates a fresh tensor
+            # The current frame (t = T-1) is ALWAYS real even when the
+            # dataset's history_state_drop_prob augmentation marks
+            # obs_history_is_pad all-True. Without this override, argmax over
+            # an all-False row would silently pick the zeroed frame 0 as the
+            # fill and replace the current frame's hidden state with it too.
+            real[:, -1] = True
             # First real index per row (argmax returns the first max=1 position).
             first_real = real.float().argmax(dim=1)  # (b,)
             fill = x[torch.arange(b, device=x.device), first_real]  # (b, n, d)
-            pad_mask = rearrange(obs_history_is_pad, "b t -> b t 1 1")
+            pad_mask = rearrange(~real, "b t -> b t 1 1")
             x = torch.where(pad_mask, rearrange(fill, "b n d -> b 1 n d"), x)
 
         # (B, T, N, D) -> (B*T*N, D), preserving the (b t h w) token order the

--- a/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
@@ -1025,7 +1025,11 @@ class PI07LowLevelPolicy(PreTrainedPolicy):
             batch: Batch of data containing video tensors.
             obs_history_is_pad: Optional bool tensor (B, T) indicating which
                 temporal frames are padded. Padded frames are zeroed out before
-                encoding so SpaceTimeSiglip does not process clamped/repeated content.
+                encoding so SpaceTimeSiglip does not process clamped/repeated
+                content. The current frame (t = T-1) is never zeroed, even
+                when flagged: the dataset's ``history_state_drop_prob``
+                augmentation marks ``obs_history_is_pad`` all-True while
+                keeping the current step.
 
         Returns:
             A tuple of (videos, vid_masks) lists.
@@ -1056,8 +1060,15 @@ class PI07LowLevelPolicy(PreTrainedPolicy):
                 vid = vid.unsqueeze(1)  # (B, C, H, W) -> (B, 1, C, H, W)
 
             if obs_history_is_pad is not None:
-                frame_mask = (~obs_history_is_pad)[:, :, None, None, None]  # (B, T, 1, 1, 1)
-                vid = vid * frame_mask
+                frame_keep = ~obs_history_is_pad  # (B, T) — `~` allocates a fresh tensor
+                # The current frame (t = T-1) is ALWAYS kept even when the
+                # dataset's history_state_drop_prob augmentation marks
+                # obs_history_is_pad all-True — the augmentation drops the
+                # *history* but keeps the current step, mirroring the state
+                # path's `state_mask[:, -1] = True` in embed_prefix. The fresh
+                # `~` tensor keeps the in-place write off the caller's mask.
+                frame_keep[:, -1] = True
+                vid = vid * frame_keep[:, :, None, None, None]  # (B, T, 1, 1, 1)
 
             if self.config.resize_imgs_with_padding is not None:
                 b, t_frames = vid.shape[:2]

--- a/src/opentau/policies/pi07/video_encoder.py
+++ b/src/opentau/policies/pi07/video_encoder.py
@@ -610,9 +610,10 @@ class SpaceTimeSiglipVideoEncoder(nn.Module):
                 marks padded history frames. Padded frames are blocked in
                 the temporal attention so the current frame cannot read
                 contaminated hidden states from them. When ``None`` and
-                ``T > 1``, falls back to "only the current frame is real"
-                (matches inference-time semantics where
-                ``_build_history_batch`` does not populate this mask).
+                ``T > 1``, falls back to "only the current frame is real" —
+                a defensive default for callers that omit the mask (the
+                built-in ``select_action -> _build_history_batch`` path
+                does emit it).
 
         Returns:
             ``(B, num_video_tokens, vlm_hidden_size)`` current-frame tokens,
@@ -648,11 +649,11 @@ class SpaceTimeSiglipVideoEncoder(nn.Module):
                     obs_history_is_pad, self.num_video_tokens, hidden.dtype
                 )
             else:
-                # Inference fallback: select_action -> _build_history_batch
-                # zero-pads missing slots but does NOT emit obs_history_is_pad.
+                # Defensive fallback for callers that omit obs_history_is_pad
+                # (the built-in select_action -> _build_history_batch path
+                # emits it, so this is not the normal inference route).
                 # Treat all history as padded so the current frame's
-                # representation is uncontaminated by the zero-pixel
-                # placeholders.
+                # representation is uncontaminated by unknown history content.
                 fallback_pad = torch.ones(b, t, dtype=torch.bool, device=hidden.device)
                 fallback_pad[:, -1] = False
                 temporal_attn_mask = self._build_temporal_attn_mask(

--- a/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
@@ -1373,6 +1373,9 @@ class PI07PaligemmaLowLevelPolicy(PreTrainedPolicy):
         Args:
             batch: Batch of data containing image/video tensors. May contain
                 ``obs_history_is_pad`` ``(B, T)`` marking padded history frames.
+                The current frame (t = T-1) is never zeroed, even when flagged:
+                the dataset's ``history_state_drop_prob`` augmentation marks
+                ``obs_history_is_pad`` all-True while keeping the current step.
 
         Returns:
             A tuple (videos, vid_masks) where each element is a list
@@ -1409,7 +1412,15 @@ class PI07PaligemmaLowLevelPolicy(PreTrainedPolicy):
                 # Zero padded history frames at the pixel level (defense in
                 # depth alongside the encoder's temporal-attention mask) so the
                 # encoder never processes clamped/repeated content.
-                vid = vid * (~obs_history_is_pad)[:, :, None, None, None]
+                frame_keep = ~obs_history_is_pad  # (B, T) — `~` allocates a fresh tensor
+                # The current frame (t = T-1) is ALWAYS kept even when the
+                # dataset's history_state_drop_prob augmentation marks
+                # obs_history_is_pad all-True — the augmentation drops the
+                # *history* but keeps the current step, mirroring the state
+                # path's `state_mask[:, -1] = True` in embed_prefix. The fresh
+                # `~` tensor keeps the in-place write off the caller's mask.
+                frame_keep[:, -1] = True
+                vid = vid * frame_keep[:, :, None, None, None]  # (B, T, 1, 1, 1)
 
             if self.config.resize_imgs_with_padding is not None:
                 b, t_frames = vid.shape[:2]

--- a/tests/policies/test_history_drop_current_frame.py
+++ b/tests/policies/test_history_drop_current_frame.py
@@ -1,0 +1,252 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU-only regression tests for the history-drop "current step is kept" invariant.
+
+The dataset-side ``history_state_drop_prob`` augmentation
+(``LeRobotDataset._emit_optional_keys``) marks ``obs_history_is_pad`` ALL-True
+while zeroing only the historical camera frames (``camera[:-1]``) — the
+documented contract (``configs/default.py``) is that the current camera frame
+and the current state are always kept. The policies' ``prepare_videos``
+re-apply the mask at the pixel level, so they must exempt the current (last)
+frame, mirroring the state path's ``state_mask[:, -1] = True`` exemption.
+
+Regression coverage for the bug where an all-True ``obs_history_is_pad``
+zeroed ALL frames including the current one, so ~30% of training samples (at
+the default drop prob of 0.3) conditioned on a blank current observation.
+
+These tests pin the contract for pi07, pi05_mem and pi07_paligemma without
+instantiating any backbone — ``prepare_videos`` only reads ``self.config``, so
+a ``SimpleNamespace`` stand-in suffices (same pattern as ``test_pi07_cpu.py``'s
+``prepare_metadata`` tests). The RLDX motion-fill tests bind
+``RLDXVideoEncoder._apply_motion`` the same way.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+import torch
+from einops import rearrange
+
+from opentau.policies.pi05_mem.modeling_pi05 import PI05MemPolicy
+from opentau.policies.pi05_mem.rldx_video_encoder import RLDXVideoEncoder
+from opentau.policies.pi07.low_level.modeling_pi07_low_level import PI07LowLevelPolicy
+from opentau.policies.pi07_paligemma.low_level.modeling_pi07_low_level import (
+    PI07PaligemmaLowLevelPolicy,
+)
+
+CAM_KEY = "camera0"
+
+
+def _fake_policy(n_obs_steps: int):
+    """Minimal ``self`` stand-in for the three ``prepare_videos`` methods.
+
+    They only read ``config.{image_features, n_obs_steps,
+    resize_imgs_with_padding, empty_cameras}`` — no backbone needed.
+    ``resize_imgs_with_padding=None`` skips the resize so frames can be
+    compared bit-exactly against the input.
+    """
+    return types.SimpleNamespace(
+        config=types.SimpleNamespace(
+            image_features=[CAM_KEY],
+            n_obs_steps=n_obs_steps,
+            resize_imgs_with_padding=None,
+            empty_cameras=0,
+        )
+    )
+
+
+def _call_prepare_videos(policy_cls, fake, video, pad):
+    """Dispatch on the two signatures: pi07_paligemma reads the mask from the batch."""
+    if policy_cls is PI07PaligemmaLowLevelPolicy:
+        return policy_cls.prepare_videos(fake, {CAM_KEY: video, "obs_history_is_pad": pad})
+    return policy_cls.prepare_videos(fake, {CAM_KEY: video}, obs_history_is_pad=pad)
+
+
+POLICIES = [PI07LowLevelPolicy, PI05MemPolicy, PI07PaligemmaLowLevelPolicy]
+
+
+@pytest.mark.parametrize("policy_cls", POLICIES)
+class TestHistoryDropKeepsCurrentFrame:
+    """A forced history drop (all-True mask) must never zero the current frame."""
+
+    @pytest.mark.parametrize("n_obs_history", [None, 1, 3])
+    def test_current_frame_survives_forced_drop(self, policy_cls, n_obs_history):
+        b, c, h, w = 2, 3, 8, 8
+        t = 1 if n_obs_history is None else n_obs_history
+        video_5d = torch.rand(b, t, c, h, w) + 0.1  # strictly nonzero everywhere
+        # n_obs_history=None yields rank-4 camera tensors (no time axis);
+        # prepare_videos unsqueezes them back to rank-5.
+        video_in = video_5d[:, 0].clone() if n_obs_history is None else video_5d.clone()
+        pad = torch.ones(b, t, dtype=torch.bool)  # forced history drop
+
+        videos, _ = _call_prepare_videos(policy_cls, _fake_policy(n_obs_steps=t), video_in, pad)
+
+        out = videos[0]
+        assert out.shape == (b, t, c, h, w)
+        torch.testing.assert_close(out[:, -1], video_5d[:, -1])
+        if t > 1:
+            assert torch.all(out[:, :-1] == 0)
+
+    def test_caller_mask_not_mutated(self, policy_cls):
+        b, t = 2, 3
+        video = torch.rand(b, t, 3, 8, 8) + 0.1
+        pad = torch.ones(b, t, dtype=torch.bool)
+        _call_prepare_videos(policy_cls, _fake_policy(n_obs_steps=t), video, pad)
+        # The [:, -1] = True exemption must act on a fresh tensor, not leak out.
+        assert torch.all(pad)
+
+    def test_genuine_start_of_episode_padding_still_zeroed(self, policy_cls):
+        b, t = 2, 3
+        video = torch.rand(b, t, 3, 8, 8) + 0.1
+        pad = torch.tensor([[True, False, False]] * b)
+
+        videos, _ = _call_prepare_videos(policy_cls, _fake_policy(n_obs_steps=t), video.clone(), pad)
+
+        out = videos[0]
+        assert torch.all(out[:, 0] == 0)
+        torch.testing.assert_close(out[:, 1:], video[:, 1:])
+
+    def test_mixed_per_sample_masks_are_independent(self, policy_cls):
+        """One batch mixing a dropped row, a prefix-padded row and a full row."""
+        t = 3
+        video = torch.rand(3, t, 3, 8, 8) + 0.1
+        pad = torch.tensor(
+            [
+                [True, True, True],  # forced history drop
+                [True, False, False],  # genuine start-of-episode prefix pad
+                [False, False, False],  # full history
+            ]
+        )
+
+        videos, _ = _call_prepare_videos(policy_cls, _fake_policy(n_obs_steps=t), video.clone(), pad)
+
+        out = videos[0]
+        assert torch.all(out[0, :-1] == 0)
+        torch.testing.assert_close(out[0, -1], video[0, -1])
+        assert torch.all(out[1, 0] == 0)
+        torch.testing.assert_close(out[1, 1:], video[1, 1:])
+        torch.testing.assert_close(out[2], video[2])
+
+    def test_multi_camera_and_empty_camera_slots(self, policy_cls):
+        """Each present camera is masked independently; empty slots stay zero."""
+        b, t = 2, 3
+        fake = _fake_policy(n_obs_steps=t)
+        fake.config.image_features = ["camera0", "camera1", "camera2"]
+        fake.config.empty_cameras = 1
+        vid0 = torch.rand(b, t, 3, 8, 8) + 0.1
+        vid1 = torch.rand(b, t, 3, 8, 8) + 0.1
+        pad = torch.ones(b, t, dtype=torch.bool)  # forced history drop
+
+        batch = {"camera0": vid0.clone(), "camera1": vid1.clone()}  # camera2 missing
+        if policy_cls is PI07PaligemmaLowLevelPolicy:
+            batch["obs_history_is_pad"] = pad
+            videos, vid_masks = policy_cls.prepare_videos(fake, batch)
+        else:
+            videos, vid_masks = policy_cls.prepare_videos(fake, batch, obs_history_is_pad=pad)
+
+        assert len(videos) == 3  # 2 present + 1 empty slot
+        for out, src in zip(videos[:2], (vid0, vid1), strict=False):
+            torch.testing.assert_close(out[:, -1], src[:, -1])
+            assert torch.all(out[:, :-1] == 0)
+        assert torch.all(videos[2] == 0)
+        assert torch.all(vid_masks[0]) and torch.all(vid_masks[1])
+        assert not vid_masks[2].any()
+
+    def test_resize_path_keeps_current_frame_content(self, policy_cls):
+        """Masking runs before the resize; the invariant must survive it."""
+        b, t = 2, 3
+        fake = _fake_policy(n_obs_steps=t)
+        fake.config.resize_imgs_with_padding = (16, 16)
+        video = torch.rand(b, t, 3, 8, 8) + 0.1
+        pad = torch.ones(b, t, dtype=torch.bool)  # forced history drop
+
+        videos, _ = _call_prepare_videos(policy_cls, fake, video.clone(), pad)
+
+        out = videos[0]
+        assert out.shape == (b, t, 3, 16, 16)
+        assert torch.all(out[:, :-1] == 0)
+        assert torch.all(out[:, -1].abs().sum(dim=(-3, -2, -1)) > 0)
+
+
+class _RecordingMotion(torch.nn.Module):
+    """Stub motion module: records its ``(B*T*N, D)`` input, contributes nothing."""
+
+    def __init__(self):
+        super().__init__()
+        self.seen: torch.Tensor | None = None
+
+    def forward(self, flat, grid_sizes):
+        self.seen = flat.detach().clone()
+        return torch.zeros_like(flat)
+
+
+class TestRLDXMotionFillTreatsCurrentFrameAsReal:
+    """``_apply_motion`` must fill padded slots from a *real* frame under a forced drop.
+
+    Before the fix, an all-True ``obs_history_is_pad`` made
+    ``(~pad).float().argmax(dim=1)`` return 0 — silently picking the *zeroed*
+    frame 0 as the fill and replacing the current frame's hidden state too, so
+    the STSS correlation ran on an all-blank clip.
+    """
+
+    B, T, GRID, DIM = 2, 3, 4, 6
+
+    def _run(self, pad):
+        n = self.GRID * self.GRID
+        hidden = torch.rand(self.B * self.T, n, self.DIM) + 0.1
+        motion = _RecordingMotion()
+        fake = types.SimpleNamespace(motion_grid_hw=self.GRID, motion_module=motion)
+
+        out = RLDXVideoEncoder._apply_motion(fake, hidden, self.B, self.T, pad)
+
+        seen = rearrange(motion.seen, "(b t n) d -> b t n d", b=self.B, t=self.T, n=n)
+        x = rearrange(hidden, "(b t) n d -> b t n d", b=self.B, t=self.T)
+        return out, seen, x, hidden
+
+    def test_forced_drop_fills_every_slot_with_current_frame(self):
+        pad = torch.ones(self.B, self.T, dtype=torch.bool)
+        out, seen, x, hidden = self._run(pad)
+        # Every STSS input frame is the (real) current frame — a static clip,
+        # i.e. "no motion" — never the zeroed frame 0.
+        for i in range(self.T):
+            torch.testing.assert_close(seen[:, i], x[:, -1])
+        # The fill only feeds the STSS input; with a zero residual the returned
+        # hidden states are bit-identical to the input, current frame included.
+        torch.testing.assert_close(out, hidden)
+        assert torch.all(pad)  # caller's mask untouched
+
+    def test_prefix_padding_forward_fills_first_real_frame(self):
+        pad = torch.tensor([[True, False, False]] * self.B)
+        _, seen, x, _ = self._run(pad)
+        torch.testing.assert_close(seen[:, 0], x[:, 1])  # padded slot <- first real
+        torch.testing.assert_close(seen[:, 1], x[:, 1])
+        torch.testing.assert_close(seen[:, 2], x[:, 2])
+
+    def test_current_slot_never_overwritten_for_any_mask_shape(self):
+        """The current frame's STSS input survives even a pathological mask.
+
+        A suffix-shaped mask ([False, True, True]) cannot occur in training
+        (padding is a prefix; the drop is all-True), but it kills a revert of
+        the ``pad_mask = ~real`` sub-fix: with the old
+        ``pad_mask = obs_history_is_pad``, the current slot would be replaced
+        by frame 0 here.
+        """
+        pad = torch.tensor([[False, True, True]] * self.B)
+        _, seen, x, _ = self._run(pad)
+        torch.testing.assert_close(seen[:, -1], x[:, -1])
+        torch.testing.assert_close(seen[:, 0], x[:, 0])
+        torch.testing.assert_close(seen[:, 1], x[:, 0])  # padded slot <- first real


### PR DESCRIPTION
## What this does
Fixes a violation of the documented `history_state_drop_prob` contract (🐛 Bug): when the history-drop augmentation fires, the dataset marks `obs_history_is_pad` all-True and zeroes only the *historical* camera frames — the current camera frame and current state are always kept (`configs/default.py`, `LeRobotDataset._emit_optional_keys`). The policies' state paths honor this via `state_mask[:, -1] = True`, but the video paths did not:

- `prepare_videos` in `pi07/low_level`, `pi05_mem`, and `pi07_paligemma/low_level` multiplied the video tensor by `~obs_history_is_pad` with no current-step exemption, so a fired drop (~30% of training samples at the default prob of 0.3) zeroed **all** T frames — the model conditioned on a blank current observation. Fixed with a `frame_keep[:, -1] = True` exemption mirroring the state path. This affected every `n_obs_history` setting (None, 1, and >1).
- `pi05_mem/rldx_video_encoder.py::_apply_motion` computed its STSS motion fill index as `(~pad).float().argmax(dim=1)`, which returns 0 on an all-True mask — silently picking the *zeroed* frame 0 as the fill and overwriting the current frame's slot too. The current frame is now treated as real (`real[:, -1] = True`, `pad_mask = ~real`), so a forced drop degrades to a static current-frame clip ("no motion") instead of an all-blank clip.
- Corrected a stale comment/docstring in `pi07/video_encoder.py` that claimed `select_action -> _build_history_batch` does not emit `obs_history_is_pad` — it does (and its last slot is always real), so the encoder's None-fallback is a defensive path for external callers, not the normal inference route.

Notes for reviewers:
- **Training curves across this fix are not directly comparable**: ~30% of samples now condition on a real current frame, so resuming a pre-fix run will show an expected step-change in loss.
- **Inference is unaffected (bit-exact)**: serve-time `_build_history_batch` masks always have a real last slot, so the exemption never fires there — checkpoints trained before this fix serve identically.
- Audited the remaining policies for the same pattern: `cosmos3` (and the `cosmos3_nano` subclass proposed in #466) are single-frame policies that never consume `obs_history_is_pad` — not affected.

## How it was tested
- Added `tests/policies/test_history_drop_current_frame.py` (27 CPU tests): the current frame survives a forced history drop for `n_obs_history` in {None, 1, 3} across all three policies; genuine start-of-episode prefix padding is still zeroed; mixed per-sample masks stay independent; multi-camera + `empty_cameras` slots; the resize path; the caller's mask is never mutated; and `_apply_motion` fill semantics, including a suffix-mask test that kills a revert of the `pad_mask = ~real` sub-fix. Reverting the four functional source files to `main` makes 20 of these tests fail.
- `pytest -m "not gpu and not network" -n auto`: full CPU suite green (2025 passed; remaining items were unrelated local environment gaps for the `libero` extra, which pass once `--extra libero` and its assets are installed).
- `pytest -m "gpu" -n 0 tests/policies/test_pi05_mem_gpu.py tests/policies/test_pi07_low_level.py tests/policies/test_pi07_paligemma_low_level.py` (targeted GPU subset for the touched policies) on a GPU dev box: green.
- `pre-commit run` clean.

## How to checkout & try? (for the reviewer)
```bash
pytest -sx tests/policies/test_history_drop_current_frame.py
```
To reproduce the bug on `main`: check out only the new test file onto `main` and run it — the forced-drop and motion-fill tests fail there.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [x] My PR includes policy-related changes.
  - [x] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
