### PR TITLE
feat(policies): native-resolution vision input + resize/resolution validation

### DIFF
--- a/src/opentau/configs/policies.py
+++ b/src/opentau/configs/policies.py
@@ -22,6 +22,7 @@ configurations from pretrained models or local paths.
 
 import abc
 import json
+import logging
 import os
 import tempfile
 import warnings
@@ -294,6 +295,22 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):
             inference. Honored by every policy whose ``from_pretrained`` (or ``_load_as_safetensor``)
             calls :py:meth:`~opentau.policies.pretrained.PreTrainedPolicy._strip_normalization_buffers_from_state_dict`.
             Defaults to ``False`` (no behaviour change).
+        skip_input_resolution_check: Escape hatch for
+            :py:meth:`validate_input_resolution`. When ``True``, a mismatch
+            between the policy's ``resize_imgs_with_padding`` and the ``(H, W)``
+            of the bound image features logs a loud warning instead of raising —
+            even on the strict (training) path. Intended for deliberately
+            resuming/finetuning a legacy checkpoint that was trained with the
+            mismatch (i.e. with the policy silently letterboxing a second time
+            inside ``prepare_images``/``prepare_videos``); leave ``False`` for
+            everything else. Eval-shaped policy construction never raises
+            regardless of this flag (it warns), so plain evaluation of legacy
+            checkpoints does not need it. Note that ``True`` persists into the
+            ``config.json`` of every checkpoint the run saves — coherent for
+            resuming that same mismatch-trained lineage, but set it back to
+            ``false`` when fine-tuning such a checkpoint against a *new*
+            dataset mixture, or a fresh mismatch there will only warn instead
+            of raising. Defaults to ``False``.
     """
 
     n_obs_steps: int = 1
@@ -327,6 +344,7 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):
 
     pretrained_path: str | None = None
     skip_normalization_weights: bool = False
+    skip_input_resolution_check: bool = False
 
     # When False, `_save_pretrained` strips normalize_*.buffer_* / unnormalize_*.buffer_*
     # keys from the state_dict before writing model.safetensors. Reloading then requires
@@ -481,6 +499,106 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):
             type VISUAL.
         """
         return {key: ft for key, ft in self.input_features.items() if ft.type is FeatureType.VISUAL}
+
+    def _bound_image_resolutions(self) -> dict[str, tuple[int, int]]:
+        """``(H, W)`` per bound image feature.
+
+        Skips the synthetic ``observation.images.empty_camera_*`` placeholders:
+        their hard-coded shape describes no real data — each policy's
+        ``prepare_images``/``prepare_videos`` fabricates those slots in-policy
+        as masked placeholder frames cloned at the shape of the processed real
+        camera tensors. Handles both the policy-side channels-first ``(C, H,
+        W)`` convention (mixture-bound features) and the raw dataset
+        channels-last ``(H, W, C)`` convention (bare
+        ``LeRobotDatasetMetadata``); shapes that are recognizably neither are
+        skipped rather than misread.
+        """
+        resolutions: dict[str, tuple[int, int]] = {}
+        for key, ft in self.image_features.items():
+            if key.startswith("observation.images.empty_camera"):
+                continue
+            shape = tuple(ft.shape)
+            if len(shape) != 3:
+                continue
+            if shape[0] in (1, 3, 4) and shape[2] not in (1, 3, 4):
+                resolutions[key] = (shape[1], shape[2])
+            elif shape[2] in (1, 3, 4) and shape[0] not in (1, 3, 4):
+                resolutions[key] = (shape[0], shape[1])
+            elif shape[0] in (1, 3, 4) and shape[2] in (1, 3, 4):
+                # Ambiguous (e.g. (3, H, 3)); prefer channels-first, the
+                # policy-side convention.
+                resolutions[key] = (shape[1], shape[2])
+        return resolutions
+
+    @property
+    def input_image_size(self) -> tuple[int, int] | None:
+        """``(H, W)`` the vision tower will actually receive.
+
+        This is ``resize_imgs_with_padding`` when the policy defines and sets
+        it (the in-policy letterbox target), else the resolution of the bound
+        image features (native pass-through), else ``None`` when neither is
+        known (e.g. a bare config before feature binding).
+        """
+        resize_target = getattr(self, "resize_imgs_with_padding", None)
+        if resize_target is not None:
+            return tuple(resize_target)
+        for resolution in self._bound_image_resolutions().values():
+            return resolution
+        return None
+
+    def validate_input_resolution(self, *, strict: bool) -> None:
+        """Check ``resize_imgs_with_padding`` against the bound image features.
+
+        The image features bound onto the config (from
+        ``TrainPipelineConfig.resolution`` via the dataset mixture at train
+        time, or carried inside a checkpoint's ``config.json`` at load time)
+        are the ``(H, W)`` the policy actually receives. A differing
+        ``resize_imgs_with_padding`` means every frame gets silently
+        letterboxed a second time inside the policy — downscaled and padded
+        with black bars — which is almost never intended.
+
+        No-op when the policy has no ``resize_imgs_with_padding`` field, the
+        field is ``None`` (native pass-through), or no comparable image
+        feature is bound.
+
+        Args:
+            strict: ``True`` for training-shaped construction — raise on
+                mismatch (unless ``skip_input_resolution_check``); ``False``
+                for eval/inference — warn loudly but keep loading, so legacy
+                checkpoints trained with the mismatch remain evaluable.
+
+        Raises:
+            ValueError: On mismatch when ``strict`` is ``True`` and
+                ``skip_input_resolution_check`` is ``False``.
+        """
+        resize_target = getattr(self, "resize_imgs_with_padding", None)
+        if resize_target is None:
+            return
+        resize_target = tuple(resize_target)
+        mismatched = {
+            key: res for key, res in self._bound_image_resolutions().items() if res != resize_target
+        }
+        if not mismatched:
+            return
+        described = ", ".join(f"{key}={res}" for key, res in sorted(mismatched.items()))
+        message = (
+            f"resize_imgs_with_padding={resize_target} (H, W) does not match the resolution of the "
+            f"bound image features: {described}. The policy would silently letterbox every frame a "
+            "second time (aspect-preserving resample + black padding), degrading the vision input. "
+            "Set policy.resize_imgs_with_padding to the input resolution (and TrainPipelineConfig."
+            "resolution to the resolution you want to train at), or set it to null to pass frames "
+            "through at the bound resolution (PaliGemma-family policies only; the Gemma3-family "
+            "pi06/pi07 require the vision tower's square image_size)."
+        )
+        if strict and not self.skip_input_resolution_check:
+            raise ValueError(
+                message + " If you are deliberately resuming a legacy checkpoint trained with this "
+                "mismatch, set policy.skip_input_resolution_check=true to downgrade this to a warning."
+            )
+        logging.warning(
+            message + " Proceeding because this is %s.",
+            "skip_input_resolution_check=true" if strict else "an eval/inference load",
+        )
 
     @property
     def action_feature(self) -> PolicyFeature | None:

--- a/src/opentau/configs/policies.py
+++ b/src/opentau/configs/policies.py
@@ -557,9 +557,14 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):
         letterboxed a second time inside the policy — downscaled and padded
         with black bars — which is almost never intended.
 
-        No-op when the policy has no ``resize_imgs_with_padding`` field, the
-        field is ``None`` (native pass-through), or no comparable image
-        feature is bound.
+        With ``resize_imgs_with_padding=None`` (native pass-through) there is
+        no target to compare against, but the bound cameras must then agree
+        with *each other* — with no in-policy resize step, a mixed-resolution
+        camera set has no single geometry the vision tower could be built
+        for, so that is flagged with the same strict/warn semantics.
+
+        No-op when the policy has no ``resize_imgs_with_padding`` field or no
+        comparable image feature is bound.
 
         Args:
             strict: ``True`` for training-shaped construction — raise on
@@ -571,25 +576,35 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):
             ValueError: On mismatch when ``strict`` is ``True`` and
                 ``skip_input_resolution_check`` is ``False``.
         """
-        resize_target = getattr(self, "resize_imgs_with_padding", None)
+        if not hasattr(self, "resize_imgs_with_padding"):
+            return
+        resize_target = self.resize_imgs_with_padding
+        resolutions = self._bound_image_resolutions()
         if resize_target is None:
-            return
-        resize_target = tuple(resize_target)
-        mismatched = {
-            key: res for key, res in self._bound_image_resolutions().items() if res != resize_target
-        }
-        if not mismatched:
-            return
-        described = ", ".join(f"{key}={res}" for key, res in sorted(mismatched.items()))
-        message = (
-            f"resize_imgs_with_padding={resize_target} (H, W) does not match the resolution of the "
-            f"bound image features: {described}. The policy would silently letterbox every frame a "
-            "second time (aspect-preserving resample + black padding), degrading the vision input. "
-            "Set policy.resize_imgs_with_padding to the input resolution (and TrainPipelineConfig."
-            "resolution to the resolution you want to train at), or set it to null to pass frames "
-            "through at the bound resolution (PaliGemma-family policies only; the Gemma3-family "
-            "pi06/pi07 require the vision tower's square image_size)."
-        )
+            if len(set(resolutions.values())) <= 1:
+                return
+            described = ", ".join(f"{key}={res}" for key, res in sorted(resolutions.items()))
+            message = (
+                f"resize_imgs_with_padding is null (native pass-through) but the bound image "
+                f"features have mixed resolutions: {described}. With no in-policy resize step "
+                "every camera must arrive at one resolution; set resize_imgs_with_padding to a "
+                "single (H, W) target instead."
+            )
+        else:
+            resize_target = tuple(resize_target)
+            mismatched = {key: res for key, res in resolutions.items() if res != resize_target}
+            if not mismatched:
+                return
+            described = ", ".join(f"{key}={res}" for key, res in sorted(mismatched.items()))
+            message = (
+                f"resize_imgs_with_padding={resize_target} (H, W) does not match the resolution of "
+                f"the bound image features: {described}. The policy would silently letterbox every "
+                "frame a second time (aspect-preserving resample + black padding), degrading the "
+                "vision input. Set policy.resize_imgs_with_padding to the input resolution (and "
+                "TrainPipelineConfig.resolution to the resolution you want to train at), or set it "
+                "to null to pass frames through at the bound resolution (PaliGemma-family policies "
+                "only; the Gemma3-family pi06/pi07 require the vision tower's square image_size)."
+            )
         if strict and not self.skip_input_resolution_check:
             raise ValueError(
                 message + " If you are deliberately resuming a legacy checkpoint trained with this "

--- a/src/opentau/configs/train.py
+++ b/src/opentau/configs/train.py
@@ -20,6 +20,7 @@ configuration, training hyperparameters, and evaluation settings.
 """
 
 import datetime as dt
+import logging
 import os
 import sys
 from dataclasses import dataclass, field
@@ -299,6 +300,34 @@ class TrainPipelineConfig(HubMixin):
             self.policy.max_state_dim = self.max_state_dim
             self.policy.max_action_state = self.max_action_dim
             self.policy.chunk_size = self.action_chunk
+
+            # The dataloader letterboxes every sample to ``self.resolution``
+            # before the policy sees it; a differing policy-side
+            # ``resize_imgs_with_padding`` means the policy silently
+            # letterboxes those frames a *second* time. Fail fast at
+            # train-config time (this method only runs for training —
+            # eval never calls validate(), so legacy checkpoints stay
+            # evaluable). ``None`` means native pass-through and is
+            # always consistent.
+            policy_resize = getattr(self.policy, "resize_imgs_with_padding", None)
+            if policy_resize is not None and tuple(policy_resize) != tuple(self.resolution):
+                message = (
+                    f"policy.resize_imgs_with_padding={tuple(policy_resize)} != "
+                    f"resolution={tuple(self.resolution)} (both (H, W)). The dataloader delivers "
+                    "frames at `resolution`, so the policy would letterbox them a second time "
+                    "(aspect-preserving resample + black padding) before the vision tower. Set the "
+                    "two fields to the same value (for the Gemma3-family policies — pi06/pi07 — "
+                    "both must equal the vision tower's image_size, e.g. 448), or set "
+                    "policy.resize_imgs_with_padding=null to feed frames to the vision tower at "
+                    "`resolution` directly (PaliGemma-family policies only)."
+                )
+                if getattr(self.policy, "skip_input_resolution_check", False):
+                    logging.warning(message + " Proceeding because skip_input_resolution_check=true.")
+                else:
+                    raise ValueError(
+                        message + " If you are deliberately resuming a legacy run trained with this "
+                        "mismatch, set policy.skip_input_resolution_check=true."
+                    )
 
             # The policy's ``n_obs_steps`` determines the T dimension its
             # encoder expects; the dataset_mixture's ``n_obs_history`` is

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -1229,6 +1229,12 @@ class BaseDataset(torch.utils.data.Dataset):
 
         cur_height, cur_width = img.shape[2:]
 
+        # Explicit no-op when the input already matches the target — native-
+        # resolution training must deliver untouched pixels, not a same-size
+        # bilinear round trip.
+        if (cur_height, cur_width) == (height, width):
+            return img if batched else img.squeeze(0)
+
         ratio = max(cur_width / width, cur_height / height)
         resized_height = int(cur_height / ratio)
         resized_width = int(cur_width / ratio)

--- a/src/opentau/envs/subgoal.py
+++ b/src/opentau/envs/subgoal.py
@@ -633,6 +633,10 @@ def _resize_with_pad(img: Tensor, width: int, height: int, pad_value: float = 0.
         raise ValueError(f"Expected (C,H,W) or (T,C,H,W), got shape {tuple(img.shape)}")
 
     cur_height, cur_width = img.shape[2:]
+    # Explicit no-op when the input already matches the target (mirrors
+    # BaseDataset.resize_with_pad).
+    if (cur_height, cur_width) == (height, width):
+        return img if batched else img.squeeze(0)
     ratio = max(cur_width / width, cur_height / height)
     resized_height = int(cur_height / ratio)
     resized_width = int(cur_width / ratio)

--- a/src/opentau/policies/factory.py
+++ b/src/opentau/policies/factory.py
@@ -263,6 +263,16 @@ def make_policy(
         cfg.output_features = {key: ft for key, ft in features.items() if ft.type is FeatureType.ACTION}
         cfg.input_features = {key: ft for key, ft in features.items() if key not in cfg.output_features}
 
+    # Now that image features are bound, cross-check them against the policy's
+    # declared resize target. Training-shaped calls (ds_meta present) fail
+    # fast on a mismatch — it means every frame would be silently letterboxed
+    # a second time inside the policy. Eval/inference loads are handled by the
+    # warn-only check inside `PreTrainedPolicy.from_pretrained` (which also
+    # covers loaders that bypass this factory, e.g. the gRPC server), so
+    # legacy checkpoints trained with the mismatch keep loading.
+    if ds_meta is not None:
+        cfg.validate_input_resolution(strict=True)
+
     if stats is not None:
         # External opaque stats override. Accept either a single
         # dict-of-features (wrapped into a singleton list) or an

--- a/src/opentau/policies/pi0/modeling_pi0.py
+++ b/src/opentau/policies/pi0/modeling_pi0.py
@@ -136,11 +136,16 @@ def resize_with_pad(img: Tensor, width: int, height: int, pad_value: int = -1) -
     Raises:
         ValueError: If the input image tensor does not have 4 dimensions.
     """
-    # assume no-op when width height fits already
     if img.ndim != 4:
         raise ValueError(f"(b,c,h,w) expected, but {img.shape}")
 
     cur_height, cur_width = img.shape[2:]
+
+    # Explicit no-op when the input already matches the target — native-
+    # resolution inputs must pass through bit-identical, not survive a
+    # same-size bilinear round trip.
+    if (cur_height, cur_width) == (height, width):
+        return img
 
     ratio = max(cur_width / width, cur_height / height)
     resized_height = int(cur_height / ratio)
@@ -594,7 +599,11 @@ class PI0Policy(PreTrainedPolicy):
             img = batch[key]
 
             if self.config.resize_imgs_with_padding is not None:
-                img = resize_with_pad(img, *self.config.resize_imgs_with_padding, pad_value=0)
+                # The config tuple is (height, width); the function signature is
+                # (width, height) — unpack explicitly so non-square targets are not
+                # transposed (invisible at the square defaults).
+                target_h, target_w = self.config.resize_imgs_with_padding
+                img = resize_with_pad(img, width=target_w, height=target_h, pad_value=0)
 
             # Normalize from range [0,1] to [-1,1] as expected by siglip
             img = img * 2.0 - 1.0

--- a/src/opentau/policies/pi05/modeling_pi05.py
+++ b/src/opentau/policies/pi05/modeling_pi05.py
@@ -181,11 +181,16 @@ def resize_with_pad(img: Tensor, width: int, height: int, pad_value: int = -1) -
     Raises:
         ValueError: If the input image tensor does not have 4 dimensions.
     """
-    # assume no-op when width height fits already
     if img.ndim != 4:
         raise ValueError(f"(b,c,h,w) expected, but {img.shape}")
 
     cur_height, cur_width = img.shape[2:]
+
+    # Explicit no-op when the input already matches the target — native-
+    # resolution inputs must pass through bit-identical, not survive a
+    # same-size bilinear round trip.
+    if (cur_height, cur_width) == (height, width):
+        return img
 
     ratio = max(cur_width / width, cur_height / height)
     resized_height = int(cur_height / ratio)
@@ -871,7 +876,11 @@ class PI05Policy(PreTrainedPolicy):
             img = batch[key]
 
             if self.config.resize_imgs_with_padding is not None:
-                img = resize_with_pad(img, *self.config.resize_imgs_with_padding, pad_value=0)
+                # The config tuple is (height, width); the function signature is
+                # (width, height) — unpack explicitly so non-square targets are not
+                # transposed (invisible at the square defaults).
+                target_h, target_w = self.config.resize_imgs_with_padding
+                img = resize_with_pad(img, width=target_w, height=target_h, pad_value=0)
 
             # Normalize from range [0,1] to [-1,1] as expected by siglip
             img = img * 2.0 - 1.0

--- a/src/opentau/policies/pi05_mem/modeling_pi05.py
+++ b/src/opentau/policies/pi05_mem/modeling_pi05.py
@@ -278,6 +278,12 @@ def resize_with_pad(img: Tensor, width: int, height: int, pad_value: int = -1) -
 
     cur_height, cur_width = img.shape[2:]
 
+    # Explicit no-op when the input already matches the target — native-
+    # resolution inputs must pass through bit-identical, not survive a
+    # same-size bilinear round trip.
+    if (cur_height, cur_width) == (height, width):
+        return img
+
     ratio = max(cur_width / width, cur_height / height)
     resized_height = int(cur_height / ratio)
     resized_width = int(cur_width / ratio)
@@ -918,7 +924,11 @@ class PI05MemPolicy(PreTrainedPolicy):
             if self.config.resize_imgs_with_padding is not None:
                 b, t_frames = vid.shape[:2]
                 flat = rearrange(vid, "B T C H W -> (B T) C H W")
-                flat = resize_with_pad(flat, *self.config.resize_imgs_with_padding, pad_value=0)
+                # The config tuple is (height, width); the function signature is
+                # (width, height) — unpack explicitly so non-square targets are not
+                # transposed (invisible at the square defaults).
+                target_h, target_w = self.config.resize_imgs_with_padding
+                flat = resize_with_pad(flat, width=target_w, height=target_h, pad_value=0)
                 vid = rearrange(flat, "(B T) C H W -> B T C H W", B=b, T=t_frames)
 
             bsize = vid.shape[0]
@@ -1032,19 +1042,41 @@ class PI05MemFlowMatching(nn.Module):
                 max_num_frames=config.n_obs_steps,
                 spacetime_layer_stride=config.spacetime_layer_stride,
                 gradient_checkpointing=config.gradient_checkpointing,
+                # (H, W) the tower will actually receive (resize target if
+                # set, else the bound image-feature resolution). Note the
+                # MRoPE square-grid check below still constrains pi05_mem to
+                # square inputs; non-square native resolutions need a
+                # follow-up there.
+                expected_image_size=config.input_image_size,
             )
 
         # Side length of the (square) video patch grid, used by interleaved
-        # MRoPE to give per-frame patches 2-D (height, width) positions. Both
-        # encoders expose ``num_video_tokens`` (a perfect square, e.g. 256 for
-        # a 224/14 grid).
+        # MRoPE to give per-frame patches 2-D (height, width) positions.
+        # Prefer the encoder's actual (grid_h, grid_w) when exposed — a
+        # non-square grid can still have a perfect-square token count (e.g.
+        # 16x4 = 64), which a sqrt-of-token-count check would wave through
+        # while MRoPE assigned positions on the wrong raster. Fall back to
+        # the sqrt check for encoders that only expose the flat count
+        # (RLDXVideoEncoder, whose square-window motion module already
+        # constrains the grid).
         num_vid_tokens = self.video_encoder.num_video_tokens
-        self._video_grid = int(round(num_vid_tokens**0.5))
-        if self._video_grid * self._video_grid != num_vid_tokens:
-            raise ValueError(
-                f"Interleaved MRoPE requires a square video patch grid; got "
-                f"{num_vid_tokens} video tokens (not a perfect square)."
-            )
+        grid_hw = getattr(self.video_encoder, "grid_hw", None)
+        if grid_hw is not None:
+            grid_h, grid_w = grid_hw
+            if grid_h != grid_w:
+                raise ValueError(
+                    f"Interleaved MRoPE requires a square video patch grid; got {grid_h}x{grid_w} "
+                    "(from the input resolution). Use a square input resolution with pi05_mem, or "
+                    "a non-MRoPE rope_type."
+                )
+            self._video_grid = grid_h
+        else:
+            self._video_grid = int(round(num_vid_tokens**0.5))
+            if self._video_grid * self._video_grid != num_vid_tokens:
+                raise ValueError(
+                    f"Interleaved MRoPE requires a square video patch grid; got "
+                    f"{num_vid_tokens} video tokens (not a perfect square)."
+                )
 
         # Per-timestep state projection: each of the T state vectors becomes one token
         self.state_proj = nn.Linear(self.config.max_state_dim, vlm_hidden_size)

--- a/src/opentau/policies/pi05_mem/modeling_pi05.py
+++ b/src/opentau/policies/pi05_mem/modeling_pi05.py
@@ -1058,24 +1058,30 @@ class PI05MemFlowMatching(nn.Module):
         # while MRoPE assigned positions on the wrong raster. Fall back to
         # the sqrt check for encoders that only expose the flat count
         # (RLDXVideoEncoder, whose square-window motion module already
-        # constrains the grid).
+        # constrains the grid). ``_video_grid`` is only consumed on the MRoPE
+        # paths, so the squareness requirement is gated on ``rope_type`` —
+        # plain "rope" runs fine on a non-square grid.
         num_vid_tokens = self.video_encoder.num_video_tokens
         grid_hw = getattr(self.video_encoder, "grid_hw", None)
         if grid_hw is not None:
             grid_h, grid_w = grid_hw
-            if grid_h != grid_w:
+            if grid_h != grid_w and self.config.rope_type == "mrope_interleaved":
                 raise ValueError(
                     f"Interleaved MRoPE requires a square video patch grid; got {grid_h}x{grid_w} "
-                    "(from the input resolution). Use a square input resolution with pi05_mem, or "
-                    "a non-MRoPE rope_type."
+                    "(from the input resolution). Use a square input resolution with "
+                    "rope_type='mrope_interleaved', or set rope_type='rope'."
                 )
             self._video_grid = grid_h
         else:
             self._video_grid = int(round(num_vid_tokens**0.5))
-            if self._video_grid * self._video_grid != num_vid_tokens:
+            if (
+                self._video_grid * self._video_grid != num_vid_tokens
+                and self.config.rope_type == "mrope_interleaved"
+            ):
                 raise ValueError(
                     f"Interleaved MRoPE requires a square video patch grid; got "
-                    f"{num_vid_tokens} video tokens (not a perfect square)."
+                    f"{num_vid_tokens} video tokens (not a perfect square). Use a square input "
+                    "resolution with rope_type='mrope_interleaved', or set rope_type='rope'."
                 )
 
         # Per-timestep state projection: each of the T state vectors becomes one token

--- a/src/opentau/policies/pi06/modeling_pi06.py
+++ b/src/opentau/policies/pi06/modeling_pi06.py
@@ -175,6 +175,12 @@ def resize_with_pad(img: Tensor, width: int, height: int, pad_value: int = -1) -
 
     cur_height, cur_width = img.shape[2:]
 
+    # Explicit no-op when the input already matches the target — native-
+    # resolution inputs must pass through bit-identical, not survive a
+    # same-size bilinear round trip.
+    if (cur_height, cur_width) == (height, width):
+        return img
+
     ratio = max(cur_width / width, cur_height / height)
     resized_height = int(cur_height / ratio)
     resized_width = int(cur_width / ratio)
@@ -685,7 +691,11 @@ class PI06Policy(PreTrainedPolicy):
         for key in present_img_keys:
             img = batch[key]
             if self.config.resize_imgs_with_padding is not None:
-                img = resize_with_pad(img, *self.config.resize_imgs_with_padding, pad_value=0)
+                # The config tuple is (height, width); the function signature is
+                # (width, height) — unpack explicitly so non-square targets are not
+                # transposed (invisible at the square defaults).
+                target_h, target_w = self.config.resize_imgs_with_padding
+                img = resize_with_pad(img, width=target_w, height=target_h, pad_value=0)
 
             img = img * 2.0 - 1.0
 
@@ -819,6 +829,21 @@ class PI06FlowMatching(nn.Module):
             gradient_checkpointing=self.config.gradient_checkpointing,
         )
         self.gemma3_with_expert = Gemma3WithExpertModel(gemma3_with_expert_config)
+
+        # Native (non-square-448) input resolutions are not yet supported on
+        # the Gemma3 backbone (Gemma3MultiModalProjector hard-codes a square
+        # patch grid); fail fast with the real diagnosis instead of a reshape
+        # crash inside the projector at first forward.
+        vision_cfg = self.gemma3_with_expert._vision_tower().config
+        expected_hw = config.input_image_size
+        if expected_hw is not None and tuple(expected_hw) != (vision_cfg.image_size, vision_cfg.image_size):
+            raise ValueError(
+                f"input resolution {tuple(expected_hw)} (resize_imgs_with_padding, or the bound "
+                f"image-feature resolution when it is null) != the Gemma 3 vision tower's "
+                f"image_size ({vision_cfg.image_size}). Native resolutions are not yet supported "
+                "for the Gemma3-family policies; set resize_imgs_with_padding (and resolution) to "
+                f"({vision_cfg.image_size}, {vision_cfg.image_size})."
+            )
 
         # Action projections stay float32 for numerical stability; they're small.
         self.action_in_proj = nn.Linear(self.config.max_action_dim, self.config.proj_width)

--- a/src/opentau/policies/pi06/modeling_pi06.py
+++ b/src/opentau/policies/pi06/modeling_pi06.py
@@ -51,7 +51,12 @@ from opentau.policies.pi06.gemma3_with_expert import (
     Gemma3WithExpertModel,
 )
 from opentau.policies.pretrained import PreTrainedPolicy, T
-from opentau.policies.utils import PerSampleLoss, ce_per_sample, flow_matching_masked_mse
+from opentau.policies.utils import (
+    PerSampleLoss,
+    assert_gemma3_input_resolution,
+    ce_per_sample,
+    flow_matching_masked_mse,
+)
 from opentau.utils.accelerate_utils import get_proc_accelerator
 from opentau.utils.utils import get_safe_dtype
 
@@ -834,16 +839,9 @@ class PI06FlowMatching(nn.Module):
         # the Gemma3 backbone (Gemma3MultiModalProjector hard-codes a square
         # patch grid); fail fast with the real diagnosis instead of a reshape
         # crash inside the projector at first forward.
-        vision_cfg = self.gemma3_with_expert._vision_tower().config
-        expected_hw = config.input_image_size
-        if expected_hw is not None and tuple(expected_hw) != (vision_cfg.image_size, vision_cfg.image_size):
-            raise ValueError(
-                f"input resolution {tuple(expected_hw)} (resize_imgs_with_padding, or the bound "
-                f"image-feature resolution when it is null) != the Gemma 3 vision tower's "
-                f"image_size ({vision_cfg.image_size}). Native resolutions are not yet supported "
-                "for the Gemma3-family policies; set resize_imgs_with_padding (and resolution) to "
-                f"({vision_cfg.image_size}, {vision_cfg.image_size})."
-            )
+        assert_gemma3_input_resolution(
+            config.input_image_size, self.gemma3_with_expert._vision_tower().config.image_size
+        )
 
         # Action projections stay float32 for numerical stability; they're small.
         self.action_in_proj = nn.Linear(self.config.max_action_dim, self.config.proj_width)

--- a/src/opentau/policies/pi07/high_level_planner/modeling_pi07_high_level.py
+++ b/src/opentau/policies/pi07/high_level_planner/modeling_pi07_high_level.py
@@ -145,11 +145,16 @@ def resize_with_pad(img: Tensor, width: int, height: int, pad_value: int = -1) -
     Raises:
         ValueError: If the input image tensor does not have 4 dimensions.
     """
-    # assume no-op when width height fits already
     if img.ndim != 4:
         raise ValueError(f"(b,c,h,w) expected, but {img.shape}")
 
     cur_height, cur_width = img.shape[2:]
+
+    # Explicit no-op when the input already matches the target — native-
+    # resolution inputs must pass through bit-identical, not survive a
+    # same-size bilinear round trip.
+    if (cur_height, cur_width) == (height, width):
+        return img
 
     ratio = max(cur_width / width, cur_height / height)
     resized_height = int(cur_height / ratio)
@@ -652,7 +657,11 @@ class PI07HighLevelPlannerPolicy(PreTrainedPolicy):
             img = batch[key]
 
             if self.config.resize_imgs_with_padding is not None:
-                img = resize_with_pad(img, *self.config.resize_imgs_with_padding, pad_value=0)
+                # The config tuple is (height, width); the function signature is
+                # (width, height) — unpack explicitly so non-square targets are not
+                # transposed (invisible at the square defaults).
+                target_h, target_w = self.config.resize_imgs_with_padding
+                img = resize_with_pad(img, width=target_w, height=target_h, pad_value=0)
 
             # Normalize from range [0,1] to [-1,1] as expected by siglip
             img = img * 2.0 - 1.0
@@ -923,6 +932,21 @@ class PI07HighLevelPlannerModel(nn.Module):
 
         self.config.vlm_config.discrete_action_vocab_size = discrete_action_vocab_size
         self.gemma3_with_expert = Gemma3WithExpertModel(self.config.vlm_config)
+
+        # Native (non-square-448) input resolutions are not yet supported on
+        # the Gemma3 backbone (Gemma3MultiModalProjector hard-codes a square
+        # patch grid); fail fast with the real diagnosis instead of a reshape
+        # crash inside the projector at first forward.
+        vision_cfg = self.gemma3_with_expert._vision_tower().config
+        expected_hw = config.input_image_size
+        if expected_hw is not None and tuple(expected_hw) != (vision_cfg.image_size, vision_cfg.image_size):
+            raise ValueError(
+                f"input resolution {tuple(expected_hw)} (resize_imgs_with_padding, or the bound "
+                f"image-feature resolution when it is null) != the Gemma 3 vision tower's "
+                f"image_size ({vision_cfg.image_size}). Native resolutions are not yet supported "
+                "for the Gemma3-family policies; set resize_imgs_with_padding (and resolution) to "
+                f"({vision_cfg.image_size}, {vision_cfg.image_size})."
+            )
 
         self.language_tokenizer = AutoTokenizer.from_pretrained("google/gemma-3-4b-pt")
 

--- a/src/opentau/policies/pi07/high_level_planner/modeling_pi07_high_level.py
+++ b/src/opentau/policies/pi07/high_level_planner/modeling_pi07_high_level.py
@@ -44,6 +44,7 @@ from opentau.policies.pi07.high_level_planner.configuration_pi07_high_level impo
     PI07HighLevelPlannerConfig,
 )
 from opentau.policies.pretrained import PreTrainedPolicy, T
+from opentau.policies.utils import assert_gemma3_input_resolution
 from opentau.utils.accelerate_utils import get_proc_accelerator
 
 
@@ -937,16 +938,9 @@ class PI07HighLevelPlannerModel(nn.Module):
         # the Gemma3 backbone (Gemma3MultiModalProjector hard-codes a square
         # patch grid); fail fast with the real diagnosis instead of a reshape
         # crash inside the projector at first forward.
-        vision_cfg = self.gemma3_with_expert._vision_tower().config
-        expected_hw = config.input_image_size
-        if expected_hw is not None and tuple(expected_hw) != (vision_cfg.image_size, vision_cfg.image_size):
-            raise ValueError(
-                f"input resolution {tuple(expected_hw)} (resize_imgs_with_padding, or the bound "
-                f"image-feature resolution when it is null) != the Gemma 3 vision tower's "
-                f"image_size ({vision_cfg.image_size}). Native resolutions are not yet supported "
-                "for the Gemma3-family policies; set resize_imgs_with_padding (and resolution) to "
-                f"({vision_cfg.image_size}, {vision_cfg.image_size})."
-            )
+        assert_gemma3_input_resolution(
+            config.input_image_size, self.gemma3_with_expert._vision_tower().config.image_size
+        )
 
         self.language_tokenizer = AutoTokenizer.from_pretrained("google/gemma-3-4b-pt")
 

--- a/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
@@ -63,7 +63,12 @@ from opentau.policies.pi07.low_level.configuration_pi07_low_level import (
 )
 from opentau.policies.pi07.video_encoder import SpaceTimeSiglipVideoEncoder
 from opentau.policies.pretrained import PreTrainedPolicy, ProjectionRemapError, T
-from opentau.policies.utils import PerSampleLoss, ce_per_sample, flow_matching_masked_mse
+from opentau.policies.utils import (
+    PerSampleLoss,
+    assert_gemma3_input_resolution,
+    ce_per_sample,
+    flow_matching_masked_mse,
+)
 from opentau.utils.accelerate_utils import get_proc_accelerator
 from opentau.utils.utils import get_safe_dtype
 
@@ -1403,16 +1408,9 @@ class PI07LowLevelFlowMatching(nn.Module):
         # so a non-default grid would crash deep inside the projector with an
         # unrelated-looking reshape error. Fail here with the real diagnosis.
         # (The PaliGemma-family policies support native resolutions.)
-        vision_cfg = self.gemma3_with_expert._vision_tower().config
-        expected_hw = config.input_image_size
-        if expected_hw is not None and tuple(expected_hw) != (vision_cfg.image_size, vision_cfg.image_size):
-            raise ValueError(
-                f"input resolution {tuple(expected_hw)} (resize_imgs_with_padding, or the bound "
-                f"image-feature resolution when it is null) != the Gemma 3 vision tower's "
-                f"image_size ({vision_cfg.image_size}). Native resolutions are not yet supported "
-                "for the Gemma3-family policies; set resize_imgs_with_padding (and resolution) to "
-                f"({vision_cfg.image_size}, {vision_cfg.image_size})."
-            )
+        assert_gemma3_input_resolution(
+            config.input_image_size, self.gemma3_with_expert._vision_tower().config.image_size
+        )
 
         self.video_encoder = SpaceTimeSiglipVideoEncoder(
             vision_tower=self.gemma3_with_expert._vision_tower(),

--- a/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
@@ -275,6 +275,12 @@ def resize_with_pad(img: Tensor, width: int, height: int, pad_value: int = -1) -
 
     cur_height, cur_width = img.shape[2:]
 
+    # Explicit no-op when the input already matches the target — native-
+    # resolution inputs must pass through bit-identical, not survive a
+    # same-size bilinear round trip.
+    if (cur_height, cur_width) == (height, width):
+        return img
+
     ratio = max(cur_width / width, cur_height / height)
     resized_height = int(cur_height / ratio)
     resized_width = int(cur_width / ratio)
@@ -1062,7 +1068,11 @@ class PI07LowLevelPolicy(PreTrainedPolicy):
             if self.config.resize_imgs_with_padding is not None:
                 b, t_frames = vid.shape[:2]
                 flat = rearrange(vid, "B T C H W -> (B T) C H W")
-                flat = resize_with_pad(flat, *self.config.resize_imgs_with_padding, pad_value=0)
+                # The config tuple is (height, width); the function signature is
+                # (width, height) — unpack explicitly so non-square targets are not
+                # transposed (invisible at the square defaults).
+                target_h, target_w = self.config.resize_imgs_with_padding
+                flat = resize_with_pad(flat, width=target_w, height=target_h, pad_value=0)
                 vid = rearrange(flat, "(B T) C H W -> B T C H W", B=b, T=t_frames)
 
             bsize = vid.shape[0]
@@ -1198,7 +1208,11 @@ class PI07LowLevelPolicy(PreTrainedPolicy):
             subgoal_img = batch[key]
 
             if self.config.resize_imgs_with_padding is not None:
-                subgoal_img = resize_with_pad(subgoal_img, *self.config.resize_imgs_with_padding, pad_value=0)
+                # The config tuple is (height, width); the function signature is
+                # (width, height) — unpack explicitly so non-square targets are not
+                # transposed (invisible at the square defaults).
+                target_h, target_w = self.config.resize_imgs_with_padding
+                subgoal_img = resize_with_pad(subgoal_img, width=target_w, height=target_h, pad_value=0)
 
             # Normalize from range [0,1] to [-1,1] as expected by siglip
             subgoal_img = subgoal_img * 2.0 - 1.0
@@ -1382,6 +1396,23 @@ class PI07LowLevelFlowMatching(nn.Module):
             )
 
         vlm_hidden_size = self.gemma3_with_expert.config.gemma3_config.text_config.hidden_size
+
+        # Native (non-square-448) input resolutions are not yet supported on
+        # the Gemma3 backbone: Gemma3MultiModalProjector hard-codes a square
+        # `patches_per_image = image_size // patch_size` reshape + avg-pool,
+        # so a non-default grid would crash deep inside the projector with an
+        # unrelated-looking reshape error. Fail here with the real diagnosis.
+        # (The PaliGemma-family policies support native resolutions.)
+        vision_cfg = self.gemma3_with_expert._vision_tower().config
+        expected_hw = config.input_image_size
+        if expected_hw is not None and tuple(expected_hw) != (vision_cfg.image_size, vision_cfg.image_size):
+            raise ValueError(
+                f"input resolution {tuple(expected_hw)} (resize_imgs_with_padding, or the bound "
+                f"image-feature resolution when it is null) != the Gemma 3 vision tower's "
+                f"image_size ({vision_cfg.image_size}). Native resolutions are not yet supported "
+                "for the Gemma3-family policies; set resize_imgs_with_padding (and resolution) to "
+                f"({vision_cfg.image_size}, {vision_cfg.image_size})."
+            )
 
         self.video_encoder = SpaceTimeSiglipVideoEncoder(
             vision_tower=self.gemma3_with_expert._vision_tower(),

--- a/src/opentau/policies/pi07/video_encoder.py
+++ b/src/opentau/policies/pi07/video_encoder.py
@@ -75,6 +75,7 @@ from transformers.models.siglip.modeling_siglip import (
 # multi_modal_projector. Our forward must match that patched behavior for
 # single-frame invariance to hold.
 import opentau.utils.transformers_patch  # noqa: F401
+from opentau.utils.vision_utils import pad_to_patch_multiple, patch_grid_hw
 
 
 def _build_temporal_sinusoidal_pe(
@@ -485,7 +486,23 @@ class SpaceTimeSiglipVideoEncoder(nn.Module):
         max_num_frames: int,
         spacetime_layer_stride: int = 4,
         gradient_checkpointing: bool = False,
+        expected_image_size: tuple[int, int] | None = None,
     ):
+        """See the class docstring; only the non-obvious arg is documented here.
+
+        Args:
+            expected_image_size: ``(H, W)`` of the frames each forward will
+                receive. ``None`` (default) means the SigLIP config's square
+                ``image_size`` — the historical behaviour. A non-default value
+                enables native-resolution encoding: frames are padded up to
+                the next ``patch_size`` multiple (so the conv patch embedding
+                never floor-crops pixels) and the pretrained position
+                embeddings are bicubically interpolated to the resulting
+                patch grid. ``num_video_tokens`` then reflects that grid, so
+                every consumer of the token count (skip-path zero fills,
+                temporal-mask expansion, per-layer shape checks) stays
+                consistent by construction.
+        """
         super().__init__()
         if max_num_frames < 1:
             raise ValueError(f"max_num_frames ({max_num_frames}) must be >= 1.")
@@ -510,10 +527,30 @@ class SpaceTimeSiglipVideoEncoder(nn.Module):
         self._vision_tower_ref: list[SiglipVisionModel] = [vision_tower]
         self._multi_modal_projector_ref: list[nn.Module] = [multi_modal_projector]
 
-        # The number of output tokens is fixed by the SigLIP patch grid
-        # (e.g. 224/14 = 16 -> 16*16 = 256 patches for the default config).
+        # The number of output tokens is fixed by the patch grid covering the
+        # expected input resolution (e.g. 224/14 = 16 -> 16*16 = 256 patches
+        # for the default config; 180x320 -> ceil grids 13x23 = 299). Ceiling
+        # division pairs with the forward-time pad_to_patch_multiple so no
+        # pixel is ever floor-cropped by the conv patch embedding.
         vision_cfg = vision_tower.config
-        num_patches = (vision_cfg.image_size // vision_cfg.patch_size) ** 2
+        self.patch_size = vision_cfg.patch_size
+        if expected_image_size is None:
+            expected_image_size = (vision_cfg.image_size, vision_cfg.image_size)
+        self.expected_image_size = tuple(expected_image_size)
+        grid_h, grid_w = patch_grid_hw(*self.expected_image_size, self.patch_size)
+        num_patches = grid_h * grid_w
+        # Interpolate the pretrained position embeddings only when the grid
+        # differs from the config grid: at the config resolution the vanilla
+        # fixed-table add is used, keeping the default path bit-identical
+        # (and trace-stable — the flag is a construction-time constant).
+        default_grid = patch_grid_hw(vision_cfg.image_size, vision_cfg.image_size, self.patch_size)
+        self._interpolate_pos_encoding = (grid_h, grid_w) != default_grid
+        # (grid_h, grid_w) of the patch grid — exposed for consumers that
+        # need the 2-D layout, not just the flat token count (e.g. pi05_mem's
+        # interleaved MRoPE, which assigns per-patch 2-D positions and must
+        # know whether the grid is actually square — a non-square grid can
+        # still have a perfect-square token count, e.g. 16x4 = 64).
+        self.grid_hw = (grid_h, grid_w)
         self.num_video_tokens = num_patches
         self.siglip_hidden_size = vision_cfg.hidden_size
 
@@ -605,7 +642,8 @@ class SpaceTimeSiglipVideoEncoder(nn.Module):
         Args:
             video: ``(B, T, C, H, W)`` pixel values in ``[0, 1]``, with
                 ``1 <= T <= max_num_frames``, ``C == 3``, and spatial size
-                matching the SigLIP config (224x224 by default).
+                matching ``expected_image_size`` (the SigLIP config's square
+                ``image_size`` unless overridden at construction).
             obs_history_is_pad: Optional ``(B, T)`` bool mask where ``True``
                 marks padded history frames. Padded frames are blocked in
                 the temporal attention so the current frame cannot read
@@ -628,6 +666,14 @@ class SpaceTimeSiglipVideoEncoder(nn.Module):
                 f"Expected T <= max_num_frames ({self.max_num_frames}); got {t}. "
                 "Reinstantiate the encoder with a larger max_num_frames."
             )
+        if (h, w) != self.expected_image_size:
+            raise ValueError(
+                f"Video frames are {(h, w)} but the encoder was constructed for "
+                f"{self.expected_image_size}. The policy's `resize_imgs_with_padding` "
+                "(or, when it is None, the bound image-feature resolution) must match "
+                "the frames actually fed to the encoder — a mismatch here would desync "
+                "the precomputed token count from the real patch grid."
+            )
 
         # SigLIP expects pixel values in [-1, 1]. The dataset loader yields
         # [0, 1]; rescale here (keeps prepare_videos producer-agnostic).
@@ -636,8 +682,14 @@ class SpaceTimeSiglipVideoEncoder(nn.Module):
         # Flatten time into batch for the SigLIP pipeline.
         flat = rearrange(video, "b t c h w -> (b t) c h w")
 
-        # Patch embedding + learned spatial position embedding.
-        hidden = self.vision_tower.vision_model.embeddings(flat)
+        # Pad up to the next patch multiple (bottom/right, black in [-1, 1])
+        # so the stride-`patch_size` conv never floor-crops pixels, then patch
+        # embedding + spatial position embedding (interpolated to the actual
+        # grid when it differs from the config grid; no-op at the default).
+        flat = pad_to_patch_multiple(flat, self.patch_size, pad_value=-1.0)
+        hidden = self.vision_tower.vision_model.embeddings(
+            flat, interpolate_pos_encoding=self._interpolate_pos_encoding
+        )
 
         # Build temporal attention mask. Skipped at T=1 because the wrapper's
         # T=1 short-circuit bypasses temporal attention entirely.

--- a/src/opentau/policies/pi07/video_encoder.py
+++ b/src/opentau/policies/pi07/video_encoder.py
@@ -501,7 +501,14 @@ class SpaceTimeSiglipVideoEncoder(nn.Module):
                 patch grid. ``num_video_tokens`` then reflects that grid, so
                 every consumer of the token count (skip-path zero fills,
                 temporal-mask expansion, per-layer shape checks) stays
-                consistent by construction.
+                consistent by construction. Determinism caveat: with
+                ``freeze_vision_encoder=False`` the interpolation backprops
+                into the trainable position-embedding table every step, and
+                CUDA's backward for bicubic ``F.interpolate`` is
+                non-deterministic (atomicAdd) — GPU native-resolution runs
+                with an *unfrozen* vision tower are therefore not
+                bit-reproducible. The default (frozen tower) is unaffected,
+                as is the config-resolution path (no interpolation).
         """
         super().__init__()
         if max_num_frames < 1:

--- a/src/opentau/policies/pi07_paligemma/high_level_planner/configuration_pi07_high_level.py
+++ b/src/opentau/policies/pi07_paligemma/high_level_planner/configuration_pi07_high_level.py
@@ -50,7 +50,13 @@ class PI07HighLevelPlannerConfig(PreTrainedConfig):
         max_state_dim: Maximum dimension for state vectors. Shorter vectors
             are zero-padded. Defaults to 32.
         resize_imgs_with_padding: Target ``(height, width)`` for image
-            resizing with aspect-ratio-preserving padding. Defaults to
+            resizing with aspect-ratio-preserving padding. Must match the
+            resolution of the input images — training fails fast on a
+            mismatch (``skip_input_resolution_check=true`` downgrades it to
+            a warning for legacy checkpoints); ``null`` passes frames
+            through at the input resolution. Non-224 values run natively
+            (pad to the next patch multiple + interpolated position
+            embeddings), with no letterboxing to 224x224. Defaults to
             ``(224, 224)``.
         empty_cameras: Number of empty (zero-filled) camera inputs to add.
             Defaults to 0.

--- a/src/opentau/policies/pi07_paligemma/high_level_planner/modeling_pi07_high_level.py
+++ b/src/opentau/policies/pi07_paligemma/high_level_planner/modeling_pi07_high_level.py
@@ -149,11 +149,16 @@ def resize_with_pad(img: Tensor, width: int, height: int, pad_value: int = -1) -
     Raises:
         ValueError: If the input image tensor does not have 4 dimensions.
     """
-    # assume no-op when width height fits already
     if img.ndim != 4:
         raise ValueError(f"(b,c,h,w) expected, but {img.shape}")
 
     cur_height, cur_width = img.shape[2:]
+
+    # Explicit no-op when the input already matches the target — native-
+    # resolution inputs must pass through bit-identical, not survive a
+    # same-size bilinear round trip.
+    if (cur_height, cur_width) == (height, width):
+        return img
 
     ratio = max(cur_width / width, cur_height / height)
     resized_height = int(cur_height / ratio)
@@ -639,7 +644,11 @@ class PI07HighLevelPlannerPolicy(PreTrainedPolicy):
             img = batch[key]
 
             if self.config.resize_imgs_with_padding is not None:
-                img = resize_with_pad(img, *self.config.resize_imgs_with_padding, pad_value=0)
+                # The config tuple is (height, width); the function signature is
+                # (width, height) — unpack explicitly so non-square targets are not
+                # transposed (invisible at the square defaults).
+                target_h, target_w = self.config.resize_imgs_with_padding
+                img = resize_with_pad(img, width=target_w, height=target_h, pad_value=0)
 
             # Normalize from range [0,1] to [-1,1] as expected by siglip
             img = img * 2.0 - 1.0

--- a/src/opentau/policies/pi07_paligemma/low_level/configuration_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/configuration_pi07_low_level.py
@@ -53,7 +53,14 @@ class PI07PaligemmaLowLevelConfig(PreTrainedConfig):
         max_state_dim: Maximum dimension for state vectors. Shorter vectors are padded. Defaults to 32.
         max_action_dim: Maximum dimension for action vectors. Shorter vectors are padded. Defaults to 32.
         resize_imgs_with_padding: Target size (height, width) for image resizing with padding.
-            Defaults to (224, 224).
+            Must match the resolution of the input images (``TrainPipelineConfig.resolution`` /
+            the bound image features) — training fails fast on a mismatch, since the policy
+            would silently letterbox every frame a second time
+            (``skip_input_resolution_check=true`` downgrades that to a warning for legacy
+            checkpoints). ``null`` passes frames through at the input resolution. Non-224
+            values are supported natively: frames are padded up to the next patch multiple
+            and the SigLIP position embeddings are interpolated to the resulting grid, so no
+            pixels are cropped and no letterboxing to 224x224 occurs. Defaults to (224, 224).
         empty_cameras: Number of empty camera inputs to add. Used for specific adaptations like
             Aloha simulation. Defaults to 0.
         prompt_max_length: Maximum length for tokenizer. Defaults to 256.

--- a/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
@@ -82,10 +82,11 @@ class ContextItem:
             ``action``: noisy actions ``(B, chunk_size, max_action_dim)``.
         item_type: Dispatch key for which embedding path to take.
         pad_mask: Padding mask. ``(B,)`` per-sample is allowed for
-            ``video``/``image`` (the model expands it to
-            ``(B, num_image_tokens)``). All other types must pass ``(B, L)``
-            matching the embedded sequence length. ``True`` = real,
-            ``False`` = padded.
+            ``video``/``image`` (the model expands it to ``(B, n_tokens)``
+            with ``n_tokens`` the grid-derived
+            ``video_encoder.num_video_tokens``). All other types must pass
+            ``(B, L)`` matching the embedded sequence length. ``True`` =
+            real, ``False`` = padded.
         attention: 1-D attention pattern for this block:
             - ``"continue"``: ``[0]*L`` — token continues the previous
               block's attention scope (bidirectional with everything before).
@@ -2096,9 +2097,11 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
 
         The pad mask is broadcast/expanded so the returned mask matches
         the embedded sequence length: per-sample ``(B,)`` is allowed for
-        ``video`` (expanded to ``(B, num_video_tokens)``) and ``image``
-        (expanded to ``(B, num_image_tokens)``); all other types pass
-        through ``(B, L)`` unchanged.
+        ``video`` and ``image``, both expanded to
+        ``(B, video_encoder.num_video_tokens)`` — subgoal images share the
+        video encoder's tower and input resolution, so their token counts
+        agree by construction; all other types pass through ``(B, L)``
+        unchanged.
         """
         t = item.item_type
         if t == "text":

--- a/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
@@ -273,11 +273,16 @@ def resize_with_pad(img: Tensor, width: int, height: int, pad_value: int = -1) -
     Raises:
         ValueError: If the input image tensor does not have 4 dimensions.
     """
-    # assume no-op when width height fits already
     if img.ndim != 4:
         raise ValueError(f"(b,c,h,w) expected, but {img.shape}")
 
     cur_height, cur_width = img.shape[2:]
+
+    # Explicit no-op when the input already matches the target — native-
+    # resolution inputs must pass through bit-identical, not survive a
+    # same-size bilinear round trip.
+    if (cur_height, cur_width) == (height, width):
+        return img
 
     ratio = max(cur_width / width, cur_height / height)
     resized_height = int(cur_height / ratio)
@@ -1413,8 +1418,9 @@ class PI07PaligemmaLowLevelPolicy(PreTrainedPolicy):
 
             if self.config.resize_imgs_with_padding is not None:
                 b, t_frames = vid.shape[:2]
+                target_h, target_w = self.config.resize_imgs_with_padding
                 flat = rearrange(vid, "B T C H W -> (B T) C H W")
-                flat = resize_with_pad(flat, *self.config.resize_imgs_with_padding, pad_value=0)
+                flat = resize_with_pad(flat, width=target_w, height=target_h, pad_value=0)
                 vid = rearrange(flat, "(B T) C H W -> B T C H W", B=b, T=t_frames)
 
             bsize = vid.shape[0]
@@ -1500,7 +1506,10 @@ class PI07PaligemmaLowLevelPolicy(PreTrainedPolicy):
             # the fill value inert (these tokens are masked out of attention), and
             # yield the same prefix as training with ``subgoal_is_pad=True``
             # everywhere (comma + ``Subgoal:`` + image tokens fully masked out).
-            h, w = self.config.resize_imgs_with_padding or (224, 224)
+            # Use the resolution the tower actually receives so the fabricated
+            # zeros embed to the same token count as real subgoals (the
+            # prefix length must not depend on which keys the batch carries).
+            h, w = self.config.input_image_size or (224, 224)
             for _ in subgoal_keys:
                 subgoal_images.append(torch.zeros(bsize, 3, h, w, device=device))
                 subgoal_img_masks.append(torch.zeros(bsize, dtype=torch.bool, device=device))
@@ -1513,7 +1522,8 @@ class PI07PaligemmaLowLevelPolicy(PreTrainedPolicy):
             subgoal_img = batch[key]  # (B, C, H, W)
 
             if self.config.resize_imgs_with_padding is not None:
-                subgoal_img = resize_with_pad(subgoal_img, *self.config.resize_imgs_with_padding, pad_value=0)
+                target_h, target_w = self.config.resize_imgs_with_padding
+                subgoal_img = resize_with_pad(subgoal_img, width=target_w, height=target_h, pad_value=0)
 
             # Normalize from [0, 1] to [-1, 1] as expected by SigLIP.
             subgoal_img = subgoal_img * 2.0 - 1.0  # (B, C, H, W)
@@ -1909,6 +1919,11 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
             max_num_frames=self.config.n_obs_steps,
             spacetime_layer_stride=self.config.spacetime_layer_stride,
             gradient_checkpointing=self.config.gradient_checkpointing,
+            # (H, W) the tower will actually receive: the resize target if
+            # set, else the bound image-feature resolution. Non-default
+            # values enable native-resolution encoding (pad-to-patch-multiple
+            # + interpolated position embeddings) instead of letterboxing.
+            expected_image_size=self.config.input_image_size,
         )
 
         vlm_hidden_size = self.paligemma_with_expert.config.paligemma_config.text_config.hidden_size
@@ -2129,10 +2144,15 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
             if run_image_tower:
                 emb = self.paligemma_with_expert.embed_image(image).to(dtype=dtype)
             else:
+                # Subgoal images share the video encoder's tower and input
+                # resolution, so its grid-derived token count is exactly what
+                # embed_image would emit — the run and skip paths MUST agree
+                # or ranks desync (the historical hard-coded
+                # `num_image_tokens=256` only held at 224x224).
                 pg_text_cfg = self.paligemma_with_expert.config.paligemma_config.text_config
                 emb = torch.zeros(
                     image.shape[0],
-                    pg_text_cfg.num_image_tokens,
+                    self.video_encoder.num_video_tokens,
                     pg_text_cfg.hidden_size,
                     device=image.device,
                     dtype=dtype,

--- a/src/opentau/policies/pretrained.py
+++ b/src/opentau/policies/pretrained.py
@@ -287,6 +287,17 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
                 **kwargs,
             )
         model_id = str(pretrained_name_or_path)
+
+        # Warn (never raise) when the checkpoint's resize target disagrees
+        # with its bound image features — the load-time symptom of a legacy
+        # checkpoint trained with the in-policy double letterbox. Placed here
+        # (mirroring `_check_norm_stats_loaded` below) so direct
+        # `from_pretrained` callers — the gRPC server, inference/export
+        # scripts, notebooks — get the same diagnostic as `make_policy`'s
+        # eval path; the strict train-time enforcement lives in
+        # `make_policy` (ds_meta path) and `TrainPipelineConfig.validate()`.
+        config.validate_input_resolution(strict=False)
+
         instance = cls(config, **kwargs)
         if os.path.isdir(model_id):
             print("Loading weights from local directory")

--- a/src/opentau/policies/utils.py
+++ b/src/opentau/policies/utils.py
@@ -32,6 +32,36 @@ from einops import rearrange, reduce
 from torch import Tensor, nn
 
 
+def assert_gemma3_input_resolution(input_image_size: tuple[int, int] | None, tower_image_size: int) -> None:
+    """Fail fast when a Gemma3-family policy would run at a native resolution.
+
+    ``Gemma3MultiModalProjector`` hard-codes a square ``patches_per_image =
+    image_size // patch_size`` reshape + avg-pool, so a non-default patch
+    grid crashes deep inside the projector with an unrelated-looking reshape
+    error. The pi06/pi07 constructors call this to surface the real
+    diagnosis instead. (The PaliGemma-family policies support native
+    resolutions.)
+
+    Args:
+        input_image_size: ``(H, W)`` the vision tower will receive
+            (``PreTrainedConfig.input_image_size``), or ``None`` when
+            underivable (no check possible).
+        tower_image_size: The Gemma 3 SigLIP config's square ``image_size``.
+
+    Raises:
+        ValueError: When ``input_image_size`` is known and differs from the
+            tower's square resolution.
+    """
+    if input_image_size is not None and tuple(input_image_size) != (tower_image_size, tower_image_size):
+        raise ValueError(
+            f"input resolution {tuple(input_image_size)} (resize_imgs_with_padding, or the bound "
+            f"image-feature resolution when it is null) != the Gemma 3 vision tower's "
+            f"image_size ({tower_image_size}). Native resolutions are not yet supported "
+            "for the Gemma3-family policies; set resize_imgs_with_padding (and resolution) to "
+            f"({tower_image_size}, {tower_image_size})."
+        )
+
+
 def populate_queues(
     queues: dict[str, deque], batch: dict[str, torch.Tensor], exclude_keys: list[str] | None = None
 ) -> dict[str, deque]:

--- a/src/opentau/policies/value/modeling_value.py
+++ b/src/opentau/policies/value/modeling_value.py
@@ -96,11 +96,16 @@ def resize_with_pad(img, width, height, pad_value=-1):
     Raises:
         ValueError: If image dimensions are not 4D (B, C, H, W).
     """
-    # assume no-op when width height fits already
     if img.ndim != 4:
         raise ValueError(f"(b,c,h,w) expected, but {img.shape}")
 
     cur_height, cur_width = img.shape[2:]
+
+    # Explicit no-op when the input already matches the target — native-
+    # resolution inputs must pass through bit-identical, not survive a
+    # same-size bilinear round trip.
+    if (cur_height, cur_width) == (height, width):
+        return img
 
     ratio = max(cur_width / width, cur_height / height)
     resized_height = int(cur_height / ratio)
@@ -497,7 +502,11 @@ class ValueFunction(PreTrainedPolicy):
             img = batch[key]
 
             if self.config.resize_imgs_with_padding is not None:
-                img = resize_with_pad(img, *self.config.resize_imgs_with_padding, pad_value=0)
+                # The config tuple is (height, width); the function signature is
+                # (width, height) — unpack explicitly so non-square targets are not
+                # transposed (invisible at the square defaults).
+                target_h, target_w = self.config.resize_imgs_with_padding
+                img = resize_with_pad(img, width=target_w, height=target_h, pad_value=0)
 
             # Normalize from range [0,1] to [-1,1] as expected by siglip
             img = img * 2.0 - 1.0

--- a/src/opentau/scripts/eval.py
+++ b/src/opentau/scripts/eval.py
@@ -982,6 +982,36 @@ def eval_main(cfg: TrainPipelineConfig):
 
     logging.info("Making policy.")
 
+    # ``preprocess_observation`` delivers env frames at exactly
+    # ``cfg.resolution``; the policy's vision tower expects
+    # ``cfg.policy.input_image_size`` (the resize target, or — when
+    # ``resize_imgs_with_padding`` is null — the resolution the checkpoint's
+    # image features were bound at). A mismatch with a resize target set
+    # merely reproduces the checkpoint's own (legacy) double letterbox, so it
+    # only warns inside ``make_policy``; with no resize target the tower
+    # would silently run at the wrong geometry, so fail fast here.
+    expected_hw = cfg.policy.input_image_size
+    if (
+        expected_hw is not None
+        and tuple(cfg.resolution) != tuple(expected_hw)
+        and getattr(cfg.policy, "resize_imgs_with_padding", None) is None
+    ):
+        if cfg.policy.skip_input_resolution_check:
+            logging.warning(
+                f"resolution={tuple(cfg.resolution)} != the policy's bound input resolution "
+                f"{tuple(expected_hw)} with resize_imgs_with_padding=null; env frames will reach "
+                "the vision tower at a different geometry than training. Proceeding because "
+                "skip_input_resolution_check=true."
+            )
+        else:
+            raise ValueError(
+                f"resolution={tuple(cfg.resolution)} but the policy was trained at "
+                f"{tuple(expected_hw)} with resize_imgs_with_padding=null (native pass-through): "
+                "env frames would reach the vision tower at the wrong geometry with nothing to "
+                "correct them. Set resolution to match the checkpoint, or set "
+                "policy.skip_input_resolution_check=true to proceed anyway."
+            )
+
     policy = make_policy(cfg=cfg.policy)
     policy.to(torch.bfloat16)
     policy = accelerator.prepare(policy)

--- a/src/opentau/scripts/eval.py
+++ b/src/opentau/scripts/eval.py
@@ -946,6 +946,51 @@ def _eval_uses_sharded_params(accelerator: Accelerator) -> bool:
     return False
 
 
+def validate_eval_input_resolution(cfg: TrainPipelineConfig) -> None:
+    """Fail fast when eval frames would reach the vision tower at the wrong geometry.
+
+    ``preprocess_observation`` delivers env frames at exactly
+    ``cfg.resolution``; the policy's vision tower expects
+    ``cfg.policy.input_image_size`` (the resize target, or — when
+    ``resize_imgs_with_padding`` is null — the resolution the checkpoint's
+    image features were bound at). A mismatch with a resize target set merely
+    reproduces the checkpoint's own (legacy) double letterbox, so it only
+    warns inside ``make_policy``; with no resize target the tower would
+    silently run at the wrong geometry, so this raises instead
+    (``policy.skip_input_resolution_check=true`` downgrades it to a warning).
+
+    Args:
+        cfg: The eval pipeline config (``resolution`` + ``policy``).
+
+    Raises:
+        ValueError: When ``resize_imgs_with_padding`` is ``None``, the
+            policy's bound input resolution is known, ``cfg.resolution``
+            differs from it, and the escape hatch is not set.
+    """
+    expected_hw = cfg.policy.input_image_size
+    if (
+        expected_hw is None
+        or tuple(cfg.resolution) == tuple(expected_hw)
+        or getattr(cfg.policy, "resize_imgs_with_padding", None) is not None
+    ):
+        return
+    if cfg.policy.skip_input_resolution_check:
+        logging.warning(
+            f"resolution={tuple(cfg.resolution)} != the policy's bound input resolution "
+            f"{tuple(expected_hw)} with resize_imgs_with_padding=null; env frames will reach "
+            "the vision tower at a different geometry than training. Proceeding because "
+            "skip_input_resolution_check=true."
+        )
+        return
+    raise ValueError(
+        f"resolution={tuple(cfg.resolution)} but the policy was trained at "
+        f"{tuple(expected_hw)} with resize_imgs_with_padding=null (native pass-through): "
+        "env frames would reach the vision tower at the wrong geometry with nothing to "
+        "correct them. Set resolution to match the checkpoint, or set "
+        "policy.skip_input_resolution_check=true to proceed anyway."
+    )
+
+
 @parser.wrap()
 def eval_main(cfg: TrainPipelineConfig):
     accelerator = Accelerator()
@@ -982,35 +1027,7 @@ def eval_main(cfg: TrainPipelineConfig):
 
     logging.info("Making policy.")
 
-    # ``preprocess_observation`` delivers env frames at exactly
-    # ``cfg.resolution``; the policy's vision tower expects
-    # ``cfg.policy.input_image_size`` (the resize target, or — when
-    # ``resize_imgs_with_padding`` is null — the resolution the checkpoint's
-    # image features were bound at). A mismatch with a resize target set
-    # merely reproduces the checkpoint's own (legacy) double letterbox, so it
-    # only warns inside ``make_policy``; with no resize target the tower
-    # would silently run at the wrong geometry, so fail fast here.
-    expected_hw = cfg.policy.input_image_size
-    if (
-        expected_hw is not None
-        and tuple(cfg.resolution) != tuple(expected_hw)
-        and getattr(cfg.policy, "resize_imgs_with_padding", None) is None
-    ):
-        if cfg.policy.skip_input_resolution_check:
-            logging.warning(
-                f"resolution={tuple(cfg.resolution)} != the policy's bound input resolution "
-                f"{tuple(expected_hw)} with resize_imgs_with_padding=null; env frames will reach "
-                "the vision tower at a different geometry than training. Proceeding because "
-                "skip_input_resolution_check=true."
-            )
-        else:
-            raise ValueError(
-                f"resolution={tuple(cfg.resolution)} but the policy was trained at "
-                f"{tuple(expected_hw)} with resize_imgs_with_padding=null (native pass-through): "
-                "env frames would reach the vision tower at the wrong geometry with nothing to "
-                "correct them. Set resolution to match the checkpoint, or set "
-                "policy.skip_input_resolution_check=true to proceed anyway."
-            )
+    validate_eval_input_resolution(cfg)
 
     policy = make_policy(cfg=cfg.policy)
     policy.to(torch.bfloat16)

--- a/src/opentau/utils/transformers_patch.py
+++ b/src/opentau/utils/transformers_patch.py
@@ -25,6 +25,8 @@ from transformers.models.gemma import modeling_gemma
 from transformers.models.gemma.configuration_gemma import GemmaConfig
 from transformers.models.paligemma.modeling_paligemma import PaliGemmaModel
 
+from opentau.utils.vision_utils import pad_to_patch_multiple, patch_grid_hw
+
 # Monkey patch __init__ of GemmaConfig to fix or modify its behavior as needed.
 
 _original_gemma_config_init = GemmaConfig.__init__
@@ -259,15 +261,32 @@ modeling_gemma.GemmaPreTrainedModel._init_weights = patched_gemma_pretrained_mod
 def patched_paligemma_model_get_image_features(self, pixel_values: torch.FloatTensor) -> torch.Tensor:
     """Obtains image last hidden states from the vision tower and apply multimodal projection.
 
+    Two deviations from stock HuggingFace:
+
+    - Drops the ``/ sqrt(text_config.hidden_size)`` scaling applied after the
+      multi-modal projector (matching the original Pi0 fork).
+    - Supports native input resolutions. Stock SigLIP silently floor-crops any
+      sub-patch remainder in its stride-``patch_size`` conv (e.g. 180×320 with
+      patch 14 loses 12 pixel rows and columns) and then fails on the fixed
+      224×224 position-embedding table. Here the pixels are padded up to the
+      next patch multiple (bottom/right, black in the ``[-1, 1]`` input range)
+      and ``interpolate_pos_encoding`` is enabled whenever the resulting patch
+      grid differs from the config grid. At the config resolution (224×224)
+      both steps are no-ops and the output is bit-identical to before.
+
     Args:
         self: The PaliGemmaModel instance.
-        pixel_values: The tensors corresponding to the input images.
-            Shape: (batch_size, channels, height, width).
+        pixel_values: The tensors corresponding to the input images, in
+            ``[-1, 1]``. Shape: (batch_size, channels, height, width).
 
     Returns:
         Image feature tensor of shape (num_images, image_length, embed_dim).
     """
-    image_outputs = self.vision_tower(pixel_values)
+    vision_cfg = self.vision_tower.config
+    pixel_values = pad_to_patch_multiple(pixel_values, vision_cfg.patch_size, pad_value=-1.0)
+    default_grid = patch_grid_hw(vision_cfg.image_size, vision_cfg.image_size, vision_cfg.patch_size)
+    actual_grid = patch_grid_hw(*pixel_values.shape[-2:], vision_cfg.patch_size)
+    image_outputs = self.vision_tower(pixel_values, interpolate_pos_encoding=actual_grid != default_grid)
     selected_image_feature = image_outputs.last_hidden_state
     image_features = self.multi_modal_projector(selected_image_feature)
     return image_features

--- a/src/opentau/utils/transformers_patch.py
+++ b/src/opentau/utils/transformers_patch.py
@@ -273,6 +273,12 @@ def patched_paligemma_model_get_image_features(self, pixel_values: torch.FloatTe
       and ``interpolate_pos_encoding`` is enabled whenever the resulting patch
       grid differs from the config grid. At the config resolution (224×224)
       both steps are no-ops and the output is bit-identical to before.
+      Determinism caveat: when the vision tower is trainable
+      (``freeze_vision_encoder=False``), the interpolation backprops into the
+      position-embedding table and CUDA's bicubic-interpolate backward is
+      non-deterministic (atomicAdd) — GPU native-resolution runs with an
+      unfrozen tower are not bit-reproducible. The default (frozen tower) and
+      the config-resolution path are unaffected.
 
     Args:
         self: The PaliGemmaModel instance.

--- a/src/opentau/utils/vision_utils.py
+++ b/src/opentau/utils/vision_utils.py
@@ -14,9 +14,17 @@
 
 """Vision-tower helpers reused across policies (pi06, pi07, ...).
 
-The current resident is :func:`bilinear_resample_pos_embed`, which adapts
-SigLIP / ViT-style learned position-embedding tables to a different patch
-count when the policy runs the vision tower at a non-published resolution.
+Residents:
+
+- :func:`bilinear_resample_pos_embed` adapts SigLIP / ViT-style learned
+  position-embedding tables to a different patch count when the policy runs
+  the vision tower at a non-published resolution (offline weight surgery).
+- :func:`patch_grid_hw` / :func:`pad_to_patch_multiple` support running the
+  SigLIP tower at native (non-square, non-patch-multiple) input resolutions
+  at forward time: the stride-``patch_size`` conv patch embedding silently
+  floor-crops any sub-patch remainder (e.g. 180×320 with patch 14 drops 12
+  pixel rows and 12 columns), so callers pad up to the next patch multiple
+  and enable ``interpolate_pos_encoding`` instead.
 
 Why this is its own module rather than inline in a policy: π0.6 uses Gemma
 3-4B at 448×448 (1024 patches) but `google/gemma-3-4b-pt` ships at 896×896
@@ -30,6 +38,55 @@ re-implementations.
 from __future__ import annotations
 
 import torch
+import torch.nn.functional as F  # noqa: N812
+
+
+def patch_grid_hw(height: int, width: int, patch_size: int) -> tuple[int, int]:
+    """Patch-grid shape ``(grid_h, grid_w)`` that fully covers an image.
+
+    Uses ceiling division, so a resolution that does not divide
+    ``patch_size`` still gets a grid covering every pixel — the caller is
+    expected to pad the image up to ``grid * patch_size`` with
+    :func:`pad_to_patch_multiple` before the conv patch embedding (which
+    would otherwise floor-crop the remainder).
+
+    Args:
+        height: Image height in pixels.
+        width: Image width in pixels.
+        patch_size: ViT patch size (14 for SigLIP so400m).
+
+    Returns:
+        ``(grid_h, grid_w)`` patch counts per axis.
+    """
+    return -(-height // patch_size), -(-width // patch_size)
+
+
+def pad_to_patch_multiple(img: torch.Tensor, patch_size: int, pad_value: float = -1.0) -> torch.Tensor:
+    """Pad the trailing two (H, W) dims up to the next multiple of ``patch_size``.
+
+    Padding goes on the bottom and right so the image origin stays
+    pixel-aligned: every patch that contains real content keeps exactly the
+    pixels it would have at a divisible resolution, and only the last patch
+    row/column mixes in padding. The default ``pad_value=-1.0`` is black in
+    the ``[-1, 1]`` range SigLIP consumes; callers padding ``[0, 1]``-range
+    pixels should pass ``0.0``.
+
+    Args:
+        img: Image tensor of shape ``(..., H, W)``.
+        patch_size: ViT patch size to pad up to a multiple of.
+        pad_value: Fill value for the padded band.
+
+    Returns:
+        The input unchanged (no copy) when ``H`` and ``W`` are already
+        multiples of ``patch_size``, else a padded copy of shape
+        ``(..., ceil(H/p)*p, ceil(W/p)*p)``.
+    """
+    height, width = img.shape[-2:]
+    pad_h = -height % patch_size
+    pad_w = -width % patch_size
+    if pad_h == 0 and pad_w == 0:
+        return img
+    return F.pad(img, (0, pad_w, 0, pad_h), value=pad_value)
 
 
 def bilinear_resample_pos_embed(old_pos: torch.Tensor, target_num_patches: int) -> torch.Tensor:

--- a/tests/configs/test_train.py
+++ b/tests/configs/test_train.py
@@ -68,6 +68,61 @@ def test_validate_with_policy_param(policy_config, dataset_mixture_config, tmp_p
     cfg.validate()
 
 
+def test_validate_rejects_resize_resolution_mismatch(policy_config, dataset_mixture_config, tmp_path):
+    """policy.resize_imgs_with_padding must match resolution at train-config time."""
+    cfg = TrainPipelineConfig(
+        dataset_mixture=dataset_mixture_config,
+        policy=policy_config,
+        output_dir=str(tmp_path / "native_res_run"),
+        job_name="test_run",
+        seed=42,
+        batch_size=8,
+        use_policy_training_preset=True,
+        resolution=(180, 320),  # policy_config default resize stays (224, 224)
+    )
+
+    with pytest.raises(ValueError, match="resize_imgs_with_padding"):
+        cfg.validate()
+
+
+def test_validate_resize_resolution_mismatch_escape_hatch(
+    policy_config, dataset_mixture_config, tmp_path, caplog
+):
+    """skip_input_resolution_check downgrades the train-time mismatch to a warning."""
+    policy_config.skip_input_resolution_check = True
+    cfg = TrainPipelineConfig(
+        dataset_mixture=dataset_mixture_config,
+        policy=policy_config,
+        output_dir=str(tmp_path / "legacy_resume_run"),
+        job_name="test_run",
+        seed=42,
+        batch_size=8,
+        use_policy_training_preset=True,
+        resolution=(180, 320),
+    )
+
+    with caplog.at_level("WARNING"):
+        cfg.validate()
+    assert any("resize_imgs_with_padding" in record.message for record in caplog.records)
+
+
+def test_validate_native_resolution_with_matching_resize(policy_config, dataset_mixture_config, tmp_path):
+    """Matching non-224 resolution and resize target validates cleanly."""
+    policy_config.resize_imgs_with_padding = (180, 320)
+    cfg = TrainPipelineConfig(
+        dataset_mixture=dataset_mixture_config,
+        policy=policy_config,
+        output_dir=str(tmp_path / "native_match_run"),
+        job_name="test_run",
+        seed=42,
+        batch_size=8,
+        use_policy_training_preset=True,
+        resolution=(180, 320),
+    )
+
+    cfg.validate()
+
+
 def test_validate_file_exits(dataset_mixture_config, policy_config, tmp_path):
     """
     Tests if validate raises FileExistsError when empty policy is passed

--- a/tests/policies/test_native_resolution.py
+++ b/tests/policies/test_native_resolution.py
@@ -47,6 +47,8 @@ from opentau.policies.pi07_paligemma.low_level.configuration_pi07_low_level impo
     PI07PaligemmaLowLevelConfig,
 )
 from opentau.policies.pi07_paligemma.low_level.modeling_pi07_low_level import resize_with_pad
+from opentau.policies.utils import assert_gemma3_input_resolution
+from opentau.scripts.eval import validate_eval_input_resolution
 from opentau.utils.transformers_patch import patched_paligemma_model_get_image_features
 from opentau.utils.vision_utils import pad_to_patch_multiple, patch_grid_hw
 
@@ -288,6 +290,42 @@ class TestValidateInputResolution:
         config = PI07PaligemmaLowLevelConfig(resize_imgs_with_padding=None)
         config.input_features = {}
         assert config.input_image_size is None
+
+    def test_gemma3_guard_rejects_native_resolution(self):
+        # pi06/pi07 constructors call this: Gemma3MultiModalProjector
+        # hard-codes a square patch grid, so native input must fail with the
+        # real diagnosis instead of a projector reshape crash.
+        with pytest.raises(ValueError, match="Gemma3-family"):
+            assert_gemma3_input_resolution(NATIVE_HW, 448)
+
+    def test_gemma3_guard_passes_tower_resolution_and_unbound(self):
+        assert_gemma3_input_resolution((448, 448), 448)
+        assert_gemma3_input_resolution(None, 448)
+
+    def test_eval_guard_native_passthrough_mismatch_raises(self):
+        cfg = SimpleNamespace(
+            policy=self._config_with_camera(resize=None),
+            resolution=(224, 224),
+        )
+        with pytest.raises(ValueError, match="native pass-through"):
+            validate_eval_input_resolution(cfg)
+
+    def test_eval_guard_matching_and_resize_set_pass(self, caplog):
+        # Matching native resolution passes.
+        validate_eval_input_resolution(
+            SimpleNamespace(policy=self._config_with_camera(resize=None), resolution=NATIVE_HW)
+        )
+        # With a resize target set, the in-policy letterbox reproduces the
+        # checkpoint's training-time geometry; make_policy owns the warning.
+        validate_eval_input_resolution(
+            SimpleNamespace(policy=self._config_with_camera(resize=(224, 224)), resolution=(448, 448))
+        )
+        # Escape hatch downgrades the native-passthrough raise to a warning.
+        skip_policy = self._config_with_camera(resize=None)
+        skip_policy.skip_input_resolution_check = True
+        with caplog.at_level("WARNING"):
+            validate_eval_input_resolution(SimpleNamespace(policy=skip_policy, resolution=(224, 224)))
+        assert any("different geometry" in record.message for record in caplog.records)
 
     def test_channels_last_shapes_recognized(self):
         # Bare LeRobotDatasetMetadata binds raw (H, W, C) shapes; the strict

--- a/tests/policies/test_native_resolution.py
+++ b/tests/policies/test_native_resolution.py
@@ -1,0 +1,290 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Native-resolution vision input across the PaliGemma-family policies.
+
+Covers the three guarantees introduced with native-resolution support:
+
+1. **Config validation** — a `resize_imgs_with_padding` that differs from the
+   resolution of the bound image features fails fast on the strict (training)
+   path and warns loudly on the eval path, with
+   `skip_input_resolution_check` as the legacy-checkpoint escape hatch.
+2. **No silent crop** — at a resolution that does not divide the SigLIP patch
+   size (e.g. 180x320 with patch 14), frames are padded up to the next patch
+   multiple and position embeddings are interpolated, so the patch grid
+   covers every pixel (ceil(180/14) x ceil(320/14) = 13 x 23 = 299 tokens
+   instead of the floor-cropped 12 x 22).
+3. **No-op passthrough** — when the input already matches the target, the
+   resize helpers return the input tensor unchanged (same object, not a
+   same-size bilinear round trip), and the 224x224 vision path stays
+   bit-identical to the historical fixed-position-embedding path.
+
+All models here are tiny random-init transformers configs — nothing is
+downloaded from the Hub.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from transformers import PaliGemmaConfig, SiglipVisionConfig, SiglipVisionModel
+from transformers.models.paligemma.modeling_paligemma import PaliGemmaMultiModalProjector
+
+from opentau.configs.types import FeatureType, PolicyFeature
+from opentau.policies.pi07.video_encoder import SpaceTimeSiglipVideoEncoder
+from opentau.policies.pi07_paligemma.low_level.configuration_pi07_low_level import (
+    PI07PaligemmaLowLevelConfig,
+)
+from opentau.policies.pi07_paligemma.low_level.modeling_pi07_low_level import resize_with_pad
+from opentau.utils.transformers_patch import patched_paligemma_model_get_image_features
+from opentau.utils.vision_utils import pad_to_patch_multiple, patch_grid_hw
+
+# 180x320 is the DROID camera resolution — the motivating native-resolution
+# case: 180 % 14 == 320 % 14 == 12, so the stride-14 conv would floor-crop 12
+# pixel rows and columns without the pad-to-patch-multiple step.
+NATIVE_HW = (180, 320)
+NATIVE_GRID_TOKENS = 13 * 23  # ceil(180/14) * ceil(320/14)
+PATCH = 14
+
+
+def _build_tiny_siglip_and_projector():
+    """Tiny random SigLIP (patch 14, image_size 224) + PaliGemma projector.
+
+    Mirrors the pattern of ``_build_paligemma_siglip_and_projector`` in
+    ``test_pi07_video_encoder_cpu.py`` but at unit-test scale.
+    """
+    vision_cfg_dict = {
+        "hidden_size": 64,
+        "intermediate_size": 128,
+        "model_type": "siglip_vision_model",
+        "num_attention_heads": 4,
+        "num_hidden_layers": 4,
+        "num_image_tokens": 256,
+        "patch_size": PATCH,
+        "image_size": 224,
+        "projection_dim": 32,
+        "vision_use_head": False,
+    }
+    vision_tower = SiglipVisionModel(SiglipVisionConfig(**vision_cfg_dict)).eval()
+    pali_cfg = PaliGemmaConfig(
+        vision_config=vision_cfg_dict,
+        text_config={"hidden_size": 32, "model_type": "gemma", "vocab_size": 64},
+        projection_dim=32,
+    )
+    projector = PaliGemmaMultiModalProjector(pali_cfg).eval()
+    return vision_tower, projector, 32
+
+
+@pytest.fixture
+def siglip_backbone():
+    torch.manual_seed(0)
+    return _build_tiny_siglip_and_projector()
+
+
+class TestPatchGridHelpers:
+    def test_patch_grid_hw_ceils(self):
+        assert patch_grid_hw(*NATIVE_HW, PATCH) == (13, 23)
+        assert patch_grid_hw(224, 224, PATCH) == (16, 16)
+        assert patch_grid_hw(14, 14, PATCH) == (1, 1)
+        assert patch_grid_hw(15, 14, PATCH) == (2, 1)
+
+    def test_pad_to_patch_multiple_is_noop_at_multiples(self):
+        img = torch.rand(2, 3, 224, 224)
+        assert pad_to_patch_multiple(img, PATCH) is img
+
+    def test_pad_to_patch_multiple_pads_bottom_right(self):
+        img = torch.rand(2, 3, *NATIVE_HW)
+        padded = pad_to_patch_multiple(img, PATCH, pad_value=-1.0)
+        assert padded.shape == (2, 3, 182, 322)
+        # Original content untouched, origin pixel-aligned.
+        assert torch.equal(padded[..., :180, :320], img)
+        # Padding is bottom/right only, at the fill value.
+        assert (padded[..., 180:, :] == -1.0).all()
+        assert (padded[..., :, 320:] == -1.0).all()
+
+    def test_padded_grid_covers_all_pixels(self):
+        grid_h, grid_w = patch_grid_hw(*NATIVE_HW, PATCH)
+        assert grid_h * PATCH >= NATIVE_HW[0]
+        assert grid_w * PATCH >= NATIVE_HW[1]
+        # And is minimal: one patch fewer would crop pixels.
+        assert (grid_h - 1) * PATCH < NATIVE_HW[0]
+        assert (grid_w - 1) * PATCH < NATIVE_HW[1]
+
+
+class TestResizeWithPadNoOp:
+    def test_same_size_returns_input_object(self):
+        img = torch.rand(2, 3, *NATIVE_HW)
+        out = resize_with_pad(img, width=NATIVE_HW[1], height=NATIVE_HW[0], pad_value=0)
+        assert out is img
+
+    def test_non_square_target_orientation(self):
+        # A half-scale native frame letterboxed up to the native target must
+        # come out (H, W) = (180, 320) — not transposed. This was latent
+        # while every target was square: the function signature is
+        # (width, height) but the config tuple is (height, width).
+        img = torch.rand(2, 3, 90, 160)
+        out = resize_with_pad(img, width=NATIVE_HW[1], height=NATIVE_HW[0], pad_value=0)
+        assert out.shape == (2, 3, *NATIVE_HW)
+
+
+class TestPatchedGetImageFeaturesNativeRes:
+    def test_native_resolution_produces_full_grid(self, siglip_backbone):
+        vision_tower, projector, vlm_hidden = siglip_backbone
+        stub = SimpleNamespace(vision_tower=vision_tower, multi_modal_projector=projector)
+        pixels = torch.rand(2, 3, *NATIVE_HW) * 2.0 - 1.0
+        with torch.no_grad():
+            out = patched_paligemma_model_get_image_features(stub, pixels)
+        assert out.shape == (2, NATIVE_GRID_TOKENS, vlm_hidden)
+
+    def test_config_resolution_is_bit_identical_to_vanilla_path(self, siglip_backbone):
+        vision_tower, projector, _ = siglip_backbone
+        stub = SimpleNamespace(vision_tower=vision_tower, multi_modal_projector=projector)
+        pixels = torch.rand(1, 3, 224, 224) * 2.0 - 1.0
+        with torch.no_grad():
+            out = patched_paligemma_model_get_image_features(stub, pixels)
+            reference = projector(vision_tower(pixels).last_hidden_state)
+        assert torch.equal(out, reference)
+
+
+class TestSpaceTimeVideoEncoderNativeRes:
+    def test_native_forward_shape_and_token_count(self, siglip_backbone):
+        vision_tower, projector, vlm_hidden = siglip_backbone
+        encoder = SpaceTimeSiglipVideoEncoder(
+            vision_tower=vision_tower,
+            multi_modal_projector=projector,
+            max_num_frames=3,
+            spacetime_layer_stride=2,
+            expected_image_size=NATIVE_HW,
+        )
+        assert encoder.num_video_tokens == NATIVE_GRID_TOKENS
+        # 2-D grid exposed for consumers needing the layout (e.g. pi05_mem
+        # MRoPE, which must distinguish 16x4 from 8x8 despite both being 64).
+        assert encoder.grid_hw == (13, 23)
+        with torch.no_grad():
+            out = encoder(torch.rand(2, 2, 3, *NATIVE_HW))
+        assert out.shape == (2, NATIVE_GRID_TOKENS, vlm_hidden)
+
+    def test_wrong_input_resolution_raises(self, siglip_backbone):
+        vision_tower, projector, _ = siglip_backbone
+        encoder = SpaceTimeSiglipVideoEncoder(
+            vision_tower=vision_tower,
+            multi_modal_projector=projector,
+            max_num_frames=2,
+            spacetime_layer_stride=2,
+            expected_image_size=NATIVE_HW,
+        )
+        with pytest.raises(ValueError, match="constructed for"):
+            encoder(torch.rand(1, 1, 3, 224, 224))
+
+    def test_default_construction_keeps_legacy_grid(self, siglip_backbone):
+        vision_tower, projector, vlm_hidden = siglip_backbone
+        encoder = SpaceTimeSiglipVideoEncoder(
+            vision_tower=vision_tower,
+            multi_modal_projector=projector,
+            max_num_frames=2,
+            spacetime_layer_stride=2,
+        )
+        assert encoder.expected_image_size == (224, 224)
+        assert encoder.num_video_tokens == 256
+        assert not encoder._interpolate_pos_encoding
+        with torch.no_grad():
+            out = encoder(torch.rand(1, 1, 3, 224, 224))
+        assert out.shape == (1, 256, vlm_hidden)
+
+    def test_single_frame_invariance_at_native_res(self, siglip_backbone):
+        # T=1 through the video encoder must stay byte-identical to
+        # embed_image (the patched get_image_features) on the same frames —
+        # this is what keeps the pi07_paligemma run/skip zero-fill paths and
+        # the subgoal image path aligned at native resolution.
+        vision_tower, projector, _ = siglip_backbone
+        encoder = SpaceTimeSiglipVideoEncoder(
+            vision_tower=vision_tower,
+            multi_modal_projector=projector,
+            max_num_frames=2,
+            spacetime_layer_stride=2,
+            expected_image_size=NATIVE_HW,
+        )
+        stub = SimpleNamespace(vision_tower=vision_tower, multi_modal_projector=projector)
+        frames = torch.rand(2, 3, *NATIVE_HW)
+        with torch.no_grad():
+            video_out = encoder(frames.unsqueeze(1))  # video path takes [0, 1]
+            image_out = patched_paligemma_model_get_image_features(stub, frames * 2.0 - 1.0)
+        assert torch.equal(video_out, image_out)
+
+
+class TestValidateInputResolution:
+    def _config_with_camera(self, resize, camera_hw=NATIVE_HW):
+        config = PI07PaligemmaLowLevelConfig(resize_imgs_with_padding=resize)
+        config.input_features = {
+            "camera0": PolicyFeature(type=FeatureType.VISUAL, shape=(3, *camera_hw)),
+        }
+        return config
+
+    def test_strict_mismatch_raises(self):
+        config = self._config_with_camera(resize=(224, 224))
+        with pytest.raises(ValueError, match="resize_imgs_with_padding"):
+            config.validate_input_resolution(strict=True)
+
+    def test_eval_mismatch_warns_but_loads(self, caplog):
+        config = self._config_with_camera(resize=(224, 224))
+        with caplog.at_level("WARNING"):
+            config.validate_input_resolution(strict=False)
+        assert any("resize_imgs_with_padding" in record.message for record in caplog.records)
+
+    def test_escape_hatch_downgrades_strict_to_warning(self, caplog):
+        config = self._config_with_camera(resize=(224, 224))
+        config.skip_input_resolution_check = True
+        with caplog.at_level("WARNING"):
+            config.validate_input_resolution(strict=True)
+        assert any("resize_imgs_with_padding" in record.message for record in caplog.records)
+
+    def test_matching_resolution_passes(self):
+        self._config_with_camera(resize=NATIVE_HW).validate_input_resolution(strict=True)
+
+    def test_none_resize_passes(self):
+        self._config_with_camera(resize=None).validate_input_resolution(strict=True)
+
+    def test_empty_camera_placeholders_ignored(self):
+        config = self._config_with_camera(resize=NATIVE_HW)
+        # validate_features()-style placeholder with its historical hard-coded
+        # shape must not trip the check — it describes no real data.
+        config.input_features["observation.images.empty_camera_0"] = PolicyFeature(
+            type=FeatureType.VISUAL, shape=(3, 480, 640)
+        )
+        config.validate_input_resolution(strict=True)
+
+    def test_input_image_size_prefers_resize_target(self):
+        config = self._config_with_camera(resize=(224, 224))
+        assert config.input_image_size == (224, 224)
+
+    def test_input_image_size_falls_back_to_bound_features(self):
+        config = self._config_with_camera(resize=None)
+        assert config.input_image_size == NATIVE_HW
+
+    def test_input_image_size_none_when_unbound(self):
+        config = PI07PaligemmaLowLevelConfig(resize_imgs_with_padding=None)
+        config.input_features = {}
+        assert config.input_image_size is None
+
+    def test_channels_last_shapes_recognized(self):
+        # Bare LeRobotDatasetMetadata binds raw (H, W, C) shapes; the strict
+        # check must not silently no-op on them.
+        config = PI07PaligemmaLowLevelConfig(resize_imgs_with_padding=(224, 224))
+        config.input_features = {
+            "camera0": PolicyFeature(type=FeatureType.VISUAL, shape=(*NATIVE_HW, 3)),
+        }
+        with pytest.raises(ValueError, match="resize_imgs_with_padding"):
+            config.validate_input_resolution(strict=True)
+        config.resize_imgs_with_padding = NATIVE_HW
+        config.validate_input_resolution(strict=True)

--- a/tests/policies/test_native_resolution.py
+++ b/tests/policies/test_native_resolution.py
@@ -255,6 +255,18 @@ class TestValidateInputResolution:
     def test_none_resize_passes(self):
         self._config_with_camera(resize=None).validate_input_resolution(strict=True)
 
+    def test_none_resize_mixed_camera_resolutions_rejected(self, caplog):
+        # Native pass-through has no resize step to harmonize cameras, so a
+        # mixed-resolution camera set must be flagged rather than silently
+        # seeding the vision tower with whichever camera iterates first.
+        config = self._config_with_camera(resize=None)
+        config.input_features["camera1"] = PolicyFeature(type=FeatureType.VISUAL, shape=(3, 224, 224))
+        with pytest.raises(ValueError, match="mixed resolutions"):
+            config.validate_input_resolution(strict=True)
+        with caplog.at_level("WARNING"):
+            config.validate_input_resolution(strict=False)
+        assert any("mixed resolutions" in record.message for record in caplog.records)
+
     def test_empty_camera_placeholders_ignored(self):
         config = self._config_with_camera(resize=NATIVE_HW)
         # validate_features()-style placeholder with its historical hard-coded

--- a/tests/policies/test_pi07_paligemma_low_level.py
+++ b/tests/policies/test_pi07_paligemma_low_level.py
@@ -702,8 +702,12 @@ class TestPI07PaligemmaLowLevelStateEmbedding:
         h = hidden_size
         model = object.__new__(PI07PaligemmaLowLevelFlowMatching)
 
-        # num_image_tokens mirrors embed_image's 4-token output below, so the
-        # image-tower skip path (zeros of that width) matches the run path.
+        # The image-tower skip path derives its zero-fill width from
+        # video_encoder.num_video_tokens (subgoal images share the video
+        # encoder's tower and input resolution, so their token counts agree
+        # by construction); text_config.num_image_tokens is no longer read
+        # there. The 4 here deliberately differs from num_video_tokens=6 so a
+        # regression back to the old num_image_tokens source is caught.
         _text_cfg = type("_TextConfig", (), {"hidden_size": h, "num_image_tokens": 4})()
         _pg_cfg = type("_PaliGemmaConfig", (), {"text_config": _text_cfg})()
         _stub_cfg = type("_StubConfig", (), {"paligemma_config": _pg_cfg})()
@@ -1277,8 +1281,12 @@ class TestPI07PaligemmaLowLevelResponseEmbedding:
         h = hidden_size
         model = object.__new__(PI07PaligemmaLowLevelFlowMatching)
 
-        # num_image_tokens mirrors embed_image's 4-token output below, so the
-        # image-tower skip path (zeros of that width) matches the run path.
+        # The image-tower skip path derives its zero-fill width from
+        # video_encoder.num_video_tokens (subgoal images share the video
+        # encoder's tower and input resolution, so their token counts agree
+        # by construction); text_config.num_image_tokens is no longer read
+        # there. The 4 here deliberately differs from num_video_tokens=6 so a
+        # regression back to the old num_image_tokens source is caught.
         _text_cfg = type("_TextConfig", (), {"hidden_size": h, "num_image_tokens": 4})()
         _pg_cfg = type("_PaliGemmaConfig", (), {"text_config": _text_cfg})()
         _stub_cfg = type("_StubConfig", (), {"paligemma_config": _pg_cfg})()
@@ -2301,10 +2309,12 @@ class TestPI07PaligemmaLowLevelSubgoalEmbedding:
     # ------------------------------------------------------------------ #
     def test_all_padded_subgoal_skips_image_tower(self):
         """All-padded subgoal mask → ``embed_image`` is not called and the image
-        block is zeros of width ``num_image_tokens``."""
+        block is zeros of width ``video_encoder.num_video_tokens`` (the shared
+        tower's grid-derived count — what ``embed_image`` emits at the
+        configured input resolution)."""
         bsz, h = 3, 8
         model = TestPI07PaligemmaLowLevelResponseEmbedding._make_mock_model(hidden_size=h)
-        n_img_tokens = model.paligemma_with_expert.config.paligemma_config.text_config.num_image_tokens
+        n_img_tokens = model.video_encoder.num_video_tokens
 
         calls: list[tuple[int, ...]] = []
 
@@ -2364,7 +2374,7 @@ class TestPI07PaligemmaLowLevelSubgoalEmbedding:
         actually control the per-item branch."""
         bsz, h = 3, 8
         model = TestPI07PaligemmaLowLevelResponseEmbedding._make_mock_model(hidden_size=h)
-        n_img_tokens = model.paligemma_with_expert.config.paligemma_config.text_config.num_image_tokens
+        n_img_tokens = model.video_encoder.num_video_tokens
         calls: list[tuple[int, ...]] = []
 
         def _capturing_embed_image(image):


### PR DESCRIPTION
## What this does

Eliminates the silent train-time image letterboxing in the π-policy family and makes native-resolution vision input first-class. (🗃️ Feature / 🐛 Bug)

**Motivating bug:** DROID data is 180×320, but with the default configs every frame was silently letterboxed to 224×224 (aspect-preserving downscale to 126×224 + 98 black rows) before SigLIP ever saw it — twice, in fact: the dataloader letterboxes to `TrainPipelineConfig.resolution` and the policy letterboxes again to `resize_imgs_with_padding`, with nothing validating the two against each other. Native resolutions were also impossible mechanically: SigLIP's stride-14 conv floor-crops any sub-patch remainder (180 % 14 = 320 % 14 = 12, so 12 pixel rows *and* columns would be dropped) and its fixed position-embedding table only covers the config's 16×16 grid.

### 1. Config validation: `resize_imgs_with_padding` must match the input resolution

- **Train-time fail-fast** in `TrainPipelineConfig.validate()` (runs only for training): `policy.resize_imgs_with_padding != resolution` now raises with an actionable message.
- **Feature-binding fail-fast** in `factory.make_policy` (when `ds_meta` is passed, i.e. training-shaped construction): the resize target is checked against the bound image-feature `(H, W)` via the new `PreTrainedConfig.validate_input_resolution()`. Handles both channels-first and channels-last feature shapes; synthetic `empty_camera_*` placeholder features are excluded.
- **Legacy checkpoints are never bricked:** every load surface (`PreTrainedPolicy.from_pretrained`, which also covers the gRPC server and inference/export scripts that bypass the factory) runs the same check **warn-only**. A new `policy.skip_input_resolution_check` escape hatch downgrades even the strict train-time check to a warning, for deliberately resuming a legacy mismatch-trained lineage. Note the flag persists into checkpoints saved by such a run (documented in the field docstring).
- Eval additionally fail-fasts when a checkpoint trained with `resize_imgs_with_padding=null` (native pass-through) is evaluated at a different `resolution` — with no resize step, env frames would silently reach the tower at the wrong geometry.

### 2. Native-resolution SigLIP path (PaliGemma family)

- The patched `PaliGemmaModel.get_image_features` (`utils/transformers_patch.py`) and `SpaceTimeSiglipVideoEncoder` (`policies/pi07/video_encoder.py`, new `expected_image_size` ctor arg) now pad frames up to the next patch multiple (bottom/right, black) and enable `interpolate_pos_encoding` whenever the patch grid differs from the config grid. 180×320 → padded 182×322 → a 13×23 grid (299 tokens) that covers **every pixel** — no silent crop. At the config resolution (224×224) both steps are no-ops and the output is **bit-identical** to before.
- Token counts derive from the covering grid: `num_video_tokens`, the pi07_paligemma run/skip zero-fill paths (previously hard-coded to `text_config.num_image_tokens=256`), the temporal-mask expansion, and the subgoal zero-fabrication all stay rank-aligned by construction (CLAUDE.md rule 5). A new forward-time check in the video encoder raises with a clear message if frames arrive at a different resolution than configured.
- `resize_with_pad` gets an explicit same-size early-return (native inputs pass through untouched instead of a same-size bilinear round trip), in all 9 policy copies plus the dataset-side and env-subgoal copies.
- Fixed a latent transposition: `resize_with_pad(img, width, height, ...)` was called with the splatted `(height, width)` config tuple at every call site — invisible at square defaults, wrong for any non-square target. All call sites now unpack explicitly into `width=`/`height=` kwargs.
- pi05_mem's interleaved-MRoPE guard now checks actual grid squareness (via the encoder's new `grid_hw`) instead of token-count squareness, which a non-square grid like 16×4 = 64 would have passed.

Covered: pi0, pi05, pi05_mem (SpaceTime encoder path), pi07_paligemma (low_level + high_level_planner). This is the whole PaliGemma family.

### 3. Follow-ups (out of scope, now fail loudly instead of confusingly)

- **Gemma3 family (pi06, pi07):** `Gemma3MultiModalProjector` hard-codes a square `patches_per_image` reshape + avg-pool, so native input needs a projector-level design. Construction now fails fast with the real diagnosis ("native resolutions not yet supported for the Gemma3-family") instead of an unrelated-looking reshape crash at first forward.
- **value policy** (bare `SiglipVisionModel` wrapper) and **pi05_mem's RLDX motion encoder** (square-window motion module): unchanged; both fail loudly at non-default resolutions.

## How it was tested

- Added `tests/policies/test_native_resolution.py` (all CPU, tiny random-init models, no Hub downloads):
  - config validation rejects a resize/input-resolution mismatch (strict raise, eval warn, escape hatch, channels-last shapes, empty-camera exclusion);
  - forward at 180×320 through both the patched `get_image_features` and `SpaceTimeSiglipVideoEncoder` produces the full 13×23 = 299-token grid, with an assertion that the grid covers all pixels and is minimal;
  - T=1 single-frame invariance at native resolution: the video path is byte-identical to `embed_image` on the same frames (the run/skip parity foundation);
  - the resize path returns the input tensor object unchanged when resolutions match, and non-square targets are not transposed;
  - the 224×224 path is bit-identical to the vanilla fixed-position-embedding path.
- Added train-config validation tests in `tests/configs/test_train.py` (mismatch raises at `validate()` time; escape hatch warns; matching native resolution passes).
- Updated the two `network`-marked skip-path tests in `tests/policies/test_pi07_paligemma_low_level.py` to the new invariant (zero-fill width comes from the shared tower's grid-derived count); the test mock now deliberately distinguishes the old and new sources so a regression is caught.
- `pre-commit run --all-files` clean; full CPU suite (`pytest -m "not gpu and not network" -n auto`, CI-equivalent invocation): 2049 passed — the only failures are pre-existing environment/timing flakes confirmed failing on the base commit (`test_utils_benchmark` timing tests, an EGL device-pinning test, and a libero-extra import error on a non-libero local env).
- The touched `network`-marked classes pass offline against the local cache (31 passed), and the full `test_pi07_video_encoder_cpu.py` suite passes (67).
- Determinism (CLAUDE.md rule 3): ran `configs/dev/ci_config.json` twice with the same seed (4 steps, CPU via `accelerate launch --cpu`); the per-step `total_loss`/`mse_loss`/`ce_loss` series is bit-identical across the two runs.
- GPU pytests: targeted `-m gpu -n 0` run over every touched policy's test files on an RTX 5090 dev box (see checklist).

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/policies/test_native_resolution.py
pytest -sx tests/configs/test_train.py -k resize
```

See the mismatch fail-fast (raises before any dataset/model build):

```bash
python src/opentau/scripts/train.py --config_path=configs/dev/dev_config.json --resolution="(180, 320)"
```

Train at native resolution (pass both fields, or set the policy one to null):

```bash
python src/opentau/scripts/train.py --config_path=configs/dev/dev_config.json \
    --resolution="(180, 320)" --policy.resize_imgs_with_padding="(180, 320)"
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [x] My PR includes policy-related changes.
  - [x] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
