### PR TITLE
chore: bump version to v0.11.0

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,8 +30,8 @@ project = "OpenTau"
 copyright = "2026, Tensor Auto Inc"
 author = "Tensor Auto Inc"
 
-version = "0.10.0"
-release = "0.10.0"
+version = "0.11.0"
+release = "0.11.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ huggingface = "https://huggingface.co/TensorAuto"
 
 [project]
 name = "opentau"
-version = "0.10.0"
+version = "0.11.0"
 description = "OpenTau: Tensor's VLA Training Infrastructure for Real-World Robotics in Pytorch"
 authors = [
     { name = "Shuheng Liu", email = "wish1104@icloud.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -2157,7 +2157,7 @@ wheels = [
 
 [[package]]
 name = "opentau"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
## What this does
Bumps the project version from `0.10.0` to `0.11.0`. (📝 Documentation / chore)

Updated in all three places the repo version is declared:
- `pyproject.toml` — `[project].version`
- `docs/source/conf.py` — Sphinx `version` and `release`
- `uv.lock` — the `opentau` editable package entry (kept in sync so `uv lock --check` passes)

Dependency-pin occurrences of `0.10.0` (`draccus`, `mediapipe`, `torchcodec`) are unrelated and were left untouched.

## How it was tested
- `uv lock --check` passes (274 packages resolved, no drift) confirming `pyproject.toml`/`uv.lock` stay consistent after the bump.
- `pre-commit run --files pyproject.toml docs/source/conf.py uv.lock` passes (check-toml, ruff, ruff-format, etc.).
- No runtime code changed — `opentau.__version__` is derived from installed package metadata via `importlib.metadata.version`.

## How to checkout & try? (for the reviewer)
```bash
git checkout bump/v0.11.0
uv lock --check
python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])"  # -> 0.11.0
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
