### PR TITLE
feat(policies): add QUANTILE normalization mode (q01/q99 robust scaling)

### DIFF
--- a/src/opentau/configs/types.py
+++ b/src/opentau/configs/types.py
@@ -46,6 +46,13 @@ class NormalizationMode(str, Enum):
     """Normalize using min-max scaling."""
     MEAN_STD = "MEAN_STD"
     """Normalize using mean and standard deviation."""
+    QUANTILE = "QUANTILE"
+    """Normalize using the q01/q99 quantiles (robust min-max scaling).
+
+    Maps ``[q01, q99]`` to ``[-1, 1]``; values outside the quantile range
+    extend beyond ``[-1, 1]`` (no clamping). Datasets whose stats carry no
+    quantiles fall back to ``min``/``max`` for that dataset's row.
+    """
     IDENTITY = "IDENTITY"
     """No normalization (identity transformation)."""
 

--- a/src/opentau/datasets/compute_stats.py
+++ b/src/opentau/datasets/compute_stats.py
@@ -354,13 +354,37 @@ def aggregate_feature_stats(
         agg_min = np.nanmin(mins_safe, axis=0)
         agg_max = np.nanmax(maxs_safe, axis=0)
 
-    return {
+    aggregated = {
         "min": agg_min,
         "max": agg_max,
         "mean": total_mean,
         "std": np.sqrt(total_variance),
         "count": total_count,
     }
+
+    # q01/q99 for QUANTILE normalization. Exact pooled quantiles are not
+    # recoverable from per-contributor quantiles, so use the count-weighted mean
+    # of the contributors' quantiles — a standard approximation that stays
+    # robust to a single contributor's extremes (unlike pooled min/max). A
+    # contributor without a stored quantile (stats predating quantile support)
+    # contributes its same-side extreme instead; non-finite entries are masked
+    # per dim like the mean.
+    for q_name, extreme in (("q01", "min"), ("q99", "max")):
+        if not any(q_name in s for s in stats_ft_list):
+            continue
+        q_vals = np.stack([s.get(q_name, s[extreme]) for s in stats_ft_list])
+        q_bad = ~np.isfinite(q_vals)
+        q_weights = np.where(q_bad, 0.0, counts).astype(np.float64)
+        q_weight_sum = q_weights.sum(axis=0)
+        safe_q = np.where(q_bad, 0.0, q_vals)
+        aggregated[q_name] = np.divide(
+            (safe_q * q_weights).sum(axis=0),
+            q_weight_sum,
+            out=np.full(q_weight_sum.shape, np.nan, dtype=np.float64),
+            where=q_weight_sum > 0,
+        )
+
+    return aggregated
 
 
 def aggregate_stats(

--- a/src/opentau/datasets/dataset_mixture.py
+++ b/src/opentau/datasets/dataset_mixture.py
@@ -544,12 +544,18 @@ class DatasetMixtureMetadata:
             else:
                 raise KeyError(f"Key '{key}' not found in stats. Available keys: {list(stats.keys())}")
 
-        # pad state and action vectors
+        # pad state and action vectors (quantiles included so the QUANTILE
+        # normalization buffers see the same padded dim as mean/std/min/max;
+        # the two dicts are padded independently because converted datasets
+        # may carry quantiles on one feature but not the other)
+        padded_stat_names = ["mean", "std", "min", "max", "q01", "q10", "q50", "q90", "q99"]
         for stat in standard_stats["state"]:
-            if stat in ["mean", "std", "min", "max"]:
+            if stat in padded_stat_names:
                 standard_stats["state"][stat] = pad_vector(
                     standard_stats["state"][stat], self.cfg.max_state_dim
                 )
+        for stat in standard_stats["actions"]:
+            if stat in padded_stat_names:
                 standard_stats["actions"][stat] = pad_vector(
                     standard_stats["actions"][stat], self.cfg.max_action_dim
                 )

--- a/src/opentau/datasets/dataset_mixture.py
+++ b/src/opentau/datasets/dataset_mixture.py
@@ -595,7 +595,9 @@ class DatasetMixtureMetadata:
         for data in standard_stats:
             if data.startswith("camera"):
                 continue
-            for stat_name in ("mean", "std", "min", "max"):
+            for stat_name in ("mean", "std", "min", "max", "q01", "q99"):
+                if stat_name not in standard_stats[data]:
+                    continue
                 arr = np.asarray(standard_stats[data][stat_name])
                 bad = np.flatnonzero(~np.isfinite(arr.ravel()))
                 if bad.size > 0:

--- a/src/opentau/policies/normalize.py
+++ b/src/opentau/policies/normalize.py
@@ -330,12 +330,15 @@ def create_stats_buffers(
                         value = resolve_stat_row(ds_stats, key, name)
                     except KeyError as e:
                         raise KeyError(f"per_dataset_stats[{i}]: {e.args[0]}") from None
+                    source = name
                     if name not in ds_stats[key]:
                         fallback_rows.append(i)
+                        source = _QUANTILE_FALLBACK[name]
                     row = _stat_to_float32_tensor(value)
                     if tuple(row.shape) != shape:
+                        via = "" if source == name else f" (resolved for '{name}' via fallback)"
                         raise ValueError(
-                            f"per_dataset_stats[{i}]['{key}']['{name}'] has shape "
+                            f"per_dataset_stats[{i}]['{key}']['{source}']{via} has shape "
                             f"{tuple(row.shape)}, expected {shape}."
                         )
                     rows.append(row)

--- a/src/opentau/policies/normalize.py
+++ b/src/opentau/policies/normalize.py
@@ -185,6 +185,61 @@ def resolve_num_datasets(
     return 1
 
 
+def stat_names_for_mode(norm_mode: NormalizationMode) -> tuple[str, ...]:
+    """Return the stat buffer names a normalization mode reads.
+
+    Single source of truth shared by ``create_stats_buffers`` and
+    ``PreTrainedPolicy._inject_stats`` so the two cannot drift.
+
+    Args:
+        norm_mode: A non-IDENTITY normalization mode.
+
+    Raises:
+        ValueError: For IDENTITY (which has no stats) or an unknown mode.
+    """
+    if norm_mode is NormalizationMode.MEAN_STD:
+        return ("mean", "std")
+    if norm_mode is NormalizationMode.MIN_MAX:
+        return ("min", "max")
+    if norm_mode is NormalizationMode.QUANTILE:
+        return ("q01", "q99")
+    raise ValueError(norm_mode)
+
+
+# QUANTILE tolerates datasets whose stats predate quantile support (e.g. LeRobot
+# v3.0 repos converted from v2.1, whose stats.json has only min/max/mean/std):
+# the missing quantile falls back to the same-side extreme, degrading that
+# dataset's row to plain min-max scaling.
+_QUANTILE_FALLBACK = {"q01": "min", "q99": "max"}
+
+
+def resolve_stat_row(
+    ds_stats: dict[str, dict[str, Tensor | np.ndarray]], key: str, name: str
+) -> Tensor | np.ndarray:
+    """Fetch stat ``name`` for feature ``key`` from one dataset's stats.
+
+    Applies the QUANTILE fallback (``q01``→``min``, ``q99``→``max``) when the
+    quantile is absent, so converted-from-v2.1 datasets remain usable.
+
+    Raises:
+        KeyError: If the feature is missing, or the stat is missing and has no
+            fallback (or its fallback is also missing).
+    """
+    if key not in ds_stats:
+        raise KeyError(f"stats are missing feature '{key}'. Available keys: {list(ds_stats)}.")
+    feat_stats = ds_stats[key]
+    if name in feat_stats:
+        return feat_stats[name]
+    fallback = _QUANTILE_FALLBACK.get(name)
+    if fallback is not None and fallback in feat_stats:
+        return feat_stats[fallback]
+    raise KeyError(
+        f"stats['{key}'] is missing stat '{name}'"
+        + (f" and its fallback '{fallback}'" if fallback else "")
+        + f". Available stats: {list(feat_stats)}."
+    )
+
+
 def _stat_to_float32_tensor(value: np.ndarray | Tensor) -> Tensor:
     """Convert one per-dataset stat (np or torch) to a float32 ``Tensor``.
 
@@ -260,12 +315,7 @@ def create_stats_buffers(
 
         stacked_shape = (num_ds, *shape)
 
-        if norm_mode is NormalizationMode.MEAN_STD:
-            stat_names = ("mean", "std")
-        elif norm_mode is NormalizationMode.MIN_MAX:
-            stat_names = ("min", "max")
-        else:
-            raise ValueError(norm_mode)
+        stat_names = stat_names_for_mode(norm_mode)
 
         params: dict[str, nn.Parameter] = {}
         for name in stat_names:
@@ -274,24 +324,32 @@ def create_stats_buffers(
                 tensor = torch.full(stacked_shape, torch.inf, dtype=torch.float32)
             else:
                 rows = []
+                fallback_rows: list[int] = []
                 for i, ds_stats in enumerate(per_dataset_stats):
-                    if key not in ds_stats:
-                        raise KeyError(
-                            f"per_dataset_stats[{i}] is missing feature '{key}'. "
-                            f"Available keys: {list(ds_stats)}."
-                        )
+                    try:
+                        value = resolve_stat_row(ds_stats, key, name)
+                    except KeyError as e:
+                        raise KeyError(f"per_dataset_stats[{i}]: {e.args[0]}") from None
                     if name not in ds_stats[key]:
-                        raise KeyError(
-                            f"per_dataset_stats[{i}]['{key}'] is missing stat '{name}'. "
-                            f"Available stats: {list(ds_stats[key])}."
-                        )
-                    row = _stat_to_float32_tensor(ds_stats[key][name])
+                        fallback_rows.append(i)
+                    row = _stat_to_float32_tensor(value)
                     if tuple(row.shape) != shape:
                         raise ValueError(
                             f"per_dataset_stats[{i}]['{key}']['{name}'] has shape "
                             f"{tuple(row.shape)}, expected {shape}."
                         )
                     rows.append(row)
+                if fallback_rows:
+                    logging.warning(
+                        "Feature '%s': %d/%d dataset rows have no '%s' quantile; fell back to "
+                        "'%s' for rows %s (those rows use plain min-max scaling).",
+                        key,
+                        len(fallback_rows),
+                        len(per_dataset_stats),
+                        name,
+                        _QUANTILE_FALLBACK[name],
+                        fallback_rows[:10],
+                    )
                 tensor = torch.stack(rows, dim=0)
             params[name] = nn.Parameter(tensor, requires_grad=False)
 
@@ -409,8 +467,9 @@ class Normalize(nn.Module):
                 if bool((torch.isfinite(std) & (std.abs() < EPS)).any()):
                     active = True
                     break
-            elif norm_mode is NormalizationMode.MIN_MAX:
-                rng = _materialize(buffer["max"]) - _materialize(buffer["min"])
+            elif norm_mode in (NormalizationMode.MIN_MAX, NormalizationMode.QUANTILE):
+                lo_name, hi_name = stat_names_for_mode(norm_mode)
+                rng = _materialize(buffer[hi_name]) - _materialize(buffer[lo_name])
                 if bool((torch.isfinite(rng) & (rng.abs() < EPS)).any()):
                     active = True
                     break
@@ -466,11 +525,14 @@ class Normalize(nn.Module):
                     and self._snapping_possible()
                 ):
                     _warn_snapped_deviation(key, std_is_zero, deviation, dataset_index, self.dataset_names)
-            elif norm_mode is NormalizationMode.MIN_MAX:
-                min_ = _gather_and_broadcast(_materialize(buffer["min"]), dataset_index, batch_val)
-                max_ = _gather_and_broadcast(_materialize(buffer["max"]), dataset_index, batch_val)
-                assert not torch.isinf(min_).any(), _no_stats_error_str("min")
-                assert not torch.isinf(max_).any(), _no_stats_error_str("max")
+            elif norm_mode in (NormalizationMode.MIN_MAX, NormalizationMode.QUANTILE):
+                # QUANTILE is MIN_MAX arithmetic on the q01/q99 buffers: [q01, q99]
+                # maps to [-1, 1] and out-of-quantile values extend beyond (no clamp).
+                lo_name, hi_name = stat_names_for_mode(norm_mode)
+                min_ = _gather_and_broadcast(_materialize(buffer[lo_name]), dataset_index, batch_val)
+                max_ = _gather_and_broadcast(_materialize(buffer[hi_name]), dataset_index, batch_val)
+                assert not torch.isinf(min_).any(), _no_stats_error_str(lo_name)
+                assert not torch.isinf(max_).any(), _no_stats_error_str(hi_name)
                 # Snap a zero range (max == min: constant dim) to 1 — same blow-up class.
                 denom = max_ - min_
                 denom_is_zero = denom.abs() < EPS
@@ -556,12 +618,13 @@ class Unnormalize(nn.Module):
                 # x*EPS+mean would collapse it to ~mean. std >= EPS dims stay bit-identical.
                 std = torch.where(std.abs() < EPS, torch.ones_like(std), std)
                 batch[key] = batch_val * (std + EPS) + mean
-            elif norm_mode is NormalizationMode.MIN_MAX:
-                min_ = _gather_and_broadcast(_materialize(buffer["min"]), dataset_index, batch_val)
-                max_ = _gather_and_broadcast(_materialize(buffer["max"]), dataset_index, batch_val)
+            elif norm_mode in (NormalizationMode.MIN_MAX, NormalizationMode.QUANTILE):
+                lo_name, hi_name = stat_names_for_mode(norm_mode)
+                min_ = _gather_and_broadcast(_materialize(buffer[lo_name]), dataset_index, batch_val)
+                max_ = _gather_and_broadcast(_materialize(buffer[hi_name]), dataset_index, batch_val)
                 if not (torch.compiler.is_compiling() or torch.onnx.is_in_onnx_export()):
-                    assert not torch.isinf(min_).any(), _no_stats_error_str("min")
-                    assert not torch.isinf(max_).any(), _no_stats_error_str("max")
+                    assert not torch.isinf(min_).any(), _no_stats_error_str(lo_name)
+                    assert not torch.isinf(max_).any(), _no_stats_error_str(hi_name)
                 # Snap a zero range to 1 to mirror Normalize (keeps the round-trip exact).
                 denom = max_ - min_
                 denom = torch.where(denom.abs() < EPS, torch.ones_like(denom), denom)

--- a/src/opentau/policies/pretrained.py
+++ b/src/opentau/policies/pretrained.py
@@ -590,7 +590,11 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
                 trusted as-is and the caller is responsible for keeping
                 ``per_dataset_stats`` in the same order.
         """
-        from opentau.policies.normalize import _stat_to_float32_tensor
+        from opentau.policies.normalize import (
+            _stat_to_float32_tensor,
+            resolve_stat_row,
+            stat_names_for_mode,
+        )
 
         if dataset_names is not None:
             existing = getattr(self.config, "dataset_names", None)
@@ -623,9 +627,12 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
                 buffer = getattr(module, buffer_attr, None)
                 if buffer is None:
                     continue
-                stat_names = ("mean", "std") if norm_mode.name == "MEAN_STD" else ("min", "max")
+                stat_names = stat_names_for_mode(norm_mode)
                 for stat in stat_names:
-                    rows = [_stat_to_float32_tensor(s[feature_key][stat]) for s in per_dataset_stats]
+                    rows = [
+                        _stat_to_float32_tensor(resolve_stat_row(s, feature_key, stat))
+                        for s in per_dataset_stats
+                    ]
                     new_tensor = torch.stack(rows, dim=0).to(
                         device=buffer[stat].device, dtype=buffer[stat].dtype
                     )

--- a/src/opentau/policies/pretrained.py
+++ b/src/opentau/policies/pretrained.py
@@ -376,9 +376,12 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
             for child_name, child in module.named_children():
                 if not child_name.startswith("buffer_"):
                     continue
-                for stat_name in ("mean", "std", "min", "max"):
-                    if stat_name in child:
-                        return int(child[stat_name].shape[0])
+                # Every stat in a buffer shares the (num_datasets, ...) leading
+                # dim by construction, so any entry works — probing values()
+                # instead of a hardcoded name list keeps this correct for every
+                # NormalizationMode (QUANTILE buffers hold only q01/q99).
+                for param in child.values():
+                    return int(param.shape[0])
         return 1
 
     def _infer_batch_size_and_device(self, batch: dict[str, Tensor]) -> tuple[int, torch.device]:

--- a/src/opentau/scripts/diagnose_norm_distribution.py
+++ b/src/opentau/scripts/diagnose_norm_distribution.py
@@ -100,7 +100,7 @@ class Args:
     num_workers: int | None = None  # default: cpu_count()
     frame_stride: int = 1  # subsample every Nth frame per episode (speed)
     max_episodes_per_dataset: int | None = None  # cap episodes/dataset (speed)
-    norm_mode: str = "MEAN_STD"  # MEAN_STD | MIN_MAX (must match the policy)
+    norm_mode: str = "MEAN_STD"  # MEAN_STD | MIN_MAX | QUANTILE (must match the policy)
     emit_corrected_stats: bool = True  # write data-derived per-head stats override
     top_n: int = 40  # console: worst-N dims by staleness
     no_plots: bool = False
@@ -214,13 +214,21 @@ def _normalize(x: np.ndarray, stat: dict, mode: str) -> np.ndarray:
         return (x - stat["mean"]) / (stat["std"] + EPS)
     if mode == "MIN_MAX":
         return (x - stat["min"]) / (stat["max"] - stat["min"] + EPS) * 2.0 - 1.0
+    if mode == "QUANTILE":
+        # Same fallback as `create_stats_buffers`: stats without stored
+        # quantiles degrade to min/max scaling for that head.
+        lo = stat["q01"] if "q01" in stat else stat["min"]
+        hi = stat["q99"] if "q99" in stat else stat["max"]
+        return (x - lo) / (hi - lo + EPS) * 2.0 - 1.0
     raise ValueError(f"unsupported norm_mode {mode!r}")
 
 
 def _slice_stat(stat: dict, dim: int) -> dict:
     """Slice a (possibly zero-padded) head stat dict down to a feature's native
-    dim, so workers normalize against the real columns only."""
-    return {k: np.asarray(stat[k], np.float64)[:dim].copy() for k in ("mean", "std", "min", "max")}
+    dim, so workers normalize against the real columns only. Quantile keys are
+    optional (absent for stats predating quantile support)."""
+    keys = [k for k in ("mean", "std", "min", "max", "q01", "q99") if k in stat]
+    return {k: np.asarray(stat[k], np.float64)[:dim].copy() for k in keys}
 
 
 # --------------------------------------------------------------------------- #

--- a/src/opentau/scripts/diagnose_norm_distribution.py
+++ b/src/opentau/scripts/diagnose_norm_distribution.py
@@ -639,6 +639,18 @@ def main(args: Args) -> None:
     (out_dir / "report.json").write_text(json.dumps(report, indent=2))
     _write_csv(rows, out_dir / "report.csv")
     if args.emit_corrected_stats:
+        if args.norm_mode == "QUANTILE":
+            # The streaming accumulator holds moments and extremes, not order
+            # statistics, so corrected_stats.json cannot carry q01/q99. A
+            # QUANTILE policy fed this artifact would fall back to the
+            # data-derived global min/max — exactly the extreme-value scaling
+            # QUANTILE exists to avoid.
+            logger.warning(
+                "emit_corrected_stats with norm_mode=QUANTILE: corrected_stats.json contains only "
+                "mean/std/min/max (quantiles are not recoverable from the streaming accumulator). "
+                "Applying it to a QUANTILE policy downgrades every head to min/max scaling; prefer "
+                "recomputing quantiles from data if the metadata quantiles are stale."
+            )
         _emit_corrected_stats(merged, norm_keys, out_dir / "corrected_stats.json")
     if not args.no_plots:
         _plot(merged, head_info, norm_keys, rows, out_dir)

--- a/tests/datasets/test_compute_stats.py
+++ b/tests/datasets/test_compute_stats.py
@@ -420,3 +420,72 @@ def test_aggregate_stats():
             results[fkey]["std"], expected_agg_stats[fkey]["std"], atol=1e-04, rtol=1e-04
         )
         np.testing.assert_allclose(results[fkey]["count"], expected_agg_stats[fkey]["count"])
+
+
+def test_aggregate_feature_stats_quantiles_weighted_mean():
+    """q01/q99 aggregate as the count-weighted mean of contributor quantiles."""
+    stats_ft = [
+        {
+            "min": np.array([0.0]),
+            "max": np.array([10.0]),
+            "mean": np.array([5.0]),
+            "std": np.array([1.0]),
+            "count": np.array([10]),
+            "q01": np.array([1.0]),
+            "q99": np.array([9.0]),
+        },
+        {
+            "min": np.array([0.0]),
+            "max": np.array([10.0]),
+            "mean": np.array([5.0]),
+            "std": np.array([1.0]),
+            "count": np.array([30]),
+            "q01": np.array([3.0]),
+            "q99": np.array([5.0]),
+        },
+    ]
+    agg = aggregate_feature_stats(stats_ft)
+    # weighted by counts 10:30 -> q01 = (1*10 + 3*30)/40 = 2.5 ; q99 = (9*10 + 5*30)/40 = 6.0
+    np.testing.assert_allclose(agg["q01"], [2.5])
+    np.testing.assert_allclose(agg["q99"], [6.0])
+
+
+def test_aggregate_feature_stats_quantile_fallback_to_extreme():
+    """A contributor without a stored quantile contributes its same-side extreme."""
+    stats_ft = [
+        {
+            "min": np.array([-8.0]),
+            "max": np.array([8.0]),
+            "mean": np.array([0.0]),
+            "std": np.array([1.0]),
+            "count": np.array([10]),
+            "q01": np.array([-2.0]),
+            "q99": np.array([2.0]),
+        },
+        {
+            # no quantiles (stats predating quantile support) -> min/max used
+            "min": np.array([-4.0]),
+            "max": np.array([4.0]),
+            "mean": np.array([0.0]),
+            "std": np.array([1.0]),
+            "count": np.array([10]),
+        },
+    ]
+    agg = aggregate_feature_stats(stats_ft)
+    np.testing.assert_allclose(agg["q01"], [(-2.0 - 4.0) / 2])
+    np.testing.assert_allclose(agg["q99"], [(2.0 + 4.0) / 2])
+
+
+def test_aggregate_feature_stats_no_quantiles_no_keys():
+    """When no contributor has quantiles, the aggregate has no quantile keys."""
+    stats_ft = [
+        {
+            "min": np.array([0.0]),
+            "max": np.array([1.0]),
+            "mean": np.array([0.5]),
+            "std": np.array([0.1]),
+            "count": np.array([5]),
+        }
+    ]
+    agg = aggregate_feature_stats(stats_ft)
+    assert "q01" not in agg and "q99" not in agg

--- a/tests/datasets/test_dataset_mixture.py
+++ b/tests/datasets/test_dataset_mixture.py
@@ -144,6 +144,53 @@ class TestDatasetMixtureMetadata:
         assert "camera2" not in result
 
     @patch("opentau.datasets.dataset_mixture.DATA_FEATURES_NAME_MAPPING")
+    def test_to_standard_data_format_pads_quantiles(self, mock_name_mapping, train_pipeline_config, caplog):
+        """Quantile keys are padded like mean/std/min/max (pinning the
+        shape-mismatch fix for QUANTILE buffers), state/actions pad
+        independently when only one side carries quantiles, and a non-finite
+        quantile gets the per-repo warning."""
+        import logging
+
+        mock_name_mapping.__getitem__.return_value = {
+            "state": "state",
+            "actions": "actions",
+        }
+        train_pipeline_config.num_cams = 0
+
+        metadata_mixture = DatasetMixtureMetadata.__new__(DatasetMixtureMetadata)
+        metadata_mixture.cfg = train_pipeline_config
+
+        base = {
+            "mean": np.array([0.5, 0.3], dtype=np.float32),
+            "std": np.array([0.1, 0.05], dtype=np.float32),
+            "min": np.array([0.0, 0.0], dtype=np.float32),
+            "max": np.array([1.0, 1.0], dtype=np.float32),
+            "count": np.array([100], dtype=np.float32),
+        }
+        stats = {
+            # state carries quantiles (one of them NaN -> must warn)
+            "state": {
+                **{k: v.copy() for k, v in base.items()},
+                "q01": np.array([np.nan, 0.01], dtype=np.float32),
+                "q99": np.array([0.99, 0.99], dtype=np.float32),
+            },
+            # actions has no quantiles at all (converted-from-v2.1 shape)
+            "actions": {k: v.copy() for k, v in base.items()},
+        }
+
+        with caplog.at_level(logging.WARNING):
+            result = metadata_mixture._to_standard_data_format("test_dataset", stats)
+
+        # quantiles padded to max_state_dim like the other stats
+        assert result["state"]["q01"].shape[-1] == train_pipeline_config.max_state_dim
+        assert result["state"]["q99"].shape[-1] == train_pipeline_config.max_state_dim
+        # actions without quantiles still pads its own stats (independent loops)
+        assert "q01" not in result["actions"]
+        assert result["actions"]["mean"].shape[-1] == train_pipeline_config.max_action_dim
+        # the NaN q01 fired the non-finite sweep with the repo name
+        assert any("non-finite" in r.getMessage() and "q01" in r.getMessage() for r in caplog.records)
+
+    @patch("opentau.datasets.dataset_mixture.DATA_FEATURES_NAME_MAPPING")
     def test_to_standard_data_format_missing_key(self, mock_name_mapping, train_pipeline_config):
         """Test _to_standard_data_format with missing key."""
         # Mock the name mapping to include a key not in stats

--- a/tests/policies/test_normalize_per_dataset.py
+++ b/tests/policies/test_normalize_per_dataset.py
@@ -572,3 +572,77 @@ class TestSnapWarning:
             norm({"action": torch.tensor([[0.0, 0.0, 0.0, 5.0]])}, idx)
         msgs = [r.getMessage() for r in caplog.records if "zero-variance guard" in r.getMessage()]
         assert len(msgs) == 1 and "dim(s)=[3]" in msgs[0] and "action" in msgs[0]
+
+
+def _build_quantile_stats(num_datasets: int) -> list[dict[str, dict[str, torch.Tensor]]]:
+    """Distinct q01/q99 (and wider min/max) per dataset row."""
+    out = []
+    for d in range(num_datasets):
+        out.append(
+            {
+                "action": {
+                    "min": torch.full((3,), -10.0 * (d + 1)),
+                    "max": torch.full((3,), 10.0 * (d + 1)),
+                    "q01": torch.full((3,), -float(d + 1)),
+                    "q99": torch.full((3,), float(d + 1)),
+                },
+            }
+        )
+    return out
+
+
+def test_per_dataset_normalize_quantile_picks_right_row():
+    """QUANTILE scales with each row's q01/q99, not min/max: q99 maps to +1."""
+    num_ds = 3
+    features = {"action": PolicyFeature(type=FeatureType.ACTION, shape=(3,))}
+    norm_map = {"ACTION": NormalizationMode.QUANTILE}
+    norm = Normalize(features, norm_map, per_dataset_stats=_build_quantile_stats(num_ds))
+
+    dataset_index = torch.tensor([0, 1, 2], dtype=torch.long)
+    # feed each row its own q99 value -> must normalize to +1 for every row
+    action = torch.stack([torch.full((3,), float(d + 1)) for d in range(num_ds)])
+    out = norm({"action": action}, dataset_index)
+    torch.testing.assert_close(out["action"], torch.ones(num_ds, 3), atol=1e-5, rtol=1e-5)
+    # a value beyond q99 extends beyond +1 (no clamp)
+    out2 = norm({"action": torch.full((1, 3), 2.0)}, torch.tensor([0]))
+    assert bool((out2["action"] > 1.0).all())
+
+
+def test_quantile_round_trip():
+    """Unnormalize(Normalize(x)) recovers x under QUANTILE."""
+    features = {"action": PolicyFeature(type=FeatureType.ACTION, shape=(3,))}
+    norm_map = {"ACTION": NormalizationMode.QUANTILE}
+    stats = _build_quantile_stats(2)
+    norm = Normalize(features, norm_map, per_dataset_stats=stats)
+    unnorm = Unnormalize(features, norm_map, per_dataset_stats=stats)
+
+    idx = torch.tensor([0, 1], dtype=torch.long)
+    x = torch.tensor([[0.3, -1.7, 0.9], [3.0, -0.2, 1.4]])
+    y = unnorm(norm({"action": x}, idx), idx)["action"]
+    torch.testing.assert_close(y, x, atol=1e-5, rtol=1e-5)
+
+
+def test_quantile_fallback_to_min_max(caplog):
+    """Rows lacking q01/q99 fall back to min/max (converted-from-v2.1 datasets)."""
+    features = {"action": PolicyFeature(type=FeatureType.ACTION, shape=(3,))}
+    norm_map = {"ACTION": NormalizationMode.QUANTILE}
+    stats = _build_quantile_stats(2)
+    # strip quantiles from row 1 -> its buffer row must equal its min/max
+    del stats[1]["action"]["q01"]
+    del stats[1]["action"]["q99"]
+    with caplog.at_level(logging.WARNING):
+        norm = Normalize(features, norm_map, per_dataset_stats=stats)
+    assert any("fell back" in r.getMessage() for r in caplog.records)
+
+    # row 0 uses q99=1 -> value 1.0 normalizes to +1; row 1 uses max=20 -> value 20 -> +1
+    out = norm({"action": torch.tensor([[1.0] * 3, [20.0] * 3])}, torch.tensor([0, 1]))
+    torch.testing.assert_close(out["action"], torch.ones(2, 3), atol=1e-5, rtol=1e-5)
+
+
+def test_quantile_missing_all_raises():
+    """A row with neither the quantile nor its min/max fallback raises KeyError."""
+    features = {"action": PolicyFeature(type=FeatureType.ACTION, shape=(3,))}
+    norm_map = {"ACTION": NormalizationMode.QUANTILE}
+    stats = [{"action": {"mean": torch.zeros(3), "std": torch.ones(3)}}]
+    with pytest.raises(KeyError, match="q01"):
+        Normalize(features, norm_map, per_dataset_stats=stats)

--- a/tests/policies/test_pretrained_skip_normalization.py
+++ b/tests/policies/test_pretrained_skip_normalization.py
@@ -655,3 +655,98 @@ class TestNormBufferInfGate:
         mean = policy.normalize_targets.buffer_action["mean"]
         for h in range(2):
             torch.testing.assert_close(mean[h], torch.full((3,), _NEW_BASE + h))
+
+
+class TestStackedNumDatasetsQuantile:
+    """`_stacked_num_datasets` must see the head count through QUANTILE-only
+    buffers (which hold q01/q99, not mean/std/min/max) — regression for the
+    silent row-0 fallback with the QUANTILE normalization_mapping."""
+
+    @pytest.mark.parametrize(
+        "norm_map, stat_row",
+        [
+            (
+                {"ACTION": NormalizationMode.QUANTILE},
+                {"q01": np.full((3,), -1.0, np.float32), "q99": np.full((3,), 1.0, np.float32)},
+            ),
+            (
+                {"ACTION": NormalizationMode.MEAN_STD},
+                {"mean": np.zeros((3,), np.float32), "std": np.ones((3,), np.float32)},
+            ),
+        ],
+        ids=["quantile", "mean_std"],
+    )
+    def test_probe_sees_all_modes(self, norm_map, stat_row):
+        from opentau.policies.pretrained import PreTrainedPolicy
+
+        features = {"action": PolicyFeature(type=FeatureType.ACTION, shape=(3,))}
+        stats = [{"action": dict(stat_row)} for _ in range(2)]
+
+        class _Shim:
+            pass
+
+        shim = _Shim()
+        shim.normalize_inputs = None
+        shim.normalize_targets = Normalize(features, norm_map, per_dataset_stats=stats)
+        shim.unnormalize_outputs = None
+        assert PreTrainedPolicy._stacked_num_datasets(shim) == 2
+
+
+class TestInjectStatsQuantile:
+    """`_inject_stats` on a QUANTILE policy: q01/q99 rows land in the buffers,
+    and stats without stored quantiles inject via the min/max fallback."""
+
+    def _quantile_policy(self, num_heads: int = 2):
+        policy = _make_multihead_policy([f"h::{i}" for i in range(num_heads)], base=_CKPT_BASE, skip=False)
+        # Rebuild the norm modules in QUANTILE mode on the same config/names.
+        in_features = {"observation.state": PolicyFeature(type=FeatureType.STATE, shape=(4,))}
+        out_features = {"action": PolicyFeature(type=FeatureType.ACTION, shape=(3,))}
+        norm_map = {"STATE": NormalizationMode.QUANTILE, "ACTION": NormalizationMode.QUANTILE}
+        names = list(policy.config.dataset_names)
+        stats = self._build_quantile_head_stats(num_heads, _CKPT_BASE)
+        policy.normalize_inputs = Normalize(
+            in_features, norm_map, per_dataset_stats=stats, dataset_names=names
+        )
+        policy.normalize_targets = Normalize(
+            out_features, norm_map, per_dataset_stats=stats, dataset_names=names
+        )
+        policy.unnormalize_outputs = Unnormalize(
+            out_features, norm_map, per_dataset_stats=stats, dataset_names=names
+        )
+        return policy
+
+    @staticmethod
+    def _build_quantile_head_stats(num_heads: int, base: float, with_quantiles: bool = True):
+        stats = []
+        for h in range(num_heads):
+            val = float(base + h)
+            row = {
+                "min": lambda v, d: np.full((d,), v - 10.0, np.float32),
+                "max": lambda v, d: np.full((d,), v + 10.0, np.float32),
+            }
+            entry = {}
+            for key, dim in (("observation.state", 4), ("action", 3)):
+                feat = {"min": row["min"](val, dim), "max": row["max"](val, dim)}
+                if with_quantiles:
+                    feat["q01"] = np.full((dim,), val - 1.0, np.float32)
+                    feat["q99"] = np.full((dim,), val + 1.0, np.float32)
+                entry[key] = feat
+            stats.append(entry)
+        return stats
+
+    def test_inject_quantile_stats_refreshes_buffers(self):
+        policy = self._quantile_policy()
+        new = self._build_quantile_head_stats(2, _NEW_BASE)
+        policy._inject_stats(new, dataset_names=["h::0", "h::1"])
+        buf = policy.normalize_targets.buffer_action
+        assert float(buf["q01"][1][0]) == _NEW_BASE + 1 - 1.0
+        assert float(buf["q99"][0][0]) == _NEW_BASE + 0 + 1.0
+
+    def test_inject_quantile_min_max_fallback(self):
+        policy = self._quantile_policy()
+        new = self._build_quantile_head_stats(2, _NEW_BASE, with_quantiles=False)
+        policy._inject_stats(new, dataset_names=["h::0", "h::1"])
+        buf = policy.normalize_targets.buffer_action
+        # fallback: q01 <- min = base - 10, q99 <- max = base + 10
+        assert float(buf["q01"][0][0]) == _NEW_BASE - 10.0
+        assert float(buf["q99"][1][0]) == _NEW_BASE + 1 + 10.0

--- a/tests/scripts/test_diagnose_norm_distribution.py
+++ b/tests/scripts/test_diagnose_norm_distribution.py
@@ -53,6 +53,23 @@ class TestNormalize:
         z = _normalize(x, stat, "MIN_MAX")
         np.testing.assert_allclose(z, [[0.5 / (1 + EPS) * 2 - 1]], atol=1e-6)
 
+    def test_quantile(self):
+        x = np.array([[3.0]])
+        stat = {
+            "min": np.array([-100.0]),
+            "max": np.array([100.0]),
+            "q01": np.array([-3.0]),
+            "q99": np.array([3.0]),
+        }
+        z = _normalize(x, stat, "QUANTILE")
+        np.testing.assert_allclose(z, [[6.0 / (6.0 + EPS) * 2 - 1]], atol=1e-6)
+
+    def test_quantile_falls_back_to_min_max(self):
+        x = np.array([[1.0]])
+        stat = {"min": np.array([0.0]), "max": np.array([1.0])}
+        z = _normalize(x, stat, "QUANTILE")
+        np.testing.assert_allclose(z, _normalize(x, stat, "MIN_MAX"))
+
     def test_unknown_mode_raises(self):
         with pytest.raises(ValueError):
             _normalize(np.zeros((1, 1)), {}, "NOPE")


### PR DESCRIPTION
## What this does

Adds a `QUANTILE` normalization mode — robust q01/q99 scaling — so heterogeneous community mixtures (like the curated SO101 era partitions from #477) can be normalized without either of the existing modes' failure cases. (🗃️ Feature)

**Why.** For community-scale mixtures, `MIN_MAX` is an extreme-value statistic — a single glitch frame in one dataset sets that dataset's entire scale — and `MEAN_STD` conflates task motion spread with units (a dataset whose task moves little gets a tiny std, blowing up its normalized values). LeRobot v3.0 datasets already ship `q01`/`q99` in `meta/stats.json` (verified present in all 406 datasets of the SO101 era-3 partition); this PR makes them usable end-to-end.

**What changed:**

- **`NormalizationMode.QUANTILE`** (`configs/types.py`): maps `[q01, q99] → [-1, 1]`. Arithmetic is identical to `MIN_MAX` but on the quantile buffers; values outside the quantile range extend beyond ±1 (no clamping). The zero-range snap guard (constant/padding dims) carries over unchanged.
- **Per-row fallback** (`policies/normalize.py`): datasets whose stats predate quantile support (v3.0 repos converted from v2.1 carry only min/max/mean/std) fall back to `min`/`max` for that dataset's row, with one aggregated warning. A row with neither raises a clear `KeyError`.
- **Norm-head aggregation** (`datasets/compute_stats.py`): `aggregate_feature_stats` now carries `q01`/`q99` through multi-dataset norm heads as the count-weighted mean of contributor quantiles (exact pooled quantiles are not recoverable from per-dataset quantiles; the weighted mean is the standard approximation and stays robust to a single contributor's extremes). Non-finite entries are masked per dim, mirroring the mean/variance handling.
- **Stats standardization** (`datasets/dataset_mixture.py`): quantile keys are now padded to `max_state_dim`/`max_action_dim` alongside mean/std/min/max (previously they passed through unpadded, which would shape-mismatch at buffer creation). State and actions are padded independently in case a converted dataset carries quantiles on only one feature.
- **`_inject_stats`** (`policies/pretrained.py`): stat names now come from the shared `stat_names_for_mode` helper (with the same fallback resolution) instead of a hardcoded `MEAN_STD`/`MIN_MAX` pair, so stats injection works for the new mode.

**Opt-in only.** No default `normalization_mapping` changes; existing `MEAN_STD`/`MIN_MAX` numerics are untouched (the `MIN_MAX` branch was refactored to share code with `QUANTILE` but performs the identical ops on the identical buffers). Enable via config override, e.g. `--policy.normalization_mapping '{"VISUAL": "IDENTITY", "STATE": "QUANTILE", "ACTION": "QUANTILE"}'`.

## How it was tested

- New unit tests (all CPU):
  - `tests/policies/test_normalize_per_dataset.py`: QUANTILE per-row selection (each sample scaled by its own dataset's q01/q99), Normalize→Unnormalize round-trip, min/max fallback for quantile-less rows (with warning), and a clear `KeyError` when neither quantiles nor extremes exist.
  - `tests/datasets/test_compute_stats.py`: count-weighted quantile aggregation, per-contributor fallback to same-side extremes, and no quantile keys emitted when no contributor has them.
- Full affected test dirs: `pytest tests/policies/ tests/datasets/ -m "not gpu and not network" -n auto` → **1270 passed, 9 skipped**.
- End-to-end sanity on real Hub stats: built `Normalize`/`Unnormalize` with QUANTILE from actual SO101 community `meta/stats.json` snapshots — per-dataset heads round-trip with max error ~4e-6, and a norm head aggregated across datasets carries `q01`/`q99` and normalizes real state values into the expected few-unit range.
- `pre-commit run --files` on all changed files: clean.

No `modeling_*.py`/`configuration_*.py`/optimizer/sampler/train-loop files are touched, and the new mode is opt-in (no default config uses it), so existing training behavior is unchanged.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/policies/test_normalize_per_dataset.py -k quantile
pytest -sx tests/datasets/test_compute_stats.py -k quantile
```

Or a 30-second interactive check:

```python
import torch
from opentau.configs.types import FeatureType, NormalizationMode, PolicyFeature
from opentau.policies.normalize import Normalize, Unnormalize

features = {"action": PolicyFeature(type=FeatureType.ACTION, shape=(2,))}
norm_map = {"ACTION": NormalizationMode.QUANTILE}
stats = [{"action": {"min": torch.tensor([-90.0, -90.0]), "max": torch.tensor([90.0, 90.0]),
                     "q01": torch.tensor([-30.0, -30.0]), "q99": torch.tensor([30.0, 30.0])}}]
norm = Normalize(features, norm_map, per_dataset_stats=stats)
print(norm({"action": torch.tensor([[30.0, -30.0]])}, torch.tensor([0])))  # -> [[1., -1.]]
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.
