### PR TITLE
feat(grpc): Support injectable request hooks for inference tracking

### DIFF
--- a/src/opentau/scripts/grpc/server.py
+++ b/src/opentau/scripts/grpc/server.py
@@ -55,7 +55,7 @@ import traceback
 from concurrent import futures
 from dataclasses import asdict
 from pprint import pformat
-from typing import Iterator
+from typing import Callable, Iterator
 
 import numpy as np
 import torch
@@ -79,6 +79,12 @@ from opentau.utils.utils import (
 
 logger = logging.getLogger(__name__)
 
+RequestHook = Callable[[str], None]
+
+
+def _noop_request_hook(_method: str) -> None:
+    """Default request hook used when an embedding application supplies none."""
+
 
 class RobotPolicyServicer(robot_inference_pb2_grpc.RobotPolicyServiceServicer):
     """gRPC servicer implementing the RobotPolicyService.
@@ -91,14 +97,22 @@ class RobotPolicyServicer(robot_inference_pb2_grpc.RobotPolicyServiceServicer):
     policy inference.
     """
 
-    def __init__(self, cfg: TrainPipelineConfig):
+    def __init__(
+        self,
+        cfg: TrainPipelineConfig,
+        request_hook: RequestHook | None = None,
+    ):
         """Initialize the servicer with model and configuration.
 
         Args:
             cfg: Training pipeline configuration including policy, server and
                 planner settings.
+            request_hook: Optional non-blocking callback invoked for every
+                accepted inference request. Hook failures are logged and never
+                fail the RPC.
         """
         self.cfg = cfg
+        self._request_hook = request_hook or _noop_request_hook
         self.device = auto_torch_device()
         self.dtype = torch.bfloat16
 
@@ -109,6 +123,13 @@ class RobotPolicyServicer(robot_inference_pb2_grpc.RobotPolicyServiceServicer):
 
         # Optionally spin up the high-level planner
         self._init_planner(cfg.planner)
+
+    def _notify_request(self, method: str) -> None:
+        """Run the embedding application's request hook without affecting RPCs."""
+        try:
+            self._request_hook(method)
+        except Exception:
+            logger.exception("gRPC request hook failed for %s", method)
 
     def _init_planner(self, pcfg):
         """Set up the high-level planner and start its background loop (if enabled)."""
@@ -447,6 +468,7 @@ class RobotPolicyServicer(robot_inference_pb2_grpc.RobotPolicyServiceServicer):
         Returns:
             ActionChunkResponse containing the predicted action chunk.
         """
+        self._notify_request("GetActionChunk")
         start_time = time.perf_counter()
         response = robot_inference_pb2.ActionChunkResponse()
         response.request_id = request.request_id
@@ -534,11 +556,12 @@ class RobotPolicyServicer(robot_inference_pb2_grpc.RobotPolicyServiceServicer):
         return response
 
 
-def serve(cfg: TrainPipelineConfig):
+def serve(cfg: TrainPipelineConfig, request_hook: RequestHook | None = None):
     """Start the gRPC server.
 
     Args:
         cfg: Training pipeline configuration including server settings.
+        request_hook: Optional callback invoked for each inference request.
     """
     server_cfg = cfg.server
 
@@ -559,7 +582,7 @@ def serve(cfg: TrainPipelineConfig):
         ],
     )
 
-    servicer = RobotPolicyServicer(cfg)
+    servicer = RobotPolicyServicer(cfg, request_hook=request_hook)
     robot_inference_pb2_grpc.add_RobotPolicyServiceServicer_to_server(servicer, server)
 
     server.add_insecure_port(f"[::]:{server_cfg.port}")

--- a/src/opentau/scripts/grpc/server.py
+++ b/src/opentau/scripts/grpc/server.py
@@ -107,9 +107,11 @@ class RobotPolicyServicer(robot_inference_pb2_grpc.RobotPolicyServiceServicer):
         Args:
             cfg: Training pipeline configuration including policy, server and
                 planner settings.
-            request_hook: Optional non-blocking callback invoked for every
-                accepted inference request. Hook failures are logged and never
-                fail the RPC.
+            request_hook: Optional callback invoked synchronously on the RPC
+                handler thread for every accepted inference request. Must be
+                fast and thread-safe (the server may call it concurrently from
+                multiple ThreadPoolExecutor workers). Hook failures are logged
+                and never fail the RPC.
         """
         self.cfg = cfg
         self._request_hook = request_hook or _noop_request_hook
@@ -562,6 +564,8 @@ def serve(cfg: TrainPipelineConfig, request_hook: RequestHook | None = None):
     Args:
         cfg: Training pipeline configuration including server settings.
         request_hook: Optional callback invoked for each inference request.
+            Must be fast and thread-safe; see ``RobotPolicyServicer`` for
+            failure semantics.
     """
     server_cfg = cfg.server
 

--- a/tests/scripts/test_grpc_planner_server.py
+++ b/tests/scripts/test_grpc_planner_server.py
@@ -70,7 +70,7 @@ def make_servicer():
     """Factory building a servicer with a patched policy path and fake planner."""
     servicers = []
 
-    def _make(**planner_overrides) -> tuple[RobotPolicyServicer, FakePlanner]:
+    def _make(request_hook=None, **planner_overrides) -> tuple[RobotPolicyServicer, FakePlanner]:
         planner_cfg = PlannerConfig(**planner_overrides)
         cfg = SimpleNamespace(planner=planner_cfg, policy=SimpleNamespace(type="pi05"))
         fake_planner = FakePlanner()
@@ -78,7 +78,7 @@ def make_servicer():
             patch.object(RobotPolicyServicer, "_load_policy"),
             patch("opentau.scripts.grpc.server.GeminiERPlanner", return_value=fake_planner),
         ):
-            servicer = RobotPolicyServicer(cfg)
+            servicer = RobotPolicyServicer(cfg, request_hook=request_hook)
         servicers.append(servicer)
         return servicer, fake_planner
 
@@ -98,6 +98,24 @@ class TestPlannerDisabled:
 
         assert request.prompt == "raw task"
         assert fake_planner.calls == []
+
+
+class TestRequestHook:
+    def test_notifies_injected_hook(self, make_servicer):
+        calls = []
+        servicer, _ = make_servicer(enabled=False, request_hook=calls.append)
+
+        servicer._notify_request("GetActionChunk")
+
+        assert calls == ["GetActionChunk"]
+
+    def test_hook_failure_does_not_escape(self, make_servicer):
+        def failing_hook(_method):
+            raise RuntimeError("reporter unavailable")
+
+        servicer, _ = make_servicer(enabled=False, request_hook=failing_hook)
+
+        servicer._notify_request("GetActionChunk")
 
 
 class TestPlannerEnabled:

--- a/tests/scripts/test_grpc_planner_server.py
+++ b/tests/scripts/test_grpc_planner_server.py
@@ -19,6 +19,7 @@ loading is patched out and the Gemini planner is replaced with a controllable
 fake. CPU-only, no network.
 """
 
+import logging
 import threading
 import time
 from types import SimpleNamespace
@@ -109,13 +110,28 @@ class TestRequestHook:
 
         assert calls == ["GetActionChunk"]
 
-    def test_hook_failure_does_not_escape(self, make_servicer):
+    def test_hook_failure_does_not_escape(self, make_servicer, caplog):
         def failing_hook(_method):
             raise RuntimeError("reporter unavailable")
 
         servicer, _ = make_servicer(enabled=False, request_hook=failing_hook)
 
-        servicer._notify_request("GetActionChunk")
+        with caplog.at_level(logging.ERROR, logger="opentau.scripts.grpc.server"):
+            servicer._notify_request("GetActionChunk")
+
+        assert "gRPC request hook failed for GetActionChunk" in caplog.text
+
+    def test_get_action_chunk_notifies_hook(self, make_servicer):
+        calls = []
+        servicer, _ = make_servicer(enabled=False, request_hook=calls.append)
+
+        servicer._prepare_observation = MagicMock(return_value=({}, None, None))
+        servicer.policy = MagicMock()
+        servicer.policy.sample_actions.return_value = torch.zeros((1, 2, 3))
+
+        servicer.GetActionChunk(_request(), MagicMock())
+
+        assert calls == ["GetActionChunk"]
 
 
 class TestPlannerEnabled:


### PR DESCRIPTION
Allow embedding applications to observe accepted inference requests without coupling OpenTau to platform-specific activity tracking.
```markdown
## What this does

Adds an optional, non-blocking request hook to the gRPC inference server so embedding applications can observe inference requests without coupling OpenTau to platform-specific tracking.

- Keeps existing behavior unchanged with a default no-op hook.
- Invokes the hook for every `GetActionChunk` request, including messages processed through `StreamActionChunks`.
- Isolates hook failures so they never fail inference RPCs.
- Adds tests for hook invocation and failure handling.

## How it was tested

- `uv run pytest -q tests/scripts/test_grpc_auth.py tests/scripts/test_grpc_planner_server.py`
  - 22 tests passed.
- Pre-commit checks passed for all modified files.

## How to checkout & try? (for the reviewer)

```bash
git fetch origin feat/grpc-request-hook
git checkout feat/grpc-request-hook
uv run pytest -q tests/scripts/test_grpc_auth.py tests/scripts/test_grpc_planner_server.py
```

Example integration:

```python
from opentau.scripts.grpc.server import serve

serve(cfg, request_hook=lambda method: print(method))
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
