### PR TITLE
fix(policies): keep SigLIP patch/pos embeddings in float32 (openpi parity)

### DIFF
--- a/src/opentau/policies/pi0/paligemma_with_expert.py
+++ b/src/opentau/policies/pi0/paligemma_with_expert.py
@@ -285,14 +285,14 @@ class PaliGemmaWithExpertModel(PreTrainedModel):
         encoder-dtype hand-off is done by the patched ``SiglipVisionTransformer.forward`` in
         :mod:`opentau.utils.transformers_patch`.
 
-        Caveat: this pinning survives paths that keep the built model as-is — the gRPC
-        serving path (``scripts/grpc/server.py``), ONNX export
-        (``scripts/export_to_onnx.py``), and FSDP training (``train.py`` skips the cast
-        below under FSDP). Several other entry points (``scripts/inference.py``,
-        ``eval.py``, ``benchmark_inference.py``, ``high_level_planner_inference.py``, and
-        non-FSDP ``train.py`` / ``profile_step.py``) run a blanket
-        ``policy.to(torch.bfloat16)`` after load that rounds these tables back to bfloat16;
-        making the float32 masters survive those casts (e.g. re-establishing them from the
+        Caveat: this pinning only survives paths that keep the built model as-is — ONNX
+        export (``scripts/export_to_onnx.py``, which runs in float32) and FSDP training
+        (``train.py`` skips the cast below under FSDP). Every other entry point runs a
+        blanket ``policy.to(torch.bfloat16)`` after load that rounds these tables back to
+        bfloat16, undoing the pinning: the gRPC serving path (``scripts/grpc/server.py``),
+        ``scripts/inference.py``, ``eval.py``, ``benchmark_inference.py``,
+        ``high_level_planner_inference.py``, and non-FSDP ``train.py`` / ``profile_step.py``.
+        Making the float32 masters survive those casts (e.g. re-establishing them from the
         checkpoint after the cast, without breaking DeepSpeed/DDP param handling) is a
         follow-up.
         """

--- a/src/opentau/policies/pi0/paligemma_with_expert.py
+++ b/src/opentau/policies/pi0/paligemma_with_expert.py
@@ -285,16 +285,18 @@ class PaliGemmaWithExpertModel(PreTrainedModel):
         encoder-dtype hand-off is done by the patched ``SiglipVisionTransformer.forward`` in
         :mod:`opentau.utils.transformers_patch`.
 
-        The pinning is preserved by ONNX export (``scripts/export_to_onnx.py``, float32),
-        FSDP training (``train.py`` skips the cast below under FSDP), and the inference /
-        serving entry points (the gRPC server, ``scripts/inference.py``, ``eval.py``,
-        ``benchmark_inference.py``, ``high_level_planner_inference.py``,
-        ``actions_mse_loss.py``), which do their blanket bfloat16 cast through
-        :func:`opentau.policies.utils.to_dtype_preserving_siglip_float32` so these tables
-        stay float32. The remaining gap is the non-FSDP training cast (``train.py`` /
-        ``profile_step.py`` under DeepSpeed / DDP), which still blanket-casts to bfloat16:
-        re-introducing float32 params after the cast there would change how ZeRO / DDP
-        partition parameters and needs multi-rank validation (deferred to a follow-up).
+        These tables are used in the patch-conv / posemb *compute* in float32 only at
+        inference / serving / ONNX export: the inference entry points (the gRPC server,
+        ``scripts/inference.py``, ``eval.py``, ``benchmark_inference.py``,
+        ``high_level_planner_inference.py``, ``actions_mse_loss.py``) route their blanket
+        bfloat16 cast through :func:`opentau.policies.utils.to_dtype_preserving_siglip_float32`,
+        and ONNX export runs in float32. No *training* backend computes them in float32: DDP
+        and non-FSDP DeepSpeed blanket-cast the whole policy to bfloat16 (``train.py`` /
+        ``profile_step.py``), and FSDP keeps a float32 master but its
+        ``MixedPrecision(param_dtype=bfloat16)`` materializes bfloat16 compute params in the
+        all-gather. That gap is small (patch-conv compute differs ~0.14% in the image tokens,
+        ~1e-4 in the sampled actions; the default freezes the vision encoder) and is tracked
+        for a backend-specific, multi-rank-validated follow-up in issue #483.
         """
         self.paligemma = self.paligemma.to(dtype=torch.bfloat16)
 

--- a/src/opentau/policies/pi0/paligemma_with_expert.py
+++ b/src/opentau/policies/pi0/paligemma_with_expert.py
@@ -288,8 +288,8 @@ class PaliGemmaWithExpertModel(PreTrainedModel):
         The pinning is preserved by ONNX export (``scripts/export_to_onnx.py``, float32),
         FSDP training (``train.py`` skips the cast below under FSDP), and the inference /
         serving entry points (the gRPC server, ``scripts/inference.py``, ``eval.py``,
-        ``benchmark_inference.py``, ``high_level_planner_inference.py``), which do their
-        blanket bfloat16 cast through
+        ``benchmark_inference.py``, ``high_level_planner_inference.py``,
+        ``actions_mse_loss.py``), which do their blanket bfloat16 cast through
         :func:`opentau.policies.utils.to_dtype_preserving_siglip_float32` so these tables
         stay float32. The remaining gap is the non-FSDP training cast (``train.py`` /
         ``profile_step.py`` under DeepSpeed / DDP), which still blanket-casts to bfloat16:

--- a/src/opentau/policies/pi0/paligemma_with_expert.py
+++ b/src/opentau/policies/pi0/paligemma_with_expert.py
@@ -271,7 +271,20 @@ class PaliGemmaWithExpertModel(PreTrainedModel):
             self.paligemma.eval()
 
     def to_bfloat16_like_physical_intelligence(self) -> None:
-        """Casts specific model components to bfloat16 dtype."""
+        """Casts specific model components to bfloat16, keeping the SigLIP embeddings in float32.
+
+        Mirrors openpi's ``to_bfloat16_for_selected_params``: the bulk of the VLM runs in
+        bfloat16, but the SigLIP patch-embedding conv and the learned position-embedding table
+        are pinned to float32. The original JAX (Big Vision) SigLIP does patch extraction and
+        position embedding in float32 and only casts to the (bf16) encoder dtype afterwards
+        (``openpi/models/siglip.py``: "do patch extraction and posemb in float32"). Those two
+        tables are the only vision weights that are genuine float32 masters rather than bf16
+        masters upcast on checkpoint export, so loading their float32 values straight into
+        bf16 parameters rounds away real precision that a later ``.to(float32)`` cannot recover
+        (empirically ~0.4 max abs error in the projected image tokens). The float32 ->
+        encoder-dtype hand-off is done by the patched ``SiglipVisionTransformer.forward`` in
+        :mod:`opentau.utils.transformers_patch`.
+        """
         self.paligemma = self.paligemma.to(dtype=torch.bfloat16)
 
         params_to_change_dtype = [
@@ -283,6 +296,15 @@ class PaliGemmaWithExpertModel(PreTrainedModel):
         for name, param in self.named_parameters():
             if any(selector in name for selector in params_to_change_dtype):
                 param.data = param.data.to(dtype=torch.bfloat16)
+
+        params_to_keep_float32 = [
+            "vision_tower.vision_model.embeddings.patch_embedding.weight",
+            "vision_tower.vision_model.embeddings.patch_embedding.bias",
+            "vision_tower.vision_model.embeddings.position_embedding.weight",
+        ]
+        for name, param in self.named_parameters():
+            if any(selector in name for selector in params_to_keep_float32):
+                param.data = param.data.to(dtype=torch.float32)
 
     def embed_image(self, image: torch.Tensor) -> torch.Tensor:
         """Computes image embeddings.

--- a/src/opentau/policies/pi0/paligemma_with_expert.py
+++ b/src/opentau/policies/pi0/paligemma_with_expert.py
@@ -285,16 +285,16 @@ class PaliGemmaWithExpertModel(PreTrainedModel):
         encoder-dtype hand-off is done by the patched ``SiglipVisionTransformer.forward`` in
         :mod:`opentau.utils.transformers_patch`.
 
-        Caveat: this pinning only survives paths that keep the built model as-is — ONNX
-        export (``scripts/export_to_onnx.py``, which runs in float32) and FSDP training
-        (``train.py`` skips the cast below under FSDP). Every other entry point runs a
-        blanket ``policy.to(torch.bfloat16)`` after load that rounds these tables back to
-        bfloat16, undoing the pinning: the gRPC serving path (``scripts/grpc/server.py``),
-        ``scripts/inference.py``, ``eval.py``, ``benchmark_inference.py``,
-        ``high_level_planner_inference.py``, and non-FSDP ``train.py`` / ``profile_step.py``.
-        Making the float32 masters survive those casts (e.g. re-establishing them from the
-        checkpoint after the cast, without breaking DeepSpeed/DDP param handling) is a
-        follow-up.
+        The pinning is preserved by ONNX export (``scripts/export_to_onnx.py``, float32),
+        FSDP training (``train.py`` skips the cast below under FSDP), and the inference /
+        serving entry points (the gRPC server, ``scripts/inference.py``, ``eval.py``,
+        ``benchmark_inference.py``, ``high_level_planner_inference.py``), which do their
+        blanket bfloat16 cast through
+        :func:`opentau.policies.utils.to_dtype_preserving_siglip_float32` so these tables
+        stay float32. The remaining gap is the non-FSDP training cast (``train.py`` /
+        ``profile_step.py`` under DeepSpeed / DDP), which still blanket-casts to bfloat16:
+        re-introducing float32 params after the cast there would change how ZeRO / DDP
+        partition parameters and needs multi-rank validation (deferred to a follow-up).
         """
         self.paligemma = self.paligemma.to(dtype=torch.bfloat16)
 

--- a/src/opentau/policies/pi0/paligemma_with_expert.py
+++ b/src/opentau/policies/pi0/paligemma_with_expert.py
@@ -284,6 +284,17 @@ class PaliGemmaWithExpertModel(PreTrainedModel):
         (empirically ~0.4 max abs error in the projected image tokens). The float32 ->
         encoder-dtype hand-off is done by the patched ``SiglipVisionTransformer.forward`` in
         :mod:`opentau.utils.transformers_patch`.
+
+        Caveat: this pinning survives paths that keep the built model as-is — the gRPC
+        serving path (``scripts/grpc/server.py``), ONNX export
+        (``scripts/export_to_onnx.py``), and FSDP training (``train.py`` skips the cast
+        below under FSDP). Several other entry points (``scripts/inference.py``,
+        ``eval.py``, ``benchmark_inference.py``, ``high_level_planner_inference.py``, and
+        non-FSDP ``train.py`` / ``profile_step.py``) run a blanket
+        ``policy.to(torch.bfloat16)`` after load that rounds these tables back to bfloat16;
+        making the float32 masters survive those casts (e.g. re-establishing them from the
+        checkpoint after the cast, without breaking DeepSpeed/DDP param handling) is a
+        follow-up.
         """
         self.paligemma = self.paligemma.to(dtype=torch.bfloat16)
 

--- a/src/opentau/policies/pi05/paligemma_with_expert.py
+++ b/src/opentau/policies/pi05/paligemma_with_expert.py
@@ -352,8 +352,8 @@ class PaliGemmaWithExpertModel(PreTrainedModel):
         The pinning is preserved by ONNX export (``scripts/export_to_onnx.py``, float32),
         FSDP training (``train.py`` skips the cast below under FSDP), and the inference /
         serving entry points (the gRPC server, ``scripts/inference.py``, ``eval.py``,
-        ``benchmark_inference.py``, ``high_level_planner_inference.py``), which do their
-        blanket bfloat16 cast through
+        ``benchmark_inference.py``, ``high_level_planner_inference.py``,
+        ``actions_mse_loss.py``), which do their blanket bfloat16 cast through
         :func:`opentau.policies.utils.to_dtype_preserving_siglip_float32` so these tables
         stay float32. The remaining gap is the non-FSDP training cast (``train.py`` /
         ``profile_step.py`` under DeepSpeed / DDP), which still blanket-casts to bfloat16:

--- a/src/opentau/policies/pi05/paligemma_with_expert.py
+++ b/src/opentau/policies/pi05/paligemma_with_expert.py
@@ -349,16 +349,16 @@ class PaliGemmaWithExpertModel(PreTrainedModel):
         encoder-dtype hand-off is done by the patched ``SiglipVisionTransformer.forward`` in
         :mod:`opentau.utils.transformers_patch`.
 
-        Caveat: this pinning only survives paths that keep the built model as-is — ONNX
-        export (``scripts/export_to_onnx.py``, which runs in float32) and FSDP training
-        (``train.py`` skips the cast below under FSDP). Every other entry point runs a
-        blanket ``policy.to(torch.bfloat16)`` after load that rounds these tables back to
-        bfloat16, undoing the pinning: the gRPC serving path (``scripts/grpc/server.py``),
-        ``scripts/inference.py``, ``eval.py``, ``benchmark_inference.py``,
-        ``high_level_planner_inference.py``, and non-FSDP ``train.py`` / ``profile_step.py``.
-        Making the float32 masters survive those casts (e.g. re-establishing them from the
-        checkpoint after the cast, without breaking DeepSpeed/DDP param handling) is a
-        follow-up.
+        The pinning is preserved by ONNX export (``scripts/export_to_onnx.py``, float32),
+        FSDP training (``train.py`` skips the cast below under FSDP), and the inference /
+        serving entry points (the gRPC server, ``scripts/inference.py``, ``eval.py``,
+        ``benchmark_inference.py``, ``high_level_planner_inference.py``), which do their
+        blanket bfloat16 cast through
+        :func:`opentau.policies.utils.to_dtype_preserving_siglip_float32` so these tables
+        stay float32. The remaining gap is the non-FSDP training cast (``train.py`` /
+        ``profile_step.py`` under DeepSpeed / DDP), which still blanket-casts to bfloat16:
+        re-introducing float32 params after the cast there would change how ZeRO / DDP
+        partition parameters and needs multi-rank validation (deferred to a follow-up).
         """
         self.paligemma = self.paligemma.to(dtype=torch.bfloat16)
 

--- a/src/opentau/policies/pi05/paligemma_with_expert.py
+++ b/src/opentau/policies/pi05/paligemma_with_expert.py
@@ -335,7 +335,20 @@ class PaliGemmaWithExpertModel(PreTrainedModel):
             self.paligemma.eval()
 
     def to_bfloat16_like_physical_intelligence(self) -> None:
-        """Casts specific model components to bfloat16 dtype."""
+        """Casts specific model components to bfloat16, keeping the SigLIP embeddings in float32.
+
+        Mirrors openpi's ``to_bfloat16_for_selected_params``: the bulk of the VLM runs in
+        bfloat16, but the SigLIP patch-embedding conv and the learned position-embedding table
+        are pinned to float32. The original JAX (Big Vision) SigLIP does patch extraction and
+        position embedding in float32 and only casts to the (bf16) encoder dtype afterwards
+        (``openpi/models/siglip.py``: "do patch extraction and posemb in float32"). Those two
+        tables are the only vision weights that are genuine float32 masters rather than bf16
+        masters upcast on checkpoint export, so loading their float32 values straight into
+        bf16 parameters rounds away real precision that a later ``.to(float32)`` cannot recover
+        (empirically ~0.4 max abs error in the projected image tokens). The float32 ->
+        encoder-dtype hand-off is done by the patched ``SiglipVisionTransformer.forward`` in
+        :mod:`opentau.utils.transformers_patch`.
+        """
         self.paligemma = self.paligemma.to(dtype=torch.bfloat16)
 
         params_to_change_dtype = [
@@ -347,6 +360,15 @@ class PaliGemmaWithExpertModel(PreTrainedModel):
         for name, param in self.named_parameters():
             if any(selector in name for selector in params_to_change_dtype):
                 param.data = param.data.to(dtype=torch.bfloat16)
+
+        params_to_keep_float32 = [
+            "vision_tower.vision_model.embeddings.patch_embedding.weight",
+            "vision_tower.vision_model.embeddings.patch_embedding.bias",
+            "vision_tower.vision_model.embeddings.position_embedding.weight",
+        ]
+        for name, param in self.named_parameters():
+            if any(selector in name for selector in params_to_keep_float32):
+                param.data = param.data.to(dtype=torch.float32)
 
     def embed_image(self, image: torch.Tensor) -> torch.Tensor:
         """Computes image embeddings.

--- a/src/opentau/policies/pi05/paligemma_with_expert.py
+++ b/src/opentau/policies/pi05/paligemma_with_expert.py
@@ -349,16 +349,18 @@ class PaliGemmaWithExpertModel(PreTrainedModel):
         encoder-dtype hand-off is done by the patched ``SiglipVisionTransformer.forward`` in
         :mod:`opentau.utils.transformers_patch`.
 
-        The pinning is preserved by ONNX export (``scripts/export_to_onnx.py``, float32),
-        FSDP training (``train.py`` skips the cast below under FSDP), and the inference /
-        serving entry points (the gRPC server, ``scripts/inference.py``, ``eval.py``,
-        ``benchmark_inference.py``, ``high_level_planner_inference.py``,
-        ``actions_mse_loss.py``), which do their blanket bfloat16 cast through
-        :func:`opentau.policies.utils.to_dtype_preserving_siglip_float32` so these tables
-        stay float32. The remaining gap is the non-FSDP training cast (``train.py`` /
-        ``profile_step.py`` under DeepSpeed / DDP), which still blanket-casts to bfloat16:
-        re-introducing float32 params after the cast there would change how ZeRO / DDP
-        partition parameters and needs multi-rank validation (deferred to a follow-up).
+        These tables are used in the patch-conv / posemb *compute* in float32 only at
+        inference / serving / ONNX export: the inference entry points (the gRPC server,
+        ``scripts/inference.py``, ``eval.py``, ``benchmark_inference.py``,
+        ``high_level_planner_inference.py``, ``actions_mse_loss.py``) route their blanket
+        bfloat16 cast through :func:`opentau.policies.utils.to_dtype_preserving_siglip_float32`,
+        and ONNX export runs in float32. No *training* backend computes them in float32: DDP
+        and non-FSDP DeepSpeed blanket-cast the whole policy to bfloat16 (``train.py`` /
+        ``profile_step.py``), and FSDP keeps a float32 master but its
+        ``MixedPrecision(param_dtype=bfloat16)`` materializes bfloat16 compute params in the
+        all-gather. That gap is small (patch-conv compute differs ~0.14% in the image tokens,
+        ~1e-4 in the sampled actions; the default freezes the vision encoder) and is tracked
+        for a backend-specific, multi-rank-validated follow-up in issue #483.
         """
         self.paligemma = self.paligemma.to(dtype=torch.bfloat16)
 

--- a/src/opentau/policies/pi05/paligemma_with_expert.py
+++ b/src/opentau/policies/pi05/paligemma_with_expert.py
@@ -348,6 +348,17 @@ class PaliGemmaWithExpertModel(PreTrainedModel):
         (empirically ~0.4 max abs error in the projected image tokens). The float32 ->
         encoder-dtype hand-off is done by the patched ``SiglipVisionTransformer.forward`` in
         :mod:`opentau.utils.transformers_patch`.
+
+        Caveat: this pinning survives paths that keep the built model as-is — the gRPC
+        serving path (``scripts/grpc/server.py``), ONNX export
+        (``scripts/export_to_onnx.py``), and FSDP training (``train.py`` skips the cast
+        below under FSDP). Several other entry points (``scripts/inference.py``,
+        ``eval.py``, ``benchmark_inference.py``, ``high_level_planner_inference.py``, and
+        non-FSDP ``train.py`` / ``profile_step.py``) run a blanket
+        ``policy.to(torch.bfloat16)`` after load that rounds these tables back to bfloat16;
+        making the float32 masters survive those casts (e.g. re-establishing them from the
+        checkpoint after the cast, without breaking DeepSpeed/DDP param handling) is a
+        follow-up.
         """
         self.paligemma = self.paligemma.to(dtype=torch.bfloat16)
 

--- a/src/opentau/policies/pi05/paligemma_with_expert.py
+++ b/src/opentau/policies/pi05/paligemma_with_expert.py
@@ -349,14 +349,14 @@ class PaliGemmaWithExpertModel(PreTrainedModel):
         encoder-dtype hand-off is done by the patched ``SiglipVisionTransformer.forward`` in
         :mod:`opentau.utils.transformers_patch`.
 
-        Caveat: this pinning survives paths that keep the built model as-is — the gRPC
-        serving path (``scripts/grpc/server.py``), ONNX export
-        (``scripts/export_to_onnx.py``), and FSDP training (``train.py`` skips the cast
-        below under FSDP). Several other entry points (``scripts/inference.py``,
-        ``eval.py``, ``benchmark_inference.py``, ``high_level_planner_inference.py``, and
-        non-FSDP ``train.py`` / ``profile_step.py``) run a blanket
-        ``policy.to(torch.bfloat16)`` after load that rounds these tables back to bfloat16;
-        making the float32 masters survive those casts (e.g. re-establishing them from the
+        Caveat: this pinning only survives paths that keep the built model as-is — ONNX
+        export (``scripts/export_to_onnx.py``, which runs in float32) and FSDP training
+        (``train.py`` skips the cast below under FSDP). Every other entry point runs a
+        blanket ``policy.to(torch.bfloat16)`` after load that rounds these tables back to
+        bfloat16, undoing the pinning: the gRPC serving path (``scripts/grpc/server.py``),
+        ``scripts/inference.py``, ``eval.py``, ``benchmark_inference.py``,
+        ``high_level_planner_inference.py``, and non-FSDP ``train.py`` / ``profile_step.py``.
+        Making the float32 masters survive those casts (e.g. re-establishing them from the
         checkpoint after the cast, without breaking DeepSpeed/DDP param handling) is a
         follow-up.
         """

--- a/src/opentau/policies/pi05_mem/rldx_video_encoder.py
+++ b/src/opentau/policies/pi05_mem/rldx_video_encoder.py
@@ -248,11 +248,10 @@ class RLDXVideoEncoder(nn.Module):
         # SiglipVisionTransformer.forward, so it has to reproduce that forward's dtype
         # bridge here: cast the float32 embeddings to the (possibly bfloat16) encoder dtype
         # before the first encoder layer. No-op when the tower is single-dtype.
-        encoder_layers = self.vision_tower.vision_model.encoder.layers
-        if len(encoder_layers) > 0:
-            encoder_dtype = encoder_layers[0].self_attn.q_proj.weight.dtype
-            if hidden.dtype != encoder_dtype:
-                hidden = hidden.to(encoder_dtype)
+        # ``post_layernorm`` is the unambiguous SigLIP encoder dtype.
+        encoder_dtype = self.vision_tower.vision_model.post_layernorm.weight.dtype
+        if hidden.dtype != encoder_dtype:
+            hidden = hidden.to(encoder_dtype)
 
         use_ckpt = self.gradient_checkpointing and self.training
         # Motion runs only with a real time axis (T > 1). It is intentionally NOT

--- a/src/opentau/policies/pi05_mem/rldx_video_encoder.py
+++ b/src/opentau/policies/pi05_mem/rldx_video_encoder.py
@@ -242,6 +242,18 @@ class RLDXVideoEncoder(nn.Module):
         flat = rearrange(video, "b t c h w -> (b t) c h w")
         hidden = self.vision_tower.vision_model.embeddings(flat)
 
+        # The SigLIP patch/position embeddings are pinned to float32 (openpi parity, see
+        # PaliGemmaWithExpertModel.to_bfloat16_like_physical_intelligence). This encoder
+        # hand-rolls the SigLIP forward instead of routing through the patched
+        # SiglipVisionTransformer.forward, so it has to reproduce that forward's dtype
+        # bridge here: cast the float32 embeddings to the (possibly bfloat16) encoder dtype
+        # before the first encoder layer. No-op when the tower is single-dtype.
+        encoder_layers = self.vision_tower.vision_model.encoder.layers
+        if len(encoder_layers) > 0:
+            encoder_dtype = encoder_layers[0].self_attn.q_proj.weight.dtype
+            if hidden.dtype != encoder_dtype:
+                hidden = hidden.to(encoder_dtype)
+
         use_ckpt = self.gradient_checkpointing and self.training
         # Motion runs only with a real time axis (T > 1). It is intentionally NOT
         # gradient-checkpointed: its BatchNorm3d (default) running stats would be

--- a/src/opentau/policies/pi07/video_encoder.py
+++ b/src/opentau/policies/pi07/video_encoder.py
@@ -699,6 +699,18 @@ class SpaceTimeSiglipVideoEncoder(nn.Module):
             flat, interpolate_pos_encoding=self._interpolate_pos_encoding
         )
 
+        # The SigLIP patch/position embeddings may be pinned to float32 (openpi parity, see
+        # PaliGemmaWithExpertModel.to_bfloat16_like_physical_intelligence). This encoder
+        # hand-rolls the SigLIP forward, so it has to reproduce the patched
+        # SiglipVisionTransformer.forward bridge: cast the (possibly float32) embeddings to the
+        # encoder dtype before the encoder layers -- and before the temporal mask below, which
+        # is built from ``hidden.dtype``. No-op when the tower is single-dtype (e.g. the Gemma3
+        # pi07 towers, which are uniform bfloat16). ``post_layernorm`` is the unambiguous SigLIP
+        # encoder dtype (a wrapped SpaceTime layer's first parameter may be a temporal module).
+        encoder_dtype = self.vision_tower.vision_model.post_layernorm.weight.dtype
+        if hidden.dtype != encoder_dtype:
+            hidden = hidden.to(encoder_dtype)
+
         # Build temporal attention mask. Skipped at T=1 because the wrapper's
         # T=1 short-circuit bypasses temporal attention entirely.
         temporal_attn_mask: Tensor | None = None

--- a/src/opentau/policies/utils.py
+++ b/src/opentau/policies/utils.py
@@ -158,6 +158,16 @@ def to_dtype_preserving_siglip_float32(
     distributed-training cast path, where re-introducing float32 params after the cast would
     change how DeepSpeed/DDP partition parameters.
 
+    Known limitation (only the *weights* are kept float32, not the *input*): the serving entry
+    points still feed a bfloat16 image — e.g. ``grpc/server.py`` casts the decoded image to the
+    policy dtype — so the patch conv runs on bfloat16-precision pixels. HF
+    ``SiglipVisionEmbeddings.forward`` upcasts ``pixel_values`` to the (float32) weight dtype, so
+    there is no dtype mismatch, but the JAX recipe is a float32 *image* into the patch conv
+    ("do patch extraction and posemb in float32"). Empirically the bfloat16 image costs ~1%
+    (~1.5 max) on ``embed_image`` — larger than the ~0.14% weight-rounding this fix removes — so
+    full JAX-recipe fidelity would additionally require keeping the served image float32. Tracked
+    as a known limitation alongside issue #483.
+
     Args:
         module: The policy (or any module) to cast in place.
         dtype: Target dtype for the blanket cast.

--- a/src/opentau/policies/utils.py
+++ b/src/opentau/policies/utils.py
@@ -125,6 +125,66 @@ def get_dtype_from_parameters(module: nn.Module) -> torch.dtype:
     return next(iter(module.parameters())).dtype
 
 
+# Full parameter-name suffixes of the SigLIP patch/position embeddings that
+# PaliGemmaWithExpertModel.to_bfloat16_like_physical_intelligence pins to float32.
+_SIGLIP_FLOAT32_PARAM_SUFFIXES = (
+    "vision_tower.vision_model.embeddings.patch_embedding.weight",
+    "vision_tower.vision_model.embeddings.patch_embedding.bias",
+    "vision_tower.vision_model.embeddings.position_embedding.weight",
+)
+
+
+def to_dtype_preserving_siglip_float32(
+    module: nn.Module,
+    *,
+    dtype: torch.dtype,
+    device: torch.device | str | None = None,
+) -> nn.Module:
+    """``module.to(...)`` that preserves the float32-pinned SigLIP patch/position embeddings.
+
+    The SigLIP patch-embedding conv and position-embedding table are pinned to float32 at
+    build time (openpi parity, see
+    ``PaliGemmaWithExpertModel.to_bfloat16_like_physical_intelligence``): Big Vision keeps
+    "patch extraction and posemb in float32", and they are the only float32-master vision
+    weights. A blanket ``policy.to(torch.bfloat16)`` in a serving / inference entry point
+    would round those tables back to bfloat16 and permanently lose precision. This wrapper
+    snapshots them before the cast and restores them (float32, on the target device)
+    afterwards, so the mixed float32-embeddings / bfloat16-encoder state the forward dtype
+    bridges expect is preserved.
+
+    Only parameters that are float32 *before* the cast are preserved, so this is a no-op for a
+    uniform-bfloat16 tower (e.g. the Gemma3 pi06/pi07 policies, whose embeddings are not
+    pinned) and for a float32 cast. This is inference/serving-only: it must not be used on the
+    distributed-training cast path, where re-introducing float32 params after the cast would
+    change how DeepSpeed/DDP partition parameters.
+
+    Args:
+        module: The policy (or any module) to cast in place.
+        dtype: Target dtype for the blanket cast.
+        device: Optional target device for the cast.
+
+    Returns:
+        The same module, cast in place.
+    """
+    saved = {
+        name: param.detach().clone()
+        for name, param in module.named_parameters()
+        if param.dtype == torch.float32
+        and any(name.endswith(suffix) for suffix in _SIGLIP_FLOAT32_PARAM_SUFFIXES)
+    }
+    if device is not None:
+        module.to(device=device, dtype=dtype)
+    else:
+        module.to(dtype=dtype)
+    if saved:
+        params_by_name = dict(module.named_parameters())
+        for name, tensor in saved.items():
+            param = params_by_name.get(name)
+            if param is not None:
+                param.data = tensor.to(device=param.data.device)
+    return module
+
+
 def get_output_shape(module: nn.Module, input_shape: tuple) -> tuple:
     """Calculates the output shape of a PyTorch module given an input shape.
 

--- a/src/opentau/scripts/actions_mse_loss.py
+++ b/src/opentau/scripts/actions_mse_loss.py
@@ -27,6 +27,7 @@ from opentau.configs import parser
 from opentau.configs.train import TrainPipelineConfig
 from opentau.datasets.factory import make_dataset_mixture
 from opentau.policies.factory import get_policy_class
+from opentau.policies.utils import to_dtype_preserving_siglip_float32
 from opentau.utils.random_utils import set_seed
 from opentau.utils.utils import (
     attempt_torch_compile,
@@ -50,7 +51,9 @@ def inference_main(cfg: TrainPipelineConfig):
     logging.info("Creating policy")
     policy_class = get_policy_class(cfg.policy.type)
     policy = policy_class.from_pretrained(cfg.policy.pretrained_path, config=cfg.policy)
-    policy = policy.to(device=device, dtype=torch.bfloat16)
+    # Preserve the float32-pinned SigLIP embeddings across the bf16 cast (openpi parity) — this
+    # script measures action fidelity, so it must run the model as served, not a re-rounded one.
+    policy = to_dtype_preserving_siglip_float32(policy, device=device, dtype=torch.bfloat16)
     policy.eval()
     policy_sample_actions = attempt_torch_compile(policy.sample_actions, device_hint=device)
 

--- a/src/opentau/scripts/benchmark_inference.py
+++ b/src/opentau/scripts/benchmark_inference.py
@@ -52,6 +52,7 @@ from opentau.configs import parser
 from opentau.configs.train import TrainPipelineConfig
 from opentau.policies.factory import make_policy
 from opentau.policies.normalize import NormalizationMode
+from opentau.policies.utils import to_dtype_preserving_siglip_float32
 from opentau.utils.random_utils import set_seed
 from opentau.utils.utils import (
     auto_torch_device,
@@ -207,7 +208,8 @@ def benchmark_main(cfg: TrainPipelineConfig):
 
     logging.info("Building policy via make_policy (features pre-set in config).")
     policy = make_policy(cfg.policy)
-    policy.to(device=device, dtype=torch.bfloat16)
+    # Preserve the float32-pinned SigLIP embeddings across the bf16 cast (openpi parity).
+    to_dtype_preserving_siglip_float32(policy, device=device, dtype=torch.bfloat16)
     policy.eval()
     policy.reset()
 

--- a/src/opentau/scripts/eval.py
+++ b/src/opentau/scripts/eval.py
@@ -68,6 +68,7 @@ from opentau.envs.utils import (
 )
 from opentau.policies.factory import make_policy
 from opentau.policies.pretrained import PreTrainedPolicy
+from opentau.policies.utils import to_dtype_preserving_siglip_float32
 from opentau.utils.accelerate_utils import acc_print, get_proc_accelerator, set_proc_accelerator
 from opentau.utils.io_utils import write_video
 from opentau.utils.libero_dataset_recorder import aggregate_task_results, consolidate_task_result
@@ -1030,7 +1031,10 @@ def eval_main(cfg: TrainPipelineConfig):
     validate_eval_input_resolution(cfg)
 
     policy = make_policy(cfg=cfg.policy)
-    policy.to(torch.bfloat16)
+    # Preserve the float32-pinned SigLIP embeddings across the bf16 cast (openpi parity);
+    # a plain policy.to(bfloat16) would round them back. Eval runs single-process / DDP, so
+    # this is safe (no ZeRO param partitioning). See to_dtype_preserving_siglip_float32.
+    to_dtype_preserving_siglip_float32(policy, dtype=torch.bfloat16)
     policy = accelerator.prepare(policy)
     policy.eval()
     with (

--- a/src/opentau/scripts/grpc/server.py
+++ b/src/opentau/scripts/grpc/server.py
@@ -69,6 +69,7 @@ from opentau.configs.train import TrainPipelineConfig
 from opentau.datasets.lerobot_dataset import BaseDataset
 from opentau.planner.gemini_er_planner import GeminiERPlanner
 from opentau.policies.factory import get_policy_class
+from opentau.policies.utils import to_dtype_preserving_siglip_float32
 from opentau.scripts.grpc import auth, robot_inference_pb2, robot_inference_pb2_grpc
 from opentau.utils.random_utils import set_seed
 from opentau.utils.utils import (
@@ -265,7 +266,9 @@ class RobotPolicyServicer(robot_inference_pb2_grpc.RobotPolicyServiceServicer):
 
         policy_class = get_policy_class(self.cfg.policy.type)
         self.policy = policy_class.from_pretrained(self.cfg.policy.pretrained_path, config=self.cfg.policy)
-        self.policy.to(device=self.device, dtype=self.dtype)
+        # Preserve the float32-pinned SigLIP embeddings across the bf16 cast (openpi parity);
+        # a plain .to(bfloat16) would round them back. Serving is single-process, so this is safe.
+        to_dtype_preserving_siglip_float32(self.policy, device=self.device, dtype=self.dtype)
         self.policy.eval()
         self.policy.model.sample_actions = attempt_torch_compile(
             self.policy.model.sample_actions, device_hint=self.device

--- a/src/opentau/scripts/high_level_planner_inference.py
+++ b/src/opentau/scripts/high_level_planner_inference.py
@@ -25,6 +25,7 @@ from opentau.configs import parser
 from opentau.configs.train import TrainPipelineConfig
 from opentau.planner import HighLevelPlanner, Memory
 from opentau.policies.factory import get_policy_class
+from opentau.policies.utils import to_dtype_preserving_siglip_float32
 from opentau.utils.random_utils import set_seed
 from opentau.utils.utils import (
     init_logging,
@@ -54,7 +55,8 @@ def inference_main(cfg: TrainPipelineConfig):
     policy_class = get_policy_class(cfg.policy.type)
     policy = policy_class.from_pretrained(cfg.policy.pretrained_path, config=cfg.policy)
     policy.to(device)
-    policy.to(dtype=torch.bfloat16)
+    # Preserve the float32-pinned SigLIP embeddings across the bf16 cast (openpi parity).
+    to_dtype_preserving_siglip_float32(policy, dtype=torch.bfloat16)
     policy.eval()
 
     hlp = HighLevelPlanner()

--- a/src/opentau/scripts/inference.py
+++ b/src/opentau/scripts/inference.py
@@ -22,6 +22,7 @@ import torch
 from opentau.configs import parser
 from opentau.configs.train import TrainPipelineConfig
 from opentau.policies.factory import get_policy_class
+from opentau.policies.utils import to_dtype_preserving_siglip_float32
 from opentau.utils.random_utils import set_seed
 from opentau.utils.utils import (
     attempt_torch_compile,
@@ -44,7 +45,8 @@ def inference_main(cfg: TrainPipelineConfig):
     logging.info("Creating policy")
     policy_class = get_policy_class(cfg.policy.type)
     policy = policy_class.from_pretrained(cfg.policy.pretrained_path, config=cfg.policy)
-    policy.to(device=device, dtype=torch.bfloat16)
+    # Preserve the float32-pinned SigLIP embeddings across the bf16 cast (openpi parity).
+    to_dtype_preserving_siglip_float32(policy, device=device, dtype=torch.bfloat16)
     policy.eval()
     policy.model.sample_actions = attempt_torch_compile(policy.model.sample_actions, device_hint=device)
 

--- a/src/opentau/utils/transformers_patch.py
+++ b/src/opentau/utils/transformers_patch.py
@@ -21,9 +21,11 @@ from typing import Optional, Tuple
 
 import torch
 from torch import nn
+from transformers.modeling_outputs import BaseModelOutputWithPooling
 from transformers.models.gemma import modeling_gemma
 from transformers.models.gemma.configuration_gemma import GemmaConfig
 from transformers.models.paligemma.modeling_paligemma import PaliGemmaModel
+from transformers.models.siglip.modeling_siglip import SiglipVisionTransformer
 
 from opentau.utils.vision_utils import pad_to_patch_multiple, patch_grid_hw
 
@@ -299,6 +301,51 @@ def patched_paligemma_model_get_image_features(self, pixel_values: torch.FloatTe
 
 
 PaliGemmaModel.get_image_features = patched_paligemma_model_get_image_features
+
+
+def patched_siglip_vision_transformer_forward(
+    self,
+    pixel_values,
+    interpolate_pos_encoding: bool = False,
+    **kwargs,
+):
+    """SigLIP vision-tower forward that bridges a float32 embedding stage into a bf16 encoder.
+
+    The original JAX (Big Vision) SigLIP — and openpi's PyTorch port — keep the patch-embedding
+    conv and the position-embedding table in float32 and cast to the (potentially bfloat16)
+    encoder dtype only *after* adding position embeddings. OpenTau pins those two tables to
+    float32 in ``to_bfloat16_like_physical_intelligence`` so their float32-master precision is
+    not rounded away on checkpoint load; stock HuggingFace
+    ``SiglipVisionTransformer.forward`` feeds the embeddings straight into the encoder without a
+    dtype cast, which would raise a dtype mismatch when the encoder is bfloat16. This patched
+    forward inserts that hand-off.
+
+    The cast is skipped whenever the tower is single-dtype (float32 everywhere as in the parity
+    harness / ONNX export, or bfloat16 everywhere as for the Gemma3 policies), so the patch is a
+    strict no-op except in the intended float32-embeddings -> bfloat16-encoder configuration.
+    Everything else mirrors the stock transformers forward.
+    """
+    hidden_states = self.embeddings(pixel_values, interpolate_pos_encoding=interpolate_pos_encoding)
+
+    if len(self.encoder.layers) > 0:
+        encoder_dtype = self.encoder.layers[0].self_attn.q_proj.weight.dtype
+        if hidden_states.dtype != encoder_dtype:
+            hidden_states = hidden_states.to(encoder_dtype)
+
+    encoder_outputs = self.encoder(inputs_embeds=hidden_states, **kwargs)
+
+    last_hidden_state = encoder_outputs.last_hidden_state
+    last_hidden_state = self.post_layernorm(last_hidden_state)
+
+    pooler_output = self.head(last_hidden_state) if self.use_head else None
+
+    return BaseModelOutputWithPooling(
+        last_hidden_state=last_hidden_state,
+        pooler_output=pooler_output,
+    )
+
+
+SiglipVisionTransformer.forward = patched_siglip_vision_transformer_forward
 
 
 # Re-export the PaliGemma entrypoint from this module so downstream code that

--- a/tests/policies/test_siglip_embedding_dtype.py
+++ b/tests/policies/test_siglip_embedding_dtype.py
@@ -34,6 +34,7 @@ from transformers.models.paligemma.modeling_paligemma import PaliGemmaMultiModal
 # patched SiglipVisionTransformer.forward under test.
 import opentau.utils.transformers_patch  # noqa: F401
 from opentau.policies.pi05_mem.rldx_video_encoder import RLDXVideoEncoder
+from opentau.policies.pi07.video_encoder import SpaceTimeSiglipVideoEncoder
 
 # The three parameter names pinned to float32 by to_bfloat16_like_physical_intelligence.
 PINNED_SUFFIXES = (
@@ -122,3 +123,31 @@ def test_rldx_video_encoder_survives_mixed_dtype_tower():
     assert out.dtype == torch.bfloat16
     assert torch.isfinite(out.float()).all()
     assert out.shape[0] == 1
+
+
+def test_spacetime_video_encoder_survives_mixed_dtype_tower():
+    """The DEFAULT pi05_mem / pi07_paligemma encoder also hand-rolls the SigLIP forward."""
+    vt = _tiny_siglip()
+    projector = _tiny_projector().to(torch.bfloat16)
+    encoder = SpaceTimeSiglipVideoEncoder(vt, projector, max_num_frames=2).eval()
+
+    # SpaceTime wraps layers in place inside ``vt``; put the whole tower (incl. any temporal
+    # modules and the encoder object) in bfloat16, then pin the patch/position embeddings back
+    # to float32 — the mixed-dtype state the pinning + build leaves the encoder in.
+    vt.to(torch.bfloat16)
+    encoder.to(torch.bfloat16)
+    vt.vision_model.embeddings.patch_embedding.to(torch.float32)
+    vt.vision_model.embeddings.position_embedding.to(torch.float32)
+
+    with torch.no_grad():
+        # T=1 short-circuits temporal attention (isolates the embeddings -> encoder bridge);
+        # T=2 additionally builds the temporal mask, which is derived from the bridged dtype.
+        out_t1 = encoder(torch.rand(1, 1, 3, 224, 224))
+        out_t2 = encoder(
+            torch.rand(1, 2, 3, 224, 224), obs_history_is_pad=torch.zeros(1, 2, dtype=torch.bool)
+        )
+
+    for out in (out_t1, out_t2):
+        assert out.dtype == torch.bfloat16
+        assert torch.isfinite(out.float()).all()
+        assert out.shape[0] == 1

--- a/tests/policies/test_siglip_embedding_dtype.py
+++ b/tests/policies/test_siglip_embedding_dtype.py
@@ -35,6 +35,7 @@ from transformers.models.paligemma.modeling_paligemma import PaliGemmaMultiModal
 import opentau.utils.transformers_patch  # noqa: F401
 from opentau.policies.pi05_mem.rldx_video_encoder import RLDXVideoEncoder
 from opentau.policies.pi07.video_encoder import SpaceTimeSiglipVideoEncoder
+from opentau.policies.utils import to_dtype_preserving_siglip_float32
 
 # The three parameter names pinned to float32 by to_bfloat16_like_physical_intelligence.
 PINNED_SUFFIXES = (
@@ -151,3 +152,33 @@ def test_spacetime_video_encoder_survives_mixed_dtype_tower():
         assert out.dtype == torch.bfloat16
         assert torch.isfinite(out.float()).all()
         assert out.shape[0] == 1
+
+
+class _DummyPolicy(torch.nn.Module):
+    """Names the tower ``vision_tower`` so param names match the helper's suffixes."""
+
+    def __init__(self, vision_tower):
+        super().__init__()
+        self.vision_tower = vision_tower
+
+
+def test_to_dtype_helper_preserves_pinned_embeddings_across_bf16_cast():
+    """The serving/inference entry points cast through this helper to keep the float32 masters."""
+    policy = _DummyPolicy(_pin_embeddings_float32(_tiny_siglip()))
+    to_dtype_preserving_siglip_float32(policy, dtype=torch.bfloat16)
+
+    emb = policy.vision_tower.vision_model.embeddings
+    assert emb.patch_embedding.weight.dtype == torch.float32
+    assert emb.patch_embedding.bias.dtype == torch.float32
+    assert emb.position_embedding.weight.dtype == torch.float32
+    assert policy.vision_tower.vision_model.encoder.layers[0].self_attn.q_proj.weight.dtype == torch.bfloat16
+
+
+def test_to_dtype_helper_is_noop_for_uniform_bf16_tower():
+    """Gemma3-style tower: embeddings are not pinned, so the helper must not force float32."""
+    policy = _DummyPolicy(_tiny_siglip().to(torch.bfloat16))
+    to_dtype_preserving_siglip_float32(policy, dtype=torch.bfloat16)
+
+    emb = policy.vision_tower.vision_model.embeddings
+    assert emb.patch_embedding.weight.dtype == torch.bfloat16
+    assert emb.position_embedding.weight.dtype == torch.bfloat16

--- a/tests/policies/test_siglip_embedding_dtype.py
+++ b/tests/policies/test_siglip_embedding_dtype.py
@@ -1,0 +1,124 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""SigLIP float32-embedding / bf16-encoder dtype-bridge regression tests.
+
+Locks the fix that keeps the SigLIP patch/position embeddings in float32 (openpi parity)
+while the encoder runs in bfloat16. The pinning itself lives on the full
+``PaliGemmaWithExpertModel`` (a ~3B random-init build, exercised by the GPU suite); here we
+lock the two things a CPU test can cover cheaply and that would otherwise regress silently:
+
+1. the patched ``SiglipVisionTransformer.forward`` bridges float32 embeddings into a bfloat16
+   encoder instead of raising a dtype mismatch, and is a faithful no-op when the tower is
+   single-dtype;
+2. ``pi05_mem``'s ``RLDXVideoEncoder``, which hand-rolls the SigLIP forward, reproduces the
+   same bridge and so survives the mixed-dtype state its shared vision tower is left in.
+"""
+
+import torch
+from transformers import PaliGemmaConfig, SiglipVisionConfig, SiglipVisionModel
+from transformers.models.paligemma.modeling_paligemma import PaliGemmaMultiModalProjector
+
+# Importing the policy package applies opentau.utils.transformers_patch, which installs the
+# patched SiglipVisionTransformer.forward under test.
+import opentau.utils.transformers_patch  # noqa: F401
+from opentau.policies.pi05_mem.rldx_video_encoder import RLDXVideoEncoder
+
+# The three parameter names pinned to float32 by to_bfloat16_like_physical_intelligence.
+PINNED_SUFFIXES = (
+    "embeddings.patch_embedding.weight",
+    "embeddings.patch_embedding.bias",
+    "embeddings.position_embedding.weight",
+)
+
+
+def _tiny_siglip():
+    cfg = SiglipVisionConfig(
+        hidden_size=64,
+        intermediate_size=128,
+        num_attention_heads=4,
+        num_hidden_layers=2,
+        num_image_tokens=256,
+        patch_size=14,
+        image_size=224,
+        vision_use_head=False,
+    )
+    return SiglipVisionModel(cfg).eval()
+
+
+def _tiny_projector():
+    pali_cfg = PaliGemmaConfig(
+        vision_config={"hidden_size": 64, "model_type": "siglip_vision_model", "projection_dim": 32},
+        text_config={"hidden_size": 32, "model_type": "gemma", "vocab_size": 64},
+        projection_dim=32,
+    )
+    return PaliGemmaMultiModalProjector(pali_cfg).eval()
+
+
+def _pin_embeddings_float32(vision_tower):
+    """Reproduce the mixed-dtype state: bf16 everywhere, float32 patch/pos embeddings."""
+    vision_tower.to(torch.bfloat16)
+    emb = vision_tower.vision_model.embeddings
+    emb.patch_embedding.to(torch.float32)
+    emb.position_embedding.to(torch.float32)
+    return vision_tower
+
+
+def test_embedding_param_names_match_pinning_selectors():
+    """Guards the pinning selectors against a transformers rename of the SigLIP embeddings."""
+    names = dict(_tiny_siglip().named_parameters())
+    for suffix in PINNED_SUFFIXES:
+        assert any(n.endswith(suffix) for n in names), f"no SigLIP param ends with {suffix!r}"
+
+
+def test_patched_forward_is_noop_when_single_dtype():
+    """In uniform float32 the bridge does nothing: output matches the hand-rolled forward."""
+    vt = _tiny_siglip()
+    torch.manual_seed(0)
+    pixels = torch.randn(1, 3, 224, 224)
+
+    hidden = vt.vision_model.embeddings(pixels)
+    for layer in vt.vision_model.encoder.layers:
+        hidden = layer(hidden, None)
+    reference = vt.vision_model.post_layernorm(hidden)
+
+    out = vt(pixels).last_hidden_state
+    assert out.dtype == torch.float32
+    assert torch.equal(out, reference)
+
+
+def test_patched_forward_bridges_float32_embeddings_into_bf16_encoder():
+    """The motivating case: pinned float32 embeddings must not crash the bfloat16 encoder."""
+    vt = _pin_embeddings_float32(_tiny_siglip())
+    assert vt.vision_model.embeddings.patch_embedding.weight.dtype == torch.float32
+    assert vt.vision_model.encoder.layers[0].self_attn.q_proj.weight.dtype == torch.bfloat16
+
+    out = vt(torch.randn(1, 3, 224, 224)).last_hidden_state
+    assert out.dtype == torch.bfloat16
+    assert torch.isfinite(out.float()).all()
+
+
+def test_rldx_video_encoder_survives_mixed_dtype_tower():
+    """pi05_mem's hand-rolled SigLIP forward must reproduce the bridge (issue: it bypassed it)."""
+    vt = _pin_embeddings_float32(_tiny_siglip())
+    projector = _tiny_projector().to(torch.bfloat16)
+    encoder = RLDXVideoEncoder(vt, projector, max_num_frames=2).eval()
+
+    video = torch.rand(1, 1, 3, 224, 224)  # (B, T, C, H, W) in [0, 1]
+    with torch.no_grad():
+        out = encoder(video)
+
+    assert out.dtype == torch.bfloat16
+    assert torch.isfinite(out.float()).all()
+    assert out.shape[0] == 1


### PR DESCRIPTION
## What this does

Fixes a checkpoint-load precision bug in the PaliGemma / SigLIP vision tower shared by `pi0`, `pi05`, `pi05_mem`, and `pi07_paligemma`, and makes the fix reach the served model. (🐛 Bug)

**Root cause.** `to_bfloat16_like_physical_intelligence` cast the **entire** SigLIP tower to bfloat16 at build time, so when `from_pretrained` loaded the float32 converted checkpoint, the **patch-embedding conv** and **position-embedding table** were rounded to bfloat16 — permanently (a later `.to(float32)` cannot recover the bits). Those two tables are the only float32-master weights in the tower (Big Vision keeps "patch extraction and posemb in float32"); every other vision weight is a bfloat16 master upcast on export, so only the embeddings lost precision. On a converted openpi `pi05_droid` checkpoint, `embed_image` diverged from openpi's own PyTorch port by up to **0.395** on the `(1, 256, 2048)` image tokens while every other vision weight loaded bit-identically. Not a SigLIP forward-structure difference, not an attention-kernel difference.

**Fix** (mirrors openpi's `to_bfloat16_for_selected_params`):

1. Pin the three SigLIP embedding tensors to float32 in `to_bfloat16_like_physical_intelligence` (`pi0` + `pi05`; `pi05_mem` / `pi07_paligemma` import `pi05`'s `PaliGemmaWithExpertModel`).
2. Bridge the resulting float32-embeddings → bfloat16-encoder boundary in **all three** hand-rolled SigLIP forwards, so bfloat16 serving doesn't hit a dtype mismatch: the patched `SiglipVisionTransformer.forward` (`utils/transformers_patch.py`), `RLDXVideoEncoder`, and `SpaceTimeSiglipVideoEncoder` (the default pi05_mem encoder + pi07_paligemma low-level's; the cast is placed before the temporal-mask build, which derives from `hidden.dtype`). No-op for single-dtype towers, so the Gemma3 `pi06`/`pi07` towers are unaffected.
3. Preserve the pinning across the blanket `policy.to(torch.bfloat16)` in the inference / serving entry points (gRPC server, `inference.py`, `eval.py`, `benchmark_inference.py`, `high_level_planner_inference.py`) via `to_dtype_preserving_siglip_float32`, which snapshots the float32 embeddings before the cast and restores them after. Only params float32 before the cast are preserved (no-op for uniform-bf16 towers).

**Out of scope / follow-up (#483):** the float32 tables are used in the patch-conv / posemb *compute* in float32 only at inference / serving / ONNX export. No *training* backend computes them in float32 — DDP and non-FSDP DeepSpeed blanket-cast to bfloat16, and FSDP keeps a float32 master but computes bfloat16 via `MixedPrecision(param_dtype=bf16)`. The gap is small (~0.14% on the image tokens, ~1e-4 on the actions; the default freezes the vision encoder) and needs backend-specific, multi-rank-validated handling — tracked in #483.

## How it was tested

Byte-identical-input parity harness (float32, CPU, eager) loading the **same** converted openpi `pi05_droid` weights into OpenTau's `PI05Policy` and openpi's `PI0Pytorch`, with the JAX model as ground truth:

- **`embed_image` vs openpi:** max|diff| **0.395 → 1.07e-4** after the fix (44/256 → 0/256 tokens > 0.05); every vision weight now loads bit-identically. OpenTau matches openpi's fidelity to the original JAX model exactly (both 1.05% vs JAX — the shared XLA-vs-Torch float32 floor).
- **bfloat16 serving:** `embed_image` runs in native bfloat16 (float32 embeddings + bfloat16 encoder) without a dtype crash — validates the forward bridges.
- **Serving helper:** validated on the real `pi05` model — after `to_dtype_preserving_siglip_float32` the patch/position embeddings are float32, the encoder is bfloat16, and `embed_image` runs.
- **Downstream:** toggling only the embedding precision through the full denoise moves the sampled actions by ~1.4e-4 max (0.005% of range).
- New `tests/policies/test_siglip_embedding_dtype.py` (CPU): the patched forward is a no-op in a single-dtype tower and bridges float32 → bfloat16; `RLDXVideoEncoder` and `SpaceTimeSiglipVideoEncoder` (T=1 and T=2) survive the mixed-dtype tower; the helper preserves the pinned embeddings and is a no-op for a uniform-bf16 tower; the pinning selectors match the transformers SigLIP parameter names.
- `pre-commit run --all-files` clean; CPU suite green (`pytest -m "not gpu and not network" tests/policies tests/scripts` → 972 passed); targeted GPU suite green on a CUDA box (`pytest -m "gpu" -n 0` over the affected policies → 9 passed, 2 skipped). Full regression runs nightly via `regression_test.yml`.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/policies/test_siglip_embedding_dtype.py
```

```bash
pytest -m "gpu" -n 0 tests/policies/test_pi05_mem_gpu.py tests/policies/test_pi07_paligemma_low_level.py
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [x] My PR includes policy-related changes.
  - [x] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.
