### PR TITLE
chore: bump version to v0.12.0

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,8 +30,8 @@ project = "OpenTau"
 copyright = "2026, Tensor Auto Inc"
 author = "Tensor Auto Inc"
 
-version = "0.11.0"
-release = "0.11.0"
+version = "0.12.0"
+release = "0.12.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ huggingface = "https://huggingface.co/TensorAuto"
 
 [project]
 name = "opentau"
-version = "0.11.0"
+version = "0.12.0"
 description = "OpenTau: Tensor's VLA Training Infrastructure for Real-World Robotics in Pytorch"
 authors = [
     { name = "Shuheng Liu", email = "wish1104@icloud.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -2166,7 +2166,7 @@ wheels = [
 
 [[package]]
 name = "opentau"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
## What this does
Bumps the package version `0.11.0` → `0.12.0`. (📝 Documentation / chore)

Updates the version string in the three places the previous bump (#472) touched:
- `pyproject.toml` (`[project].version`)
- `docs/source/conf.py` (`version` and `release`)
- `uv.lock` (the `opentau` editable package entry)

No behavioral, policy, or dependency changes — only the version identifier.

## How it was tested
- `uv lock --check` passes (lockfile consistent with `pyproject.toml`).
- `pre-commit run` on the commit passed (ruff, ruff-format, toml check, secrets, bandit, etc.).
- Diff is byte-for-byte the same shape as the prior bump commit #472 (3 files, 4 insertions, 4 deletions).

## How to checkout & try? (for the reviewer)
```bash
git fetch origin worktree-bump-v0.12.0 && git checkout worktree-bump-v0.12.0
uv lock --check
python -c "import importlib.metadata as m; print(m.version('opentau'))"  # after uv sync
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.
