### PR TITLE
feat(policies): add train_vision_encoder_only flag across all policies

### DIFF
--- a/src/opentau/policies/cosmos3/configuration_cosmos3.py
+++ b/src/opentau/policies/cosmos3/configuration_cosmos3.py
@@ -82,6 +82,11 @@ class Cosmos3Config(PreTrainedConfig):
         freeze_vision_encoder: Freeze the Qwen3-VL vision tower. Defaults to True.
         train_expert_only: Freeze the entire backbone; train only the expert +
             projections. Defaults to True (cosmos3's intended regime).
+        train_vision_encoder_only: Mirror image of ``train_expert_only`` — train ONLY the
+            Qwen3-VL vision tower (its ``merger`` / ``deepstack_merger_list`` projector lives
+            inside the tower, so it trains too) and freeze the LLM backbone, the action
+            expert, and all projections. Requires ``freeze_vision_encoder=False`` and
+            ``train_expert_only=False`` (they are mutually exclusive). Defaults to False.
         gradient_checkpointing: Checkpoint the expert decoder layers to trade
             compute for activation memory. Defaults to False.
         dropout: Dropout probability inside the expert. Defaults to 0.1.
@@ -156,6 +161,7 @@ class Cosmos3Config(PreTrainedConfig):
     attention_implementation: str = "sdpa"
     freeze_vision_encoder: bool = True
     train_expert_only: bool = True
+    train_vision_encoder_only: bool = False
     gradient_checkpointing: bool = False
     dropout: float = 0.1
 
@@ -193,6 +199,16 @@ class Cosmos3Config(PreTrainedConfig):
         """Validate the configuration."""
         super().__post_init__()
 
+        if self.train_vision_encoder_only and self.train_expert_only:
+            raise ValueError(
+                "`train_vision_encoder_only=True` and `train_expert_only=True` are mutually exclusive. "
+                "cosmos3 defaults `train_expert_only=True`; set it to False to train the vision tower only."
+            )
+        if self.train_vision_encoder_only and self.freeze_vision_encoder:
+            raise ValueError(
+                "`train_vision_encoder_only=True` requires `freeze_vision_encoder=False` — the vision "
+                "encoder cannot be both frozen and the only trained component."
+            )
         if self.n_action_steps > self.chunk_size:
             raise ValueError(
                 "The chunk size is the upper bound for the number of action steps per model "

--- a/src/opentau/policies/cosmos3/modeling_cosmos3.py
+++ b/src/opentau/policies/cosmos3/modeling_cosmos3.py
@@ -49,7 +49,11 @@ from opentau.policies.cosmos3.qwen3vl_with_expert import Qwen3VLWithExpertModel
 from opentau.policies.normalize import Normalize, Unnormalize
 from opentau.policies.normalize import resolve_num_datasets as _num_datasets
 from opentau.policies.pretrained import PreTrainedPolicy
-from opentau.policies.utils import PerSampleLoss, flow_matching_masked_mse
+from opentau.policies.utils import (
+    PerSampleLoss,
+    flow_matching_masked_mse,
+    freeze_policy_level_params_for_vision_only,
+)
 
 
 def _preferred_dtype():
@@ -146,6 +150,7 @@ class Cosmos3FlowMatching(nn.Module):
             attention_implementation=config.attention_implementation,
             freeze_vision_encoder=config.freeze_vision_encoder,
             train_expert_only=config.train_expert_only,
+            train_vision_encoder_only=config.train_vision_encoder_only,
             gradient_checkpointing=config.gradient_checkpointing,
             load_pretrained_backbone_repo=(
                 config.pretrained_backbone_repo_id if config.load_pretrained_backbone else None
@@ -175,6 +180,13 @@ class Cosmos3FlowMatching(nn.Module):
             self.state_proj,
         ):
             module.to(dtype=backbone_dtype)
+
+        if config.train_vision_encoder_only:
+            # Freeze every policy-level projection (action/time/adarms/state) so ONLY the
+            # Qwen3-VL vision tower trains. Its merger / deepstack projector lives inside
+            # backbone.model.visual, already configured by qwen3vl_with_expert's own
+            # set_requires_grad.
+            freeze_policy_level_params_for_vision_only(self, self.qwen3vl_with_expert)
 
     # ----- flow-matching sampling utilities (identical to pi05) -----
 

--- a/src/opentau/policies/cosmos3/qwen3vl_with_expert.py
+++ b/src/opentau/policies/cosmos3/qwen3vl_with_expert.py
@@ -356,6 +356,7 @@ class Qwen3VLWithExpertModel(nn.Module):
         attention_implementation: str,
         freeze_vision_encoder: bool = True,
         train_expert_only: bool = True,
+        train_vision_encoder_only: bool = False,
         gradient_checkpointing: bool = False,
         load_pretrained_backbone_repo: str | None = None,
         condition_on_layer: int | None = None,
@@ -363,6 +364,7 @@ class Qwen3VLWithExpertModel(nn.Module):
         super().__init__()
         self.freeze_vision_encoder = freeze_vision_encoder
         self.train_expert_only = train_expert_only
+        self.train_vision_encoder_only = train_vision_encoder_only
 
         # Deepcopy so the layer-count / attn-impl mutations below stay local and never
         # corrupt the caller's config object (e.g. a shared tiny config across tests).
@@ -460,11 +462,33 @@ class Qwen3VLWithExpertModel(nn.Module):
             self.backbone.eval()
             for p in self.backbone.parameters():
                 p.requires_grad = False
+        if self.train_vision_encoder_only:
+            # Mirror image of train_expert_only: freeze the whole backbone (Qwen3-VL
+            # LLM + lm_head) AND the action expert; leave ONLY the vision tower
+            # trainable. The multimodal projector (``merger`` + ``deepstack_merger_list``)
+            # lives *inside* ``backbone.model.visual``, so it trains together with the
+            # ViT trunk. Frozen modules still transmit gradients, and because
+            # train_expert_only is False (enforced by config validation) the backbone
+            # forward in ``run_prefix`` keeps its graph, so the vision tower's loss
+            # reaches it.
+            self.backbone.eval()
+            for p in self.backbone.parameters():
+                p.requires_grad = False
+            self.expert.eval()
+            for p in self.expert.parameters():
+                p.requires_grad = False
+            for p in self.backbone.model.visual.parameters():
+                p.requires_grad = True
 
     def train(self, mode: bool = True):
         super().train(mode)
         if self.train_expert_only:
             self.backbone.eval()
+        elif self.train_vision_encoder_only:
+            # Only the vision tower trains; the backbone LLM and the expert stay frozen.
+            self.backbone.eval()
+            self.expert.eval()
+            self.backbone.model.visual.train(mode)
         elif self.freeze_vision_encoder:
             self.backbone.model.visual.eval()
         return self
@@ -505,9 +529,16 @@ class Qwen3VLWithExpertModel(nn.Module):
         When ``train_expert_only`` (the default), the backbone is fully frozen: the forward
         runs under ``no_grad`` and the cached KV is ``.detach()``'d, so the expert reads it
         as a constant. When ``train_expert_only`` is False (partial unfreeze, e.g. a
-        trainable text tower with a frozen vision encoder), the forward keeps its graph and
-        the KV is **not** detached, so the expert's loss backpropagates into the (unfrozen)
-        backbone — otherwise unfreezing would be a silent no-op.
+        trainable text tower with a frozen vision encoder, or ``train_vision_encoder_only``
+        with a trainable vision tower and a frozen text tower), the forward keeps its graph
+        and the KV is **not** detached, so the expert's loss backpropagates into the
+        (unfrozen part of the) backbone — otherwise unfreezing would be a silent no-op.
+
+        This ctx MUST stay keyed on ``train_expert_only`` alone: ``train_vision_encoder_only``
+        is mutually exclusive with it (config validation), so it always takes the
+        ``nullcontext`` branch and gradients reach ``backbone.model.visual``. OR-ing
+        ``train_vision_encoder_only`` into the ``no_grad`` predicate would silently detach the
+        vision tower and make vision-only training a no-op.
         """
         ctx = torch.no_grad() if self.train_expert_only else nullcontext()
         with ctx:

--- a/src/opentau/policies/pi0/configuration_pi0.py
+++ b/src/opentau/policies/pi0/configuration_pi0.py
@@ -72,6 +72,11 @@ class PI0Config(PreTrainedConfig):
             for backward compatibility but logs a warning and falls back to "eager".
         freeze_vision_encoder: Whether to freeze the vision encoder during fine-tuning. Defaults to True.
         train_expert_only: Whether to train only the expert module. Defaults to False.
+        train_vision_encoder_only: Mirror image of ``train_expert_only`` — train ONLY the
+            vision encoder (SigLIP tower + multimodal projector) and freeze the LLM
+            backbone, the action expert, and all action/state/time projections. Requires
+            ``freeze_vision_encoder=False`` and is incompatible with ``train_expert_only=True``.
+            Defaults to False.
         train_state_proj: Whether to train the state projection layer. Defaults to True.
         optimizer_lr: Learning rate for the optimizer. Defaults to 2.5e-5.
         optimizer_betas: Beta parameters for AdamW optimizer. Defaults to (0.9, 0.95).
@@ -135,6 +140,7 @@ class PI0Config(PreTrainedConfig):
     # Finetuning settings
     freeze_vision_encoder: bool = True
     train_expert_only: bool = False
+    train_vision_encoder_only: bool = False
     train_state_proj: bool = True
 
     # Wrap each transformer-layer forward in torch.utils.checkpoint to trade
@@ -170,6 +176,15 @@ class PI0Config(PreTrainedConfig):
 
         # TODO(Steven): Validate device and amp? in all policy configs?
         """Input validation (not exhaustive)."""
+        if self.train_vision_encoder_only and self.train_expert_only:
+            raise ValueError(
+                "`train_vision_encoder_only=True` and `train_expert_only=True` are mutually exclusive."
+            )
+        if self.train_vision_encoder_only and self.freeze_vision_encoder:
+            raise ValueError(
+                "`train_vision_encoder_only=True` requires `freeze_vision_encoder=False` — the vision "
+                "encoder cannot be both frozen and the only trained component."
+            )
         if self.n_action_steps > self.chunk_size:
             raise ValueError(
                 f"The chunk size is the upper bound for the number of action steps per model invocation. Got "

--- a/src/opentau/policies/pi0/modeling_pi0.py
+++ b/src/opentau/policies/pi0/modeling_pi0.py
@@ -37,7 +37,12 @@ from opentau.policies.pi0.paligemma_with_expert import (
     PaliGemmaWithExpertModel,
 )
 from opentau.policies.pretrained import PreTrainedPolicy
-from opentau.policies.utils import PerSampleLoss, log_model_loading_keys, make_action_dim_mask
+from opentau.policies.utils import (
+    PerSampleLoss,
+    freeze_policy_level_params_for_vision_only,
+    log_model_loading_keys,
+    make_action_dim_mask,
+)
 from opentau.utils.accelerate_utils import get_proc_accelerator
 from opentau.utils.utils import get_safe_dtype
 
@@ -713,6 +718,7 @@ class PI0FlowMatching(nn.Module):
         paligemma_with_export_config = PaliGemmaWithExpertConfig(
             freeze_vision_encoder=self.config.freeze_vision_encoder,
             train_expert_only=self.config.train_expert_only,
+            train_vision_encoder_only=self.config.train_vision_encoder_only,
             attention_implementation=self.config.attention_implementation,
             dropout=self.config.dropout,
             gradient_checkpointing=self.config.gradient_checkpointing,
@@ -733,6 +739,12 @@ class PI0FlowMatching(nn.Module):
         """Sets the requires_grad attribute for state projection parameters."""
         for params in self.state_proj.parameters():
             params.requires_grad = self.config.train_state_proj
+
+        if self.config.train_vision_encoder_only:
+            # Freeze every policy-level projection (state/action/time) so ONLY the
+            # vision encoder (inside paligemma_with_expert, already configured by its
+            # own set_requires_grad) trains. Overrides the train_state_proj setting above.
+            freeze_policy_level_params_for_vision_only(self, self.paligemma_with_expert)
 
     def sample_noise(self, shape: tuple[int, ...], device: torch.device | str) -> Tensor:
         """Samples Gaussian noise.

--- a/src/opentau/policies/pi0/paligemma_with_expert.py
+++ b/src/opentau/policies/pi0/paligemma_with_expert.py
@@ -82,6 +82,7 @@ class PaliGemmaWithExpertConfig(PretrainedConfig):
         gemma_expert_config: dict | None = None,
         freeze_vision_encoder: bool = True,
         train_expert_only: bool = True,
+        train_vision_encoder_only: bool = False,
         attention_implementation: str = "eager",
         dropout: float = 0.1,
         gradient_checkpointing: bool = False,
@@ -94,6 +95,11 @@ class PaliGemmaWithExpertConfig(PretrainedConfig):
             gemma_expert_config: Configuration dictionary for the Gemma expert model.
             freeze_vision_encoder: Whether to freeze the vision encoder. Defaults to True.
             train_expert_only: Whether to train only the expert model. Defaults to True.
+            train_vision_encoder_only: Mirror image of ``train_expert_only`` — freeze the
+                Gemma LLM backbone and the action expert, and train ONLY the vision pathway
+                (the SigLIP tower + the multimodal projector). Requires
+                ``freeze_vision_encoder=False`` and is incompatible with
+                ``train_expert_only=True``. Defaults to False.
             attention_implementation: Attention implementation to use ("eager", "sdpa",
                 or "fa2"). Defaults to "eager".
             dropout: Dropout probability. Defaults to 0.1.
@@ -108,6 +114,7 @@ class PaliGemmaWithExpertConfig(PretrainedConfig):
         """
         self.freeze_vision_encoder = freeze_vision_encoder
         self.train_expert_only = train_expert_only
+        self.train_vision_encoder_only = train_vision_encoder_only
         self.attention_implementation = attention_implementation
         self.dropout = dropout
         self.gradient_checkpointing = gradient_checkpointing
@@ -198,6 +205,16 @@ class PaliGemmaWithExpertConfig(PretrainedConfig):
             raise ValueError(
                 "You set `freeze_vision_encoder=False` and `train_expert_only=True` which are not compatible."
             )
+        if self.train_vision_encoder_only and self.train_expert_only:
+            raise ValueError(
+                "`train_vision_encoder_only=True` and `train_expert_only=True` are mutually exclusive."
+            )
+        if self.train_vision_encoder_only and self.freeze_vision_encoder:
+            raise ValueError(
+                "You set `train_vision_encoder_only=True` and `freeze_vision_encoder=True` which are not "
+                "compatible — the vision encoder cannot be both frozen and the only trained component. "
+                "Set `freeze_vision_encoder=False`."
+            )
         if self.attention_implementation not in ["eager", "sdpa", "fa2"]:
             raise ValueError(
                 f"Wrong value provided for `attention_implementation` ({self.attention_implementation}). "
@@ -244,6 +261,22 @@ class PaliGemmaWithExpertModel(PreTrainedModel):
         self.to_bfloat16_like_physical_intelligence()
         self.set_requires_grad()
 
+    def _multi_modal_projector(self):
+        """Return the multimodal projector, tolerating the ``.model.`` nesting that
+        varies across transformers versions."""
+        for path in ("multi_modal_projector", "model.multi_modal_projector"):
+            obj = self.paligemma
+            ok = True
+            for part in path.split("."):
+                if hasattr(obj, part):
+                    obj = getattr(obj, part)
+                else:
+                    ok = False
+                    break
+            if ok:
+                return obj
+        return None
+
     def set_requires_grad(self) -> None:
         """Sets the requires_grad attribute for model parameters based on configuration."""
         if self.config.freeze_vision_encoder:
@@ -255,6 +288,25 @@ class PaliGemmaWithExpertModel(PreTrainedModel):
             self.paligemma.eval()
             for params in self.paligemma.parameters():
                 params.requires_grad = False
+
+        if self.config.train_vision_encoder_only:
+            # Mirror image of ``train_expert_only``: freeze the Gemma LLM backbone and
+            # the action expert; leave ONLY the vision pathway (SigLIP tower + multimodal
+            # projector) trainable. The frozen modules still transmit gradients, so the
+            # vision pathway's loss reaches it.
+            self.paligemma.eval()
+            for params in self.paligemma.parameters():
+                params.requires_grad = False
+            self.gemma_expert.eval()
+            for param in self.gemma_expert.parameters():
+                param.requires_grad = False
+            # Re-enable the vision pathway (SigLIP tower + multimodal projector).
+            for params in self.paligemma.vision_tower.parameters():
+                params.requires_grad = True
+            projector = self._multi_modal_projector()
+            if projector is not None:
+                for params in projector.parameters():
+                    params.requires_grad = True
 
     def train(self, mode: bool = True) -> None:
         """Sets the module in training mode.
@@ -269,6 +321,15 @@ class PaliGemmaWithExpertModel(PreTrainedModel):
 
         if self.config.train_expert_only:
             self.paligemma.eval()
+
+        if self.config.train_vision_encoder_only:
+            # Everything except the vision pathway is frozen -> keep it in eval.
+            self.paligemma.eval()
+            self.gemma_expert.eval()
+            self.paligemma.vision_tower.train(mode)
+            projector = self._multi_modal_projector()
+            if projector is not None:
+                projector.train(mode)
 
     def to_bfloat16_like_physical_intelligence(self) -> None:
         """Casts specific model components to bfloat16, keeping the SigLIP embeddings in float32.

--- a/src/opentau/policies/pi05/configuration_pi05.py
+++ b/src/opentau/policies/pi05/configuration_pi05.py
@@ -20,6 +20,7 @@ for the PI05 Vision-Language-Action Flow Model. It includes settings for the mod
 optimization, scheduling, and data processing.
 """
 
+import logging
 import warnings
 from dataclasses import dataclass, field
 from typing import Literal
@@ -72,7 +73,9 @@ class PI05Config(PreTrainedConfig):
             vision encoder (SigLIP tower + multimodal projector) and freeze the LLM
             backbone, the action expert, and all heads/projections. Requires
             ``freeze_vision_encoder=False`` and is incompatible with ``train_expert_only=True``.
-            Defaults to False.
+            Note: with ``knowledge_insulation=True`` (the default) the action (MSE) loss is
+            detached from the VLM, so the vision encoder trains on the CE loss only — set
+            ``knowledge_insulation=False`` to train it from the action loss. Defaults to False.
         optimizer_lr: Learning rate for the optimizer. Defaults to 2.5e-5.
         optimizer_betas: Beta parameters for AdamW optimizer. Defaults to (0.9, 0.95).
         optimizer_eps: Epsilon parameter for AdamW optimizer. Defaults to 1e-8.
@@ -228,6 +231,15 @@ class PI05Config(PreTrainedConfig):
             raise ValueError(
                 "`train_vision_encoder_only=True` requires `freeze_vision_encoder=False` — the vision "
                 "encoder cannot be both frozen and the only trained component."
+            )
+        if self.train_vision_encoder_only and self.knowledge_insulation:
+            logging.warning(
+                "train_vision_encoder_only=True with knowledge_insulation=True: knowledge insulation "
+                "detaches the VLM prefix KV cache before the action expert, so the flow-matching "
+                "action (MSE) loss does not reach the vision encoder — it trains on the CE loss only, "
+                "and if the CE loss weight is 0 the step has no gradient path to any trainable "
+                "parameter. Set knowledge_insulation=False to train the vision encoder from the "
+                "action loss."
             )
         if self.n_action_steps > self.chunk_size:
             raise ValueError(

--- a/src/opentau/policies/pi05/configuration_pi05.py
+++ b/src/opentau/policies/pi05/configuration_pi05.py
@@ -68,6 +68,11 @@ class PI05Config(PreTrainedConfig):
             backward compatibility but logs a warning and falls back to "eager".
         freeze_vision_encoder: Whether to freeze the vision encoder during fine-tuning. Defaults to True.
         train_expert_only: Whether to train only the expert module. Defaults to False.
+        train_vision_encoder_only: Mirror image of ``train_expert_only`` — train ONLY the
+            vision encoder (SigLIP tower + multimodal projector) and freeze the LLM
+            backbone, the action expert, and all heads/projections. Requires
+            ``freeze_vision_encoder=False`` and is incompatible with ``train_expert_only=True``.
+            Defaults to False.
         optimizer_lr: Learning rate for the optimizer. Defaults to 2.5e-5.
         optimizer_betas: Beta parameters for AdamW optimizer. Defaults to (0.9, 0.95).
         optimizer_eps: Epsilon parameter for AdamW optimizer. Defaults to 1e-8.
@@ -155,6 +160,7 @@ class PI05Config(PreTrainedConfig):
     # Finetuning settings
     freeze_vision_encoder: bool = True
     train_expert_only: bool = False
+    train_vision_encoder_only: bool = False
 
     # Knowledge insulation (π0.5): when True (default), the prefix/VLM KV cache
     # is detached before the action expert reads it, so the flow-matching action
@@ -214,6 +220,15 @@ class PI05Config(PreTrainedConfig):
 
         # TODO(Steven): Validate device and amp? in all policy configs?
         """Input validation (not exhaustive)."""
+        if self.train_vision_encoder_only and self.train_expert_only:
+            raise ValueError(
+                "`train_vision_encoder_only=True` and `train_expert_only=True` are mutually exclusive."
+            )
+        if self.train_vision_encoder_only and self.freeze_vision_encoder:
+            raise ValueError(
+                "`train_vision_encoder_only=True` requires `freeze_vision_encoder=False` — the vision "
+                "encoder cannot be both frozen and the only trained component."
+            )
         if self.n_action_steps > self.chunk_size:
             raise ValueError(
                 f"The chunk size is the upper bound for the number of action steps per model invocation. Got "

--- a/src/opentau/policies/pi05/modeling_pi05.py
+++ b/src/opentau/policies/pi05/modeling_pi05.py
@@ -45,7 +45,12 @@ from opentau.policies.pi05.paligemma_with_expert import (
     PaliGemmaWithExpertModel,
 )
 from opentau.policies.pretrained import PreTrainedPolicy, T
-from opentau.policies.utils import PerSampleLoss, ce_per_sample, flow_matching_masked_mse
+from opentau.policies.utils import (
+    PerSampleLoss,
+    ce_per_sample,
+    flow_matching_masked_mse,
+    freeze_policy_level_params_for_vision_only,
+)
 from opentau.utils.accelerate_utils import get_proc_accelerator
 from opentau.utils.utils import get_safe_dtype
 
@@ -1102,6 +1107,7 @@ class PI05FlowMatching(nn.Module):
         paligemma_with_expert_config = PaliGemmaWithExpertConfig(
             freeze_vision_encoder=self.config.freeze_vision_encoder,
             train_expert_only=self.config.train_expert_only,
+            train_vision_encoder_only=self.config.train_vision_encoder_only,
             attention_implementation=self.config.attention_implementation,
             discrete_action_vocab_size=discrete_action_vocab_size,
             dropout=self.config.dropout,
@@ -1142,6 +1148,12 @@ class PI05FlowMatching(nn.Module):
         # match mode (no new IDs, no embedding resize on PaliGemma) and
         # mutates the shared tokenizer instance for `PI05Policy` too.
         ensure_loc_tokens(self.language_tokenizer)
+
+        if self.config.train_vision_encoder_only:
+            # Freeze every policy-level projection (state/action/time + optional
+            # modality embeddings) so ONLY the vision encoder inside
+            # paligemma_with_expert trains.
+            freeze_policy_level_params_for_vision_only(self, self.paligemma_with_expert)
 
     def sample_noise(self, shape: tuple[int, ...], device: torch.device | str) -> Tensor:
         """Samples Gaussian noise.

--- a/src/opentau/policies/pi05/paligemma_with_expert.py
+++ b/src/opentau/policies/pi05/paligemma_with_expert.py
@@ -115,6 +115,7 @@ class PaliGemmaWithExpertConfig(PretrainedConfig):
         gemma_expert_config: dict | None = None,
         freeze_vision_encoder: bool = True,
         train_expert_only: bool = True,
+        train_vision_encoder_only: bool = False,
         attention_implementation: str = "eager",
         discrete_action_vocab_size: int | None = None,
         dropout: float = 0.1,
@@ -128,6 +129,11 @@ class PaliGemmaWithExpertConfig(PretrainedConfig):
             gemma_expert_config: Configuration dictionary for the Gemma expert model.
             freeze_vision_encoder: Whether to freeze the vision encoder. Defaults to True.
             train_expert_only: Whether to train only the expert model. Defaults to True.
+            train_vision_encoder_only: Mirror image of ``train_expert_only`` — freeze the
+                Gemma LLM backbone, the action expert, and the discrete-action heads, and
+                train ONLY the vision pathway (the SigLIP tower + the multimodal projector).
+                Requires ``freeze_vision_encoder=False`` and is incompatible with
+                ``train_expert_only=True``. Defaults to False.
             attention_implementation: Attention implementation to use ("eager", "sdpa",
                 or "fa2"). Defaults to "eager".
             discrete_action_vocab_size: Vocabulary size for discrete actions.
@@ -143,6 +149,7 @@ class PaliGemmaWithExpertConfig(PretrainedConfig):
         """
         self.freeze_vision_encoder = freeze_vision_encoder
         self.train_expert_only = train_expert_only
+        self.train_vision_encoder_only = train_vision_encoder_only
         self.attention_implementation = attention_implementation
         self.discrete_action_vocab_size = discrete_action_vocab_size
         self.dropout = dropout
@@ -241,6 +248,16 @@ class PaliGemmaWithExpertConfig(PretrainedConfig):
             raise ValueError(
                 "You set `freeze_vision_encoder=False` and `train_expert_only=True` which are not compatible."
             )
+        if self.train_vision_encoder_only and self.train_expert_only:
+            raise ValueError(
+                "`train_vision_encoder_only=True` and `train_expert_only=True` are mutually exclusive."
+            )
+        if self.train_vision_encoder_only and self.freeze_vision_encoder:
+            raise ValueError(
+                "You set `train_vision_encoder_only=True` and `freeze_vision_encoder=True` which are not "
+                "compatible — the vision encoder cannot be both frozen and the only trained component. "
+                "Set `freeze_vision_encoder=False`."
+            )
 
         if self.attention_implementation not in ["eager", "sdpa", "fa2", "flash_cuda"]:
             raise ValueError(
@@ -304,6 +321,22 @@ class PaliGemmaWithExpertModel(PreTrainedModel):
             self.to_bfloat16_like_physical_intelligence()
         self.set_requires_grad()
 
+    def _multi_modal_projector(self):
+        """Return the multimodal projector, tolerating the ``.model.`` nesting that
+        varies across transformers versions (mirrors ``embed_image``'s resolution)."""
+        for path in ("multi_modal_projector", "model.multi_modal_projector"):
+            obj = self.paligemma
+            ok = True
+            for part in path.split("."):
+                if hasattr(obj, part):
+                    obj = getattr(obj, part)
+                else:
+                    ok = False
+                    break
+            if ok:
+                return obj
+        return None
+
     def set_requires_grad(self) -> None:
         """Sets the requires_grad attribute for model parameters based on configuration."""
         if self.config.freeze_vision_encoder:
@@ -320,6 +353,29 @@ class PaliGemmaWithExpertModel(PreTrainedModel):
             for param in self.discrete_action_embedding.parameters():
                 param.requires_grad = False
 
+        if self.config.train_vision_encoder_only:
+            # Mirror image of ``train_expert_only``: freeze the Gemma LLM backbone,
+            # the action expert, and the discrete-action heads; leave ONLY the vision
+            # pathway (SigLIP tower + multimodal projector) trainable. The frozen
+            # modules still transmit gradients, so the vision pathway's loss reaches it.
+            self.paligemma.eval()
+            for params in self.paligemma.parameters():
+                params.requires_grad = False
+            self.gemma_expert.eval()
+            for param in self.gemma_expert.parameters():
+                param.requires_grad = False
+            for param in self.da_head.parameters():
+                param.requires_grad = False
+            for param in self.discrete_action_embedding.parameters():
+                param.requires_grad = False
+            # Re-enable the vision pathway (SigLIP tower + multimodal projector).
+            for params in self.paligemma.vision_tower.parameters():
+                params.requires_grad = True
+            projector = self._multi_modal_projector()
+            if projector is not None:
+                for params in projector.parameters():
+                    params.requires_grad = True
+
     def train(self, mode: bool = True) -> None:
         """Sets the module in training mode.
 
@@ -333,6 +389,18 @@ class PaliGemmaWithExpertModel(PreTrainedModel):
 
         if self.config.train_expert_only:
             self.paligemma.eval()
+
+        if self.config.train_vision_encoder_only:
+            # Everything except the vision pathway is frozen -> keep it in eval so
+            # dropout etc. do not perturb the frozen backbone/expert forward.
+            self.paligemma.eval()
+            self.gemma_expert.eval()
+            self.da_head.eval()
+            self.discrete_action_embedding.eval()
+            self.paligemma.vision_tower.train(mode)
+            projector = self._multi_modal_projector()
+            if projector is not None:
+                projector.train(mode)
 
     def to_bfloat16_like_physical_intelligence(self) -> None:
         """Casts specific model components to bfloat16, keeping the SigLIP embeddings in float32.

--- a/src/opentau/policies/pi05_mem/configuration_pi05.py
+++ b/src/opentau/policies/pi05_mem/configuration_pi05.py
@@ -76,6 +76,11 @@ class PI05MemConfig(PreTrainedConfig):
             When True the ``multi_modal_projector`` remains trainable, matching
             the semantics in ``pi05_continuous_state``. Defaults to True.
         train_expert_only: Whether to train only the expert module. Defaults to False.
+        train_vision_encoder_only: Mirror image of ``train_expert_only`` — train ONLY the
+            video encoder (SigLIP tower + multimodal projector + the RLDX
+            ``motion_module``) and freeze the LLM backbone, the action expert, and all
+            heads/projections. Requires ``freeze_vision_encoder=False`` and is incompatible
+            with ``train_expert_only=True``. Defaults to False.
         spacetime_layer_stride: Every ``stride``-th SigLIP encoder layer gets
             the temporal self-attention sublayer added. Defaults to 4, matching
             the MEM paper. The video encoder introduces no new learnable
@@ -160,6 +165,7 @@ class PI05MemConfig(PreTrainedConfig):
     # Finetuning settings
     freeze_vision_encoder: bool = True
     train_expert_only: bool = False
+    train_vision_encoder_only: bool = False
 
     # Knowledge insulation (π0.5): when True (default), the prefix/VLM KV cache
     # is detached before the action expert reads it, so the flow-matching action
@@ -244,6 +250,15 @@ class PI05MemConfig(PreTrainedConfig):
         """Post-initialization validation."""
         super().__post_init__()
 
+        if self.train_vision_encoder_only and self.train_expert_only:
+            raise ValueError(
+                "`train_vision_encoder_only=True` and `train_expert_only=True` are mutually exclusive."
+            )
+        if self.train_vision_encoder_only and self.freeze_vision_encoder:
+            raise ValueError(
+                "`train_vision_encoder_only=True` requires `freeze_vision_encoder=False` — the vision "
+                "encoder cannot be both frozen and the only trained component."
+            )
         if not isinstance(self.n_obs_steps, int) or self.n_obs_steps < 1:
             raise ValueError(f"`n_obs_steps` must be a positive integer, got {self.n_obs_steps}.")
         if not isinstance(self.history_interval, int) or self.history_interval < 1:

--- a/src/opentau/policies/pi05_mem/configuration_pi05.py
+++ b/src/opentau/policies/pi05_mem/configuration_pi05.py
@@ -23,6 +23,7 @@ architecture), and processes temporal state sequences (one continuous token
 per timestep).
 """
 
+import logging
 from dataclasses import dataclass, field
 
 from opentau.configs.policies import PreTrainedConfig
@@ -80,7 +81,10 @@ class PI05MemConfig(PreTrainedConfig):
             video encoder (SigLIP tower + multimodal projector + the RLDX
             ``motion_module``) and freeze the LLM backbone, the action expert, and all
             heads/projections. Requires ``freeze_vision_encoder=False`` and is incompatible
-            with ``train_expert_only=True``. Defaults to False.
+            with ``train_expert_only=True``. Note: with ``knowledge_insulation=True`` (the
+            default) the action (MSE) loss is detached from the VLM, so the video encoder
+            trains on the CE loss only — set ``knowledge_insulation=False`` to train it from
+            the action loss. Defaults to False.
         spacetime_layer_stride: Every ``stride``-th SigLIP encoder layer gets
             the temporal self-attention sublayer added. Defaults to 4, matching
             the MEM paper. The video encoder introduces no new learnable
@@ -258,6 +262,15 @@ class PI05MemConfig(PreTrainedConfig):
             raise ValueError(
                 "`train_vision_encoder_only=True` requires `freeze_vision_encoder=False` — the vision "
                 "encoder cannot be both frozen and the only trained component."
+            )
+        if self.train_vision_encoder_only and self.knowledge_insulation:
+            logging.warning(
+                "train_vision_encoder_only=True with knowledge_insulation=True: knowledge insulation "
+                "detaches the VLM prefix KV cache before the action expert, so the flow-matching "
+                "action (MSE) loss does not reach the video encoder — it trains on the CE loss only, "
+                "and if the CE loss weight is 0 the step has no gradient path to any trainable "
+                "parameter. Set knowledge_insulation=False to train the video encoder from the "
+                "action loss."
             )
         if not isinstance(self.n_obs_steps, int) or self.n_obs_steps < 1:
             raise ValueError(f"`n_obs_steps` must be a positive integer, got {self.n_obs_steps}.")

--- a/src/opentau/policies/pi05_mem/modeling_pi05.py
+++ b/src/opentau/policies/pi05_mem/modeling_pi05.py
@@ -57,7 +57,12 @@ from opentau.policies.pi05_mem.configuration_pi05 import PI05MemConfig
 from opentau.policies.pi05_mem.rldx_video_encoder import RLDXVideoEncoder
 from opentau.policies.pi07.video_encoder import SpaceTimeSiglipVideoEncoder
 from opentau.policies.pretrained import PreTrainedPolicy, T
-from opentau.policies.utils import PerSampleLoss, ce_per_sample, flow_matching_masked_mse
+from opentau.policies.utils import (
+    PerSampleLoss,
+    ce_per_sample,
+    flow_matching_masked_mse,
+    freeze_policy_level_params_for_vision_only,
+)
 from opentau.utils.accelerate_utils import get_proc_accelerator
 from opentau.utils.utils import get_safe_dtype
 
@@ -1025,6 +1030,7 @@ class PI05MemFlowMatching(nn.Module):
         paligemma_with_expert_config = PaliGemmaWithExpertConfig(
             freeze_vision_encoder=self.config.freeze_vision_encoder,
             train_expert_only=self.config.train_expert_only,
+            train_vision_encoder_only=self.config.train_vision_encoder_only,
             attention_implementation=self.config.attention_implementation,
             discrete_action_vocab_size=discrete_action_vocab_size,
             dropout=self.config.dropout,
@@ -1117,6 +1123,14 @@ class PI05MemFlowMatching(nn.Module):
 
         self.time_mlp_in = nn.Linear(self.config.proj_width, self.config.proj_width)
         self.time_mlp_out = nn.Linear(self.config.proj_width, self.config.proj_width)
+
+        if self.config.train_vision_encoder_only:
+            # Freeze every policy-level projection (state/action/time) so ONLY the video
+            # encoder trains. The RLDX ``video_encoder.motion_module`` is part of the video
+            # encoder and is left trainable by the helper (matched by name); the SigLIP
+            # tower + projector live under paligemma_with_expert and are already configured
+            # by its own set_requires_grad.
+            freeze_policy_level_params_for_vision_only(self, self.paligemma_with_expert)
 
     def sample_noise(self, shape: tuple[int, ...], device: torch.device | str) -> Tensor:
         return torch.normal(mean=0.0, std=1.0, size=shape, dtype=torch.float32, device=device)

--- a/src/opentau/policies/pi06/configuration_pi06.py
+++ b/src/opentau/policies/pi06/configuration_pi06.py
@@ -80,6 +80,11 @@ class PI06Config(PreTrainedConfig):
             compatibility but logs a warning and falls back to eager.
         freeze_vision_encoder: Whether to freeze the vision encoder. Defaults to True.
         train_expert_only: Whether to train only the expert module. Defaults to False.
+        train_vision_encoder_only: Mirror image of ``train_expert_only`` — train ONLY the
+            vision encoder (SigLIP tower + multimodal projector) and freeze the Gemma 3
+            backbone, the action expert, and all heads/projections. Requires
+            ``freeze_vision_encoder=False`` and is incompatible with ``train_expert_only=True``.
+            Defaults to False.
         optimizer_lr: AdamW learning rate. Defaults to 2.5e-5.
         optimizer_betas: AdamW betas. Defaults to (0.9, 0.95).
         optimizer_eps: AdamW epsilon. Defaults to 1e-8.
@@ -148,6 +153,7 @@ class PI06Config(PreTrainedConfig):
     # Finetuning settings
     freeze_vision_encoder: bool = True
     train_expert_only: bool = False
+    train_vision_encoder_only: bool = False
 
     # Knowledge insulation (π0.5): when True (default), the prefix/VLM KV cache
     # is detached before the action expert reads it, so the flow-matching action
@@ -181,6 +187,15 @@ class PI06Config(PreTrainedConfig):
         """Post-initialization validation."""
         super().__post_init__()
 
+        if self.train_vision_encoder_only and self.train_expert_only:
+            raise ValueError(
+                "`train_vision_encoder_only=True` and `train_expert_only=True` are mutually exclusive."
+            )
+        if self.train_vision_encoder_only and self.freeze_vision_encoder:
+            raise ValueError(
+                "`train_vision_encoder_only=True` requires `freeze_vision_encoder=False` — the vision "
+                "encoder cannot be both frozen and the only trained component."
+            )
         if self.n_action_steps > self.chunk_size:
             raise ValueError(
                 f"The chunk size is the upper bound for the number of action steps per model invocation. Got "

--- a/src/opentau/policies/pi06/configuration_pi06.py
+++ b/src/opentau/policies/pi06/configuration_pi06.py
@@ -22,6 +22,7 @@ Insulation gradient-stop) but upgrades the backbone to Gemma 3 4B with 448×448
 vision and a larger action expert.
 """
 
+import logging
 from dataclasses import dataclass, field
 
 from opentau.configs.policies import PreTrainedConfig
@@ -84,7 +85,9 @@ class PI06Config(PreTrainedConfig):
             vision encoder (SigLIP tower + multimodal projector) and freeze the Gemma 3
             backbone, the action expert, and all heads/projections. Requires
             ``freeze_vision_encoder=False`` and is incompatible with ``train_expert_only=True``.
-            Defaults to False.
+            Note: with ``knowledge_insulation=True`` (the default) the action (MSE) loss is
+            detached from the VLM, so the vision encoder trains on the CE loss only — set
+            ``knowledge_insulation=False`` to train it from the action loss. Defaults to False.
         optimizer_lr: AdamW learning rate. Defaults to 2.5e-5.
         optimizer_betas: AdamW betas. Defaults to (0.9, 0.95).
         optimizer_eps: AdamW epsilon. Defaults to 1e-8.
@@ -195,6 +198,15 @@ class PI06Config(PreTrainedConfig):
             raise ValueError(
                 "`train_vision_encoder_only=True` requires `freeze_vision_encoder=False` — the vision "
                 "encoder cannot be both frozen and the only trained component."
+            )
+        if self.train_vision_encoder_only and self.knowledge_insulation:
+            logging.warning(
+                "train_vision_encoder_only=True with knowledge_insulation=True: knowledge insulation "
+                "detaches the VLM prefix KV cache before the action expert, so the flow-matching "
+                "action (MSE) loss does not reach the vision encoder — it trains on the CE loss only, "
+                "and if the CE loss weight is 0 the step has no gradient path to any trainable "
+                "parameter. Set knowledge_insulation=False to train the vision encoder from the "
+                "action loss."
             )
         if self.n_action_steps > self.chunk_size:
             raise ValueError(

--- a/src/opentau/policies/pi06/gemma3_with_expert.py
+++ b/src/opentau/policies/pi06/gemma3_with_expert.py
@@ -111,6 +111,7 @@ class Gemma3WithExpertConfig(PretrainedConfig):
         gemma_expert_config: dict | None = None,
         freeze_vision_encoder: bool = True,
         train_expert_only: bool = True,
+        train_vision_encoder_only: bool = False,
         attention_implementation: str = "eager",
         discrete_action_vocab_size: int | None = None,
         dropout: float = 0.1,
@@ -126,6 +127,11 @@ class Gemma3WithExpertConfig(PretrainedConfig):
                 Defaults to a ~860M-parameter Gemma with AdaRMS enabled.
             freeze_vision_encoder: Freeze the SigLIP tower during training.
             train_expert_only: Only update the expert and its heads.
+            train_vision_encoder_only: Mirror image of ``train_expert_only`` — freeze the
+                Gemma 3 backbone, the action expert, and the discrete-action heads, and
+                train ONLY the vision pathway (the SigLIP tower + the multimodal
+                projector). Requires ``freeze_vision_encoder=False`` and is incompatible
+                with ``train_expert_only=True``.
             attention_implementation: "eager", "sdpa", or "fa2". "fa2" is not
                 implemented and falls back to eager with a warning. "sdpa"
                 dispatches to ``torch.nn.functional.scaled_dot_product_attention``;
@@ -146,6 +152,7 @@ class Gemma3WithExpertConfig(PretrainedConfig):
         """
         self.freeze_vision_encoder = freeze_vision_encoder
         self.train_expert_only = train_expert_only
+        self.train_vision_encoder_only = train_vision_encoder_only
         self.attention_implementation = attention_implementation
         self.discrete_action_vocab_size = discrete_action_vocab_size
         self.dropout = dropout
@@ -248,6 +255,16 @@ class Gemma3WithExpertConfig(PretrainedConfig):
             raise ValueError(
                 "You set `freeze_vision_encoder=False` and `train_expert_only=True` which are not compatible."
             )
+        if self.train_vision_encoder_only and self.train_expert_only:
+            raise ValueError(
+                "`train_vision_encoder_only=True` and `train_expert_only=True` are mutually exclusive."
+            )
+        if self.train_vision_encoder_only and self.freeze_vision_encoder:
+            raise ValueError(
+                "You set `train_vision_encoder_only=True` and `freeze_vision_encoder=True` which are not "
+                "compatible — the vision encoder cannot be both frozen and the only trained component. "
+                "Set `freeze_vision_encoder=False`."
+            )
         if self.attention_implementation not in ["eager", "sdpa", "fa2"]:
             raise ValueError(
                 f"Wrong value provided for `attention_implementation` ({self.attention_implementation}). "
@@ -334,6 +351,27 @@ class Gemma3WithExpertModel(PreTrainedModel):
             for param in self.discrete_action_embedding.parameters():
                 param.requires_grad = False
 
+        if self.config.train_vision_encoder_only:
+            # Mirror image of ``train_expert_only``: freeze the Gemma 3 backbone,
+            # the action expert, and the discrete-action heads; leave ONLY the vision
+            # pathway (SigLIP tower + multimodal projector) trainable. Frozen modules
+            # still transmit gradients, so the vision pathway's loss reaches it.
+            self.gemma3.eval()
+            for params in self.gemma3.parameters():
+                params.requires_grad = False
+            self.gemma_expert.eval()
+            for param in self.gemma_expert.parameters():
+                param.requires_grad = False
+            for param in self.da_head.parameters():
+                param.requires_grad = False
+            for param in self.discrete_action_embedding.parameters():
+                param.requires_grad = False
+            # Re-enable the vision pathway (SigLIP tower + multimodal projector).
+            for module in (self._vision_tower(), self._multi_modal_projector()):
+                if module is not None:
+                    for params in module.parameters():
+                        params.requires_grad = True
+
     def train(self, mode: bool = True):
         super().train(mode)
         if self.config.freeze_vision_encoder:
@@ -342,6 +380,15 @@ class Gemma3WithExpertModel(PreTrainedModel):
                 vision_tower.eval()
         if self.config.train_expert_only:
             self.gemma3.eval()
+        if self.config.train_vision_encoder_only:
+            # Everything except the vision pathway is frozen -> keep it in eval.
+            self.gemma3.eval()
+            self.gemma_expert.eval()
+            self.da_head.eval()
+            self.discrete_action_embedding.eval()
+            for module in (self._vision_tower(), self._multi_modal_projector()):
+                if module is not None:
+                    module.train(mode)
         return self
 
     def to_bfloat16_like_physical_intelligence(self) -> None:
@@ -362,6 +409,21 @@ class Gemma3WithExpertModel(PreTrainedModel):
         # Gemma 3's vision tower lives at `gemma3.model.vision_tower` depending on
         # the transformers version; fall back gracefully.
         for path in ("vision_tower", "model.vision_tower"):
+            obj = self.gemma3
+            ok = True
+            for part in path.split("."):
+                if hasattr(obj, part):
+                    obj = getattr(obj, part)
+                else:
+                    ok = False
+                    break
+            if ok:
+                return obj
+        return None
+
+    def _multi_modal_projector(self):
+        # Same ``.model.`` version tolerance as ``_vision_tower``.
+        for path in ("multi_modal_projector", "model.multi_modal_projector"):
             obj = self.gemma3
             ok = True
             for part in path.split("."):

--- a/src/opentau/policies/pi06/modeling_pi06.py
+++ b/src/opentau/policies/pi06/modeling_pi06.py
@@ -56,6 +56,7 @@ from opentau.policies.utils import (
     assert_gemma3_input_resolution,
     ce_per_sample,
     flow_matching_masked_mse,
+    freeze_policy_level_params_for_vision_only,
 )
 from opentau.utils.accelerate_utils import get_proc_accelerator
 from opentau.utils.utils import get_safe_dtype
@@ -843,6 +844,7 @@ class PI06FlowMatching(nn.Module):
         gemma3_with_expert_config = Gemma3WithExpertConfig(
             freeze_vision_encoder=self.config.freeze_vision_encoder,
             train_expert_only=self.config.train_expert_only,
+            train_vision_encoder_only=self.config.train_vision_encoder_only,
             attention_implementation=self.config.attention_implementation,
             discrete_action_vocab_size=discrete_action_vocab_size,
             dropout=self.config.dropout,
@@ -879,6 +881,11 @@ class PI06FlowMatching(nn.Module):
         # weights (above), so the original 256K rows survive and only the 1024
         # new rows are freshly initialized.
         ensure_loc_tokens(self.language_tokenizer, model=self.gemma3_with_expert.gemma3)
+
+        if self.config.train_vision_encoder_only:
+            # Freeze every policy-level projection (action/time) so ONLY the vision
+            # encoder inside gemma3_with_expert trains.
+            freeze_policy_level_params_for_vision_only(self, self.gemma3_with_expert)
 
     def sample_noise(self, shape: tuple[int, ...], device: torch.device | str) -> Tensor:
         """Standard Gaussian noise (float32)."""

--- a/src/opentau/policies/pi07/gemma3_with_expert.py
+++ b/src/opentau/policies/pi07/gemma3_with_expert.py
@@ -111,6 +111,7 @@ class Gemma3WithExpertConfig(PretrainedConfig):
         gemma_expert_config: dict | None = None,
         freeze_vision_encoder: bool = True,
         train_expert_only: bool = True,
+        train_vision_encoder_only: bool = False,
         attention_implementation: str = "eager",
         load_pretrained_gemma3: bool = False,
         discrete_action_vocab_size: int | None = None,
@@ -129,6 +130,12 @@ class Gemma3WithExpertConfig(PretrainedConfig):
                 Defaults to a ~860M-parameter Gemma with AdaRMS enabled.
             freeze_vision_encoder: Freeze the SigLIP tower during training.
             train_expert_only: Only update the expert and its heads.
+            train_vision_encoder_only: Mirror image of ``train_expert_only`` — freeze the
+                Gemma 3 backbone (including the reparented interleaved backbone layers),
+                the action expert, and the discrete-action heads, and train ONLY the vision
+                pathway (the SigLIP tower + the multimodal projector). Requires
+                ``freeze_vision_encoder=False`` and is incompatible with
+                ``train_expert_only=True``.
             attention_implementation: "eager", "sdpa", or "fa2". "fa2" is not
                 implemented and falls back to eager with a warning. "sdpa"
                 dispatches to ``torch.nn.functional.scaled_dot_product_attention``;
@@ -172,6 +179,7 @@ class Gemma3WithExpertConfig(PretrainedConfig):
         """
         self.freeze_vision_encoder = freeze_vision_encoder
         self.train_expert_only = train_expert_only
+        self.train_vision_encoder_only = train_vision_encoder_only
         self.attention_implementation = attention_implementation
         self.load_pretrained_gemma3 = load_pretrained_gemma3
         self.discrete_action_vocab_size = discrete_action_vocab_size
@@ -283,6 +291,16 @@ class Gemma3WithExpertConfig(PretrainedConfig):
                 "`train_expert_only=True` would then have nothing to train. Set "
                 "`train_expert_only=False` (the high-level-planner default) when "
                 "`disable_action_expert=True`."
+            )
+        if self.train_vision_encoder_only and self.train_expert_only:
+            raise ValueError(
+                "`train_vision_encoder_only=True` and `train_expert_only=True` are mutually exclusive."
+            )
+        if self.train_vision_encoder_only and self.freeze_vision_encoder:
+            raise ValueError(
+                "You set `train_vision_encoder_only=True` and `freeze_vision_encoder=True` which are not "
+                "compatible — the vision encoder cannot be both frozen and the only trained component. "
+                "Set `freeze_vision_encoder=False`."
             )
         if self.attention_implementation not in ["eager", "sdpa", "fa2"]:
             raise ValueError(
@@ -701,6 +719,20 @@ class Gemma3WithExpertModel(PreTrainedModel):
             for param in self.discrete_action_embedding.parameters():
                 param.requires_grad = False
 
+        if self.config.train_vision_encoder_only:
+            # Mirror image of train_expert_only: leave ONLY the vision pathway
+            # (SigLIP tower + multimodal projector) trainable. Freeze every param
+            # first — this covers gemma3, the reparented interleaved backbone AND
+            # expert layers, gemma_expert, da_head, discrete_action_embedding — then
+            # re-enable the vision pathway. Frozen modules still transmit gradients,
+            # so the vision pathway's loss reaches it.
+            for params in self.parameters():
+                params.requires_grad = False
+            for module in (self._vision_tower(), self._multi_modal_projector()):
+                if module is not None:
+                    for params in module.parameters():
+                        params.requires_grad = True
+
     def train(self, mode: bool = True):
         super().train(mode)
         if self.config.freeze_vision_encoder:
@@ -713,6 +745,22 @@ class Gemma3WithExpertModel(PreTrainedModel):
             # explicitly so dropout / etc. honour the frozen state.
             for layer in self._iter_interleaved_layers():
                 layer.backbone_layer.eval()
+        if self.config.train_vision_encoder_only:
+            # Everything except the vision pathway is frozen -> eval. The reparented
+            # interleaved layers live outside gemma3, so eval them explicitly too.
+            self.gemma3.eval()
+            if self.gemma_expert is not None:
+                self.gemma_expert.eval()
+            for layer in self._iter_interleaved_layers():
+                layer.backbone_layer.eval()
+                if getattr(layer, "expert_layer", None) is not None:
+                    layer.expert_layer.eval()
+            self.da_head.eval()
+            self.discrete_action_embedding.eval()
+            # Put the vision pathway back into `mode`.
+            for module in (self._vision_tower(), self._multi_modal_projector()):
+                if module is not None:
+                    module.train(mode)
         return self
 
     def to_bfloat16_like_physical_intelligence(self) -> None:

--- a/src/opentau/policies/pi07/low_level/configuration_pi07_low_level.py
+++ b/src/opentau/policies/pi07/low_level/configuration_pi07_low_level.py
@@ -23,6 +23,7 @@ separable attention) as a video encoder, processes temporal state sequences
 subgoal image, and metadata conditioning.
 """
 
+import logging
 from dataclasses import dataclass, field
 
 from opentau.configs.policies import PreTrainedConfig
@@ -294,6 +295,18 @@ class PI07LowLevelConfig(PreTrainedConfig):
             self.vlm_config.attention_implementation = self.attention_implementation
         if self.gradient_checkpointing:
             self.vlm_config.gradient_checkpointing = self.gradient_checkpointing
+
+        # pi07 exposes ``train_vision_encoder_only`` on ``vlm_config`` (like
+        # ``freeze_vision_encoder`` / ``train_expert_only``), so read it from there.
+        if self.vlm_config.train_vision_encoder_only and self.knowledge_insulation:
+            logging.warning(
+                "vlm_config.train_vision_encoder_only=True with knowledge_insulation=True: knowledge "
+                "insulation detaches the VLM prefix KV cache before the action expert, so the "
+                "flow-matching action (MSE) loss does not reach the video encoder — it trains on the "
+                "CE loss only, and if the CE loss weight is 0 the step has no gradient path to any "
+                "trainable parameter. Set knowledge_insulation=False to train the video encoder from "
+                "the action loss."
+            )
 
         if not isinstance(self.n_obs_steps, int) or self.n_obs_steps < 1:
             raise ValueError(f"`n_obs_steps` must be a positive integer, got {self.n_obs_steps}.")

--- a/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
@@ -68,6 +68,7 @@ from opentau.policies.utils import (
     assert_gemma3_input_resolution,
     ce_per_sample,
     flow_matching_masked_mse,
+    freeze_policy_level_params_for_vision_only,
 )
 from opentau.utils.accelerate_utils import get_proc_accelerator
 from opentau.utils.utils import get_safe_dtype
@@ -1474,6 +1475,15 @@ class PI07LowLevelFlowMatching(nn.Module):
         # cross-attention prefix slice in forward()/sample_actions(), so the
         # action expert sees the same prefix length at train and inference.
         self._action_indicator_len = len(self.language_tokenizer.encode("Action: ", add_special_tokens=False))
+
+        if self.config.vlm_config.train_vision_encoder_only:
+            # Freeze every policy-level projection (state/action/time) so ONLY the
+            # video encoder trains. pi07 exposes the flag on ``vlm_config`` (like
+            # ``freeze_vision_encoder`` / ``train_expert_only``); the SigLIP tower +
+            # projector live under gemma3_with_expert and are already configured by
+            # its own set_requires_grad. The SpaceTime video_encoder is param-less
+            # (it reuses the tower), so nothing extra stays trainable there.
+            freeze_policy_level_params_for_vision_only(self, self.gemma3_with_expert)
 
     def sample_noise(self, shape: tuple[int, ...], device: torch.device | str) -> Tensor:
         return torch.normal(mean=0.0, std=1.0, size=shape, dtype=torch.float32, device=device)

--- a/src/opentau/policies/pi07_paligemma/high_level_planner/configuration_pi07_high_level.py
+++ b/src/opentau/policies/pi07_paligemma/high_level_planner/configuration_pi07_high_level.py
@@ -81,6 +81,9 @@ class PI07HighLevelPlannerConfig(PreTrainedConfig):
             ``"fa2"`` (Flash Attention 2). Defaults to ``"eager"``.
         freeze_vision_encoder: Whether to freeze the SigLIP vision encoder
             during fine-tuning. Defaults to True.
+        train_vision_encoder_only: Train ONLY the vision encoder (SigLIP tower +
+            multimodal projector) and freeze the Gemma LLM backbone (the planner has no
+            action expert). Requires ``freeze_vision_encoder=False``. Defaults to False.
         optimizer_lr: Peak learning rate for AdamW. Defaults to 2.5e-5.
         optimizer_betas: Beta parameters for AdamW. Defaults to (0.9, 0.95).
         optimizer_eps: Epsilon for AdamW. Defaults to 1e-8.
@@ -141,6 +144,7 @@ class PI07HighLevelPlannerConfig(PreTrainedConfig):
 
     # Finetuning settings
     freeze_vision_encoder: bool = True
+    train_vision_encoder_only: bool = False
 
     # Training presets
     optimizer_lr: float = 2.5e-5
@@ -160,6 +164,11 @@ class PI07HighLevelPlannerConfig(PreTrainedConfig):
         """
         super().__post_init__()
 
+        if self.train_vision_encoder_only and self.freeze_vision_encoder:
+            raise ValueError(
+                "`train_vision_encoder_only=True` requires `freeze_vision_encoder=False` — the vision "
+                "encoder cannot be both frozen and the only trained component."
+            )
         if self.n_obs_steps != 1:
             raise ValueError(
                 f"Multiple observation steps not handled yet. Got `nobs_steps={self.n_obs_steps}`"

--- a/src/opentau/policies/pi07_paligemma/high_level_planner/modeling_pi07_high_level.py
+++ b/src/opentau/policies/pi07_paligemma/high_level_planner/modeling_pi07_high_level.py
@@ -898,6 +898,7 @@ class PI07HighLevelPlannerModel(nn.Module):
         paligemma_with_expert_config = PaliGemmaWithExpertConfig(
             freeze_vision_encoder=self.config.freeze_vision_encoder,
             train_expert_only=False,
+            train_vision_encoder_only=self.config.train_vision_encoder_only,
             attention_implementation=self.config.attention_implementation,
             load_pretrained_paligemma=False,
             discrete_action_vocab_size=discrete_action_vocab_size,

--- a/src/opentau/policies/pi07_paligemma/low_level/configuration_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/configuration_pi07_low_level.py
@@ -82,6 +82,11 @@ class PI07PaligemmaLowLevelConfig(PreTrainedConfig):
             CUDA/compiler) the forward raises rather than silently using sdpa/eager.
         freeze_vision_encoder: Whether to freeze the vision encoder during fine-tuning. Defaults to True.
         train_expert_only: Whether to train only the expert module. Defaults to False.
+        train_vision_encoder_only: Mirror image of ``train_expert_only`` — train ONLY the
+            vision/video encoder (SigLIP tower + multimodal projector) and freeze the LLM
+            backbone, the action expert, and all heads/projections. Requires
+            ``freeze_vision_encoder=False`` and is incompatible with ``train_expert_only=True``.
+            Defaults to False.
         optimizer_lr: Learning rate for the optimizer. Defaults to 2.5e-5.
         optimizer_betas: Beta parameters for AdamW optimizer. Defaults to (0.9, 0.95).
         optimizer_eps: Epsilon parameter for AdamW optimizer. Defaults to 1e-8.
@@ -190,6 +195,7 @@ class PI07PaligemmaLowLevelConfig(PreTrainedConfig):
     # Finetuning settings
     freeze_vision_encoder: bool = True
     train_expert_only: bool = False
+    train_vision_encoder_only: bool = False
 
     # Knowledge insulation (π0.5): when True (default), the prefix/VLM KV cache
     # is detached before the action expert reads it, so the flow-matching action
@@ -249,6 +255,15 @@ class PI07PaligemmaLowLevelConfig(PreTrainedConfig):
 
         # TODO(Steven): Validate device and amp? in all policy configs?
         """Input validation (not exhaustive)."""
+        if self.train_vision_encoder_only and self.train_expert_only:
+            raise ValueError(
+                "`train_vision_encoder_only=True` and `train_expert_only=True` are mutually exclusive."
+            )
+        if self.train_vision_encoder_only and self.freeze_vision_encoder:
+            raise ValueError(
+                "`train_vision_encoder_only=True` requires `freeze_vision_encoder=False` — the vision "
+                "encoder cannot be both frozen and the only trained component."
+            )
         if not isinstance(self.n_obs_steps, int) or self.n_obs_steps < 1:
             raise ValueError(f"`n_obs_steps` must be a positive integer, got {self.n_obs_steps}.")
         if not isinstance(self.history_interval, int) or self.history_interval < 1:

--- a/src/opentau/policies/pi07_paligemma/low_level/configuration_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/configuration_pi07_low_level.py
@@ -20,6 +20,7 @@ for the PI05 Vision-Language-Action Flow Model. It includes settings for the mod
 optimization, scheduling, and data processing.
 """
 
+import logging
 from dataclasses import dataclass, field
 
 from opentau.configs.policies import PreTrainedConfig
@@ -86,7 +87,9 @@ class PI07PaligemmaLowLevelConfig(PreTrainedConfig):
             vision/video encoder (SigLIP tower + multimodal projector) and freeze the LLM
             backbone, the action expert, and all heads/projections. Requires
             ``freeze_vision_encoder=False`` and is incompatible with ``train_expert_only=True``.
-            Defaults to False.
+            Note: with ``knowledge_insulation=True`` (the default) the action (MSE) loss is
+            detached from the VLM, so the encoder trains on the CE loss only — set
+            ``knowledge_insulation=False`` to train it from the action loss. Defaults to False.
         optimizer_lr: Learning rate for the optimizer. Defaults to 2.5e-5.
         optimizer_betas: Beta parameters for AdamW optimizer. Defaults to (0.9, 0.95).
         optimizer_eps: Epsilon parameter for AdamW optimizer. Defaults to 1e-8.
@@ -263,6 +266,14 @@ class PI07PaligemmaLowLevelConfig(PreTrainedConfig):
             raise ValueError(
                 "`train_vision_encoder_only=True` requires `freeze_vision_encoder=False` — the vision "
                 "encoder cannot be both frozen and the only trained component."
+            )
+        if self.train_vision_encoder_only and self.knowledge_insulation:
+            logging.warning(
+                "train_vision_encoder_only=True with knowledge_insulation=True: knowledge insulation "
+                "detaches the VLM prefix KV cache before the action expert, so the flow-matching "
+                "action (MSE) loss does not reach the vision/video encoder — it trains on the CE loss "
+                "only, and if the CE loss weight is 0 the step has no gradient path to any trainable "
+                "parameter. Set knowledge_insulation=False to train the encoder from the action loss."
             )
         if not isinstance(self.n_obs_steps, int) or self.n_obs_steps < 1:
             raise ValueError(f"`n_obs_steps` must be a positive integer, got {self.n_obs_steps}.")

--- a/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
@@ -53,7 +53,12 @@ from opentau.policies.pi07_paligemma.low_level.configuration_pi07_low_level impo
     PI07PaligemmaLowLevelConfig,
 )
 from opentau.policies.pretrained import PreTrainedPolicy, ProjectionRemapError, T
-from opentau.policies.utils import PerSampleLoss, ce_per_sample, flow_matching_masked_mse
+from opentau.policies.utils import (
+    PerSampleLoss,
+    ce_per_sample,
+    flow_matching_masked_mse,
+    freeze_policy_level_params_for_vision_only,
+)
 from opentau.utils.accelerate_utils import get_proc_accelerator
 from opentau.utils.utils import get_safe_dtype
 
@@ -1944,6 +1949,7 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
         paligemma_with_expert_config = PaliGemmaWithExpertConfig(
             freeze_vision_encoder=self.config.freeze_vision_encoder,
             train_expert_only=self.config.train_expert_only,
+            train_vision_encoder_only=self.config.train_vision_encoder_only,
             attention_implementation=self.config.attention_implementation,
             load_pretrained_paligemma=False,
             discrete_action_vocab_size=discrete_action_vocab_size,
@@ -1988,6 +1994,13 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
         self.time_mlp_out = nn.Linear(self.config.proj_width, self.config.proj_width)
 
         self.language_tokenizer = AutoTokenizer.from_pretrained("google/paligemma-3b-pt-224")
+
+        if self.config.train_vision_encoder_only:
+            # Freeze every policy-level projection (state/action/time) so ONLY the
+            # video encoder trains. The SpaceTime video_encoder is param-less (it reuses
+            # the SigLIP tower under paligemma_with_expert, already configured by its own
+            # set_requires_grad).
+            freeze_policy_level_params_for_vision_only(self, self.paligemma_with_expert)
 
     def sample_noise(self, shape: tuple[int, ...], device: torch.device | str) -> Tensor:
         """Samples Gaussian noise.

--- a/src/opentau/policies/utils.py
+++ b/src/opentau/policies/utils.py
@@ -396,3 +396,35 @@ def log_model_loading_keys(missing_keys: list[str], unexpected_keys: list[str]) 
     if unexpected_keys:
         # DO NOT UPDATE THIS MESSAGE WITHOUT UPDATING THE REGEX IN .gitlab/scripts/check_pi0_state_keys.py
         logging.warning(f"Unexpected key(s) when loading model: {unexpected_keys}")
+
+
+def freeze_policy_level_params_for_vision_only(
+    policy_module: nn.Module, with_expert_module: nn.Module
+) -> None:
+    """Freeze the policy-level (outer) parameters for ``train_vision_encoder_only``.
+
+    The vision/video encoder — the SigLIP / Gemma3 / Qwen3-VL tower plus its
+    multimodal projector — lives *inside* ``with_expert_module``; its
+    ``set_requires_grad`` has already left exactly that pathway trainable and frozen
+    the LLM backbone, action expert and discrete heads. What remains are the
+    *policy-level* projections that live on the enclosing flow-matching module
+    (``state_proj`` / ``action_in_proj`` / ``action_out_proj`` / ``time_mlp_*`` /
+    ``action_time_mlp_*`` / ``adarms_proj`` / optional modality embeddings). Those
+    must be frozen so that **only** the vision/video encoder trains.
+
+    Rather than enumerate every projection per policy (a single omission would let a
+    head silently keep training and quietly break the "vision only" contract), this
+    freezes every outer parameter that is neither part of ``with_expert_module`` nor
+    a video-encoder ``motion_module`` — the pi05_mem RLDX encoder's own temporal
+    block, which *is* part of the video encoder and stays trainable.
+
+    Args:
+        policy_module: the enclosing flow-matching / planner ``nn.Module``.
+        with_expert_module: the inner ``*WithExpertModel`` submodule whose own
+            ``set_requires_grad`` has already configured the vision pathway.
+    """
+    protected = {id(p) for p in with_expert_module.parameters()}
+    for name, param in policy_module.named_parameters():
+        if id(param) in protected or "motion_module" in name:
+            continue
+        param.requires_grad = False

--- a/tests/policies/test_cosmos3_cpu.py
+++ b/tests/policies/test_cosmos3_cpu.py
@@ -532,3 +532,75 @@ def test_cosmos3_partial_unfreeze_backbone_receives_grad():
     assert any(p.grad is not None for p in text_backbone.parameters()), (
         "unfrozen text backbone must receive gradients via the (non-detached) cached KV"
     )
+
+
+def test_cosmos3_train_vision_encoder_only_config_validation():
+    # cosmos3 defaults train_expert_only=True, so the bare combo is mutually exclusive.
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        _tiny_cosmos3_config(train_vision_encoder_only=True)
+    # With the expert-only regime off, the vision encoder must be unfrozen.
+    with pytest.raises(ValueError, match="freeze_vision_encoder"):
+        _tiny_cosmos3_config(train_expert_only=False, train_vision_encoder_only=True)
+
+
+def test_cosmos3_train_vision_encoder_only_freezes_all_but_visual():
+    model = _build_model(
+        train_expert_only=False,
+        freeze_vision_encoder=False,
+        train_vision_encoder_only=True,
+    )
+    we = model.qwen3vl_with_expert
+
+    # The Qwen3-VL vision tower (its merger / deepstack projector lives inside it) trains ...
+    assert all(p.requires_grad for p in we.backbone.model.visual.parameters())
+    # ... the LLM backbone and the action expert are frozen ...
+    assert not any(p.requires_grad for p in we.backbone.model.language_model.parameters())
+    assert not any(p.requires_grad for p in we.expert.parameters())
+    # ... and every policy-level projection is frozen.
+    for proj in (
+        model.action_in_proj,
+        model.action_out_proj,
+        model.time_mlp_in,
+        model.time_mlp_out,
+        model.adarms_proj,
+        model.state_proj,
+    ):
+        assert not any(p.requires_grad for p in proj.parameters())
+
+    # Nothing trainable lives outside the visual tower.
+    visual_ids = {id(p) for p in we.backbone.model.visual.parameters()}
+    for name, p in model.named_parameters():
+        if p.requires_grad:
+            assert id(p) in visual_ids, f"{name} unexpectedly trainable"
+
+
+def test_cosmos3_train_vision_encoder_only_grad_flows_to_visual():
+    """The no_grad ctx in run_prefix must stay off (train_expert_only=False), so the
+    vision tower's loss backpropagates into ``backbone.model.visual``."""
+    model = _build_model(
+        train_expert_only=False,
+        freeze_vision_encoder=False,
+        train_vision_encoder_only=True,
+    )
+    input_ids, attention_mask, pixel_values, image_grid_thw = _image_inputs()
+    bsize = input_ids.shape[0]
+    state = torch.randn(bsize, MAX_STATE_DIM)
+    actions = torch.randn(bsize, CHUNK, MAX_ACTION_DIM)
+    out = model(
+        input_ids=input_ids,
+        attention_mask=attention_mask,
+        pixel_values=pixel_values,
+        image_grid_thw=image_grid_thw,
+        state=state,
+        actions=actions,
+        noise=torch.randn_like(actions),
+        time=torch.rand(bsize),
+    )
+    out["MSE"].backward()
+
+    we = model.qwen3vl_with_expert
+    assert any(p.grad is not None for p in we.backbone.model.visual.parameters()), (
+        "vision tower must receive gradients under train_vision_encoder_only"
+    )
+    assert all(p.grad is None for p in we.expert.parameters())
+    assert all(p.grad is None for p in we.backbone.model.language_model.parameters())

--- a/tests/policies/test_freeze_vision_only_helper.py
+++ b/tests/policies/test_freeze_vision_only_helper.py
@@ -1,0 +1,150 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``freeze_policy_level_params_for_vision_only``.
+
+The helper backs the ``train_vision_encoder_only`` flag: it freezes every
+policy-level (outer) parameter that is NOT part of the vision/video encoder,
+while leaving the inner ``*WithExpertModel`` params untouched (their own
+``set_requires_grad`` already configured the vision pathway) and preserving any
+``motion_module`` (the pi05_mem RLDX video encoder's own temporal block, which
+*is* part of the video encoder).
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+from opentau.policies.utils import freeze_policy_level_params_for_vision_only
+
+
+class _FakeWithExpert(nn.Module):
+    """Stands in for a ``*WithExpertModel``: a trainable vision tower + a frozen LLM."""
+
+    def __init__(self):
+        super().__init__()
+        self.vision_tower = nn.Linear(4, 4)
+        self.multi_modal_projector = nn.Linear(4, 4)
+        self.language_model = nn.Linear(4, 4)
+
+
+class _FakeVideoEncoder(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.motion_module = nn.Linear(4, 4)
+
+
+class _FakePolicy(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.with_expert = _FakeWithExpert()
+        self.video_encoder = _FakeVideoEncoder()
+        self.action_in_proj = nn.Linear(4, 4)
+        self.action_out_proj = nn.Linear(4, 4)
+        self.state_proj = nn.Linear(4, 4)
+
+
+def _simulate_inner_set_requires_grad(with_expert: _FakeWithExpert) -> None:
+    """Mimic the inner set_requires_grad: freeze the LLM, keep the vision pathway."""
+    for p in with_expert.language_model.parameters():
+        p.requires_grad = False
+
+
+def test_freezes_outer_projections_only():
+    model = _FakePolicy()
+    _simulate_inner_set_requires_grad(model.with_expert)
+
+    freeze_policy_level_params_for_vision_only(model, model.with_expert)
+
+    # The outer projections are frozen ...
+    assert not any(p.requires_grad for p in model.action_in_proj.parameters())
+    assert not any(p.requires_grad for p in model.action_out_proj.parameters())
+    assert not any(p.requires_grad for p in model.state_proj.parameters())
+
+
+def test_preserves_inner_with_expert_requires_grad():
+    model = _FakePolicy()
+    _simulate_inner_set_requires_grad(model.with_expert)
+
+    freeze_policy_level_params_for_vision_only(model, model.with_expert)
+
+    # The vision pathway (already trainable) is untouched ...
+    assert all(p.requires_grad for p in model.with_expert.vision_tower.parameters())
+    assert all(p.requires_grad for p in model.with_expert.multi_modal_projector.parameters())
+    # ... and the frozen LLM stays frozen (not accidentally re-enabled).
+    assert not any(p.requires_grad for p in model.with_expert.language_model.parameters())
+
+
+def test_motion_module_stays_trainable():
+    """The RLDX video encoder's ``motion_module`` is part of the video encoder and
+    must remain trainable even though it lives OUTSIDE the with-expert model."""
+    model = _FakePolicy()
+    _simulate_inner_set_requires_grad(model.with_expert)
+
+    freeze_policy_level_params_for_vision_only(model, model.with_expert)
+
+    assert all(p.requires_grad for p in model.video_encoder.motion_module.parameters())
+
+
+def test_no_video_encoder_is_fine():
+    """A policy without a video encoder / motion_module (e.g. pi0) still freezes
+    exactly its outer projections."""
+
+    class _PolicyNoVideo(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.with_expert = _FakeWithExpert()
+            self.action_in_proj = nn.Linear(4, 4)
+
+    model = _PolicyNoVideo()
+    _simulate_inner_set_requires_grad(model.with_expert)
+
+    freeze_policy_level_params_for_vision_only(model, model.with_expert)
+
+    assert all(p.requires_grad for p in model.with_expert.vision_tower.parameters())
+    assert not any(p.requires_grad for p in model.action_in_proj.parameters())
+
+
+def test_only_vision_pathway_trainable_end_to_end():
+    """The invariant the flag promises: after the helper runs, every trainable
+    param is either in the vision pathway or the motion_module."""
+    model = _FakePolicy()
+    _simulate_inner_set_requires_grad(model.with_expert)
+
+    freeze_policy_level_params_for_vision_only(model, model.with_expert)
+
+    allowed = {id(p) for p in model.with_expert.vision_tower.parameters()}
+    allowed |= {id(p) for p in model.with_expert.multi_modal_projector.parameters()}
+    allowed |= {id(p) for p in model.video_encoder.motion_module.parameters()}
+    for name, p in model.named_parameters():
+        if p.requires_grad:
+            assert id(p) in allowed, f"{name} unexpectedly trainable"
+
+
+def test_backward_updates_only_vision_pathway():
+    """A gradient step touches only the still-trainable params."""
+    model = _FakePolicy()
+    _simulate_inner_set_requires_grad(model.with_expert)
+    freeze_policy_level_params_for_vision_only(model, model.with_expert)
+
+    x = torch.randn(2, 4)
+    # Route x through the vision tower then the (frozen) action proj so the graph
+    # spans both trainable and frozen params.
+    y = model.action_in_proj(model.with_expert.vision_tower(x))
+    y.sum().backward()
+
+    assert model.with_expert.vision_tower.weight.grad is not None
+    assert model.action_in_proj.weight.grad is None
+    assert model.with_expert.language_model.weight.grad is None

--- a/tests/policies/test_pi0.py
+++ b/tests/policies/test_pi0.py
@@ -529,3 +529,82 @@ class TestPI0ExecutionHorizon:
         pad_masks, att_masks = out[1], out[2]
         # one state token + chunk_size action tokens.
         assert pad_masks.shape[1] == att_masks.shape[1] == 1 + cfg.chunk_size
+
+
+class TestTrainVisionEncoderOnly:
+    """`train_vision_encoder_only` — mirror image of `train_expert_only`.
+
+    Only the vision pathway (SigLIP tower + multimodal projector) trains; the
+    Gemma LLM backbone and the action expert are frozen. PaliGemma backbone; pi0
+    is continuous-only, so there are no discrete-action heads.
+    """
+
+    def test_config_rejects_combo_with_train_expert_only(self):
+        # freeze_vision_encoder=True so the pre-existing train_expert_only guard
+        # does not preempt the mutual-exclusion check.
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            PaliGemmaWithExpertConfig(
+                freeze_vision_encoder=True,
+                train_expert_only=True,
+                train_vision_encoder_only=True,
+            )
+
+    def test_config_requires_unfrozen_vision(self):
+        with pytest.raises(ValueError, match="freeze_vision_encoder"):
+            PaliGemmaWithExpertConfig(
+                freeze_vision_encoder=True,
+                train_expert_only=False,
+                train_vision_encoder_only=True,
+            )
+
+    def test_policy_config_rejects_frozen_vision(self):
+        with pytest.raises(ValueError, match="freeze_vision_encoder"):
+            PI0Config(train_vision_encoder_only=True, freeze_vision_encoder=True)
+
+    def test_policy_config_rejects_combo_with_train_expert_only(self):
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            PI0Config(
+                train_vision_encoder_only=True,
+                train_expert_only=True,
+                freeze_vision_encoder=False,
+            )
+
+    @staticmethod
+    def _vision_only_engine():
+        cfg = _make_tiny_pi0_engine_config()
+        cfg.freeze_vision_encoder = False
+        cfg.train_expert_only = False
+        cfg.train_vision_encoder_only = True
+        return PaliGemmaWithExpertModel(cfg)
+
+    def test_only_vision_pathway_is_trainable(self):
+        model = self._vision_only_engine()
+
+        vision_tower = model.paligemma.vision_tower
+        projector = model._multi_modal_projector()
+        assert projector is not None, "PaliGemma should expose a multimodal projector"
+
+        # The vision pathway trains ...
+        assert all(p.requires_grad for p in vision_tower.parameters())
+        assert all(p.requires_grad for p in projector.parameters())
+
+        # ... and nothing else does (LLM backbone + action expert frozen).
+        allowed = {id(p) for p in vision_tower.parameters()}
+        allowed |= {id(p) for p in projector.parameters()}
+        for name, p in model.named_parameters():
+            if id(p) in allowed:
+                continue
+            assert not p.requires_grad, f"{name} should be frozen under train_vision_encoder_only"
+
+        # The action expert is definitely frozen.
+        assert not any(p.requires_grad for p in model.gemma_expert.parameters())
+
+    def test_train_mode_keeps_backbone_and_expert_in_eval(self):
+        model = self._vision_only_engine()
+        model.train(True)
+        # Vision pathway follows the requested training mode ...
+        assert model.paligemma.vision_tower.training is True
+        assert model._multi_modal_projector().training is True
+        # ... while the frozen bulk stays in eval regardless of train(True).
+        assert model.paligemma.training is False
+        assert model.gemma_expert.training is False

--- a/tests/policies/test_pi06.py
+++ b/tests/policies/test_pi06.py
@@ -24,6 +24,8 @@ resizing, and discrete-action padding.
 
 from __future__ import annotations
 
+import logging
+
 import pytest
 import torch
 
@@ -358,6 +360,25 @@ class TestPI06Config:
     def test_n_action_steps_larger_than_chunk_size_raises(self):
         with pytest.raises(ValueError, match="chunk size"):
             PI06Config(chunk_size=4, n_action_steps=8)
+
+    def test_train_vision_encoder_only_warns_under_knowledge_insulation(self, caplog):
+        # knowledge_insulation defaults True -> the action (MSE) loss can't reach the
+        # vision encoder, so training it vision-only must emit the severing warning.
+        with caplog.at_level(logging.WARNING):
+            PI06Config(train_vision_encoder_only=True, freeze_vision_encoder=False)
+        assert any(
+            "knowledge_insulation" in r.message and "train_vision_encoder_only" in r.message
+            for r in caplog.records
+        )
+
+    def test_train_vision_encoder_only_no_warn_without_knowledge_insulation(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            PI06Config(
+                train_vision_encoder_only=True,
+                freeze_vision_encoder=False,
+                knowledge_insulation=False,
+            )
+        assert not any("knowledge_insulation" in r.message for r in caplog.records)
 
     def test_max_delay_larger_than_chunk_size_raises(self):
         with pytest.raises(ValueError, match="max delay"):

--- a/tests/policies/test_pi07_cpu.py
+++ b/tests/policies/test_pi07_cpu.py
@@ -2359,3 +2359,63 @@ class TestGlobalOrBranchDecisions:
                 field_names=("a", "b", "c"),
                 device=torch.device("cpu"),
             )
+
+
+class TestTrainVisionEncoderOnly:
+    """`train_vision_encoder_only` on the Gemma 3 backbone — mirror of
+    `train_expert_only`. Only the SigLIP tower + multimodal projector train; the
+    Gemma 3 backbone (including the reparented interleaved layers), the action
+    expert, and the discrete-action heads are frozen."""
+
+    def test_config_rejects_combo_with_train_expert_only(self):
+        # freeze_vision_encoder=True so the pre-existing train_expert_only guard
+        # does not preempt the mutual-exclusion check.
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            Gemma3WithExpertConfig(
+                freeze_vision_encoder=True,
+                train_expert_only=True,
+                train_vision_encoder_only=True,
+            )
+
+    def test_config_requires_unfrozen_vision(self):
+        # freeze_vision_encoder defaults True; train_expert_only must be off first.
+        with pytest.raises(ValueError, match="freeze_vision_encoder"):
+            Gemma3WithExpertConfig(train_expert_only=False, train_vision_encoder_only=True)
+
+    @staticmethod
+    def _vision_only_model():
+        cfg = _make_tiny_g3we_cfg()
+        cfg.freeze_vision_encoder = False
+        cfg.train_expert_only = False
+        cfg.train_vision_encoder_only = True
+        return Gemma3WithExpertModel(cfg).to(dtype=torch.float32)
+
+    def test_only_vision_pathway_is_trainable(self):
+        model = self._vision_only_model()
+        vision_tower = model._vision_tower()
+        projector = model._multi_modal_projector()
+        assert vision_tower is not None and projector is not None
+
+        assert all(p.requires_grad for p in vision_tower.parameters())
+        assert all(p.requires_grad for p in projector.parameters())
+
+        allowed = {id(p) for p in vision_tower.parameters()}
+        allowed |= {id(p) for p in projector.parameters()}
+        for name, p in model.named_parameters():
+            if id(p) in allowed:
+                continue
+            assert not p.requires_grad, f"{name} should be frozen under train_vision_encoder_only"
+
+        # The reparented interleaved backbone layers are frozen; the expert too.
+        for layer in model.interleaved_layers:
+            assert not any(p.requires_grad for p in layer.backbone_layer.parameters())
+        assert not any(p.requires_grad for p in model.da_head.parameters())
+        assert not any(p.requires_grad for p in model.discrete_action_embedding.parameters())
+
+    def test_train_mode_keeps_backbone_and_interleaved_in_eval(self):
+        model = self._vision_only_model()
+        model.train(True)
+        assert model._vision_tower().training is True
+        assert model.gemma3.training is False
+        for layer in model.interleaved_layers:
+            assert layer.backbone_layer.training is False

--- a/tests/policies/test_pi07_cpu.py
+++ b/tests/policies/test_pi07_cpu.py
@@ -2419,3 +2419,22 @@ class TestTrainVisionEncoderOnly:
         assert model.gemma3.training is False
         for layer in model.interleaved_layers:
             assert layer.backbone_layer.training is False
+
+    def test_vlm_config_train_vision_encoder_only_warns_under_knowledge_insulation(self, caplog):
+        # pi07 exposes the flag on vlm_config; the policy config reads it from there and
+        # must warn that knowledge_insulation (default True) severs the MSE loss path.
+        import logging
+
+        from opentau.policies.pi07.low_level.configuration_pi07_low_level import PI07LowLevelConfig
+
+        vlm = Gemma3WithExpertConfig(
+            train_vision_encoder_only=True,
+            freeze_vision_encoder=False,
+            train_expert_only=False,
+        )
+        with caplog.at_level(logging.WARNING):
+            PI07LowLevelConfig(vlm_config=vlm)  # knowledge_insulation defaults True
+        assert any(
+            "knowledge_insulation" in r.message and "train_vision_encoder_only" in r.message
+            for r in caplog.records
+        )

--- a/tests/policies/test_rldx_motion_cpu.py
+++ b/tests/policies/test_rldx_motion_cpu.py
@@ -423,3 +423,48 @@ class TestRLDXMotionConfig:
         # Bad motion settings are ignored entirely when use_motion is False.
         c = self._cfg(use_motion=False, motion_norm="nonsense", n_obs_steps=1)
         assert c.use_motion is False
+
+
+def test_freeze_vision_only_keeps_real_rldx_motion_module_trainable():
+    """Pin the name contract that ``freeze_policy_level_params_for_vision_only`` relies
+    on against a REAL ``RLDXVideoEncoder``.
+
+    The helper keeps pi05_mem's temporal block trainable purely via a
+    ``"motion_module" in name`` match. If ``RLDXVideoEncoder.motion_module`` is ever
+    renamed, the helper would silently freeze it — this test (which exercises the real
+    module, not a fake) breaks in that case, so the contract can't drift unnoticed.
+    """
+    from torch import nn
+
+    from opentau.policies.utils import freeze_policy_level_params_for_vision_only
+
+    vision_tower, projector = _build_tiny_siglip_and_projector()
+    encoder = _make_encoder((vision_tower, projector))
+
+    # Minimal pi05_mem-shaped tree: the with-expert model owns the SigLIP tower +
+    # projector; the video encoder holds them by reference and owns motion_module;
+    # an action projection stands in for the frozen policy-level heads.
+    class _WithExpert(nn.Module):
+        def __init__(self, tower, proj):
+            super().__init__()
+            self.vision_tower = tower
+            self.multi_modal_projector = proj
+
+    class _Policy(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.paligemma_with_expert = _WithExpert(vision_tower, projector)
+            self.video_encoder = encoder
+            self.action_in_proj = nn.Linear(8, 8)
+
+    policy = _Policy()
+    freeze_policy_level_params_for_vision_only(policy, policy.paligemma_with_expert)
+
+    # The REAL motion_module stays trainable ...
+    motion_params = list(encoder.motion_module.parameters())
+    assert motion_params, "RLDXVideoEncoder.motion_module has no parameters — contract broken"
+    assert all(p.requires_grad for p in motion_params)
+    # ... the "motion_module" name match still fires for the real module ...
+    assert any("motion_module" in name for name, _ in encoder.named_parameters())
+    # ... and a sibling policy-level projection is frozen.
+    assert not any(p.requires_grad for p in policy.action_in_proj.parameters())


### PR DESCRIPTION
## What this does

Adds a `train_vision_encoder_only` policy-config flag (🗃️ Feature) — the mirror
image of the existing `train_expert_only`. When set, **only** the vision/video
encoder trains and everything else is frozen:

- **Trainable:** the SigLIP / Gemma 3 / Qwen3-VL vision tower **and** its
  multimodal projector (for Qwen3-VL the `merger` / `deepstack_merger_list` lives
  inside `backbone.model.visual`, so it trains with the trunk), plus the pi05_mem
  RLDX `motion_module` (part of the video encoder).
- **Frozen:** the LLM backbone (including pi07's reparented interleaved backbone
  layers), the action expert, the discrete-action heads (`da_head`,
  `discrete_action_embedding`), and all outer projections (`state_proj`,
  `action_in_proj`, `action_out_proj`, `time_mlp_*` / `action_time_mlp_*`,
  cosmos3's `adarms_proj`, optional modality embeddings).

Before this PR there was no way to express "train the encoder only": the two
existing knobs are `freeze_vision_encoder` (freeze the tower) and
`train_expert_only` (freeze the whole backbone, train only the expert) — the
exact opposite of what this adds.

Coverage across every policy: **pi0, pi05, pi05_mem, pi06, pi07 (low + high),
pi07_paligemma (low + high), cosmos3 / cosmos3_nano.** The freeze spans two
levels — the inner `*WithExpertModel` (`set_requires_grad` + `train`) and the
outer flow-matching module — wired through a shared helper
`freeze_policy_level_params_for_vision_only` in `policies/utils.py`. The helper
freezes every outer parameter that is not part of the with-expert model or a
`motion_module`, so the "only the encoder trains" contract can't be broken by
forgetting to enumerate a projection.

Notable per-backbone details:
- **cosmos3**: `run_prefix` keeps its autograd graph alive whenever
  `train_expert_only` is `False`, so gradients reach `backbone.model.visual`. The
  `no_grad` ctx stays keyed on `train_expert_only` alone (documented + tested) so
  vision-only training never becomes a silent no-op.
- **pi07 (current)** exposes the flag through `vlm_config`
  (`--policy.vlm_config.train_vision_encoder_only=true`), exactly like it already
  exposes `freeze_vision_encoder` / `train_expert_only`; its policy-level freeze
  fields are vestigial/unplumbed, so no new top-level field was added there.
- The SpaceTime video encoders (pi07, pi07_paligemma) register no parameters of
  their own — temporal attention reuses the frozen/unfrozen tower's Q/K/V/O — so
  the tower toggle covers them.

Validation: `train_vision_encoder_only` is mutually exclusive with
`train_expert_only` and requires `freeze_vision_encoder=False`.

The field defaults to `False`, so existing checkpoints and configs are byte-for-
byte unaffected — **no `config_version` bump** (this is a training-time knob, not
a checkpoint behavioral convention).

## How it was tested

- Added `tests/policies/test_freeze_vision_only_helper.py` (unit tests for the
  shared helper, including the pi05_mem `motion_module`-stays-trainable case and
  a backward pass that touches only the vision pathway).
- Added `TestTrainVisionEncoderOnly` to `tests/policies/test_pi0.py` (PaliGemma)
  and `tests/policies/test_pi07_cpu.py` (Gemma 3), and three
  `test_cosmos3_train_vision_encoder_only_*` tests to
  `tests/policies/test_cosmos3_cpu.py` (Qwen3-VL) — each asserts that exactly the
  vision-pathway params have `requires_grad=True` and everything else is frozen,
  that `train()` keeps the frozen bulk in eval, and (cosmos3) that a real
  backward populates gradients on `backbone.model.visual` but not on the expert
  or the LLM.
- Config-validation tests for the mutual-exclusion and `freeze_vision_encoder`
  guards on both the with-expert configs and the policy configs.
- Full CPU suite green: `pytest -m "not gpu and not network" -n auto
  tests/policies` → 751 passed, 2 skipped; plus the affected config/dataset
  tests.
- GPU suite (`pytest -m "gpu"`) run on the GPU dev box for the affected policy
  test files across all three backbone families (PaliGemma, Gemma 3, Qwen3-VL) —
  green.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/policies/test_freeze_vision_only_helper.py
```
```bash
pytest -sx "tests/policies/test_pi0.py::TestTrainVisionEncoderOnly"
pytest -sx "tests/policies/test_pi07_cpu.py::TestTrainVisionEncoderOnly"
pytest -sx tests/policies/test_cosmos3_cpu.py -k train_vision_encoder_only
```
Enable it on a smoke run (must pair with `freeze_vision_encoder=false`):
```bash
opentau-train --config_path=configs/examples/pi05_training_config.json \
  --policy.train_vision_encoder_only=true --policy.freeze_vision_encoder=false
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [x] My PR includes policy-related changes.
  - [x] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
