### PR TITLE
feat(datasets): cap rows for on-the-fly delta-action stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,3 +102,42 @@ carry a concrete `config_version` (and an informational `opentau_version`).
   `hf_config.json`. Tooling that instead writes a HuggingFace `config.json` from a
   hand-built dict must re-emit it from the loaded config, or the tag is absent and
   the checkpoint is read as legacy.
+
+### Added — row cap for on-the-fly delta-action stats — *opt-in, no default change*
+
+`DatasetMixtureConfig.delta_stats_max_rows: int | None` (default `None`) caps how
+many anchor frames each `use_delta_joint_actions` dataset contributes to the
+delta-action normalization stats computed on the fly at dataset load
+(`opentau/datasets/delta_action_stats.py`). That pass is `O(frames x chunk_size)`
+— an `H`-fold blow-up over a per-frame stats pass — so on a very large source the
+first run (before the disk cache is warm) can cost hours.
+
+Set a positive int to bound it. Rows are subsampled with a **uniform stride over
+the whole dataset**, never a prefix, and the stride's phase carries across episode
+boundaries so episodes aren't all anchored at frame 0; a dataset's cap is split
+across its parquet files in proportion to the rows each actually contributes
+(counting only what an `episodes` / `excluded_episodes` filter selects), so a
+capped dataset pools in the same file ratio an uncapped one would. Cross-dataset
+pooling into a shared normalization head is unaffected either way — that path
+weights members by `info["total_frames"]`, not by the sampled `count`, so capping
+changes a dataset's estimator *precision*, never its share of the head. The cap
+applies **per dataset**, so
+one value bounds the worst case across a heterogeneous mixture while leaving
+datasets smaller than the cap byte-identical to before.
+
+The cap is folded into the stats cache key, so changing it recomputes instead of
+serving numbers from a different sampling budget. It is folded in **only when
+set**, so uncapped configs keep the digest — and therefore the already-computed
+cache files — they had before this change.
+
+Cost and fidelity, measured on a 100k-frame / 50-step-horizon source: the capped
+run drops the accumulation from `O(frames x chunk_size)` to `O(cap x chunk_size)`
+(2.10s → 0.23s of compute at a 20x subsample; 7.36s → 0.44s at a 200-step
+horizon), leaving only the parquet column read, which the cap does not shrink.
+`mean`/`std` and `q01`/`q99` stay within 0.02 / 0.05 standard deviations of the
+uncapped values at that subsample; `min`/`max` degrade first (~0.9 sd), since a
+subsample doesn't see the extremes — so MIN_MAX normalization is the mode most
+sensitive to a tight cap, and MEAN_STD / QUANTILE the least.
+
+Default `None` reads every row, exactly as before; nothing changes unless you set
+the field.

--- a/src/opentau/configs/default.py
+++ b/src/opentau/configs/default.py
@@ -546,6 +546,36 @@ class DatasetMixtureConfig:
             load. Defaults to ``False``. A per-dataset
             ``DatasetConfig.skip_timestamp_check`` overrides this value when
             set. Does not affect the record-time check inside ``add_episode``.
+        delta_stats_max_rows: Cap on how many anchor frames each
+            ``use_delta_joint_actions`` dataset contributes to its on-the-fly
+            delta-action normalization stats. ``None`` (default) reads every
+            frame — exact, but an ``O(frames x chunk_size)`` first-run pass
+            that costs hours on a million-episode source. A positive int caps
+            that pass: rows are subsampled with a uniform stride over the
+            whole dataset (never a prefix, so the sample stays
+            representative), split across the dataset's parquet files in
+            proportion to the rows each actually contributes — so a capped
+            dataset pools in the same file ratio an uncapped one would.
+            Cross-dataset pooling into a shared normalization head is
+            unaffected: that path weights members by
+            ``info["total_frames"]``, not by the sampled ``count``, so
+            capping changes a dataset's estimator *precision*, never its
+            share of the head. Applies **per dataset**, not as a
+            shared budget across the mixture, so one value bounds the worst
+            case for a heterogeneous mixture while leaving datasets smaller
+            than the cap untouched. Ignored by datasets that don't set
+            ``use_delta_joint_actions``. The value is folded into the stats
+            cache key, so changing it recomputes rather than reusing stale
+            numbers. Must be ``>= 1`` when set.
+
+            What degrades as the cap tightens, measured on a 100k-frame /
+            50-step-horizon source: ``mean``/``std`` and ``q01``/``q99`` hold up
+            well (at 5k rows — a 20x subsample — they land within 0.02 and 0.05
+            standard deviations of the uncapped values), but ``min``/``max`` are
+            the first casualty (~0.9 sd off at the same cap) because a
+            subsample simply doesn't see the extremes. So MEAN_STD and QUANTILE
+            normalization tolerate a tight cap far better than MIN_MAX, whose
+            buffers *are* the pooled extremes.
 
     Note:
         Dropout rolls use the default torch RNG. PyTorch DataLoader workers
@@ -621,6 +651,13 @@ class DatasetMixtureConfig:
     tolerance_s: float = 1e-4
     skip_timestamp_check: bool = False
 
+    # Cap on the anchor frames each `use_delta_joint_actions` dataset feeds into its on-the-fly
+    # delta-action stats (`opentau.datasets.delta_action_stats`). `None` reads every frame; a
+    # positive int strides uniformly over the whole dataset to hit that budget, trading estimator
+    # precision for a bounded first-run wait. Per dataset, not a shared mixture budget. Part of
+    # the stats cache key, so changing it recomputes.
+    delta_stats_max_rows: int | None = None
+
     def __post_init__(self):
         """Validate dataset mixture configuration."""
         if self.weights is not None and len(self.datasets) != len(self.weights):
@@ -643,6 +680,15 @@ class DatasetMixtureConfig:
             not isinstance(self.n_obs_history, int) or self.n_obs_history < 1
         ):
             raise ValueError(f"`n_obs_history` must be None or a positive integer, got {self.n_obs_history}.")
+        if self.delta_stats_max_rows is not None and (
+            not isinstance(self.delta_stats_max_rows, int)
+            or isinstance(self.delta_stats_max_rows, bool)
+            or self.delta_stats_max_rows < 1
+        ):
+            raise ValueError(
+                "`delta_stats_max_rows` must be None (uncapped) or a positive integer, got "
+                f"{self.delta_stats_max_rows!r}."
+            )
         for name in (
             "history_state_drop_prob",
             "subgoal_drop_prob",

--- a/src/opentau/datasets/delta_action_stats.py
+++ b/src/opentau/datasets/delta_action_stats.py
@@ -29,13 +29,17 @@ displacement over a chunk is far smaller than its absolute range.
 
 Recomputing them is unavoidably more work than reading a file: a chunk of length ``H`` turns each
 frame into ``H`` delta values, so the pass is ``H`` times the data volume of a per-frame stats
-pass. Two things keep that affordable:
+pass. Three things keep that affordable:
 
 * **No video decode.** Only the numeric ``state`` / ``action`` columns are read, straight out of
   parquet. Video is never touched, which is what makes an ``H``-fold pass tractable at all.
 * **Disk cache.** Results are written under each dataset's own root, keyed by a hash of
   everything that affects them (column indices, delta map, chunk length, resample settings, ...),
   so the cost is paid once per configuration rather than once per run.
+* **Optional row cap.** ``DatasetMixtureConfig.delta_stats_max_rows`` bounds how many anchor
+  frames each dataset contributes, so a million-episode source costs the same first-run wait as a
+  small one. The cap subsamples with a uniform stride over the whole dataset rather than reading a
+  prefix, so the estimate stays representative — see :func:`_select_anchor_rows`.
 
 Distribution: the compute is rank-0-only, and other ranks wait by **polling the filesystem**
 rather than sitting in a collective — see :func:`load_or_compute_delta_action_stats`.
@@ -223,6 +227,7 @@ def delta_stats_cache_key(
     excluded_episodes: Sequence[int] | None,
     fps: float | None,
     revision: str | None,
+    max_rows: int | None = None,
 ) -> str:
     """Hash everything that changes the computed stats into a short cache key.
 
@@ -241,6 +246,7 @@ def delta_stats_cache_key(
         excluded_episodes: Dropped episode indices, or ``None``.
         fps: Dataset frame rate.
         revision: Dataset revision when pinned.
+        max_rows: Anchor-row cap the stats were computed under, or ``None`` for uncapped.
 
     Returns:
         A 12-character hex digest.
@@ -261,6 +267,11 @@ def delta_stats_cache_key(
         "fps": round(float(fps), 6) if fps is not None else None,
         "revision": revision,
     }
+    # Folded in only when set, so an uncapped config keeps the digest it had before the cap
+    # existed and its cache file — the expensive one, computed over every row — stays valid.
+    # An absent key and `max_rows=None` mean the same thing, so they cannot collide.
+    if max_rows is not None:
+        payload["max_rows"] = int(max_rows)
     blob = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
     return hashlib.sha256(blob).hexdigest()[:12]
 
@@ -306,6 +317,133 @@ def _gather_chunks(
         hi = values[ceil]
         return lo + frac[..., None] * (hi - lo)
     raise ValueError(f"Unsupported vector_resample_strategy: {strategy!r}. Use 'linear' or 'nearest'.")
+
+
+def _select_anchor_rows(
+    spans: Sequence[tuple[int, int]], max_rows: int | None
+) -> list[tuple[np.ndarray, int, int]]:
+    """Pick which frames anchor a chunk, honoring an optional cap on how many.
+
+    Uncapped, every row of every selected episode is an anchor. Capped, a single uniform stride
+    runs *across* the concatenated spans:
+
+    * **Strided, not truncated.** Keeping a prefix would describe only the first few episodes of
+      a dataset whose later episodes are the ones that widen the delta range. A stride samples
+      the whole file, so the estimate degrades in precision as the cap tightens rather than
+      collapsing onto one region of the data.
+    * **Phase-continuous across episodes.** The stride does not restart at each span, so
+      consecutive episodes get their anchors at different in-episode phases. Restarting would
+      anchor every episode at frame 0 — over-sampling the episode-start transient that
+      ``_gather_chunks``' clipping already treats specially.
+
+    The episode bounds travel alongside the rows because clipping must still use the *true*
+    extent: a chunk anchored near the end of an episode repeats that episode's last frame
+    whether or not the frames in between survived the stride.
+
+    Args:
+        spans: ``(start, end)`` row ranges of the selected episodes, in file order.
+        max_rows: At most this many anchor rows across all spans; ``None`` disables the cap.
+
+    Returns:
+        ``(rows, ep_start, ep_end)`` per span that kept at least one anchor.
+    """
+    if max_rows is None:
+        return [(np.arange(lo, hi, dtype=np.int64), lo, hi) for lo, hi in spans]
+    total = sum(hi - lo for lo, hi in spans)
+    if total <= max_rows:
+        return [(np.arange(lo, hi, dtype=np.int64), lo, hi) for lo, hi in spans]
+    # Ceiling division: `ceil(total / stride) <= max_rows` for every `total > max_rows >= 1`,
+    # so the cap is a hard bound rather than an approximate one.
+    stride = -(-total // max_rows)
+    selected, seen = [], 0
+    for lo, hi in spans:
+        rows = np.arange(lo + (-seen) % stride, hi, stride, dtype=np.int64)
+        seen += hi - lo
+        if rows.size:
+            selected.append((rows, lo, hi))
+    return selected
+
+
+def _parquet_selected_rows(path: str, episodes: set[int] | None) -> int | None:
+    """How many rows of ``path`` this run will actually use, or ``None`` if it can't be read.
+
+    Without an episode selection this is the parquet footer's row count — metadata only, so it
+    costs a seek rather than a read of the (potentially multi-GB) columns.
+
+    With one, the footer count is *wrong* for budgeting: a file may hold 10,000 rows of which 10
+    are selected, and sizing its share of the cap by 10,000 would over-weight it in the pooled
+    merge. So read the one narrow ``episode_index`` column and count the rows that survive. That
+    column is a single int64 per row — a few percent of the state/action volume this pass reads
+    anyway — and the cost is only paid when a cap and an episode filter are both in play.
+    """
+    import pyarrow.parquet as pq  # lazy, like `_process_parquet_file`
+
+    try:
+        if episodes is None:
+            return int(pq.ParquetFile(path).metadata.num_rows)
+        column = pq.read_table(path, columns=["episode_index"])["episode_index"].to_numpy()
+        wanted = np.fromiter(episodes, dtype=np.int64, count=len(episodes))
+        return int(np.isin(column, wanted).sum())
+    except Exception as e:  # noqa: BLE001 - mirrors the read path: one bad shard is survivable
+        logging.warning("delta stats: could not read the row count of %s (%r).", path, e)
+        return None
+
+
+def _allocate_row_budgets(
+    parquet_paths: Sequence[str], max_rows: int | None, episodes: set[int] | None = None
+) -> list[int | None]:
+    """Split a dataset-wide anchor-row cap across its files, proportional to their sizes.
+
+    Proportional rather than even because the per-file results are pooled by
+    :func:`_merge_running` **weighted by the counts they contribute**: giving a 10-episode shard
+    the same budget as a 10,000-episode one would weight them equally in the merged mean, which
+    is a different (and wrong) distribution. Proportional budgets keep the merge weights tracking
+    the true file sizes, so a capped dataset pools in the same ratio an uncapped one would.
+
+    Sizes count only the rows ``episodes`` selects (see :func:`_parquet_selected_rows`), so the
+    ratio holds under episode filtering too, not just for whole-dataset runs.
+
+    One deliberate deviation: each file gets a floor of 2 rows so a tiny shard still clears
+    :class:`RunningStats`' two-sample minimum instead of silently dropping out. With more files
+    than half the cap the floors dominate and the realized total exceeds the cap; that is logged
+    rather than enforced, since the alternative is discarding whole shards.
+
+    Args:
+        parquet_paths: The dataset's deduplicated data files.
+        max_rows: Dataset-wide anchor-row cap, or ``None`` for uncapped.
+        episodes: Selected episode indices, or ``None`` for all.
+
+    Returns:
+        One per-file cap (or ``None`` for uncapped), positionally aligned with ``parquet_paths``.
+    """
+    if max_rows is None:
+        return [None] * len(parquet_paths)
+
+    counts = [_parquet_selected_rows(p, episodes) for p in parquet_paths]
+    known = [c for c in counts if c is not None]
+    if not known:
+        # Nothing readable up front. These files will almost certainly fail the real read too,
+        # but an even split keeps the cap in force if any of them surprises us.
+        return [max(2, max_rows // len(parquet_paths))] * len(parquet_paths)
+
+    # Size an unreadable file at the mean known count rather than 0, so a footer quirk can't
+    # starve a file that the full read does manage to open.
+    fallback = max(1, sum(known) // len(known))
+    sizes = [fallback if c is None else c for c in counts]
+    total = sum(sizes)
+    if total <= max_rows:
+        return [None] * len(parquet_paths)
+
+    budgets = [max(2, (max_rows * s) // total) for s in sizes]
+    if sum(budgets) > max_rows:
+        logging.info(
+            "delta stats: %d file(s) share a %d-row cap, so the per-file floor of 2 rows raises "
+            "the realized total to %d. Raise the cap to sample proportionally.",
+            len(parquet_paths),
+            max_rows,
+            sum(budgets),
+        )
+    return budgets
 
 
 def _process_parquet_file(task: dict[str, Any]) -> dict[str, dict[str, np.ndarray]] | None:
@@ -363,10 +501,15 @@ def _process_parquet_file(task: dict[str, Any]) -> dict[str, dict[str, np.ndarra
     if not spans:
         return None
 
+    # Anchors, after the optional row cap. The cap is what keeps a huge source's first-run cost
+    # bounded; `None` (the default) keeps every row, i.e. the uncapped behavior.
+    anchors = _select_anchor_rows(spans, task.get("max_rows"))
+    if not anchors:
+        return None
+
     def _iter_delta_chunks():
         """Yield ``(frames, horizon, dim)`` delta-action blocks, episode by episode."""
-        for ep_start, ep_end in spans:
-            rows = np.arange(ep_start, ep_end, dtype=np.int64)
+        for rows, ep_start, ep_end in anchors:
             for begin in range(0, len(rows), block):
                 frame_rows = rows[begin : begin + block]
                 chunk = _gather_chunks(actions, frame_rows, offsets, ep_start, ep_end, task["strategy"])
@@ -391,7 +534,9 @@ def _process_parquet_file(task: dict[str, Any]) -> dict[str, dict[str, np.ndarra
     for chunk in _iter_delta_chunks():
         action_acc.update(chunk)
 
-    state_rows = np.concatenate([np.arange(lo_, hi_, dtype=np.int64) for lo_, hi_ in spans])
+    # State stats read the same anchors, so both features describe one sample set and a capped
+    # run bounds this pass' peak memory too (it materializes `rows x dim` float64 at once).
+    state_rows = np.concatenate([rows for rows, _, _ in anchors])
     state_values = states[state_rows]
     state_acc = RunningStats(bounds=(state_values.min(axis=0), state_values.max(axis=0)))
     state_acc.update(state_values)
@@ -444,6 +589,7 @@ def compute_delta_action_stats(
     episodes: set[int] | None,
     max_workers: int = 1,
     block_frames: int = 4096,
+    max_rows: int | None = None,
 ) -> dict[str, dict[str, np.ndarray]]:
     """Compute delta-action (and state) stats for one dataset from its parquet files.
 
@@ -462,13 +608,26 @@ def compute_delta_action_stats(
             and avoids pool overhead for a single small file.
         block_frames: Chunk anchors processed per gather, bounding peak memory at roughly
             ``block_frames x len(chunk_offsets) x dim`` float64 values.
+        max_rows: Cap on how many anchor frames this dataset contributes, split across its files
+            in proportion to their selected-row counts (see :func:`_allocate_row_budgets`) and
+            sampled with a uniform stride (see :func:`_select_anchor_rows`), so a capped dataset
+            pools in the same file ratio an uncapped one would. ``None`` (default) reads every row.
+            Trades estimator precision for a bounded first-run wait on very large sources; the
+            columns are still read in full, so this caps compute, not I/O.
 
     Returns:
         ``{"actions": {...}, "state": {...}}`` in OpenTau's per-feature stats layout.
 
     Raises:
-        ValueError: If no file produced usable samples.
+        ValueError: If ``max_rows`` is non-positive, or if no file produced usable samples.
     """
+    if max_rows is not None and max_rows < 1:
+        raise ValueError(f"compute_delta_action_stats: max_rows must be >= 1 or None, got {max_rows}.")
+
+    if not parquet_paths:
+        raise ValueError("compute_delta_action_stats: no parquet paths given.")
+
+    budgets = _allocate_row_budgets([str(p) for p in parquet_paths], max_rows, episodes)
     tasks = [
         {
             "path": str(p),
@@ -481,11 +640,10 @@ def compute_delta_action_stats(
             "strategy": strategy,
             "episodes": episodes,
             "block_frames": block_frames,
+            "max_rows": budget,
         }
-        for p in parquet_paths
+        for p, budget in zip(parquet_paths, budgets, strict=True)
     ]
-    if not tasks:
-        raise ValueError("compute_delta_action_stats: no parquet paths given.")
 
     if max_workers <= 1 or len(tasks) == 1:
         parts = [_process_parquet_file(t) for t in tasks]
@@ -495,9 +653,19 @@ def compute_delta_action_stats(
 
     usable = [p for p in parts if p]
     if not usable:
+        # A file also drops out when it yields fewer than two samples, which a tight `max_rows`
+        # can cause on its own — call that out rather than blaming the data. Only when the cap
+        # actually bound: budgets are all `None` when the dataset was smaller than the cap.
+        bound = [b for b in budgets if b is not None]
+        cap_hint = (
+            f" max_rows={max_rows} was in force, leaving each file at most {max(bound)} anchor "
+            "row(s); a cap that tight can starve every file below the two-sample minimum."
+            if bound
+            else ""
+        )
         raise ValueError(
             "compute_delta_action_stats: every parquet file was empty, unreadable, or excluded "
-            f"by the episode selection ({len(tasks)} file(s) tried)."
+            f"by the episode selection ({len(tasks)} file(s) tried).{cap_hint}"
         )
     return _merge_running(usable)
 

--- a/src/opentau/datasets/delta_action_stats.py
+++ b/src/opentau/datasets/delta_action_stats.py
@@ -621,8 +621,13 @@ def compute_delta_action_stats(
     Raises:
         ValueError: If ``max_rows`` is non-positive, or if no file produced usable samples.
     """
-    if max_rows is not None and max_rows < 1:
-        raise ValueError(f"compute_delta_action_stats: max_rows must be >= 1 or None, got {max_rows}.")
+    # `bool` is an `int` subclass, so `max_rows=True` passes a bare `>= 1` check and caps the
+    # pass at one anchor row — which does not raise, it silently returns stats fitted to two
+    # samples. Reject it here as well as at the config layer: this function is exported and the
+    # module is meant to be driven directly (e.g. the openpi parity harness), so the config
+    # validator is not the only path in.
+    if max_rows is not None and (isinstance(max_rows, bool) or max_rows < 1):
+        raise ValueError(f"compute_delta_action_stats: max_rows must be >= 1 or None, got {max_rows!r}.")
 
     if not parquet_paths:
         raise ValueError("compute_delta_action_stats: no parquet paths given.")

--- a/src/opentau/datasets/factory.py
+++ b/src/opentau/datasets/factory.py
@@ -168,7 +168,8 @@ def _compute_or_load_delta_stats(
     Args:
         dataset: The configured dataset (already carrying its resolved delta map).
         dataset_cfg: Its config entry.
-        train_cfg: Pipeline config, read for ``num_workers``.
+        train_cfg: Pipeline config, read for ``num_workers`` and
+            ``dataset_mixture.delta_stats_max_rows``.
 
     Returns:
         ``{"actions": {...}, "state": {...}}`` in post-index space.
@@ -187,6 +188,9 @@ def _compute_or_load_delta_stats(
     chunk_offsets = np.asarray(dt_mean["actions"], dtype=np.float64) * dataset.fps
 
     name_map = dataset._get_name_map()
+    # Bounds the O(frames x chunk_size) pass on very large sources. In the cache key too, so
+    # flipping the cap recomputes instead of serving stats from a different sampling budget.
+    max_rows = getattr(train_cfg.dataset_mixture, "delta_stats_max_rows", None)
     cache_key = delta_stats_cache_key(
         state_index=dataset_cfg.state_index,
         action_index=dataset_cfg.action_index,
@@ -197,6 +201,7 @@ def _compute_or_load_delta_stats(
         excluded_episodes=dataset_cfg.excluded_episodes,
         fps=dataset.fps,
         revision=dataset_cfg.revision,
+        max_rows=max_rows,
     )
     # Only the main process computes, so sizing the pool from the full `num_workers` neither
     # oversubscribes the node nor leaves it idle.
@@ -215,6 +220,7 @@ def _compute_or_load_delta_stats(
             "strategy": dataset.vector_resample_strategy,
             "episodes": set(episodes),
             "max_workers": max_workers,
+            "max_rows": max_rows,
         },
     )
 

--- a/tests/configs/test_default.py
+++ b/tests/configs/test_default.py
@@ -228,6 +228,26 @@ def test_invalid_negative_bare_dataset_tolerance_raises():
         DatasetConfig(repo_id="foo/bar", tolerance_s=-1.0)
 
 
+def test_delta_stats_max_rows_defaults_to_uncapped():
+    """The on-the-fly delta-stats row cap is opt-in: `None` keeps the exact all-rows pass."""
+    assert DatasetMixtureConfig().delta_stats_max_rows is None
+
+
+def test_delta_stats_max_rows_accepts_a_positive_int():
+    assert DatasetMixtureConfig(delta_stats_max_rows=250_000).delta_stats_max_rows == 250_000
+
+
+@pytest.mark.parametrize("bad", [0, -1, 1.5, True])
+def test_invalid_delta_stats_max_rows_raises(bad):
+    """Zero / negative / non-int caps are rejected up front, not at first dataset load.
+
+    `True` is in the list because `bool` is an `int` subclass: `delta_stats_max_rows=True` would
+    otherwise pass the `>= 1` check and silently cap the pass at one row.
+    """
+    with pytest.raises(ValueError, match=r"`delta_stats_max_rows` must be None"):
+        DatasetMixtureConfig(delta_stats_max_rows=bad)
+
+
 class TestWandBConfig:
     """Cover the ``disable_video`` flag and the ``on_resume`` fork/continue behavior.
 

--- a/tests/datasets/test_delta_action_stats.py
+++ b/tests/datasets/test_delta_action_stats.py
@@ -15,6 +15,9 @@
 
 """On-the-fly delta-action statistics and their disk cache."""
 
+from pathlib import Path
+from types import SimpleNamespace
+
 import numpy as np
 import pyarrow as pa
 import pyarrow.parquet as pq
@@ -23,6 +26,9 @@ import pytest
 from opentau.datasets.delta_action_stats import (
     CACHE_SUBDIR,
     RunningStats,
+    _allocate_row_budgets,
+    _merge_running,
+    _select_anchor_rows,
     compute_delta_action_stats,
     delta_stats_cache_key,
     load_or_compute_delta_action_stats,
@@ -273,6 +279,257 @@ class TestComputeDeltaActionStats:
         np.testing.assert_allclose(inline["mean"], pooled["mean"])
 
 
+class TestRowCap:
+    """`max_rows` bounds the O(frames x horizon) pass without biasing the sample."""
+
+    def test_cap_is_a_hard_bound_on_anchor_rows(self):
+        """Never more than the cap, for every span layout and every cap."""
+        layouts = [
+            [(0, 100)],
+            [(0, 10), (10, 20), (20, 30)],
+            [(0, 1), (1, 2), (2, 3), (3, 400)],
+            [(5, 7), (100, 101)],
+        ]
+        for spans in layouts:
+            total = sum(hi - lo for lo, hi in spans)
+            for cap in range(1, total + 3):
+                kept = sum(len(rows) for rows, _, _ in _select_anchor_rows(spans, cap))
+                assert kept <= cap, f"spans={spans} cap={cap} kept={kept}"
+
+    def test_uncapped_keeps_every_row(self):
+        spans = [(0, 4), (4, 9)]
+        assert [rows.tolist() for rows, _, _ in _select_anchor_rows(spans, None)] == [
+            [0, 1, 2, 3],
+            [4, 5, 6, 7, 8],
+        ]
+
+    def test_cap_at_or_above_the_row_count_keeps_every_row(self):
+        spans = [(0, 4), (4, 9)]
+        for cap in (9, 10, 10_000):
+            selected = _select_anchor_rows(spans, cap)
+            assert sum(len(rows) for rows, _, _ in selected) == 9
+
+    def test_stride_phase_continues_across_episode_boundaries(self):
+        """Anchors must not restart at frame 0 of every episode.
+
+        A per-span restart would anchor every episode at its first frame, over-sampling the
+        episode-start transient (which `_gather_chunks` already treats specially by clipping).
+        """
+        spans = [(0, 10), (10, 20), (20, 30)]
+        selected = _select_anchor_rows(spans, 10)  # stride 3
+        assert [rows.tolist() for rows, _, _ in selected] == [
+            [0, 3, 6, 9],
+            [12, 15, 18],
+            [21, 24, 27],
+        ]
+        starts = [int(rows[0]) - lo for rows, lo, _ in selected]
+        assert len(set(starts)) > 1, "every episode was anchored at the same in-episode phase"
+
+    def test_true_episode_bounds_survive_subsampling(self):
+        """Clipping still uses the real episode extent, not the sampled rows' extent."""
+        selected = _select_anchor_rows([(0, 100), (100, 200)], 4)
+        assert [(lo, hi) for _, lo, hi in selected] == [(0, 100), (100, 200)]
+
+    def test_cap_bounds_the_accumulated_sample_count(self, tmp_path):
+        path, _, _ = _write_dataset(tmp_path)
+        cap = 200
+        stats = compute_delta_action_stats(**_kwargs(path, max_rows=cap))
+        assert stats["state"]["count"].tolist()[0] <= cap
+        assert stats["actions"]["count"].tolist()[0] <= cap * HORIZON
+        # And it really did bind — the uncapped pass sees far more.
+        assert stats["state"]["count"].tolist()[0] < N_EP * T_PER_EP
+
+    def test_cap_above_the_dataset_size_is_a_no_op(self, tmp_path):
+        """A cap the dataset never reaches must produce bit-identical stats to no cap."""
+        path, _, _ = _write_dataset(tmp_path)
+        uncapped = compute_delta_action_stats(**_kwargs(path))["actions"]
+        capped = compute_delta_action_stats(**_kwargs(path, max_rows=10 * N_EP * T_PER_EP))["actions"]
+        for stat in ("mean", "std", "min", "max", "q01", "q99", "count"):
+            np.testing.assert_array_equal(uncapped[stat], capped[stat])
+
+    def test_cap_samples_the_whole_dataset_not_a_prefix(self, tmp_path):
+        """The tail of the dataset must still reach the stats.
+
+        Truncating to the first N rows is the obvious wrong implementation and would be invisible
+        in a mean/std check on smooth data. Here the LAST episode is shifted far away, so its
+        contribution shows up in `max` — a prefix sample would miss it entirely.
+        """
+        rng = np.random.default_rng(7)
+        states, actions, episodes = [], [], []
+        for e in range(N_EP):
+            walk = np.cumsum(rng.normal(size=(T_PER_EP, DIM_S)) * 0.1, axis=0)
+            act = np.concatenate([walk[:, : DIM_A - 1], rng.uniform(0, 1, size=(T_PER_EP, 1))], axis=1)
+            if e == N_EP - 1:
+                act = act + 50.0  # only the final episode reaches this scale
+            states.append(walk)
+            actions.append(act)
+            episodes.append(np.full(T_PER_EP, e))
+        states, actions, episodes = map(np.concatenate, (states, actions, episodes))
+        path = tmp_path / "data.parquet"
+        pq.write_table(
+            pa.table(
+                {
+                    "observation.state": [r.tolist() for r in states],
+                    "action": [r.tolist() for r in actions],
+                    "episode_index": episodes.tolist(),
+                }
+            ),
+            path,
+        )
+        got = compute_delta_action_stats(**_kwargs(path, max_rows=40))["actions"]
+        assert float(got["max"][0]) > 40.0
+
+    def test_capped_mean_tracks_the_uncapped_mean(self, tmp_path):
+        """A uniform stride is an unbiased sample, so a generous cap barely moves the mean."""
+        path, _, _ = _write_dataset(tmp_path)
+        full = compute_delta_action_stats(**_kwargs(path))["actions"]
+        capped = compute_delta_action_stats(**_kwargs(path, max_rows=N_EP * T_PER_EP // 2))["actions"]
+        for dim in range(DIM_A):
+            spread = float(full["std"][dim])
+            assert abs(float(capped["mean"][dim]) - float(full["mean"][dim])) < 0.25 * spread
+
+    def test_every_episode_still_contributes_under_a_loose_cap(self):
+        """Striding across spans keeps whole episodes from dropping out."""
+        selected = _select_anchor_rows([(e * T_PER_EP, (e + 1) * T_PER_EP) for e in range(N_EP)], 100)
+        assert len(selected) == N_EP
+
+    def test_non_positive_cap_raises(self, tmp_path):
+        path, _, _ = _write_dataset(tmp_path)
+        with pytest.raises(ValueError, match="max_rows must be >= 1"):
+            compute_delta_action_stats(**_kwargs(path, max_rows=0))
+
+    def test_multiprocess_matches_inline_under_a_cap(self, tmp_path):
+        """The cap must be applied identically on both execution paths."""
+        path, _, _ = _write_dataset(tmp_path)
+        inline = compute_delta_action_stats(**_kwargs(path, max_rows=137, max_workers=1))["actions"]
+        pooled = compute_delta_action_stats(**_kwargs(path, max_rows=137, max_workers=4))["actions"]
+        np.testing.assert_allclose(inline["mean"], pooled["mean"])
+        np.testing.assert_array_equal(inline["count"], pooled["count"])
+
+
+class TestRowBudgetAllocation:
+    """Splitting a dataset-wide cap across a multi-file dataset."""
+
+    def _write(self, path, n_rows, n_ep=2):
+        rng = np.random.default_rng(0)
+        episodes = np.repeat(np.arange(n_ep), n_rows // n_ep)
+        n = len(episodes)
+        pq.write_table(
+            pa.table(
+                {
+                    "observation.state": [r.tolist() for r in rng.normal(size=(n, DIM_S))],
+                    "action": [r.tolist() for r in rng.normal(size=(n, DIM_A))],
+                    "episode_index": episodes.tolist(),
+                }
+            ),
+            path,
+        )
+        return str(path)
+
+    def test_uncapped_gives_every_file_no_budget(self, tmp_path):
+        paths = [self._write(tmp_path / f"{i}.parquet", 100) for i in range(3)]
+        assert _allocate_row_budgets(paths, None) == [None, None, None]
+
+    def test_cap_larger_than_the_dataset_does_not_bind(self, tmp_path):
+        paths = [self._write(tmp_path / f"{i}.parquet", 100) for i in range(3)]
+        assert _allocate_row_budgets(paths, 10_000) == [None, None, None]
+
+    def test_budgets_track_file_sizes(self, tmp_path):
+        """Proportional, not even — `_merge_running` weights each file by what it contributes,
+        so an even split would over-weight a small shard in the pooled mean."""
+        big = self._write(tmp_path / "big.parquet", 900)
+        small = self._write(tmp_path / "small.parquet", 100)
+        budgets = _allocate_row_budgets([big, small], 100)
+        assert sum(budgets) <= 100
+        assert budgets[0] == 90 and budgets[1] == 10
+
+    def test_unreadable_file_does_not_starve_the_rest(self, tmp_path):
+        """A footer we can't read is sized at the mean, so the readable files keep sane budgets."""
+        good = self._write(tmp_path / "good.parquet", 1000)
+        missing = str(tmp_path / "nope.parquet")
+        budgets = _allocate_row_budgets([good, missing], 100)
+        assert budgets[0] >= 40
+        assert all(b >= 2 for b in budgets)
+
+    def test_budgets_track_selected_rows_under_an_episode_filter(self, tmp_path):
+        """Sizes count the rows the run will *use*, not every row in the file.
+
+        Two same-size files, but the episode filter keeps 1 of 10 episodes in the first and all
+        10 in the second. Sizing by the parquet footer would call them equal and hand each half
+        the cap, over-weighting the barely-selected file 10x in the pooled merge.
+        """
+        a = self._write(tmp_path / "a.parquet", 1000, n_ep=10)  # episodes 0-9
+        b = self._write(tmp_path / "b.parquet", 1000, n_ep=10)  # episodes 0-9
+        # `episodes` is matched on the value in the column, so this keeps 1/10 of each file...
+        budgets = _allocate_row_budgets([a, b], 110, episodes={0})
+        assert budgets == [55, 55], "equal selections must still split equally"
+        # ...whereas an asymmetric selection has to shift the split. Rebuild `b` with a single
+        # episode index so every one of its rows is selected.
+        b_all = self._write(tmp_path / "b_all.parquet", 1000, n_ep=1)  # all rows are episode 0
+        budgets = _allocate_row_budgets([a, b_all], 110, episodes={0})
+        assert sum(budgets) <= 110
+        assert budgets[1] > 5 * budgets[0], f"expected a ~10:1 split by selected rows, got {budgets}"
+
+    def test_every_file_clears_the_two_sample_minimum(self, tmp_path):
+        """A tiny cap must not silently drop whole shards below `RunningStats`' minimum."""
+        paths = [self._write(tmp_path / f"{i}.parquet", 200) for i in range(8)]
+        assert all(b >= 2 for b in _allocate_row_budgets(paths, 4))
+
+    def test_multi_file_dataset_respects_the_cap_end_to_end(self, tmp_path):
+        paths = [self._write(tmp_path / f"{i}.parquet", 600) for i in range(3)]
+        stats = compute_delta_action_stats(**_kwargs(paths[0], parquet_paths=paths, max_rows=300))
+        assert stats["state"]["count"].tolist()[0] <= 300
+
+    def _write_at(self, path, n_rows, centre):
+        """A file whose rows all sit near `centre`, so its share of the pool is visible."""
+        rng = np.random.default_rng(int(centre))
+        eps = np.repeat(np.arange(2), n_rows // 2)
+        n = len(eps)
+        pq.write_table(
+            pa.table(
+                {
+                    "observation.state": [r.tolist() for r in rng.normal(size=(n, DIM_S)) * 0.1 + centre],
+                    "action": [r.tolist() for r in rng.normal(size=(n, DIM_A)) * 0.1 + centre],
+                    "episode_index": eps.tolist(),
+                }
+            ),
+            path,
+        )
+        return str(path)
+
+    def test_capping_preserves_the_ratio_between_files(self, tmp_path):
+        """A 9:1 pair of files must still pool 9:1 after the cap.
+
+        `_merge_running` pools the per-file results weighted by the counts they contribute, so
+        the budget split *is* the mixture ratio within a dataset. An even split — the obvious
+        alternative — would re-weight a 9:1 dataset to 1:1 and drag the pooled mean most of the
+        way to the small file's distribution.
+        """
+        big = self._write_at(tmp_path / "big.parquet", 9000, 0.0)
+        small = self._write_at(tmp_path / "small.parquet", 1000, 10.0)
+        # No delta map and a 1-step horizon: the action stats are then just the raw rows, so the
+        # pooled mean reads directly as each file's share of the sample.
+        kw = {"delta_map": {}, "chunk_offsets": np.array([0.0])}
+
+        full = compute_delta_action_stats(**_kwargs(big, parquet_paths=[big, small], **kw))["actions"]
+        capped = compute_delta_action_stats(**_kwargs(big, parquet_paths=[big, small], max_rows=500, **kw))[
+            "actions"
+        ]
+
+        # True pooled mean is 0.9 * 0 + 0.1 * 10 == 1.0.
+        assert abs(float(full["mean"][0]) - 1.0) < 0.1
+        assert abs(float(capped["mean"][0]) - float(full["mean"][0])) < 0.1
+
+        # Pin the counterfactual: had the budgets been split evenly, the pool would land ~5.0.
+        even = _merge_running(
+            [
+                compute_delta_action_stats(**_kwargs(big, parquet_paths=[big], max_rows=250, **kw)),
+                compute_delta_action_stats(**_kwargs(small, parquet_paths=[small], max_rows=250, **kw)),
+            ]
+        )
+        assert abs(float(even["actions"]["mean"][0]) - 1.0) > 3.0
+
+
 class TestCacheKey:
     def _key(self, **overrides):
         base = {
@@ -310,10 +567,82 @@ class TestCacheKey:
             {"excluded_episodes": [3]},
             {"fps": 30.0},
             {"revision": "v2"},
+            {"max_rows": 100_000},
         ],
     )
     def test_every_input_that_changes_the_stats_changes_the_key(self, override):
         assert self._key(**override) != self._key()
+
+    def test_an_absent_cap_keeps_the_pre_cap_digest(self):
+        """Uncapped configs must keep the key they had before `max_rows` existed.
+
+        Their cache files hold the expensive all-rows result; folding an always-present
+        `max_rows: null` into the payload would invalidate every one of them on upgrade.
+        """
+        assert self._key(max_rows=None) == self._key()
+        # Pinned against the digest this input produced before `max_rows` existed. Any future
+        # payload change that would orphan existing cache files has to break this line first.
+        assert self._key() == "f4c5d10ec6db"
+
+    def test_distinct_caps_do_not_collide(self):
+        assert self._key(max_rows=1000) != self._key(max_rows=2000)
+
+
+class TestFactoryWiring:
+    """`DatasetMixtureConfig.delta_stats_max_rows` has to reach BOTH consumers.
+
+    Threading it into the compute but not the cache key would serve a previously-cached uncapped
+    (or differently-capped) result forever; threading it into the key but not the compute would
+    recompute the identical numbers under a new key. Neither failure raises.
+    """
+
+    def _fake_dataset(self, root):
+        meta = SimpleNamespace(
+            root=root,
+            episodes=[0, 1],
+            get_data_file_path=lambda ep: Path("data.parquet"),
+        )
+        return SimpleNamespace(
+            meta=meta,
+            episodes=None,
+            delta_timestamps_params=[{"actions": [0.0, 0.05]}],
+            fps=20.0,
+            vector_resample_strategy="nearest",
+            delta_action_state_map={0: 0},
+            _get_name_map=lambda: {"state": "observation.state", "actions": "action"},
+        )
+
+    def _run(self, tmp_path, monkeypatch, max_rows):
+        from opentau.configs.default import DatasetConfig, DatasetMixtureConfig
+        from opentau.datasets import factory
+
+        seen = {}
+
+        def _capture(*, root, cache_key, compute_kwargs):
+            seen.update(cache_key=cache_key, compute_kwargs=compute_kwargs)
+            return {"actions": {}, "state": {}}
+
+        monkeypatch.setattr(factory, "load_or_compute_delta_action_stats", _capture)
+        factory._compute_or_load_delta_stats(
+            self._fake_dataset(tmp_path),
+            DatasetConfig(repo_id="fake/ds", use_delta_joint_actions=True, delta_action_state_map={0: 0}),
+            SimpleNamespace(
+                num_workers=2, dataset_mixture=DatasetMixtureConfig(delta_stats_max_rows=max_rows)
+            ),
+        )
+        return seen
+
+    def test_cap_reaches_the_compute(self, tmp_path, monkeypatch):
+        assert self._run(tmp_path, monkeypatch, 1234)["compute_kwargs"]["max_rows"] == 1234
+
+    def test_cap_reaches_the_cache_key(self, tmp_path, monkeypatch):
+        capped = self._run(tmp_path, monkeypatch, 1234)["cache_key"]
+        other = self._run(tmp_path, monkeypatch, 5678)["cache_key"]
+        uncapped = self._run(tmp_path, monkeypatch, None)["cache_key"]
+        assert len({capped, other, uncapped}) == 3
+
+    def test_default_is_uncapped(self, tmp_path, monkeypatch):
+        assert self._run(tmp_path, monkeypatch, None)["compute_kwargs"]["max_rows"] is None
 
 
 class TestLoadOrCompute:

--- a/tests/datasets/test_delta_action_stats.py
+++ b/tests/datasets/test_delta_action_stats.py
@@ -393,10 +393,18 @@ class TestRowCap:
         selected = _select_anchor_rows([(e * T_PER_EP, (e + 1) * T_PER_EP) for e in range(N_EP)], 100)
         assert len(selected) == N_EP
 
-    def test_non_positive_cap_raises(self, tmp_path):
+    @pytest.mark.parametrize("bad", [0, -1, True])
+    def test_invalid_cap_raises(self, tmp_path, bad):
+        """`True` is in the list because `bool` is an `int` subclass.
+
+        A bare `>= 1` check lets `max_rows=True` through as 1, which does not raise — it caps the
+        pass at one anchor row and silently returns stats fitted to two samples (a measured std
+        of 0.13 where the true value is 0.99). The config layer rejects bools, but this function
+        is exported and the module is documented as usable directly, so guard it here too.
+        """
         path, _, _ = _write_dataset(tmp_path)
         with pytest.raises(ValueError, match="max_rows must be >= 1"):
-            compute_delta_action_stats(**_kwargs(path, max_rows=0))
+            compute_delta_action_stats(**_kwargs(path, max_rows=bad))
 
     def test_multiprocess_matches_inline_under_a_cap(self, tmp_path):
         """The cap must be applied identically on both execution paths."""

--- a/tests/datasets/test_norm_key_aggregation.py
+++ b/tests/datasets/test_norm_key_aggregation.py
@@ -357,6 +357,79 @@ class TestDatasetMixtureMetadataNormAggregation:
         np.testing.assert_allclose(head["state"]["mean"][0], expected_mean, atol=1e-5)
         np.testing.assert_allclose(head["state"]["std"][0], np.sqrt(expected_var), atol=1e-5)
 
+    def test_pooling_weight_is_total_frames_not_the_stats_count(self):
+        """A head pools by `info["total_frames"]`, ignoring the `count` inside the stats.
+
+        Every other pooling test sets `count == total_frames`, so the two are indistinguishable
+        there and dropping the explicit `weights=` argument would stay green. They are NOT equal
+        for a dataset whose stats were **subsampled** — which is exactly what
+        `DatasetMixtureConfig.delta_stats_max_rows` produces: a capped dataset carries a `count`
+        of the sampled rows while still representing all of its frames.
+
+        If pooling ever fell back to `count`, capping one dataset would silently shrink its share
+        of a shared normalization head — a mixture-ratio change with no error and no log line.
+        So make `count` disagree with `total_frames` and pin which one wins.
+        """
+        _patch_name_mapping(["repo/a", "repo/b"])
+        cfg = _make_cfg(max_state_dim=4, max_action_dim=4)
+        # `repo/a` is 9x the data but its stats were sampled 90x more thinly than `repo/b`'s,
+        # so `count` and `total_frames` point in opposite directions.
+        frames_a, frames_b = 9000, 1000
+        sampled_a, sampled_b = 100, 1000
+        mean_a, mean_b = 0.0, 10.0
+
+        def stats_for(mean: float, n: int) -> dict:
+            per_feature = {
+                "mean": np.full((4,), mean, dtype=np.float32),
+                "std": np.full((4,), 1.0, dtype=np.float32),
+                "min": np.full((4,), mean - 5.0, dtype=np.float32),
+                "max": np.full((4,), mean + 5.0, dtype=np.float32),
+                "count": np.array([n], dtype=np.int64),
+            }
+            return {
+                "state": dict(per_feature),
+                "actions": dict(per_feature),
+                "camera0": {
+                    "mean": np.full((3, 1, 1), 0.5, dtype=np.float32),
+                    "std": np.full((3, 1, 1), 0.5, dtype=np.float32),
+                    "min": np.zeros((3, 1, 1), dtype=np.float32),
+                    "max": np.ones((3, 1, 1), dtype=np.float32),
+                    "count": np.array([n], dtype=np.int64),
+                },
+            }
+
+        meta = DatasetMixtureMetadata(
+            cfg,
+            [
+                _make_metadata(
+                    "repo/a",
+                    info={
+                        "robot_type": "franka",
+                        "control_mode": "joint",
+                        "total_frames": frames_a,
+                    },
+                    stats=stats_for(mean_a, sampled_a),
+                ),
+                _make_metadata(
+                    "repo/b",
+                    info={
+                        "robot_type": "franka",
+                        "control_mode": "joint",
+                        "total_frames": frames_b,
+                    },
+                    stats=stats_for(mean_b, sampled_b),
+                ),
+            ],
+            dataset_weights=[0.5, 0.5],
+            dataset_names=["repo/a", "repo/b"],
+        )
+        head = meta.per_norm_key_stats[0]
+
+        by_frames = (frames_a * mean_a + frames_b * mean_b) / (frames_a + frames_b)  # 1.0
+        by_count = (sampled_a * mean_a + sampled_b * mean_b) / (sampled_a + sampled_b)  # ~9.09
+        np.testing.assert_allclose(head["state"]["mean"][0], by_frames, atol=1e-5)
+        assert abs(float(head["state"]["mean"][0]) - by_count) > 1.0
+
     def test_norm_head_summary_logged(self, caplog):
         _patch_name_mapping(["repo/a", "repo/b", "repo/c"])
         cfg = _make_cfg()


### PR DESCRIPTION
## What this does

Adds `DatasetMixtureConfig.delta_stats_max_rows: int | None` (default `None`), an opt-in cap on how many anchor frames each `use_delta_joint_actions` dataset contributes to the delta-action normalization stats computed on the fly at dataset load (`src/opentau/datasets/delta_action_stats.py`).

**Why.** When `use_delta_joint_actions` is on, each action in a chunk has the chunk-start state subtracted, so `meta/stats.json` (absolute, per-frame actions) no longer describes the training targets and the stats must be recomputed. That pass is `O(frames x chunk_size)` — an `H`-fold blow-up over a per-frame stats pass — so on a very large source the first run, before the disk cache is warm, can take hours.

**How the cap samples.** Three properties, each of which the obvious implementation gets wrong:

* **Strided, not truncated.** A prefix would describe only the first few episodes — precisely the ones least likely to widen the delta range. A uniform stride samples the whole dataset, so tightening the cap costs precision rather than collapsing onto one region of the data.
* **Phase-continuous across episode boundaries.** The stride does not restart per episode, so consecutive episodes are anchored at different in-episode phases. Restarting would anchor every episode at frame 0, over-sampling the episode-start transient that the chunk gather's clipping already treats specially.
* **Ratio-preserving.** A dataset's cap is split across its parquet files in proportion to the rows each *actually contributes* (counting only what an `episodes` / `excluded_episodes` filter selects, read from the narrow `episode_index` column). `_merge_running` pools per-file results weighted by the counts they contribute, so the budget split **is** the mixture ratio within a dataset — an even split would re-weight a 9:1 dataset to 1:1. Cross-dataset pooling into a shared normalization head is unaffected either way: that path weights members by `info["total_frames"]`, not by the sampled `count`, so capping changes a dataset's estimator *precision*, never its share of the head.

**Cache compatibility.** The cap is folded into the stats cache key **only when set**, so uncapped configs keep the digest — and therefore the already-computed cache files, which are the expensive ones — that they had before this change. Verified against `HEAD`'s source and pinned by a test.

Default `None` reads every row, exactly as before; nothing changes unless the field is set.

### Cost and fidelity (measured, 100k-frame source)

Capping drops the accumulation from `O(frames x chunk_size)` to `O(cap x chunk_size)`, leaving only the parquet column read (which the cap does not shrink — this bounds compute, not I/O):

| horizon | uncapped compute | capped compute (20x subsample) |
|---------|------------------|-------------------------------|
| 50      | 2.10s            | 0.23s                         |
| 200     | 7.36s            | 0.44s                         |

At that subsample `mean`/`std` and `q01`/`q99` land within 0.02 / 0.05 standard deviations of the uncapped values; `min`/`max` degrade first (~0.9 sd), since a subsample doesn't see the extremes. So MIN_MAX normalization is the mode most sensitive to a tight cap, and MEAN_STD / QUANTILE the least. This is documented on the config field and in `CHANGELOG.md`.

## How it was tested

Added 14 tests. The three ratio-critical ones are **mutation-verified** — each was confirmed to fail against a deliberately broken implementation:

* `tests/datasets/test_delta_action_stats.py`
  * `TestRowCap` — the cap is a hard bound across every span layout and every cap value; uncapped and above-dataset-size caps are byte-identical to no cap; the stride is phase-continuous; true episode bounds survive subsampling (clipping is unaffected); the tail of the dataset still reaches the stats (a prefix implementation would miss it); the capped mean tracks the uncapped mean; the pool and inline paths agree under a cap.
  * `TestRowBudgetAllocation` — budgets track file sizes (**mutation-verified**: an even split fails this); budgets track *selected* rows under an episode filter (**mutation-verified**: footer-count sizing fails this); every file clears `RunningStats`' two-sample minimum; an unreadable footer doesn't starve the rest; capping preserves the ratio between a 9:1 pair of files, with the even-split counterfactual pinned (**mutation-verified**).
  * `TestCacheKey` — the cap changes the key; distinct caps don't collide; an absent cap keeps the pre-`max_rows` digest, pinned as a literal so any future payload change that would orphan existing cache files breaks this line first.
  * `TestFactoryWiring` — the config field reaches **both** the cache key and the compute kwargs (threading it into one but not the other fails silently in opposite directions).
* `tests/datasets/test_norm_key_aggregation.py::test_pooling_weight_is_total_frames_not_the_stats_count` — pins that a shared norm head pools by `info["total_frames"]`, not the stats `count`. Every pre-existing pooling test sets the two equal, so they cannot distinguish them; **mutation-verified**: dropping the explicit `weights=member_weights` leaves all 18 of them green and fails only this new test. Without it, capping one dataset could silently shrink its share of a shared head with no error and no log line.
* `tests/configs/test_default.py` — the field defaults to uncapped, accepts a positive int, and rejects `0` / negative / non-int / `bool` (`bool` is an `int` subclass, so `True` would otherwise pass a bare `>= 1` check and cap the pass at one row).

Full CPU suite (`pytest -m "not gpu and not network" -n auto`): **2275 passed**, 13 skipped. The 3 failures and 2 collection errors in `tests/envs/` are pre-existing on a clean tree in this environment (the `libero` extra is not installed) — confirmed by stashing the change and re-running. `pre-commit run --files <changed>` clean.

Not a policy change — the diff touches `src/opentau/datasets/` and `src/opentau/configs/default.py` only, no `modeling_*` / `configuration_*` / `optim/` / `sampler.py` / `train.py` — so the policy and GPU checklist boxes are left unchecked and no GPU run is claimed.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/datasets/test_delta_action_stats.py
```

```bash
pytest -sx tests/datasets/test_norm_key_aggregation.py::TestDatasetMixtureMetadataNormAggregation::test_pooling_weight_is_total_frames_not_the_stats_count
```

To use it, add the field to a mixture that has `use_delta_joint_actions` datasets:

```bash
opentau-train --config_path=<your_config.json> --dataset_mixture.delta_stats_max_rows=500000
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.
