### PR TITLE
docs: scope the "loadable by repo id" claim to --policy.path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,13 +90,24 @@ carry a concrete `config_version` (and an informational `opentau_version`).
   rather than as a bogus repo id. Parsed by `split_repo_revision` in
   `opentau/utils/hub.py`; passing both an `@` suffix and a conflicting
   `revision=` raises rather than silently picking one.
-* **Published checkpoints are loadable by repo id.** Uploaded repos carried only
-  `hf_config.json`, so `--policy.path=<repo>` failed on the missing `config.json`
-  and `--config_path=<repo>` on the missing `train_config.json`; you had to fetch
-  `hf_config.json` by hand. `PreTrainedConfig.from_pretrained` and
+* **`--policy.path=<repo>` works against a published checkpoint.** Uploaded repos
+  carried only `hf_config.json`, so `--policy.path=<repo>` failed on the missing
+  `config.json` and `--config_path=<repo>` on the missing `train_config.json`; you
+  had to fetch `hf_config.json` by hand. `PreTrainedConfig.from_pretrained` and
   `TrainPipelineConfig.from_pretrained` now fall back to `hf_config.json` (reading
-  its `.policy` sub-object for the former), which also fixes every checkpoint
-  already on the Hub.
+  its `.policy` sub-object for the former), so the file is always found.
+
+  **Scope:** finding the file is not the same as decoding it. `--policy.path` reads
+  only the `.policy` sub-object and works on checkpoints going back as far as we
+  have tested. `--config_path` decodes the *whole* pipeline config, so it still
+  fails on a checkpoint whose train config predates an unrelated schema change —
+  verified against a real 2-step consolidated repo, where
+  `dataset_mixture.datasets[].grounding` (renamed to `vqa` in #124) raises a
+  `DecodingError`. That is deliberate: `grounding` was renamed, not deleted, so
+  stripping it would silently load the config with `vqa` at its default and lose a
+  setting the run was actually trained with. Failing loudly is the correct
+  behavior; use `--policy.path` for old checkpoints, or hand-edit the fetched
+  config.
 * `config_version: int | None` and `opentau_version: str | None` on
   `PreTrainedConfig`. `config_version` is a monotonic schema version for
   behavioral conventions; `opentau_version` is an informational package-version


### PR DESCRIPTION
## What this does

Docs-only follow-up to #492, correcting an overclaim of mine that landed in that PR's CHANGELOG entry.

#492 says the `hf_config.json` fallback makes published checkpoints "loadable by repo id … which also fixes every checkpoint already on the Hub". Testing it against a real consolidated repo rather than a mock shows that finding the file is not the same as decoding it:

- **`--policy.path=<repo>@<step>` works.** It reads only the `.policy` sub-object of `hf_config.json`.
- **`--config_path=<repo>@<step>` still fails on older checkpoints.** It decodes the *whole* pipeline config, so a train config that predates an unrelated schema change raises before the policy is ever reached. Concretely, on a real 2-step consolidated repo:

  ```
  draccus.utils.DecodingError: `dataset_mixture.datasets.0`: The fields `grounding` are not valid for DatasetConfig
  ```

  `grounding` was renamed to `vqa` in #124.

**`grounding` is deliberately not added to `_STRIPPED_FIELDS`.** That machinery exists for *removed* fields, where dropping them is lossless. This one was **renamed**, so stripping it would let the config decode with `vqa` at its default and silently lose a setting the run was actually trained with — strictly worse than failing loudly. The behavior is right; the claim was wrong, so this narrows the claim and documents the workaround (`--policy.path`, or hand-edit the fetched config).

No code changes, no test changes, no `config_version` implications.

## How it was tested

The claim was checked directly against a published, consolidated checkpoint repo — config-only loads, no weights fetched:

```
policy  OK    <repo>@20000 | type= pi05 | config_version= None
train   FAIL  <repo>@20000 DecodingError `dataset_mixture.datasets.0`: The fields `grounding` …
policy  OK    <repo>@55000 | type= pi05 | config_version= None
train   FAIL  <repo>@55000 DecodingError …
policy  OK    <repo>        | type= pi05 | config_version= None
train   FAIL  <repo>        DecodingError …
```

`grounding`'s history was confirmed with `git log -S grounding -- src/opentau/configs/default.py` → "Rename grounding to vqa (#124)", which is what rules out stripping it.

`pre-commit run --files CHANGELOG.md` clean. No test run applies to a docs-only change; the suites from #492 are unaffected.

Worth noting in passing: that repo is a real instance of the `config_version` bug #492 fixed — its policy config carries no `config_version`, so before that PR it would have been normalized under the *current* convention despite being a pre-versioning checkpoint. It now resolves to legacy `0`.

## How to checkout & try? (for the reviewer)

```bash
git checkout claude/scope-repo-id-loadable-claim
git diff origin/main -- CHANGELOG.md
```

To reproduce the distinction against any pre-`vqa` published checkpoint (downloads only small JSON, no weights):

```bash
uv run python -c "
from opentau.configs.policies import PreTrainedConfig
from opentau.configs.train import TrainPipelineConfig
spec = 'TensorAuto/<some-older-run>@<step>'
print('policy:', PreTrainedConfig.from_pretrained(spec).type)   # works
TrainPipelineConfig.from_pretrained(spec)                        # raises on old schemas
"
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
