### PR TITLE
fix(datasets): read the delta-action horizon under the raw action column

### DIFF
--- a/src/opentau/datasets/factory.py
+++ b/src/opentau/datasets/factory.py
@@ -185,9 +185,12 @@ def _compute_or_load_delta_stats(
     # these stats describe the mean horizon rather than any single draw — an approximation
     # documented on the module.
     dt_mean = dataset.delta_timestamps_params[0]
-    chunk_offsets = np.asarray(dt_mean["actions"], dtype=np.float64) * dataset.fps
-
     name_map = dataset._get_name_map()
+    # `resolve_delta_timestamps` keys its output by RAW on-disk column names (it iterates
+    # `ds_meta.features`), so the action horizon must be looked up under this dataset's own
+    # action column — `"action"` for a standard LeRobot repo — not the `"actions"` alias.
+    chunk_offsets = np.asarray(dt_mean[name_map["actions"]], dtype=np.float64) * dataset.fps
+
     # Bounds the O(frames x chunk_size) pass on very large sources. In the cache key too, so
     # flipping the cap recomputes instead of serving stats from a different sampling budget.
     max_rows = getattr(train_cfg.dataset_mixture, "delta_stats_max_rows", None)

--- a/tests/datasets/test_delta_action_stats.py
+++ b/tests/datasets/test_delta_action_stats.py
@@ -604,7 +604,21 @@ class TestFactoryWiring:
     recompute the identical numbers under a new key. Neither failure raises.
     """
 
-    def _fake_dataset(self, root):
+    def _fake_dataset(self, root, action_col="action"):
+        """A stand-in dataset whose delta-timestamp keys match its own name map.
+
+        ``resolve_delta_timestamps`` keys its output by RAW on-disk column names, so a fake
+        whose ``_get_name_map`` reports ``action_col`` must key ``delta_timestamps_params``
+        by ``action_col`` too. Keying it by the ``"actions"`` alias instead would model no
+        real dataset and would hide a wrong lookup in the code under test.
+
+        Args:
+            root: Dataset root the fake metadata should report.
+            action_col: Raw on-disk name of the action column.
+
+        Returns:
+            A ``SimpleNamespace`` exposing the attributes ``_compute_or_load_delta_stats`` reads.
+        """
         meta = SimpleNamespace(
             root=root,
             episodes=[0, 1],
@@ -613,14 +627,14 @@ class TestFactoryWiring:
         return SimpleNamespace(
             meta=meta,
             episodes=None,
-            delta_timestamps_params=[{"actions": [0.0, 0.05]}],
+            delta_timestamps_params=[{action_col: [0.0, 0.05]}],
             fps=20.0,
             vector_resample_strategy="nearest",
             delta_action_state_map={0: 0},
-            _get_name_map=lambda: {"state": "observation.state", "actions": "action"},
+            _get_name_map=lambda: {"state": "observation.state", "actions": action_col},
         )
 
-    def _run(self, tmp_path, monkeypatch, max_rows):
+    def _run(self, tmp_path, monkeypatch, max_rows, action_col="action"):
         from opentau.configs.default import DatasetConfig, DatasetMixtureConfig
         from opentau.datasets import factory
 
@@ -632,7 +646,7 @@ class TestFactoryWiring:
 
         monkeypatch.setattr(factory, "load_or_compute_delta_action_stats", _capture)
         factory._compute_or_load_delta_stats(
-            self._fake_dataset(tmp_path),
+            self._fake_dataset(tmp_path, action_col=action_col),
             DatasetConfig(repo_id="fake/ds", use_delta_joint_actions=True, delta_action_state_map={0: 0}),
             SimpleNamespace(
                 num_workers=2, dataset_mixture=DatasetMixtureConfig(delta_stats_max_rows=max_rows)
@@ -651,6 +665,29 @@ class TestFactoryWiring:
 
     def test_default_is_uncapped(self, tmp_path, monkeypatch):
         assert self._run(tmp_path, monkeypatch, None)["compute_kwargs"]["max_rows"] is None
+
+    # `delta_timestamps_params` is keyed by the dataset's RAW action column, so the horizon
+    # lookup must go through the name map. Hard-coding the `"actions"` alias raised
+    # `KeyError: 'actions'` at dataset build for every delta run on a repo whose column is
+    # named `action` — which is the LeRobot standard, and most of the registered mappings.
+    @pytest.mark.parametrize("action_col", ["action", "actions"])
+    def test_action_horizon_is_read_under_the_raw_column_name(self, tmp_path, monkeypatch, action_col):
+        chunk_offsets = self._run(tmp_path, monkeypatch, None, action_col=action_col)["compute_kwargs"][
+            "chunk_offsets"
+        ]
+        # [0.0s, 0.05s] at 20 fps -> frame offsets [0, 1].
+        np.testing.assert_allclose(chunk_offsets, [0.0, 1.0])
+
+    def test_raw_column_name_does_not_change_the_cache_key(self, tmp_path, monkeypatch):
+        """Same horizon, different on-disk spelling -> same stats, so the same key.
+
+        The key is built from `chunk_offsets`, not the column name; a rename that reached the
+        key would orphan every cached result for no numerical reason.
+        """
+        assert (
+            self._run(tmp_path, monkeypatch, None, action_col="action")["cache_key"]
+            == self._run(tmp_path, monkeypatch, None, action_col="actions")["cache_key"]
+        )
 
 
 class TestLoadOrCompute:


### PR DESCRIPTION
## What this does

Fixes a `KeyError: 'actions'` that killed **every** `use_delta_joint_actions: true` run at dataset build. (🐛 Bug)

`_compute_or_load_delta_stats` read the action horizon as `dt_mean["actions"]`:

```python
dt_mean = dataset.delta_timestamps_params[0]
chunk_offsets = np.asarray(dt_mean["actions"], dtype=np.float64) * dataset.fps
name_map = dataset._get_name_map()   # fetched, but one line too late
```

But `delta_timestamps_params` comes from `resolve_delta_timestamps`, which keys its output by **raw on-disk column names** — it iterates `ds_meta.features` and writes `delta_timestamps[key]` under that raw key, using `reverse_name_map` only to pick which branch applies. A standard LeRobot repo names the column `action`, so `dt_mean` is `{"action": [...], "observation.state": [...], ...}` and the `"actions"` lookup raises.

Scope:

- `_compute_or_load_delta_stats` has exactly one caller, on the `use_delta_joint_actions` path — absolute-action runs are unaffected.
- Of the 20 mappings in `standard_data_format_mapping.py`, **13 use `"actions": "action"` and 7 use `"actions": "actions"`**. The 7 worked; the 13 — including the LeRobot standard — died before step 1.
- It fails loudly and immediately, so there is no silent-corruption risk, only a wasted allocation for whoever hits it.

The fix moves `name_map` up one line and indexes through it.

Introduced in #485; #491 rewrote the lines immediately below without touching it.

## How it was tested

**The existing test could not have caught this**, which is worth calling out. The one test exercising the function built a fake dataset that was internally inconsistent with itself:

```python
delta_timestamps_params=[{"actions": [0.0, 0.05]}],                         # keyed "actions"
_get_name_map=lambda: {"state": "observation.state", "actions": "action"},  # but the column is "action"
```

A real dataset with that name map keys `delta_timestamps_params` by `"action"`. The fixture keyed it by `"actions"` — modelling no real dataset and matching the buggy lookup exactly, so it passed with the bug and would have kept passing after a naive fix.

- Fixed the fixture to key by the raw column name, and parameterized it on `action_col`. This alone makes the three existing `TestFactoryWiring` tests fail against the old code.
- Added `test_action_horizon_is_read_under_the_raw_column_name`, parameterized over `["action", "actions"]`. It asserts the resulting `chunk_offsets` are `[0.0, 1.0]` (a `[0.0s, 0.05s]` horizon at 20 fps), so it pins the values rather than just asserting no exception.
- Added `test_raw_column_name_does_not_change_the_cache_key` — the key is built from `chunk_offsets`, not the column name, so a rename must not orphan cached stats.

Verified the tests actually fail without the source change (reverted the one line, confirmed 5 failures with `KeyError: 'actions'`, restored it):

- Against the old code: `5 failed, 1 passed`
- With the fix: `65 passed`
- Full directory: `pytest -m "not gpu and not network" -n auto tests/datasets/` → `685 passed, 7 skipped`
- `pre-commit run --files <changed>` → clean

Also confirmed against a real dataset outside CI: a 3-camera LeRobot v3.0 repo with a 16-dim `action` column, `use_delta_joint_actions: true` plus `state_index`/`action_index` subsetting, previously died at `KeyError: 'actions'` and now builds its mixture and computes delta stats end to end.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/datasets/test_delta_action_stats.py -k FactoryWiring
```

To see the bug the tests now pin, revert just the source hunk and re-run — the three pre-existing cases plus the two new ones fail with `KeyError: 'actions'`:

```bash
git stash push src/opentau/datasets/factory.py && pytest -q tests/datasets/test_delta_action_stats.py -k FactoryWiring; git stash pop
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
