### PR TITLE
feat(policies): train_state_action_representation_only finetuning mode

### DIFF
--- a/src/opentau/policies/cosmos3/configuration_cosmos3.py
+++ b/src/opentau/policies/cosmos3/configuration_cosmos3.py
@@ -42,6 +42,7 @@ from opentau.optim.schedulers import (
     CosineDecayWithWarmupSchedulerConfig,
     LRSchedulerConfig,
 )
+from opentau.policies.utils import validate_state_action_representation_only_config
 
 
 @PreTrainedConfig.register_subclass("cosmos3")
@@ -87,6 +88,16 @@ class Cosmos3Config(PreTrainedConfig):
             inside the tower, so it trains too) and freeze the LLM backbone, the action
             expert, and all projections. Requires ``freeze_vision_encoder=False`` and
             ``train_expert_only=False`` (they are mutually exclusive). Defaults to False.
+        train_state_action_representation_only: Train ONLY the dataset-specific state/action
+            representation -- ``state_proj`` / ``action_in_proj`` / ``action_out_proj``, the three
+            projections whose shape is a function of the robot rather than of the architecture --
+            and freeze everything else: the Qwen3-VL backbone, the vision tower, the action expert,
+            and the flow-matching time conditioning (``time_mlp_in`` / ``time_mlp_out`` /
+            ``adarms_proj``). cosmos3 has no FAST discrete-action branch, so unlike π0.5 there is no
+            discrete-action embedding or logit head to train and the mode degenerates to the three
+            projections alone (warned about by the shared validator). Because cosmos3 defaults
+            ``train_expert_only=True``, this flag must be paired with ``train_expert_only=False``.
+            Defaults to False.
         gradient_checkpointing: Checkpoint the expert decoder layers to trade
             compute for activation memory. Defaults to False.
         dropout: Dropout probability inside the expert. Defaults to 0.1.
@@ -162,6 +173,14 @@ class Cosmos3Config(PreTrainedConfig):
     freeze_vision_encoder: bool = True
     train_expert_only: bool = True
     train_vision_encoder_only: bool = False
+
+    # Train ONLY the dataset-specific state/action projections of an otherwise generic
+    # checkpoint; the backbone, the vision tower, the action expert and the flow-matching
+    # time conditioning are all frozen. There is no discrete-action pathway here, so this
+    # is the whole trainable set. Must be paired with train_expert_only=False, which
+    # cosmos3 defaults to True. Defaults to False.
+    train_state_action_representation_only: bool = False
+
     gradient_checkpointing: bool = False
     dropout: float = 0.1
 
@@ -209,6 +228,20 @@ class Cosmos3Config(PreTrainedConfig):
                 "`train_vision_encoder_only=True` requires `freeze_vision_encoder=False` — the vision "
                 "encoder cannot be both frozen and the only trained component."
             )
+        if self.train_state_action_representation_only and self.train_expert_only:
+            # The shared validator rejects this pair too, but its message is generic and
+            # cosmos3 is the one policy that defaults `train_expert_only=True` — so the
+            # collision fires for a user who overrode nothing but the new flag, and a
+            # message about a conflict they never asked for reads like a bug. Name the fix.
+            raise ValueError(
+                "`train_state_action_representation_only=True` and `train_expert_only=True` are "
+                "mutually exclusive, and cosmos3 defaults `train_expert_only=True` — so this flag on "
+                "its own always collides. Set `train_expert_only=False` as well (e.g. "
+                "`--policy.train_expert_only=false`) to train the state/action projections only."
+            )
+        validate_state_action_representation_only_config(
+            self, policy_name=self.type, has_discrete_actions=False
+        )
         if self.n_action_steps > self.chunk_size:
             raise ValueError(
                 "The chunk size is the upper bound for the number of action steps per model "

--- a/src/opentau/policies/cosmos3/modeling_cosmos3.py
+++ b/src/opentau/policies/cosmos3/modeling_cosmos3.py
@@ -52,6 +52,7 @@ from opentau.policies.pretrained import PreTrainedPolicy
 from opentau.policies.utils import (
     PerSampleLoss,
     flow_matching_masked_mse,
+    freeze_policy_level_params_for_state_action_representation_only,
     freeze_policy_level_params_for_vision_only,
 )
 
@@ -151,6 +152,7 @@ class Cosmos3FlowMatching(nn.Module):
             freeze_vision_encoder=config.freeze_vision_encoder,
             train_expert_only=config.train_expert_only,
             train_vision_encoder_only=config.train_vision_encoder_only,
+            train_state_action_representation_only=config.train_state_action_representation_only,
             gradient_checkpointing=config.gradient_checkpointing,
             load_pretrained_backbone_repo=(
                 config.pretrained_backbone_repo_id if config.load_pretrained_backbone else None
@@ -187,6 +189,15 @@ class Cosmos3FlowMatching(nn.Module):
             # backbone.model.visual, already configured by qwen3vl_with_expert's own
             # set_requires_grad.
             freeze_policy_level_params_for_vision_only(self, self.qwen3vl_with_expert)
+
+        if config.train_state_action_representation_only:
+            # Keep ONLY the state/action projections (state_proj / action_in_proj /
+            # action_out_proj) trainable; time_mlp_in/out and adarms_proj are frozen with
+            # everything else, since they map hidden->hidden off the flow-matching time and
+            # condition the (frozen) expert rather than adapting this robot's vector space.
+            # qwen3vl_with_expert has already frozen everything it owns, so this is the
+            # whole trainable set of the policy.
+            freeze_policy_level_params_for_state_action_representation_only(self, self.qwen3vl_with_expert)
 
     # ----- flow-matching sampling utilities (identical to pi05) -----
 

--- a/src/opentau/policies/cosmos3/qwen3vl_with_expert.py
+++ b/src/opentau/policies/cosmos3/qwen3vl_with_expert.py
@@ -580,11 +580,14 @@ class Qwen3VLWithExpertModel(nn.Module):
           ``backbone.model.visual``, so detaching would make vision-only training a silent
           no-op. It is mutually exclusive with ``train_expert_only`` (config validation), so
           it always reaches the ``nullcontext`` branch.
-        * ``train_state_action_representation_only`` **must** be OR-ed in. It freezes the
-          entire backbone (and the expert), so nothing behind the KV can consume a gradient;
-          without it the 32B tower would build and retain a full activation graph for a
-          backward that never reaches it — no crash, just an order-of-magnitude activation
-          memory bill for nothing.
+        * ``train_state_action_representation_only`` is OR-ed in as **belt-and-braces**,
+          not because it changes behaviour today. It freezes every backbone parameter, so
+          with no leaf requiring grad autograd already builds no graph and retains no
+          activations — ``no_grad`` and ``nullcontext`` are observably identical under it
+          (verified: the cached KV has ``grad_fn=None`` and ``requires_grad=False`` either
+          way). Including it keeps the predicate a truthful answer to the question above
+          rather than an accident of which flags happen to freeze what, so it stays correct
+          if the mode's freeze set is ever narrowed.
         """
         backbone_is_frozen = self.train_expert_only or self.train_state_action_representation_only
         ctx = torch.no_grad() if backbone_is_frozen else nullcontext()

--- a/src/opentau/policies/cosmos3/qwen3vl_with_expert.py
+++ b/src/opentau/policies/cosmos3/qwen3vl_with_expert.py
@@ -69,6 +69,11 @@ from torch import Tensor, nn
 from transformers import Qwen3VLConfig, Qwen3VLForConditionalGeneration
 from transformers.models.qwen3_vl.modeling_qwen3_vl import apply_rotary_pos_emb
 
+from opentau.policies.utils import (
+    freeze_with_expert_params_for_state_action_representation_only,
+    set_with_expert_train_mode_for_state_action_representation_only,
+)
+
 
 def _repeat_kv(x: Tensor, n_rep: int) -> Tensor:
     """Expand GQA key/value heads. ``x`` is (B, n_kv, S, hd) -> (B, n_kv*n_rep, S, hd)."""
@@ -357,6 +362,7 @@ class Qwen3VLWithExpertModel(nn.Module):
         freeze_vision_encoder: bool = True,
         train_expert_only: bool = True,
         train_vision_encoder_only: bool = False,
+        train_state_action_representation_only: bool = False,
         gradient_checkpointing: bool = False,
         load_pretrained_backbone_repo: str | None = None,
         condition_on_layer: int | None = None,
@@ -365,6 +371,18 @@ class Qwen3VLWithExpertModel(nn.Module):
         self.freeze_vision_encoder = freeze_vision_encoder
         self.train_expert_only = train_expert_only
         self.train_vision_encoder_only = train_vision_encoder_only
+        self.train_state_action_representation_only = train_state_action_representation_only
+
+        # This wrapper is also constructed directly (CPU tests, bespoke harnesses), where
+        # the policy config's validation never runs — and `train_expert_only` defaults to
+        # True here too, so the collision is the likely mistake rather than an exotic one.
+        if train_state_action_representation_only and (train_expert_only or train_vision_encoder_only):
+            raise ValueError(
+                "`train_state_action_representation_only=True` is mutually exclusive with "
+                "`train_expert_only=True` and `train_vision_encoder_only=True` — it freezes the "
+                "backbone, the vision tower and the action expert, so it cannot be combined with a "
+                "mode that trains one of them. Pass `train_expert_only=False` (it defaults to True)."
+            )
 
         # Deepcopy so the layer-count / attn-impl mutations below stay local and never
         # corrupt the caller's config object (e.g. a shared tiny config across tests).
@@ -479,6 +497,21 @@ class Qwen3VLWithExpertModel(nn.Module):
                 p.requires_grad = False
             for p in self.backbone.model.visual.parameters():
                 p.requires_grad = True
+        if self.train_state_action_representation_only:
+            # Everything this wrapper owns is frozen: the Qwen3-VL backbone (vision tower,
+            # LLM and the never-called lm_head alike) and the action expert. Only the
+            # policy-level state/action projections train, and those live on the enclosing
+            # Cosmos3FlowMatching. The shared default-deny helper would keep a
+            # discrete-action embedding/head trainable, but cosmos3 has neither — so here it
+            # returns an empty trainable set, which is the documented degenerate case.
+            self.backbone.eval()
+            self.expert.eval()
+            freeze_with_expert_params_for_state_action_representation_only(self)
+            # `__init__` leaves the module in training mode, so pin the frozen trunk to
+            # eval right away rather than waiting for the first `train()` call — the
+            # explicit evals above miss this wrapper's own `self.dropout`, a direct child
+            # that fires inside the decoder loop.
+            set_with_expert_train_mode_for_state_action_representation_only(self, self.training)
 
     def train(self, mode: bool = True):
         super().train(mode)
@@ -489,6 +522,11 @@ class Qwen3VLWithExpertModel(nn.Module):
             self.backbone.eval()
             self.expert.eval()
             self.backbone.model.visual.train(mode)
+        elif self.train_state_action_representation_only:
+            # Nothing inside the wrapper trains, so pin it all to eval — otherwise the
+            # expert's `nn.Dropout` would keep firing and inject pure variance between the
+            # frozen features and the tiny projections reading them.
+            set_with_expert_train_mode_for_state_action_representation_only(self, mode)
         elif self.freeze_vision_encoder:
             self.backbone.model.visual.eval()
         return self
@@ -528,19 +566,28 @@ class Qwen3VLWithExpertModel(nn.Module):
 
         When ``train_expert_only`` (the default), the backbone is fully frozen: the forward
         runs under ``no_grad`` and the cached KV is ``.detach()``'d, so the expert reads it
-        as a constant. When ``train_expert_only`` is False (partial unfreeze, e.g. a
-        trainable text tower with a frozen vision encoder, or ``train_vision_encoder_only``
-        with a trainable vision tower and a frozen text tower), the forward keeps its graph
-        and the KV is **not** detached, so the expert's loss backpropagates into the
-        (unfrozen part of the) backbone — otherwise unfreezing would be a silent no-op.
+        as a constant. When the backbone is (partially) unfrozen — e.g. a trainable text
+        tower with a frozen vision encoder, or ``train_vision_encoder_only`` with a trainable
+        vision tower and a frozen text tower — the forward keeps its graph and the KV is
+        **not** detached, so the expert's loss backpropagates into the (unfrozen part of
+        the) backbone; otherwise unfreezing would be a silent no-op.
 
-        This ctx MUST stay keyed on ``train_expert_only`` alone: ``train_vision_encoder_only``
-        is mutually exclusive with it (config validation), so it always takes the
-        ``nullcontext`` branch and gradients reach ``backbone.model.visual``. OR-ing
-        ``train_vision_encoder_only`` into the ``no_grad`` predicate would silently detach the
-        vision tower and make vision-only training a no-op.
+        The predicate below therefore tracks exactly one question — *is any backbone
+        parameter trainable?* — and the two "train only X" flags fall on opposite sides of
+        it, for opposite reasons:
+
+        * ``train_vision_encoder_only`` must **never** be OR-ed in. It trains
+          ``backbone.model.visual``, so detaching would make vision-only training a silent
+          no-op. It is mutually exclusive with ``train_expert_only`` (config validation), so
+          it always reaches the ``nullcontext`` branch.
+        * ``train_state_action_representation_only`` **must** be OR-ed in. It freezes the
+          entire backbone (and the expert), so nothing behind the KV can consume a gradient;
+          without it the 32B tower would build and retain a full activation graph for a
+          backward that never reaches it — no crash, just an order-of-magnitude activation
+          memory bill for nothing.
         """
-        ctx = torch.no_grad() if self.train_expert_only else nullcontext()
+        backbone_is_frozen = self.train_expert_only or self.train_state_action_representation_only
+        ctx = torch.no_grad() if backbone_is_frozen else nullcontext()
         with ctx:
             out = self.backbone.model(
                 input_ids=input_ids,
@@ -554,7 +601,7 @@ class Qwen3VLWithExpertModel(nn.Module):
         cached = []
         for i in range(self.num_layers):
             key, value = pkv[i]
-            if self.train_expert_only:
+            if backbone_is_frozen:
                 key, value = key.detach(), value.detach()
             cached.append((key, value))
         return cached

--- a/src/opentau/policies/pi0/configuration_pi0.py
+++ b/src/opentau/policies/pi0/configuration_pi0.py
@@ -31,6 +31,7 @@ from opentau.optim.schedulers import (
     CosineDecayWithWarmupSchedulerConfig,
     LRSchedulerConfig,
 )
+from opentau.policies.utils import validate_state_action_representation_only_config
 
 
 @PreTrainedConfig.register_subclass("pi0")
@@ -78,6 +79,13 @@ class PI0Config(PreTrainedConfig):
             ``freeze_vision_encoder=False`` and is incompatible with ``train_expert_only=True``.
             Defaults to False.
         train_state_proj: Whether to train the state projection layer. Defaults to True.
+        train_state_action_representation_only: Train ONLY the dataset-specific
+            state/action representation of an otherwise generic checkpoint, freezing the
+            VLM, the vision encoder and the action expert. pi0 has no discrete-action
+            pathway, so this reduces to training ``state_proj`` / ``action_in_proj`` /
+            ``action_out_proj``; ``action_time_mlp_in/out`` stay frozen. Mutually exclusive
+            with ``train_expert_only`` and ``train_vision_encoder_only``, and requires
+            ``train_state_proj=True``. Defaults to False.
         optimizer_lr: Learning rate for the optimizer. Defaults to 2.5e-5.
         optimizer_betas: Beta parameters for AdamW optimizer. Defaults to (0.9, 0.95).
         optimizer_eps: Epsilon parameter for AdamW optimizer. Defaults to 1e-8.
@@ -143,6 +151,16 @@ class PI0Config(PreTrainedConfig):
     train_vision_encoder_only: bool = False
     train_state_proj: bool = True
 
+    # Train ONLY the dataset-specific state/action representation of an otherwise
+    # generic checkpoint: the state/action projections that bridge this robot's raw
+    # vector space and the model's hidden space. The VLM, the vision encoder and the
+    # action expert are all frozen, and so are action_time_mlp_in/out (hidden-size to
+    # hidden-size, fed a sinusoidal embedding of flow-matching time alone). pi0 has no
+    # discrete-action pathway, so unlike the π0.5-family policies there is no embedding
+    # table or logit head to train here and the mode degenerates to "train the three
+    # projections"; the shared validator warns about that. Defaults to False.
+    train_state_action_representation_only: bool = False
+
     # Wrap each transformer-layer forward in torch.utils.checkpoint to trade
     # ~25-33%% same-batch compute for ~30-40 GB of activation memory per rank,
     # typically netting +10-25%% throughput once the freed memory is spent on
@@ -184,6 +202,19 @@ class PI0Config(PreTrainedConfig):
             raise ValueError(
                 "`train_vision_encoder_only=True` requires `freeze_vision_encoder=False` — the vision "
                 "encoder cannot be both frozen and the only trained component."
+            )
+        validate_state_action_representation_only_config(
+            self, policy_name=self.type, has_discrete_actions=False
+        )
+        if self.train_state_action_representation_only and not self.train_state_proj:
+            # Contradictory rather than merely narrower: the state projection is one of
+            # the three parameters this mode exists to train, and pi0 is the only policy
+            # that can even express "freeze it" (`train_state_proj` is pi0-only). Raising
+            # beats silently overriding one flag with the other in either direction.
+            raise ValueError(
+                "`train_state_action_representation_only=True` requires `train_state_proj=True`: "
+                "the state projection is part of the state/action representation this mode trains, "
+                "so asking for it to be frozen at the same time is self-contradictory."
             )
         if self.n_action_steps > self.chunk_size:
             raise ValueError(

--- a/src/opentau/policies/pi0/modeling_pi0.py
+++ b/src/opentau/policies/pi0/modeling_pi0.py
@@ -39,6 +39,7 @@ from opentau.policies.pi0.paligemma_with_expert import (
 from opentau.policies.pretrained import PreTrainedPolicy
 from opentau.policies.utils import (
     PerSampleLoss,
+    freeze_policy_level_params_for_state_action_representation_only,
     freeze_policy_level_params_for_vision_only,
     log_model_loading_keys,
     make_action_dim_mask,
@@ -719,6 +720,7 @@ class PI0FlowMatching(nn.Module):
             freeze_vision_encoder=self.config.freeze_vision_encoder,
             train_expert_only=self.config.train_expert_only,
             train_vision_encoder_only=self.config.train_vision_encoder_only,
+            train_state_action_representation_only=self.config.train_state_action_representation_only,
             attention_implementation=self.config.attention_implementation,
             dropout=self.config.dropout,
             gradient_checkpointing=self.config.gradient_checkpointing,
@@ -745,6 +747,15 @@ class PI0FlowMatching(nn.Module):
             # vision encoder (inside paligemma_with_expert, already configured by its
             # own set_requires_grad) trains. Overrides the train_state_proj setting above.
             freeze_policy_level_params_for_vision_only(self, self.paligemma_with_expert)
+
+        if self.config.train_state_action_representation_only:
+            # Keep ONLY state_proj / action_in_proj / action_out_proj trainable and
+            # freeze action_time_mlp_in/out — nn.Linear defaults to requires_grad=True,
+            # so the two action projections and the time MLPs are never touched by the
+            # train_state_proj loop above and would otherwise stay trainable. Runs last
+            # so it wins; the config already rejects the one combination where the two
+            # would disagree (train_state_proj=False).
+            freeze_policy_level_params_for_state_action_representation_only(self, self.paligemma_with_expert)
 
     def sample_noise(self, shape: tuple[int, ...], device: torch.device | str) -> Tensor:
         """Samples Gaussian noise.

--- a/src/opentau/policies/pi0/paligemma_with_expert.py
+++ b/src/opentau/policies/pi0/paligemma_with_expert.py
@@ -36,6 +36,11 @@ from transformers import (
 )
 from transformers.models.auto import CONFIG_MAPPING
 
+from opentau.policies.utils import (
+    freeze_with_expert_params_for_state_action_representation_only,
+    set_with_expert_train_mode_for_state_action_representation_only,
+)
+
 
 def apply_rope(x: torch.Tensor, positions: torch.Tensor, max_wavelength: int = 10_000) -> torch.Tensor:
     """Applies RoPE positions to the input tensor.
@@ -83,6 +88,7 @@ class PaliGemmaWithExpertConfig(PretrainedConfig):
         freeze_vision_encoder: bool = True,
         train_expert_only: bool = True,
         train_vision_encoder_only: bool = False,
+        train_state_action_representation_only: bool = False,
         attention_implementation: str = "eager",
         dropout: float = 0.1,
         gradient_checkpointing: bool = False,
@@ -100,6 +106,13 @@ class PaliGemmaWithExpertConfig(PretrainedConfig):
                 (the SigLIP tower + the multimodal projector). Requires
                 ``freeze_vision_encoder=False`` and is incompatible with
                 ``train_expert_only=True``. Defaults to False.
+            train_state_action_representation_only: Freeze everything this wrapper owns —
+                the Gemma LLM backbone, the vision pathway (tower *and* multimodal
+                projector) and the action expert. pi0 has no discrete-action embedding or
+                logit head, so nothing here stays trainable; the state/action projections
+                the mode does train live on the enclosing flow-matching module. Mutually
+                exclusive with ``train_expert_only`` and ``train_vision_encoder_only``.
+                Defaults to False.
             attention_implementation: Attention implementation to use ("eager", "sdpa",
                 or "fa2"). Defaults to "eager".
             dropout: Dropout probability. Defaults to 0.1.
@@ -115,6 +128,7 @@ class PaliGemmaWithExpertConfig(PretrainedConfig):
         self.freeze_vision_encoder = freeze_vision_encoder
         self.train_expert_only = train_expert_only
         self.train_vision_encoder_only = train_vision_encoder_only
+        self.train_state_action_representation_only = train_state_action_representation_only
         self.attention_implementation = attention_implementation
         self.dropout = dropout
         self.gradient_checkpointing = gradient_checkpointing
@@ -215,6 +229,15 @@ class PaliGemmaWithExpertConfig(PretrainedConfig):
                 "compatible — the vision encoder cannot be both frozen and the only trained component. "
                 "Set `freeze_vision_encoder=False`."
             )
+        if self.train_state_action_representation_only and (
+            self.train_expert_only or self.train_vision_encoder_only
+        ):
+            raise ValueError(
+                "`train_state_action_representation_only=True` is mutually exclusive with "
+                "`train_expert_only=True` and `train_vision_encoder_only=True` — it freezes the "
+                "action expert and the vision encoder, so it cannot be combined with a mode that "
+                "trains one of them."
+            )
         if self.attention_implementation not in ["eager", "sdpa", "fa2"]:
             raise ValueError(
                 f"Wrong value provided for `attention_implementation` ({self.attention_implementation}). "
@@ -308,6 +331,23 @@ class PaliGemmaWithExpertModel(PreTrainedModel):
                 for params in projector.parameters():
                     params.requires_grad = True
 
+        if self.config.train_state_action_representation_only:
+            # Freeze the VLM (tower, projector and Gemma LLM) and the action expert:
+            # pi0 has no discrete-action embedding or head, so this wrapper keeps
+            # nothing trainable and the whole trainable set is the state/action
+            # projections on the enclosing flow-matching module. Default-deny in one
+            # pass rather than an enumerated freeze list, so a module added later
+            # cannot silently keep training — and so the multimodal projector, which
+            # `freeze_vision_encoder` misses, is covered for free.
+            self.paligemma.eval()
+            self.gemma_expert.eval()
+            freeze_with_expert_params_for_state_action_representation_only(self)
+            # `__init__` leaves the module in training mode, so pin the frozen trunk to
+            # eval right away rather than waiting for the first `train()` call — the
+            # explicit evals above miss this wrapper's own `self.dropout`, a direct child
+            # that fires inside the decoder loop.
+            set_with_expert_train_mode_for_state_action_representation_only(self, self.training)
+
     def train(self, mode: bool = True) -> None:
         """Sets the module in training mode.
 
@@ -330,6 +370,14 @@ class PaliGemmaWithExpertModel(PreTrainedModel):
             projector = self._multi_modal_projector()
             if projector is not None:
                 projector.train(mode)
+
+        if self.config.train_state_action_representation_only:
+            # Nothing this wrapper owns is trainable, so pin all of it to eval —
+            # including this wrapper's own `self.dropout`, which fires on the attention
+            # and MLP outputs inside the decoder loop. Trunk dropout under this flag is
+            # pure variance between frozen features and the projections that read them,
+            # with no regularization benefit, so `config.dropout` has no effect here.
+            set_with_expert_train_mode_for_state_action_representation_only(self, mode)
 
     def to_bfloat16_like_physical_intelligence(self) -> None:
         """Casts specific model components to bfloat16, keeping the SigLIP embeddings in float32.

--- a/src/opentau/policies/pi05/configuration_pi05.py
+++ b/src/opentau/policies/pi05/configuration_pi05.py
@@ -32,6 +32,7 @@ from opentau.optim.schedulers import (
     CosineDecayWithWarmupSchedulerConfig,
     LRSchedulerConfig,
 )
+from opentau.policies.utils import validate_state_action_representation_only_config
 
 
 @PreTrainedConfig.register_subclass("pi05")
@@ -76,6 +77,13 @@ class PI05Config(PreTrainedConfig):
             Note: with ``knowledge_insulation=True`` (the default) the action (MSE) loss is
             detached from the VLM, so the vision encoder trains on the CE loss only — set
             ``knowledge_insulation=False`` to train it from the action loss. Defaults to False.
+        train_state_action_representation_only: Train ONLY the dataset-specific
+            state/action representation of an otherwise generic checkpoint — the
+            discrete-action embedding table + its logit head, and ``state_proj`` (only when
+            ``state_type='continuous'``) / ``action_in_proj`` / ``action_out_proj``. The VLM,
+            the vision encoder and the action expert are frozen, as are ``time_mlp_in/out``
+            and the optional modality embeddings. Mutually exclusive with
+            ``train_expert_only`` and ``train_vision_encoder_only``. Defaults to False.
         optimizer_lr: Learning rate for the optimizer. Defaults to 2.5e-5.
         optimizer_betas: Beta parameters for AdamW optimizer. Defaults to (0.9, 0.95).
         optimizer_eps: Epsilon parameter for AdamW optimizer. Defaults to 1e-8.
@@ -165,6 +173,14 @@ class PI05Config(PreTrainedConfig):
     train_expert_only: bool = False
     train_vision_encoder_only: bool = False
 
+    # Train ONLY the dataset-specific state/action representation of an otherwise
+    # generic checkpoint: the discrete-action embedding table + its logit head, and
+    # the state/action projections that bridge this robot's raw vector space and the
+    # model's hidden space. The VLM, the vision encoder and the action expert are all
+    # frozen. Excludes time_mlp_in/out (hidden-size-only, fed by flow-matching time)
+    # and the optional modality embeddings. Defaults to False.
+    train_state_action_representation_only: bool = False
+
     # Knowledge insulation (π0.5): when True (default), the prefix/VLM KV cache
     # is detached before the action expert reads it, so the flow-matching action
     # loss does NOT backpropagate into the VLM backbone. Set False to let the
@@ -240,6 +256,16 @@ class PI05Config(PreTrainedConfig):
                 "and if the CE loss weight is 0 the step has no gradient path to any trainable "
                 "parameter. Set knowledge_insulation=False to train the vision encoder from the "
                 "action loss."
+            )
+        validate_state_action_representation_only_config(
+            self, policy_name=self.type, has_discrete_actions=True
+        )
+        if self.train_state_action_representation_only and self.state_type == "discrete":
+            logging.warning(
+                "train_state_action_representation_only=True with state_type='discrete': there is "
+                "no state_proj to train (discrete state is binned into text tokens read through "
+                "the frozen VLM embedding table), so the trainable set is the discrete-action "
+                "embedding + head and action_in_proj / action_out_proj only."
             )
         if self.n_action_steps > self.chunk_size:
             raise ValueError(

--- a/src/opentau/policies/pi05/modeling_pi05.py
+++ b/src/opentau/policies/pi05/modeling_pi05.py
@@ -55,6 +55,7 @@ from opentau.policies.utils import (
     PerSampleLoss,
     ce_per_sample,
     flow_matching_masked_mse,
+    freeze_policy_level_params_for_state_action_representation_only,
     freeze_policy_level_params_for_vision_only,
 )
 from opentau.utils.accelerate_utils import get_proc_accelerator
@@ -1144,6 +1145,7 @@ class PI05FlowMatching(nn.Module):
             freeze_vision_encoder=self.config.freeze_vision_encoder,
             train_expert_only=self.config.train_expert_only,
             train_vision_encoder_only=self.config.train_vision_encoder_only,
+            train_state_action_representation_only=self.config.train_state_action_representation_only,
             attention_implementation=self.config.attention_implementation,
             discrete_action_vocab_size=discrete_action_vocab_size,
             dropout=self.config.dropout,
@@ -1190,6 +1192,14 @@ class PI05FlowMatching(nn.Module):
             # modality embeddings) so ONLY the vision encoder inside
             # paligemma_with_expert trains.
             freeze_policy_level_params_for_vision_only(self, self.paligemma_with_expert)
+
+        if self.config.train_state_action_representation_only:
+            # Keep ONLY the state/action projections trainable at the policy level;
+            # the discrete-action representation inside paligemma_with_expert is
+            # already handled by its own set_requires_grad. time_mlp_in/out and the
+            # optional modality embeddings are frozen. Note `state_proj` exists only
+            # when state_type="continuous", which the helper tolerates.
+            freeze_policy_level_params_for_state_action_representation_only(self, self.paligemma_with_expert)
 
     def sample_noise(self, shape: tuple[int, ...], device: torch.device | str) -> Tensor:
         """Samples Gaussian noise.

--- a/src/opentau/policies/pi05/paligemma_with_expert.py
+++ b/src/opentau/policies/pi05/paligemma_with_expert.py
@@ -39,6 +39,10 @@ from transformers.models.auto import CONFIG_MAPPING
 from transformers.models.gemma import modeling_gemma
 
 from opentau.policies import flash_attn_cuda
+from opentau.policies.utils import (
+    freeze_with_expert_params_for_state_action_representation_only,
+    set_with_expert_train_mode_for_state_action_representation_only,
+)
 
 
 def _preferred_dtype():
@@ -116,6 +120,7 @@ class PaliGemmaWithExpertConfig(PretrainedConfig):
         freeze_vision_encoder: bool = True,
         train_expert_only: bool = True,
         train_vision_encoder_only: bool = False,
+        train_state_action_representation_only: bool = False,
         attention_implementation: str = "eager",
         discrete_action_vocab_size: int | None = None,
         dropout: float = 0.1,
@@ -134,6 +139,12 @@ class PaliGemmaWithExpertConfig(PretrainedConfig):
                 train ONLY the vision pathway (the SigLIP tower + the multimodal projector).
                 Requires ``freeze_vision_encoder=False`` and is incompatible with
                 ``train_expert_only=True``. Defaults to False.
+            train_state_action_representation_only: Freeze the VLM backbone, the vision
+                pathway (tower *and* multimodal projector) and the action expert, and
+                train ONLY the discrete-action representation — the embedding table and
+                its logit head. The policy-level state/action projections are handled by
+                the enclosing flow-matching module. Mutually exclusive with
+                ``train_expert_only`` and ``train_vision_encoder_only``. Defaults to False.
             attention_implementation: Attention implementation to use ("eager", "sdpa",
                 or "fa2"). Defaults to "eager".
             discrete_action_vocab_size: Vocabulary size for discrete actions.
@@ -150,6 +161,7 @@ class PaliGemmaWithExpertConfig(PretrainedConfig):
         self.freeze_vision_encoder = freeze_vision_encoder
         self.train_expert_only = train_expert_only
         self.train_vision_encoder_only = train_vision_encoder_only
+        self.train_state_action_representation_only = train_state_action_representation_only
         self.attention_implementation = attention_implementation
         self.discrete_action_vocab_size = discrete_action_vocab_size
         self.dropout = dropout
@@ -238,6 +250,22 @@ class PaliGemmaWithExpertConfig(PretrainedConfig):
 
             cfg_cls = CONFIG_MAPPING[paligemma_config["model_type"]]
             self.gemma_expert_config = cfg_cls(**gemma_expert_config)
+
+        # NOTE: the `__post_init__` below is dead code — `PretrainedConfig` is not a
+        # dataclass, so nothing ever calls it. New validation therefore goes here, in
+        # `__init__`, where it actually runs. (The pre-existing checks are left in
+        # place rather than moved: promoting them to live checks could reject configs
+        # that have been constructed this way for a long time, which belongs in its
+        # own change.)
+        if self.train_state_action_representation_only and (
+            self.train_expert_only or self.train_vision_encoder_only
+        ):
+            raise ValueError(
+                "`train_state_action_representation_only=True` is mutually exclusive with "
+                "`train_expert_only=True` and `train_vision_encoder_only=True` — it freezes the "
+                "action expert and the vision encoder, so it cannot be combined with a mode that "
+                "trains one of them."
+            )
 
         super().__init__(**kwargs)
 
@@ -376,6 +404,21 @@ class PaliGemmaWithExpertModel(PreTrainedModel):
                 for params in projector.parameters():
                     params.requires_grad = True
 
+        if self.config.train_state_action_representation_only:
+            # Mirror image of both modes above: freeze the VLM (tower, projector and
+            # Gemma LLM) and the action expert, leaving ONLY the discrete-action
+            # representation — the embedding table and its logit head — trainable.
+            # Default-deny in one pass rather than an enumerated freeze list, so a
+            # module added later cannot silently keep training.
+            self.paligemma.eval()
+            self.gemma_expert.eval()
+            freeze_with_expert_params_for_state_action_representation_only(self)
+            # `__init__` leaves the module in training mode, so pin the frozen trunk to
+            # eval right away rather than waiting for the first `train()` call — the
+            # explicit evals above miss this wrapper's own `self.dropout`, a direct child
+            # that fires inside the decoder loop.
+            set_with_expert_train_mode_for_state_action_representation_only(self, self.training)
+
     def train(self, mode: bool = True) -> None:
         """Sets the module in training mode.
 
@@ -401,6 +444,12 @@ class PaliGemmaWithExpertModel(PreTrainedModel):
             projector = self._multi_modal_projector()
             if projector is not None:
                 projector.train(mode)
+
+        if self.config.train_state_action_representation_only:
+            # Only the discrete-action representation trains, so pin the entire frozen
+            # trunk — including this wrapper's own `self.dropout`, which fires inside
+            # the decoder loop — to eval. `config.dropout` has no effect under this flag.
+            set_with_expert_train_mode_for_state_action_representation_only(self, mode)
 
     def to_bfloat16_like_physical_intelligence(self) -> None:
         """Casts specific model components to bfloat16, keeping the SigLIP embeddings in float32.

--- a/src/opentau/policies/pi05_mem/configuration_pi05.py
+++ b/src/opentau/policies/pi05_mem/configuration_pi05.py
@@ -33,6 +33,7 @@ from opentau.optim.schedulers import (
     CosineDecayWithWarmupSchedulerConfig,
     LRSchedulerConfig,
 )
+from opentau.policies.utils import validate_state_action_representation_only_config
 
 
 @PreTrainedConfig.register_subclass("pi05_mem")
@@ -85,6 +86,13 @@ class PI05MemConfig(PreTrainedConfig):
             default) the action (MSE) loss is detached from the VLM, so the video encoder
             trains on the CE loss only — set ``knowledge_insulation=False`` to train it from
             the action loss. Defaults to False.
+        train_state_action_representation_only: Train ONLY the dataset-specific
+            state/action representation of an otherwise generic checkpoint — the
+            discrete-action embedding table + its logit head, and ``state_proj`` /
+            ``action_in_proj`` / ``action_out_proj``. The VLM, the video encoder and the
+            action expert are frozen, as are ``time_mlp_in/out`` and — unlike
+            ``train_vision_encoder_only`` — the RLDX ``motion_module``. Mutually exclusive
+            with ``train_expert_only`` and ``train_vision_encoder_only``. Defaults to False.
         spacetime_layer_stride: Every ``stride``-th SigLIP encoder layer gets
             the temporal self-attention sublayer added. Defaults to 4, matching
             the MEM paper. The video encoder introduces no new learnable
@@ -170,6 +178,17 @@ class PI05MemConfig(PreTrainedConfig):
     freeze_vision_encoder: bool = True
     train_expert_only: bool = False
     train_vision_encoder_only: bool = False
+
+    # Train ONLY the dataset-specific state/action representation of an otherwise
+    # generic checkpoint: the discrete-action embedding table + its logit head, and
+    # the state/action projections that bridge this robot's raw vector space and the
+    # model's hidden space. The VLM, the video encoder and the action expert are all
+    # frozen. Excludes time_mlp_in/out (hidden-size-only, fed by flow-matching time)
+    # and — unlike train_vision_encoder_only — the RLDX ``video_encoder.motion_module``:
+    # it is the one module a generic checkpoint does not carry, so it would start from
+    # a fresh zero-gated init in a run whose premise is that only the dataset-facing
+    # adapters move. Defaults to False.
+    train_state_action_representation_only: bool = False
 
     # Knowledge insulation (π0.5): when True (default), the prefix/VLM KV cache
     # is detached before the action expert reads it, so the flow-matching action
@@ -272,6 +291,9 @@ class PI05MemConfig(PreTrainedConfig):
                 "parameter. Set knowledge_insulation=False to train the video encoder from the "
                 "action loss."
             )
+        validate_state_action_representation_only_config(
+            self, policy_name=self.type, has_discrete_actions=True
+        )
         if not isinstance(self.n_obs_steps, int) or self.n_obs_steps < 1:
             raise ValueError(f"`n_obs_steps` must be a positive integer, got {self.n_obs_steps}.")
         if not isinstance(self.history_interval, int) or self.history_interval < 1:

--- a/src/opentau/policies/pi05_mem/modeling_pi05.py
+++ b/src/opentau/policies/pi05_mem/modeling_pi05.py
@@ -67,6 +67,7 @@ from opentau.policies.utils import (
     PerSampleLoss,
     ce_per_sample,
     flow_matching_masked_mse,
+    freeze_policy_level_params_for_state_action_representation_only,
     freeze_policy_level_params_for_vision_only,
 )
 from opentau.utils.accelerate_utils import get_proc_accelerator
@@ -1068,6 +1069,7 @@ class PI05MemFlowMatching(nn.Module):
             freeze_vision_encoder=self.config.freeze_vision_encoder,
             train_expert_only=self.config.train_expert_only,
             train_vision_encoder_only=self.config.train_vision_encoder_only,
+            train_state_action_representation_only=self.config.train_state_action_representation_only,
             attention_implementation=self.config.attention_implementation,
             discrete_action_vocab_size=discrete_action_vocab_size,
             dropout=self.config.dropout,
@@ -1168,6 +1170,16 @@ class PI05MemFlowMatching(nn.Module):
             # tower + projector live under paligemma_with_expert and are already configured
             # by its own set_requires_grad.
             freeze_policy_level_params_for_vision_only(self, self.paligemma_with_expert)
+
+        if self.config.train_state_action_representation_only:
+            # Keep ONLY the state/action projections trainable at the policy level; the
+            # discrete-action representation inside paligemma_with_expert is already
+            # handled by its own set_requires_grad. time_mlp_in/out are frozen, and so
+            # is the RLDX ``video_encoder.motion_module`` — the helper deliberately drops
+            # the name carve-out ``freeze_policy_level_params_for_vision_only`` applies
+            # above, because a fresh zero-gated temporal block is exactly what this mode
+            # must not start learning.
+            freeze_policy_level_params_for_state_action_representation_only(self, self.paligemma_with_expert)
 
     def sample_noise(self, shape: tuple[int, ...], device: torch.device | str) -> Tensor:
         return torch.normal(mean=0.0, std=1.0, size=shape, dtype=torch.float32, device=device)

--- a/src/opentau/policies/pi06/configuration_pi06.py
+++ b/src/opentau/policies/pi06/configuration_pi06.py
@@ -32,6 +32,7 @@ from opentau.optim.schedulers import (
     CosineDecayWithWarmupSchedulerConfig,
     LRSchedulerConfig,
 )
+from opentau.policies.utils import validate_state_action_representation_only_config
 
 
 @PreTrainedConfig.register_subclass("pi06")
@@ -88,6 +89,13 @@ class PI06Config(PreTrainedConfig):
             Note: with ``knowledge_insulation=True`` (the default) the action (MSE) loss is
             detached from the VLM, so the vision encoder trains on the CE loss only — set
             ``knowledge_insulation=False`` to train it from the action loss. Defaults to False.
+        train_state_action_representation_only: Train ONLY the dataset-specific
+            state/action representation of an otherwise generic checkpoint — the
+            discrete-action embedding table + its logit head, plus ``action_in_proj`` /
+            ``action_out_proj``. π0.6 bins state into text tokens and has no ``state_proj``,
+            so there is none to train. The Gemma 3 backbone, the vision encoder and the
+            action expert are frozen, as are ``time_mlp_in/out``. Mutually exclusive with
+            ``train_expert_only`` and ``train_vision_encoder_only``. Defaults to False.
         optimizer_lr: AdamW learning rate. Defaults to 2.5e-5.
         optimizer_betas: AdamW betas. Defaults to (0.9, 0.95).
         optimizer_eps: AdamW epsilon. Defaults to 1e-8.
@@ -158,6 +166,16 @@ class PI06Config(PreTrainedConfig):
     train_expert_only: bool = False
     train_vision_encoder_only: bool = False
 
+    # Train ONLY the dataset-specific state/action representation of an otherwise
+    # generic checkpoint: the discrete-action embedding table + its logit head, and
+    # the projections that bridge this robot's raw action vector space and the model's
+    # hidden space. The Gemma 3 backbone, the vision encoder and the action expert are
+    # all frozen. Note π0.6 has no `state_proj` at all — the state is binned into text
+    # tokens read through the frozen backbone embedding table — so the trainable set
+    # here is narrower than on π0.5: action_in_proj / action_out_proj only. Excludes
+    # time_mlp_in/out (hidden-size-only, fed by flow-matching time). Defaults to False.
+    train_state_action_representation_only: bool = False
+
     # Knowledge insulation (π0.5): when True (default), the prefix/VLM KV cache
     # is detached before the action expert reads it, so the flow-matching action
     # loss does NOT backpropagate into the VLM backbone. Set False to let the
@@ -208,6 +226,9 @@ class PI06Config(PreTrainedConfig):
                 "parameter. Set knowledge_insulation=False to train the vision encoder from the "
                 "action loss."
             )
+        validate_state_action_representation_only_config(
+            self, policy_name=self.type, has_discrete_actions=True
+        )
         if self.n_action_steps > self.chunk_size:
             raise ValueError(
                 f"The chunk size is the upper bound for the number of action steps per model invocation. Got "

--- a/src/opentau/policies/pi06/gemma3_with_expert.py
+++ b/src/opentau/policies/pi06/gemma3_with_expert.py
@@ -47,6 +47,11 @@ from transformers import (
 from transformers.models.auto import CONFIG_MAPPING
 from transformers.models.gemma import modeling_gemma
 
+from opentau.policies.utils import (
+    freeze_with_expert_params_for_state_action_representation_only,
+    set_with_expert_train_mode_for_state_action_representation_only,
+)
+
 # Ensure the Gemma-v1 AdaRMS / gated-residual patches are live before we
 # construct an action expert. Import for side effects only.
 from opentau.utils import transformers_patch  # noqa: F401
@@ -112,6 +117,7 @@ class Gemma3WithExpertConfig(PretrainedConfig):
         freeze_vision_encoder: bool = True,
         train_expert_only: bool = True,
         train_vision_encoder_only: bool = False,
+        train_state_action_representation_only: bool = False,
         attention_implementation: str = "eager",
         discrete_action_vocab_size: int | None = None,
         dropout: float = 0.1,
@@ -132,6 +138,12 @@ class Gemma3WithExpertConfig(PretrainedConfig):
                 train ONLY the vision pathway (the SigLIP tower + the multimodal
                 projector). Requires ``freeze_vision_encoder=False`` and is incompatible
                 with ``train_expert_only=True``.
+            train_state_action_representation_only: Freeze the Gemma 3 backbone, the
+                vision pathway (tower *and* multimodal projector) and the action expert,
+                and train ONLY the discrete-action representation — the embedding table
+                and its logit head. The policy-level action projections are handled by
+                the enclosing flow-matching module. Mutually exclusive with
+                ``train_expert_only`` and ``train_vision_encoder_only``.
             attention_implementation: "eager", "sdpa", or "fa2". "fa2" is not
                 implemented and falls back to eager with a warning. "sdpa"
                 dispatches to ``torch.nn.functional.scaled_dot_product_attention``;
@@ -153,6 +165,7 @@ class Gemma3WithExpertConfig(PretrainedConfig):
         self.freeze_vision_encoder = freeze_vision_encoder
         self.train_expert_only = train_expert_only
         self.train_vision_encoder_only = train_vision_encoder_only
+        self.train_state_action_representation_only = train_state_action_representation_only
         self.attention_implementation = attention_implementation
         self.discrete_action_vocab_size = discrete_action_vocab_size
         self.dropout = dropout
@@ -265,6 +278,15 @@ class Gemma3WithExpertConfig(PretrainedConfig):
                 "compatible — the vision encoder cannot be both frozen and the only trained component. "
                 "Set `freeze_vision_encoder=False`."
             )
+        if self.train_state_action_representation_only and (
+            self.train_expert_only or self.train_vision_encoder_only
+        ):
+            raise ValueError(
+                "`train_state_action_representation_only=True` is mutually exclusive with "
+                "`train_expert_only=True` and `train_vision_encoder_only=True` — it freezes the "
+                "action expert and the vision encoder, so it cannot be combined with a mode that "
+                "trains one of them."
+            )
         if self.attention_implementation not in ["eager", "sdpa", "fa2"]:
             raise ValueError(
                 f"Wrong value provided for `attention_implementation` ({self.attention_implementation}). "
@@ -372,6 +394,22 @@ class Gemma3WithExpertModel(PreTrainedModel):
                     for params in module.parameters():
                         params.requires_grad = True
 
+        if self.config.train_state_action_representation_only:
+            # Mirror image of both modes above: freeze the Gemma 3 backbone (SigLIP
+            # tower, multimodal projector and text stack) and the action expert,
+            # leaving ONLY the discrete-action representation — the embedding table
+            # and its logit head — trainable. Default-deny in one pass rather than an
+            # enumerated freeze list, so a module added later cannot silently keep
+            # training.
+            self.gemma3.eval()
+            self.gemma_expert.eval()
+            freeze_with_expert_params_for_state_action_representation_only(self)
+            # `__init__` leaves the module in training mode, so pin the frozen trunk to
+            # eval right away rather than waiting for the first `train()` call — the
+            # explicit evals above miss this wrapper's own `self.dropout`, a direct child
+            # that fires inside the decoder loop.
+            set_with_expert_train_mode_for_state_action_representation_only(self, self.training)
+
     def train(self, mode: bool = True):
         super().train(mode)
         if self.config.freeze_vision_encoder:
@@ -389,6 +427,12 @@ class Gemma3WithExpertModel(PreTrainedModel):
             for module in (self._vision_tower(), self._multi_modal_projector()):
                 if module is not None:
                     module.train(mode)
+        if self.config.train_state_action_representation_only:
+            # Only the discrete-action representation trains, so pin the entire frozen
+            # trunk — including this wrapper's own `self.dropout`, which fires on every
+            # attention and MLP output inside the decoder loop — to eval.
+            # `config.dropout` therefore has no effect under this flag.
+            set_with_expert_train_mode_for_state_action_representation_only(self, mode)
         return self
 
     def to_bfloat16_like_physical_intelligence(self) -> None:

--- a/src/opentau/policies/pi06/modeling_pi06.py
+++ b/src/opentau/policies/pi06/modeling_pi06.py
@@ -62,6 +62,7 @@ from opentau.policies.utils import (
     assert_gemma3_input_resolution,
     ce_per_sample,
     flow_matching_masked_mse,
+    freeze_policy_level_params_for_state_action_representation_only,
     freeze_policy_level_params_for_vision_only,
 )
 from opentau.utils.accelerate_utils import get_proc_accelerator
@@ -883,6 +884,7 @@ class PI06FlowMatching(nn.Module):
             freeze_vision_encoder=self.config.freeze_vision_encoder,
             train_expert_only=self.config.train_expert_only,
             train_vision_encoder_only=self.config.train_vision_encoder_only,
+            train_state_action_representation_only=self.config.train_state_action_representation_only,
             attention_implementation=self.config.attention_implementation,
             discrete_action_vocab_size=discrete_action_vocab_size,
             dropout=self.config.dropout,
@@ -924,6 +926,15 @@ class PI06FlowMatching(nn.Module):
             # Freeze every policy-level projection (action/time) so ONLY the vision
             # encoder inside gemma3_with_expert trains.
             freeze_policy_level_params_for_vision_only(self, self.gemma3_with_expert)
+
+        if self.config.train_state_action_representation_only:
+            # Keep ONLY the action projections trainable at the policy level; the
+            # discrete-action representation inside gemma3_with_expert is already
+            # handled by its own set_requires_grad. time_mlp_in/out are frozen. π0.6
+            # builds no `state_proj` (state is binned into text tokens), which the
+            # helper tolerates — so the outer trainable set is action_in_proj and
+            # action_out_proj alone.
+            freeze_policy_level_params_for_state_action_representation_only(self, self.gemma3_with_expert)
 
     def sample_noise(self, shape: tuple[int, ...], device: torch.device | str) -> Tensor:
         """Standard Gaussian noise (float32)."""

--- a/src/opentau/policies/pi07/gemma3_with_expert.py
+++ b/src/opentau/policies/pi07/gemma3_with_expert.py
@@ -47,6 +47,11 @@ from transformers import (
 from transformers.models.auto import CONFIG_MAPPING
 from transformers.models.gemma import modeling_gemma
 
+from opentau.policies.utils import (
+    freeze_with_expert_params_for_state_action_representation_only,
+    set_with_expert_train_mode_for_state_action_representation_only,
+)
+
 # Ensure the Gemma-v1 AdaRMS / gated-residual patches are live before we
 # construct an action expert. Import for side effects only.
 from opentau.utils import transformers_patch  # noqa: F401
@@ -112,6 +117,7 @@ class Gemma3WithExpertConfig(PretrainedConfig):
         freeze_vision_encoder: bool = True,
         train_expert_only: bool = True,
         train_vision_encoder_only: bool = False,
+        train_state_action_representation_only: bool = False,
         attention_implementation: str = "eager",
         load_pretrained_gemma3: bool = False,
         discrete_action_vocab_size: int | None = None,
@@ -136,6 +142,16 @@ class Gemma3WithExpertConfig(PretrainedConfig):
                 pathway (the SigLIP tower + the multimodal projector). Requires
                 ``freeze_vision_encoder=False`` and is incompatible with
                 ``train_expert_only=True``.
+            train_state_action_representation_only: Freeze the Gemma 3 backbone
+                (including the reparented interleaved backbone layers), the vision
+                pathway (SigLIP tower *and* multimodal projector) and the action
+                expert, and train ONLY the discrete-action representation — the
+                embedding table and its logit head. The policy-level state/action
+                projections are handled by the enclosing flow-matching module.
+                Mutually exclusive with ``train_expert_only`` and
+                ``train_vision_encoder_only``. Set from the policy config's
+                top-level flag of the same name (plumbed in its ``__post_init__``),
+                not overridden directly. Defaults to False.
             attention_implementation: "eager", "sdpa", or "fa2". "fa2" is not
                 implemented and falls back to eager with a warning. "sdpa"
                 dispatches to ``torch.nn.functional.scaled_dot_product_attention``;
@@ -180,6 +196,7 @@ class Gemma3WithExpertConfig(PretrainedConfig):
         self.freeze_vision_encoder = freeze_vision_encoder
         self.train_expert_only = train_expert_only
         self.train_vision_encoder_only = train_vision_encoder_only
+        self.train_state_action_representation_only = train_state_action_representation_only
         self.attention_implementation = attention_implementation
         self.load_pretrained_gemma3 = load_pretrained_gemma3
         self.discrete_action_vocab_size = discrete_action_vocab_size
@@ -301,6 +318,15 @@ class Gemma3WithExpertConfig(PretrainedConfig):
                 "You set `train_vision_encoder_only=True` and `freeze_vision_encoder=True` which are not "
                 "compatible — the vision encoder cannot be both frozen and the only trained component. "
                 "Set `freeze_vision_encoder=False`."
+            )
+        if self.train_state_action_representation_only and (
+            self.train_expert_only or self.train_vision_encoder_only
+        ):
+            raise ValueError(
+                "`train_state_action_representation_only=True` is mutually exclusive with "
+                "`train_expert_only=True` and `train_vision_encoder_only=True` — it freezes the "
+                "action expert and the vision encoder, so it cannot be combined with a mode that "
+                "trains one of them."
             )
         if self.attention_implementation not in ["eager", "sdpa", "fa2"]:
             raise ValueError(
@@ -733,6 +759,22 @@ class Gemma3WithExpertModel(PreTrainedModel):
                     for params in module.parameters():
                         params.requires_grad = True
 
+        if self.config.train_state_action_representation_only:
+            # Mirror image of both modes above: freeze the Gemma 3 backbone, the vision
+            # pathway and the action expert, leaving ONLY the discrete-action
+            # representation — the embedding table and its logit head — trainable.
+            # Default-deny in one pass rather than an enumerated freeze list, so a module
+            # added later cannot silently keep training; the sweep is over
+            # ``named_parameters()``, which already sees the reparented interleaved
+            # layers wherever they now live.
+            freeze_with_expert_params_for_state_action_representation_only(self)
+            # ``__init__`` leaves the module in training mode, so pin the frozen trunk to
+            # eval right away rather than waiting for the first ``train()`` call. Routed
+            # through the same helper because the backbone/expert layers no longer live
+            # under ``self.gemma3`` / ``self.gemma_expert`` — eval-ing those two by name
+            # would miss them.
+            set_with_expert_train_mode_for_state_action_representation_only(self, self.training)
+
     def train(self, mode: bool = True):
         super().train(mode)
         if self.config.freeze_vision_encoder:
@@ -761,6 +803,14 @@ class Gemma3WithExpertModel(PreTrainedModel):
             for module in (self._vision_tower(), self._multi_modal_projector()):
                 if module is not None:
                     module.train(mode)
+        if self.config.train_state_action_representation_only:
+            # Only the discrete-action representation trains, so pin the whole frozen
+            # trunk — including this wrapper's own ``self.dropout``, which fires inside
+            # the interleaved decoder loop — to eval; ``config.dropout`` therefore has no
+            # effect under this flag. Eval-ing every direct child reaches the reparented
+            # interleaved layers through the ModuleList without calling into their
+            # sub-components, so FSDP's all-gather unit stays whole (CLAUDE.md rule 5).
+            set_with_expert_train_mode_for_state_action_representation_only(self, mode)
         return self
 
     def to_bfloat16_like_physical_intelligence(self) -> None:

--- a/src/opentau/policies/pi07/low_level/configuration_pi07_low_level.py
+++ b/src/opentau/policies/pi07/low_level/configuration_pi07_low_level.py
@@ -34,6 +34,7 @@ from opentau.optim.schedulers import (
     LRSchedulerConfig,
 )
 from opentau.policies.pi07.gemma3_with_expert import Gemma3WithExpertConfig
+from opentau.policies.utils import validate_state_action_representation_only_config
 
 
 @PreTrainedConfig.register_subclass("pi07_low_level")
@@ -114,6 +115,10 @@ class PI07LowLevelConfig(PreTrainedConfig):
             Defaults to True.
         train_expert_only: Whether to train only the action expert.
             Defaults to False.
+        train_state_action_representation_only: Train ONLY the dataset-specific
+            state/action representation of an otherwise generic checkpoint;
+            everything else is frozen. Pushed down into ``vlm_config`` in
+            ``__post_init__``. Defaults to False.
         vlm_config: Bundled :class:`Gemma3WithExpertConfig` for the Gemma 3
             VLM backbone + Gemma-v1 action expert.
         spacetime_layer_stride: Wrap every Nth SigLIP encoder layer with
@@ -213,6 +218,18 @@ class PI07LowLevelConfig(PreTrainedConfig):
     freeze_vision_encoder: bool = True
     train_expert_only: bool = False
 
+    # Train ONLY the dataset-specific state/action representation of an otherwise
+    # generic checkpoint: the discrete-action embedding table + its logit head, and
+    # the state/action projections that bridge this robot's raw vector space and the
+    # model's hidden space (per (robot_type, control_mode) copies of those three when
+    # `per_group_projection` is on). The Gemma 3 VLM, the SpaceTime video encoder and
+    # the action expert are all frozen. Excludes time_mlp_in/out (hidden-size-only,
+    # fed by flow-matching time). Unlike `train_vision_encoder_only`, which pi07
+    # carries on `vlm_config` alone, this one is declared here and pushed down in
+    # `__post_init__` so `--policy.train_state_action_representation_only` is the same
+    # CLI spelling on every policy. Defaults to False.
+    train_state_action_representation_only: bool = False
+
     # Knowledge insulation (π0.5): when True (default), the prefix/VLM KV cache
     # is detached before the action expert reads it, so the flow-matching action
     # loss does NOT backpropagate into the VLM backbone. Set False to let the
@@ -280,14 +297,19 @@ class PI07LowLevelConfig(PreTrainedConfig):
     def __post_init__(self):
         """Post-initialization validation and policy → vlm_config plumbing.
 
-        Plumbs the policy-level ``attention_implementation`` and
-        ``gradient_checkpointing`` flags into ``vlm_config`` so a single
-        ``--policy.attention_implementation`` / ``--policy.gradient_checkpointing``
+        Plumbs the policy-level ``attention_implementation``,
+        ``gradient_checkpointing`` and ``train_state_action_representation_only``
+        flags into ``vlm_config`` so a single ``--policy.attention_implementation``
+        / ``--policy.gradient_checkpointing`` /
+        ``--policy.train_state_action_representation_only``
         CLI override reaches the engine. The video-encoder half of
         ``gradient_checkpointing`` is plumbed separately at model construction
         time (see ``modeling_pi07_low_level.py``). Direct overrides on
         ``--policy.vlm_config.*`` still work and are honoured as-is when the
-        policy-level field is at its default.
+        policy-level field is at its default — except for
+        ``train_state_action_representation_only``, whose two halves must agree, so
+        the policy-level field is authoritative and is pushed down in both
+        directions (see the comment at the push-down site).
         """
         super().__post_init__()
 
@@ -307,6 +329,55 @@ class PI07LowLevelConfig(PreTrainedConfig):
                 "trainable parameter. Set knowledge_insulation=False to train the video encoder from "
                 "the action loss."
             )
+
+        validate_state_action_representation_only_config(
+            self, policy_name=self.type, has_discrete_actions=True
+        )
+        if self.train_state_action_representation_only:
+            # The shared validator reads the sibling "train only X" flags off the policy
+            # config, but on pi07 the ones the engine actually obeys live on
+            # ``vlm_config`` — ``train_vision_encoder_only`` is only declared there, and
+            # the policy-level ``train_expert_only`` is never plumbed down. Re-check both
+            # against ``vlm_config`` here; ``Gemma3WithExpertConfig.__init__`` cannot
+            # catch the conflict itself because the push-down below happens after it ran.
+            for conflicting in ("train_expert_only", "train_vision_encoder_only"):
+                if getattr(self.vlm_config, conflicting):
+                    raise ValueError(
+                        f"`train_state_action_representation_only=True` and "
+                        f"`vlm_config.{conflicting}=True` are mutually exclusive on pi07_low_level: "
+                        f"this mode freezes the VLM, the video encoder and the action expert, so it "
+                        f"cannot be combined with a mode that trains one of them."
+                    )
+        # Push the flag down UNCONDITIONALLY — the policy-level field is the single
+        # source of truth. The True-only shape used by `attention_implementation` and
+        # `gradient_checkpointing` above is safe for those (performance knobs, and a
+        # stale True is harmless), but it is not safe here, because this flag decides
+        # what trains AND `vlm_config` is serialized into the saved config.json. A
+        # one-way push-down leaves two silent half-frozen states:
+        #   * reload an adapter-trained checkpoint with
+        #     `--policy.train_state_action_representation_only=false` to fully finetune:
+        #     the policy-level flag clears but the serialized `vlm_config` one stays
+        #     True, so the VLM and expert stay frozen while the outer projections
+        #     unfreeze — a mode nobody asked for, with no error;
+        #   * set only `--policy.vlm_config.train_state_action_representation_only=true`:
+        #     the trunk freezes but `freeze_policy_level_params_...` never runs, so
+        #     `time_mlp_*` and every other outer parameter keep training.
+        # Warn only when clearing an inner True the policy level did not ask for —
+        # either an inner-only override, or a stale value deserialized from a config
+        # saved by an earlier adapter run. The False -> True direction is the ordinary
+        # push-down and says nothing worth logging.
+        if (
+            self.vlm_config.train_state_action_representation_only
+            and not self.train_state_action_representation_only
+        ):
+            logging.warning(
+                "vlm_config.train_state_action_representation_only=True is cleared because the "
+                "policy-level train_state_action_representation_only=False is authoritative. Set "
+                "the flag on the policy (`--policy.train_state_action_representation_only`), not "
+                "on `vlm_config` — the two halves of this mode must agree, and a half-applied "
+                "freeze would train the outer projections against a frozen VLM silently."
+            )
+        self.vlm_config.train_state_action_representation_only = self.train_state_action_representation_only
 
         if not isinstance(self.n_obs_steps, int) or self.n_obs_steps < 1:
             raise ValueError(f"`n_obs_steps` must be a positive integer, got {self.n_obs_steps}.")

--- a/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
@@ -75,6 +75,7 @@ from opentau.policies.utils import (
     assert_gemma3_input_resolution,
     ce_per_sample,
     flow_matching_masked_mse,
+    freeze_policy_level_params_for_state_action_representation_only,
     freeze_policy_level_params_for_vision_only,
 )
 from opentau.utils.accelerate_utils import get_proc_accelerator
@@ -1521,6 +1522,17 @@ class PI07LowLevelFlowMatching(nn.Module):
             # its own set_requires_grad. The SpaceTime video_encoder is param-less
             # (it reuses the tower), so nothing extra stays trainable there.
             freeze_policy_level_params_for_vision_only(self, self.gemma3_with_expert)
+
+        if self.config.train_state_action_representation_only:
+            # Keep ONLY the state/action projections trainable at the policy level.
+            # Here they may be PerGroupLinear — one (weight, bias) per (robot_type,
+            # control_mode) — which is the most dataset-specific state in the model and
+            # exactly what this mode exists to fit; the helper resolves them by module,
+            # so both flavours are covered. time_mlp_in/out are frozen, and so is the
+            # video encoder: it is param-less and its tower/projector live under
+            # gemma3_with_expert, already frozen by that module's own set_requires_grad
+            # along with everything but the discrete-action representation.
+            freeze_policy_level_params_for_state_action_representation_only(self, self.gemma3_with_expert)
 
     def sample_noise(self, shape: tuple[int, ...], device: torch.device | str) -> Tensor:
         return torch.normal(mean=0.0, std=1.0, size=shape, dtype=torch.float32, device=device)

--- a/src/opentau/policies/pi07_paligemma/low_level/configuration_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/configuration_pi07_low_level.py
@@ -30,6 +30,7 @@ from opentau.optim.schedulers import (
     CosineDecayWithWarmupSchedulerConfig,
     LRSchedulerConfig,
 )
+from opentau.policies.utils import validate_state_action_representation_only_config
 
 
 @PreTrainedConfig.register_subclass("pi07_paligemma_low_level")
@@ -90,6 +91,13 @@ class PI07PaligemmaLowLevelConfig(PreTrainedConfig):
             Note: with ``knowledge_insulation=True`` (the default) the action (MSE) loss is
             detached from the VLM, so the encoder trains on the CE loss only — set
             ``knowledge_insulation=False`` to train it from the action loss. Defaults to False.
+        train_state_action_representation_only: Train ONLY the dataset-specific state/action
+            representation of an otherwise generic checkpoint — the discrete-action embedding
+            table and its logit head, plus ``state_proj`` / ``action_in_proj`` /
+            ``action_out_proj`` (per-group copies included when ``per_group_projection`` is
+            on). The VLM backbone, the SigLIP tower, the multimodal projector and the action
+            expert are frozen, as are ``time_mlp_in``/``time_mlp_out``. Mutually exclusive with
+            ``train_expert_only`` and ``train_vision_encoder_only``. Defaults to False.
         optimizer_lr: Learning rate for the optimizer. Defaults to 2.5e-5.
         optimizer_betas: Beta parameters for AdamW optimizer. Defaults to (0.9, 0.95).
         optimizer_eps: Epsilon parameter for AdamW optimizer. Defaults to 1e-8.
@@ -200,6 +208,17 @@ class PI07PaligemmaLowLevelConfig(PreTrainedConfig):
     train_expert_only: bool = False
     train_vision_encoder_only: bool = False
 
+    # Train ONLY the dataset-specific state/action representation of an otherwise
+    # generic checkpoint: the discrete-action embedding table + its logit head, and
+    # the state/action projections that bridge this robot's raw vector space and the
+    # model's hidden space (per-group copies included when per_group_projection is
+    # on). The VLM, the vision encoder and the action expert are all frozen, as are
+    # time_mlp_in/out (hidden-size-only, fed by flow-matching time). Note that on
+    # this policy `da_head` is not a training-only head: with
+    # eval_use_discrete_actions=True the AR decode argmaxes its logits and re-embeds
+    # the result, so this flag moves serving behavior directly. Defaults to False.
+    train_state_action_representation_only: bool = False
+
     # Knowledge insulation (π0.5): when True (default), the prefix/VLM KV cache
     # is detached before the action expert reads it, so the flow-matching action
     # loss does NOT backpropagate into the VLM backbone. Set False to let the
@@ -275,6 +294,9 @@ class PI07PaligemmaLowLevelConfig(PreTrainedConfig):
                 "only, and if the CE loss weight is 0 the step has no gradient path to any trainable "
                 "parameter. Set knowledge_insulation=False to train the encoder from the action loss."
             )
+        validate_state_action_representation_only_config(
+            self, policy_name=self.type, has_discrete_actions=True
+        )
         if not isinstance(self.n_obs_steps, int) or self.n_obs_steps < 1:
             raise ValueError(f"`n_obs_steps` must be a positive integer, got {self.n_obs_steps}.")
         if not isinstance(self.history_interval, int) or self.history_interval < 1:

--- a/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
@@ -64,6 +64,7 @@ from opentau.policies.utils import (
     PerSampleLoss,
     ce_per_sample,
     flow_matching_masked_mse,
+    freeze_policy_level_params_for_state_action_representation_only,
     freeze_policy_level_params_for_vision_only,
 )
 from opentau.utils.accelerate_utils import get_proc_accelerator
@@ -1985,6 +1986,7 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
             freeze_vision_encoder=self.config.freeze_vision_encoder,
             train_expert_only=self.config.train_expert_only,
             train_vision_encoder_only=self.config.train_vision_encoder_only,
+            train_state_action_representation_only=self.config.train_state_action_representation_only,
             attention_implementation=self.config.attention_implementation,
             load_pretrained_paligemma=False,
             discrete_action_vocab_size=discrete_action_vocab_size,
@@ -2036,6 +2038,15 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
             # the SigLIP tower under paligemma_with_expert, already configured by its own
             # set_requires_grad).
             freeze_policy_level_params_for_vision_only(self, self.paligemma_with_expert)
+
+        if self.config.train_state_action_representation_only:
+            # Keep ONLY the state/action projections trainable at the policy level;
+            # the discrete-action representation inside paligemma_with_expert is
+            # already handled by its own set_requires_grad. time_mlp_in/out are
+            # frozen. This resolves the projections by module identity, so the
+            # PerGroupLinear copies `per_group_projection` builds stay trainable
+            # exactly like the plain nn.Linear ones.
+            freeze_policy_level_params_for_state_action_representation_only(self, self.paligemma_with_expert)
 
     def sample_noise(self, shape: tuple[int, ...], device: torch.device | str) -> Tensor:
         """Samples Gaussian noise.

--- a/src/opentau/policies/utils.py
+++ b/src/opentau/policies/utils.py
@@ -428,3 +428,232 @@ def freeze_policy_level_params_for_vision_only(
         if id(param) in protected or "motion_module" in name:
             continue
         param.requires_grad = False
+
+
+#: Policy-level projections that bridge a *dataset's* raw state/action vector space
+#: and the model's hidden space. Their in- or out-features are ``max_state_dim`` /
+#: ``max_action_dim``, so they are the only outer projections whose shape is a
+#: function of the robot rather than of the architecture — which is exactly what
+#: makes them dataset-specific. Deliberately excludes ``time_mlp_in``/``time_mlp_out``
+#: (and pi0's ``action_time_mlp_*``, cosmos3's ``adarms_proj``): those are
+#: hidden-size-to-hidden-size, are fed a sinusoidal embedding of flow-matching time
+#: alone, and condition the action expert — the same line ``per_group_projection``
+#: already draws when it gives per-(robot_type, control_mode) copies to these three
+#: and notes that "time_mlp_in/out stay shared".
+STATE_ACTION_PROJECTION_ATTRS: tuple[str, ...] = ("state_proj", "action_in_proj", "action_out_proj")
+
+#: With-expert-level modules holding the discrete-action (FAST token) representation:
+#: the input embedding table and the untied head producing logits over the action
+#: vocabulary. Both are pure functions of the fitted FAST tokenizer's vocabulary and
+#: are invalidated by the same event (a tokenizer re-fit), so they move as one unit —
+#: as every existing freeze flag already treats them.
+DISCRETE_ACTION_REPRESENTATION_ATTRS: tuple[str, ...] = ("discrete_action_embedding", "da_head")
+
+
+def validate_state_action_representation_only_config(
+    config: object, *, policy_name: str, has_discrete_actions: bool
+) -> None:
+    """Validate ``train_state_action_representation_only`` on a policy config.
+
+    Shared by every policy config's ``__post_init__`` so the rules cannot drift, and
+    so a policy added later gets them by calling one function rather than by copying
+    a block (the copy-a-block approach is how ``train_vision_encoder_only`` ended up
+    reaching the pi07_paligemma planner but not the pi07 one).
+
+    Enforces mutual exclusion with the two other "train only X" modes, and warns —
+    rather than raises — in the two situations where the flag is legal but trains
+    less than a reader might expect:
+
+    * **No discrete-action pathway** (pi0, cosmos3/cosmos3_nano): bucket (1) is empty
+      and the flag degenerates to "train the state/action projections only". That is
+      a real and useful mode, so it is allowed, but a user who set the flag expecting
+      embedding training must be told.
+    * **Knowledge insulation on** (the default): KI detaches the prefix KV cache
+      before the action expert, which splits the trainable set across two losses —
+      ``state_proj`` and the discrete-action modules are reachable only from CE, while
+      ``action_in_proj``/``action_out_proj`` are reachable only from MSE. Zeroing
+      either ``loss_weighting`` term starves one group entirely.
+
+    Args:
+        config: the policy config being validated (read via ``getattr`` so configs
+            that do not declare a given sibling flag are handled).
+        policy_name: policy name used in the messages, e.g. ``"pi05"``.
+        has_discrete_actions: whether this policy has a discrete-action pathway at
+            all. A static per-policy fact, passed explicitly so the empty-bucket
+            warning cannot be silently skipped by an attribute lookup returning None.
+
+    Raises:
+        ValueError: if combined with ``train_expert_only`` or ``train_vision_encoder_only``.
+    """
+    if not getattr(config, "train_state_action_representation_only", False):
+        return
+
+    for conflicting in ("train_expert_only", "train_vision_encoder_only"):
+        if getattr(config, conflicting, False):
+            raise ValueError(
+                f"`train_state_action_representation_only=True` and `{conflicting}=True` are mutually "
+                f"exclusive on {policy_name}: this mode freezes the VLM, the vision encoder and the "
+                f"action expert, so it cannot be combined with a mode that trains one of them."
+            )
+
+    if not has_discrete_actions:
+        logging.warning(
+            "train_state_action_representation_only=True on %s, which has no discrete-action "
+            "pathway: there is no discrete-action embedding or logit head to train, so this run "
+            "trains ONLY the state/action projections (state_proj / action_in_proj / "
+            "action_out_proj). That is a supported mode, but if you expected the discrete-action "
+            "embeddings to train, you want one of the policies that has a FAST discrete-action "
+            "branch (pi05, pi05_mem, pi06, pi07_low_level, pi07_paligemma_low_level).",
+            policy_name,
+        )
+
+    if getattr(config, "knowledge_insulation", False):
+        logging.warning(
+            "train_state_action_representation_only=True with knowledge_insulation=True on %s: "
+            "knowledge insulation detaches the VLM prefix KV cache before the action expert, so "
+            "the trainable parameters split across two losses — state_proj and the discrete-action "
+            "embedding/head receive gradient ONLY from the CE loss, while action_in_proj and "
+            "action_out_proj receive gradient ONLY from the flow-matching MSE loss. If either "
+            "`loss_weighting` term is 0, that half of the trainable set gets no gradient at all.",
+            policy_name,
+        )
+
+
+def _param_ids_of_attrs(module: nn.Module, attrs: tuple[str, ...]) -> set[int]:
+    """Collect ``id()`` of every parameter under ``attrs`` that exists on ``module``.
+
+    Resolution is by *module object*, never by parameter name. Name matching is
+    unsafe here: ``Normalize``/``Unnormalize`` register their per-dataset statistics
+    as ``nn.Parameter(..., requires_grad=False)`` (see :mod:`opentau.policies.normalize`),
+    so they appear in ``named_parameters()`` as ``normalize_*.buffer_state`` /
+    ``buffer_actions``. Any pattern matching ``state`` or ``action`` would flip those
+    normalization statistics into learned parameters, and the optimizer factory —
+    which selects on ``requires_grad`` alone — would happily optimize them.
+
+    Args:
+        module: the module to resolve attributes against.
+        attrs: attribute names to look up; missing attributes are skipped, since
+            which projections/heads exist varies by policy (pi06 has no
+            ``state_proj`` at all, pi05 only builds one for ``state_type="continuous"``).
+
+    Returns:
+        The set of ``id()`` values of the collected parameters.
+    """
+    ids: set[int] = set()
+    for attr in attrs:
+        submodule = getattr(module, attr, None)
+        if isinstance(submodule, nn.Module):
+            ids.update(id(p) for p in submodule.parameters())
+    return ids
+
+
+def freeze_with_expert_params_for_state_action_representation_only(
+    with_expert_module: nn.Module,
+) -> list[str]:
+    """Freeze the whole VLM/vision/expert stack, keeping only the discrete-action
+    representation trainable, for ``train_state_action_representation_only``.
+
+    This is the inner half of the flag: it configures the ``*WithExpertModel``
+    wrapper. Everything it owns — the VLM backbone and its tied ``lm_head``, the
+    SigLIP/Gemma3/Qwen3-VL vision tower, the multimodal projector, the action expert
+    and its AdaRMS conditioning — is frozen, and only
+    :data:`DISCRETE_ACTION_REPRESENTATION_ATTRS` is left trainable.
+
+    The polarity is deliberately *default-deny*: every parameter is set to
+    ``requires_grad = id(param) in keep`` in one pass, rather than freezing an
+    enumerated list of submodules. Enumerating is how a head silently keeps training
+    when a new module is added — and it is why ``freeze_vision_encoder`` leaves the
+    multimodal projector trainable to this day (it freezes ``vision_tower`` only).
+    Here the projector is covered for free.
+
+    Args:
+        with_expert_module: the ``*WithExpertModel`` wrapper (PaliGemma, Gemma 3 or
+            Qwen3-VL flavour).
+
+    Returns:
+        Sorted names of the parameters left trainable, for logging and tests. Empty
+        for policies with no discrete-action pathway (pi0, cosmos3), which is a
+        supported — and warned-about — degenerate case.
+    """
+    keep = _param_ids_of_attrs(with_expert_module, DISCRETE_ACTION_REPRESENTATION_ATTRS)
+    trainable: list[str] = []
+    for name, param in with_expert_module.named_parameters():
+        param.requires_grad = id(param) in keep
+        if param.requires_grad:
+            trainable.append(name)
+    return sorted(trainable)
+
+
+def set_with_expert_train_mode_for_state_action_representation_only(
+    with_expert_module: nn.Module, mode: bool
+) -> None:
+    """Pin every frozen submodule of the wrapper to ``eval()`` under the flag.
+
+    ``requires_grad=False`` stops weights from updating but does **not** stop
+    ``nn.Dropout`` from firing inside the frozen trunk, and ``update_policy`` calls
+    ``policy.train()`` on every step. Under this flag the trainable set is a single
+    embedding table plus one linear head, so trunk dropout is pure variance injected
+    between the frozen features and the tiny head that reads them — with no
+    regularization benefit, since no trunk weight can move. The wrapper's own
+    ``self.dropout`` (applied to attention and MLP outputs inside the decoder loop)
+    is therefore pinned to eval as well, which means ``config.dropout`` has no effect
+    under this flag.
+
+    Every direct child is evaluated and only the discrete-action modules follow
+    ``mode`` — correct by construction, because under this flag everything that is
+    not a discrete-action module is frozen.
+
+    Args:
+        with_expert_module: the ``*WithExpertModel`` wrapper.
+        mode: the training mode requested by the caller's ``train(mode)``.
+    """
+    for child in with_expert_module.children():
+        child.eval()
+    for attr in DISCRETE_ACTION_REPRESENTATION_ATTRS:
+        submodule = getattr(with_expert_module, attr, None)
+        if isinstance(submodule, nn.Module):
+            submodule.train(mode)
+
+
+def freeze_policy_level_params_for_state_action_representation_only(
+    policy_module: nn.Module, with_expert_module: nn.Module
+) -> list[str]:
+    """Freeze the policy-level (outer) parameters for
+    ``train_state_action_representation_only``, keeping only the state/action
+    projections trainable.
+
+    This is the outer half of the flag, and the mirror image of
+    :func:`freeze_policy_level_params_for_vision_only`: the inner wrapper's
+    ``set_requires_grad`` has already frozen everything it owns except the
+    discrete-action representation, and what remains are the projections and other
+    modules that live on the enclosing flow-matching module. Only
+    :data:`STATE_ACTION_PROJECTION_ATTRS` survives; ``time_mlp_*`` /
+    ``action_time_mlp_*``, the optional modality embeddings, and any video-encoder
+    parameters are frozen.
+
+    Note that unlike :func:`freeze_policy_level_params_for_vision_only` this function
+    has **no ``motion_module`` carve-out**. The pi05_mem RLDX temporal block is part
+    of the video encoder, and it is the one module a generic pretrained checkpoint
+    does *not* contain — it loads fresh and zero-gated. Inheriting the carve-out would
+    silently train a randomly-initialized temporal block in a run whose entire premise
+    is that only the dataset-facing adapters move.
+
+    Args:
+        policy_module: the enclosing flow-matching ``nn.Module``.
+        with_expert_module: the inner ``*WithExpertModel`` submodule, already
+            configured by its own ``set_requires_grad``; its parameters are left
+            untouched here.
+
+    Returns:
+        Sorted names of the outer parameters left trainable, for logging and tests.
+    """
+    protected = {id(p) for p in with_expert_module.parameters()}
+    keep = _param_ids_of_attrs(policy_module, STATE_ACTION_PROJECTION_ATTRS)
+    trainable: list[str] = []
+    for name, param in policy_module.named_parameters():
+        if id(param) in protected:
+            continue
+        param.requires_grad = id(param) in keep
+        if param.requires_grad:
+            trainable.append(name)
+    return sorted(trainable)

--- a/tests/policies/test_cosmos3_cpu.py
+++ b/tests/policies/test_cosmos3_cpu.py
@@ -604,3 +604,123 @@ def test_cosmos3_train_vision_encoder_only_grad_flows_to_visual():
     )
     assert all(p.grad is None for p in we.expert.parameters())
     assert all(p.grad is None for p in we.backbone.model.language_model.parameters())
+
+
+# --------------------------------------------------- train_state_action_representation_only
+
+
+def _tiny_repr_only_model():
+    """Tiny cosmos3 with the state/action-representation-only regime enabled.
+
+    ``train_expert_only`` defaults to True on cosmos3 and is mutually exclusive with
+    this flag, so it has to be turned off explicitly.
+    """
+    torch.manual_seed(0)
+    cfg = _tiny_cosmos3_config(
+        train_expert_only=False,
+        freeze_vision_encoder=True,
+        train_state_action_representation_only=True,
+    )
+    return Cosmos3FlowMatching(cfg, qwen3vl_config=_tiny_qwen3vl_config())
+
+
+def test_cosmos3_state_action_representation_only_trainable_set():
+    """cosmos3 has no FAST discrete-action branch, so the mode reduces to the three
+    dataset-facing projections; the time MLPs and adarms_proj stay frozen."""
+    model = _tiny_repr_only_model()
+
+    trainable = sorted(n for n, p in model.named_parameters() if p.requires_grad)
+
+    assert trainable == [
+        "action_in_proj.bias",
+        "action_in_proj.weight",
+        "action_out_proj.bias",
+        "action_out_proj.weight",
+        "state_proj.bias",
+        "state_proj.weight",
+    ]
+    # The wrapper itself ends fully frozen — including the never-called `lm_head`,
+    # which stays trainable if `backbone.model` is frozen instead of `backbone`.
+    assert not any(p.requires_grad for p in model.qwen3vl_with_expert.parameters())
+
+
+def test_cosmos3_state_action_representation_only_pins_trunk_to_eval():
+    model = _tiny_repr_only_model()
+
+    model.train(True)
+
+    we = model.qwen3vl_with_expert
+    assert not we.backbone.training
+    assert not we.expert.training
+    assert not any(m.training for m in we.modules() if isinstance(m, torch.nn.Dropout))
+
+
+def test_cosmos3_state_action_representation_only_prefix_kv_carries_no_graph():
+    """The prefix KV reaching the expert carries no autograd graph under this flag.
+
+    Note what this does and does not pin. It pins the *observable contract* — the
+    expert reads the prefix as a constant, so no gradient can flow back into the
+    backbone. It deliberately does NOT claim to be a regression guard on the
+    ``backbone_is_frozen`` predicate in ``run_prefix``: because the flag freezes every
+    backbone parameter, no leaf requires grad and autograd builds no graph whether the
+    forward runs under ``no_grad`` or ``nullcontext``. Reverting that predicate to
+    ``train_expert_only`` alone leaves this assertion passing, by design — the OR is
+    belt-and-braces, not load-bearing (see the ``run_prefix`` docstring). The real
+    guards on this mode are the trainable-set and gradient-reachability tests above.
+    """
+    model = _tiny_repr_only_model()
+    input_ids, attention_mask, _, _ = _text_batch()
+
+    prefix_position_ids, _ = model.qwen3vl_with_expert.get_rope_index(
+        input_ids=input_ids, image_grid_thw=None, attention_mask=attention_mask
+    )
+    cached = model.qwen3vl_with_expert.run_prefix(
+        input_ids=input_ids,
+        attention_mask=attention_mask,
+        position_ids=prefix_position_ids,
+        pixel_values=None,
+        image_grid_thw=None,
+    )
+
+    for key, value in cached:
+        assert key.grad_fn is None, "prefix KV must be detached when the backbone is frozen"
+        assert value.grad_fn is None
+        assert not key.requires_grad
+        assert not value.requires_grad
+
+
+def test_cosmos3_state_action_representation_only_grad_reaches_only_projections():
+    model = _tiny_repr_only_model()
+    input_ids, attention_mask, state, actions = _text_batch()
+
+    out = model(
+        input_ids=input_ids,
+        attention_mask=attention_mask,
+        pixel_values=None,
+        image_grid_thw=None,
+        state=state,
+        actions=actions,
+        noise=torch.randn_like(actions),
+        time=torch.rand(actions.shape[0]),
+    )
+    out["MSE"].backward()
+
+    we = model.qwen3vl_with_expert
+    assert model.action_in_proj.weight.grad is not None
+    assert model.action_out_proj.weight.grad is not None
+    assert model.time_mlp_in.weight.grad is None
+    assert all(p.grad is None for p in we.backbone.parameters())
+    assert all(p.grad is None for p in we.expert.parameters())
+
+
+def test_cosmos3_state_action_representation_only_config_validation():
+    # cosmos3 defaults train_expert_only=True, so the bare flag collides.
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        _tiny_cosmos3_config(train_state_action_representation_only=True)
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        _tiny_cosmos3_config(
+            train_expert_only=False,
+            freeze_vision_encoder=False,
+            train_vision_encoder_only=True,
+            train_state_action_representation_only=True,
+        )

--- a/tests/policies/test_cosmos3_cpu.py
+++ b/tests/policies/test_cosmos3_cpu.py
@@ -708,6 +708,9 @@ def test_cosmos3_state_action_representation_only_grad_reaches_only_projections(
     we = model.qwen3vl_with_expert
     assert model.action_in_proj.weight.grad is not None
     assert model.action_out_proj.weight.grad is not None
+    # state_proj is the third trainable projection and the only one whose path runs
+    # through embed_suffix into the (frozen) expert rather than straight to the loss.
+    assert model.state_proj.weight.grad is not None
     assert model.time_mlp_in.weight.grad is None
     assert all(p.grad is None for p in we.backbone.parameters())
     assert all(p.grad is None for p in we.expert.parameters())

--- a/tests/policies/test_state_action_representation_only_helper.py
+++ b/tests/policies/test_state_action_representation_only_helper.py
@@ -1,0 +1,333 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the ``train_state_action_representation_only`` helpers.
+
+The flag trains only the dataset-specific state/action representation of an
+otherwise-generic VLA checkpoint: the discrete-action embedding table plus its
+logit head (inner, on the ``*WithExpertModel``) and the state/action projections
+(outer, on the flow-matching module). Everything else — VLM, vision encoder,
+multimodal projector, action expert, time MLPs, modality embeddings, the RLDX
+``motion_module`` — is frozen.
+
+These tests use hand-rolled fakes so they pin the helpers' *semantics* rather
+than any one policy's wiring; the per-policy end-to-end coverage lives in
+``test_state_action_representation_only_policies.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import pytest
+import torch
+from torch import nn
+
+from opentau.policies.utils import (
+    freeze_policy_level_params_for_state_action_representation_only,
+    freeze_with_expert_params_for_state_action_representation_only,
+    set_with_expert_train_mode_for_state_action_representation_only,
+    validate_state_action_representation_only_config,
+)
+
+
+class _FakeWithExpert(nn.Module):
+    """Stands in for a ``*WithExpertModel``: VLM + vision + expert + discrete heads."""
+
+    def __init__(self, *, discrete: bool = True):
+        super().__init__()
+        self.vision_tower = nn.Linear(4, 4)
+        self.multi_modal_projector = nn.Linear(4, 4)
+        self.language_model = nn.Linear(4, 4)
+        self.expert = nn.Linear(4, 4)
+        self.dropout = nn.Dropout(0.5)
+        if discrete:
+            self.discrete_action_embedding = nn.Embedding(8, 4)
+            self.da_head = nn.Linear(4, 8)
+
+
+class _FakeVideoEncoder(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.motion_module = nn.Linear(4, 4)
+
+
+class _FakePolicy(nn.Module):
+    def __init__(self, *, discrete: bool = True, state_proj: bool = True):
+        super().__init__()
+        self.with_expert = _FakeWithExpert(discrete=discrete)
+        self.video_encoder = _FakeVideoEncoder()
+        self.action_in_proj = nn.Linear(4, 4)
+        self.action_out_proj = nn.Linear(4, 4)
+        if state_proj:
+            self.state_proj = nn.Linear(4, 4)
+        # Frozen by the flag: hidden-size-only, fed by flow-matching time.
+        self.time_mlp_in = nn.Linear(4, 4)
+        self.time_mlp_out = nn.Linear(4, 4)
+        self.modality_embedding = nn.Embedding(5, 4)
+
+
+def _configure(model: _FakePolicy) -> None:
+    """Run both halves of the flag, in the order the policies run them."""
+    freeze_with_expert_params_for_state_action_representation_only(model.with_expert)
+    freeze_policy_level_params_for_state_action_representation_only(model, model.with_expert)
+
+
+# --------------------------------------------------------------------------- inner half
+
+
+def test_with_expert_keeps_only_the_discrete_action_representation():
+    with_expert = _FakeWithExpert()
+
+    kept = freeze_with_expert_params_for_state_action_representation_only(with_expert)
+
+    assert kept == ["da_head.bias", "da_head.weight", "discrete_action_embedding.weight"]
+    assert all(p.requires_grad for p in with_expert.discrete_action_embedding.parameters())
+    assert all(p.requires_grad for p in with_expert.da_head.parameters())
+    for frozen in (with_expert.vision_tower, with_expert.language_model, with_expert.expert):
+        assert not any(p.requires_grad for p in frozen.parameters())
+
+
+def test_with_expert_freezes_the_multimodal_projector():
+    """``freeze_vision_encoder`` freezes only the tower and leaves the projector
+    trainable; the default-deny helper must cover the projector too."""
+    with_expert = _FakeWithExpert()
+
+    freeze_with_expert_params_for_state_action_representation_only(with_expert)
+
+    assert not any(p.requires_grad for p in with_expert.multi_modal_projector.parameters())
+
+
+def test_with_expert_without_discrete_modules_freezes_everything():
+    """pi0 / cosmos3 have no discrete-action pathway: the wrapper ends fully frozen."""
+    with_expert = _FakeWithExpert(discrete=False)
+
+    kept = freeze_with_expert_params_for_state_action_representation_only(with_expert)
+
+    assert kept == []
+    assert not any(p.requires_grad for p in with_expert.parameters())
+
+
+def test_with_expert_freeze_is_idempotent():
+    with_expert = _FakeWithExpert()
+
+    first = freeze_with_expert_params_for_state_action_representation_only(with_expert)
+    second = freeze_with_expert_params_for_state_action_representation_only(with_expert)
+
+    assert first == second
+
+
+# --------------------------------------------------------------------------- outer half
+
+
+def test_policy_level_keeps_only_the_state_action_projections():
+    model = _FakePolicy()
+
+    _configure(model)
+
+    kept = sorted(n for n, p in model.named_parameters() if p.requires_grad)
+    assert kept == [
+        "action_in_proj.bias",
+        "action_in_proj.weight",
+        "action_out_proj.bias",
+        "action_out_proj.weight",
+        "state_proj.bias",
+        "state_proj.weight",
+        "with_expert.da_head.bias",
+        "with_expert.da_head.weight",
+        "with_expert.discrete_action_embedding.weight",
+    ]
+
+
+def test_time_mlps_and_modality_embeddings_are_frozen():
+    """The time MLPs are hidden-size-only and condition the (frozen) expert; the
+    modality embeddings are not a state/action representation. Both stay frozen."""
+    model = _FakePolicy()
+
+    _configure(model)
+
+    assert not any(p.requires_grad for p in model.time_mlp_in.parameters())
+    assert not any(p.requires_grad for p in model.time_mlp_out.parameters())
+    assert not any(p.requires_grad for p in model.modality_embedding.parameters())
+
+
+def test_motion_module_is_frozen_unlike_the_vision_only_helper():
+    """Regression guard: ``freeze_policy_level_params_for_vision_only`` carves the
+    RLDX ``motion_module`` out by name so it keeps training. Inheriting that clause
+    here would silently train a freshly-initialized temporal block in a run whose
+    whole premise is that only the dataset-facing adapters move."""
+    model = _FakePolicy()
+
+    _configure(model)
+
+    assert not any(p.requires_grad for p in model.video_encoder.motion_module.parameters())
+
+
+def test_policy_without_state_proj_is_fine():
+    """pi06 has no ``state_proj`` at all, and pi05 only builds one for
+    ``state_type='continuous'``. A missing attribute is not an error."""
+    model = _FakePolicy(state_proj=False)
+
+    _configure(model)
+
+    kept = sorted(n for n, p in model.named_parameters() if p.requires_grad)
+    assert "action_in_proj.weight" in kept
+    assert not any(n.startswith("state_proj") for n in kept)
+
+
+def test_inner_params_are_not_re_enabled_by_the_outer_helper():
+    """The outer helper must skip everything the inner one already configured,
+    rather than re-deriving it — otherwise the two halves can disagree."""
+    model = _FakePolicy()
+    freeze_with_expert_params_for_state_action_representation_only(model.with_expert)
+
+    freeze_policy_level_params_for_state_action_representation_only(model, model.with_expert)
+
+    assert all(p.requires_grad for p in model.with_expert.discrete_action_embedding.parameters())
+    assert not any(p.requires_grad for p in model.with_expert.language_model.parameters())
+
+
+def test_normalization_buffers_are_never_unfrozen():
+    """``Normalize``/``Unnormalize`` register per-dataset statistics as
+    ``nn.Parameter(requires_grad=False)``, so they show up in ``named_parameters()``
+    under names containing 'state'/'actions'. Selecting the trainable set by NAME
+    would turn normalization statistics into learned parameters — and the optimizer
+    factory selects on ``requires_grad`` alone, so nothing downstream would catch it."""
+
+    class _PolicyWithNormBuffers(_FakePolicy):
+        def __init__(self):
+            super().__init__()
+            self.normalize_inputs = nn.Module()
+            self.normalize_inputs.buffer_state = nn.Parameter(torch.zeros(4), requires_grad=False)
+            self.normalize_targets = nn.Module()
+            self.normalize_targets.buffer_actions = nn.Parameter(torch.zeros(4), requires_grad=False)
+
+    model = _PolicyWithNormBuffers()
+
+    _configure(model)
+
+    assert not model.normalize_inputs.buffer_state.requires_grad
+    assert not model.normalize_targets.buffer_actions.requires_grad
+
+
+def test_backward_reaches_only_the_representation_params():
+    model = _FakePolicy()
+    _configure(model)
+
+    x = torch.randn(2, 4)
+    y = model.action_out_proj(model.with_expert.language_model(model.action_in_proj(x)))
+    y.sum().backward()
+
+    assert model.action_in_proj.weight.grad is not None
+    assert model.action_out_proj.weight.grad is not None
+    assert model.with_expert.language_model.weight.grad is None
+    assert model.time_mlp_in.weight.grad is None
+
+
+# --------------------------------------------------------------------------- train() pinning
+
+
+def test_train_mode_pins_the_frozen_trunk_to_eval():
+    with_expert = _FakeWithExpert()
+    freeze_with_expert_params_for_state_action_representation_only(with_expert)
+
+    with_expert.train(True)
+    set_with_expert_train_mode_for_state_action_representation_only(with_expert, True)
+
+    assert not with_expert.vision_tower.training
+    assert not with_expert.language_model.training
+    assert not with_expert.expert.training
+    # The wrapper's own dropout fires inside the decoder loop, i.e. inside the frozen
+    # trunk: it must be pinned to eval too, so `config.dropout` is a no-op under the flag.
+    assert not with_expert.dropout.training
+    # ... while the trained representation follows the requested mode.
+    assert with_expert.discrete_action_embedding.training
+    assert with_expert.da_head.training
+
+
+def test_train_mode_false_leaves_everything_in_eval():
+    with_expert = _FakeWithExpert()
+
+    # Mirror the real call sequence: the wrapper's `train()` runs `super().train(mode)`
+    # (which sets the wrapper's own flag) before delegating to the helper.
+    with_expert.train(False)
+    set_with_expert_train_mode_for_state_action_representation_only(with_expert, False)
+
+    assert not any(m.training for m in with_expert.modules())
+
+
+# --------------------------------------------------------------------------- config validation
+
+
+@dataclass
+class _FakeConfig:
+    train_state_action_representation_only: bool = True
+    train_expert_only: bool = False
+    train_vision_encoder_only: bool = False
+    knowledge_insulation: bool = False
+
+
+def test_validator_is_a_noop_when_the_flag_is_off():
+    cfg = _FakeConfig(train_state_action_representation_only=False, train_expert_only=True)
+
+    validate_state_action_representation_only_config(cfg, policy_name="fake", has_discrete_actions=True)
+
+
+@pytest.mark.parametrize("conflicting", ["train_expert_only", "train_vision_encoder_only"])
+def test_validator_rejects_the_other_train_only_modes(conflicting):
+    cfg = _FakeConfig(**{conflicting: True})
+
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        validate_state_action_representation_only_config(cfg, policy_name="fake", has_discrete_actions=True)
+
+
+def test_validator_warns_when_there_is_no_discrete_action_pathway(caplog):
+    cfg = _FakeConfig()
+
+    with caplog.at_level(logging.WARNING):
+        validate_state_action_representation_only_config(cfg, policy_name="pi0", has_discrete_actions=False)
+
+    assert "no discrete-action" in caplog.text
+    assert "pi0" in caplog.text
+
+
+def test_validator_does_not_warn_when_the_discrete_pathway_exists(caplog):
+    cfg = _FakeConfig()
+
+    with caplog.at_level(logging.WARNING):
+        validate_state_action_representation_only_config(cfg, policy_name="pi05", has_discrete_actions=True)
+
+    assert "no discrete-action" not in caplog.text
+
+
+def test_validator_warns_under_knowledge_insulation(caplog):
+    """KI splits the trainable set across two losses; it is a warning, not an error,
+    so a CE-only or MSE-only run stays possible on purpose."""
+    cfg = _FakeConfig(knowledge_insulation=True)
+
+    with caplog.at_level(logging.WARNING):
+        validate_state_action_representation_only_config(cfg, policy_name="pi05", has_discrete_actions=True)
+
+    assert "knowledge_insulation" in caplog.text
+    assert "CE loss" in caplog.text
+
+
+def test_validator_does_not_warn_without_knowledge_insulation(caplog):
+    cfg = _FakeConfig(knowledge_insulation=False)
+
+    with caplog.at_level(logging.WARNING):
+        validate_state_action_representation_only_config(cfg, policy_name="pi05", has_discrete_actions=True)
+
+    assert "knowledge_insulation" not in caplog.text

--- a/tests/policies/test_state_action_representation_only_policies.py
+++ b/tests/policies/test_state_action_representation_only_policies.py
@@ -1,0 +1,559 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end coverage for ``train_state_action_representation_only`` on the
+*real* policy modules.
+
+``test_state_action_representation_only_helper.py`` pins the helpers' semantics
+against hand-rolled fakes. That is not enough on its own: the fakes cannot catch
+a wrapper whose layout differs from the fake (pi07 reparents its decoder layers
+into ``InterleavedDecoderLayer``, so eval-ing ``self.gemma3`` by name would miss
+them), nor a policy that simply forgets to thread the flag into its with-expert
+config — which is a silent no-op on the whole VLM side.
+
+So these tests construct the actual ``*WithExpertModel`` wrappers and the actual
+flow-matching modules with tiny configs, and assert the observed trainable set
+and eval pinning.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import draccus
+import pytest
+import torch
+from torch import nn
+from transformers.models.auto import CONFIG_MAPPING
+
+from opentau.policies.factory import make_policy_config
+from opentau.policies.pi0.paligemma_with_expert import (
+    PaliGemmaWithExpertConfig as PI0WithExpertConfig,
+)
+from opentau.policies.pi0.paligemma_with_expert import (
+    PaliGemmaWithExpertModel as PI0WithExpertModel,
+)
+from opentau.policies.pi05 import modeling_pi05
+from opentau.policies.pi05.configuration_pi05 import PI05Config
+from opentau.policies.pi05.modeling_pi05 import PI05FlowMatching
+from opentau.policies.pi05.paligemma_with_expert import (
+    PaliGemmaWithExpertConfig as PI05WithExpertConfig,
+)
+from opentau.policies.pi05.paligemma_with_expert import (
+    PaliGemmaWithExpertModel as PI05WithExpertModel,
+)
+from opentau.policies.pi06.gemma3_with_expert import (
+    Gemma3WithExpertConfig as PI06WithExpertConfig,
+)
+from opentau.policies.pi06.gemma3_with_expert import (
+    Gemma3WithExpertModel as PI06WithExpertModel,
+)
+from opentau.policies.pi07.gemma3_with_expert import (
+    Gemma3WithExpertConfig as PI07WithExpertConfig,
+)
+from opentau.policies.pi07.gemma3_with_expert import (
+    Gemma3WithExpertModel as PI07WithExpertModel,
+)
+
+DISCRETE_PARAMS = {
+    "da_head.bias",
+    "da_head.weight",
+    "discrete_action_embedding.weight",
+}
+
+
+# --------------------------------------------------------------------------- tiny configs
+
+
+def _tiny_paligemma_sub_configs(cfg):
+    """Overwrite a ``PaliGemmaWithExpertConfig``'s sub-configs with tiny ones.
+
+    Mirrors ``_make_tiny_pi0_engine_config`` in ``test_pi0.py``: the config's
+    ``elif isinstance(self.paligemma_config, dict)`` branch is broken, so tiny
+    sub-configs have to be assigned after construction.
+    """
+    cfg.paligemma_config = CONFIG_MAPPING["paligemma"](
+        _vocab_size=128,
+        bos_token_id=2,
+        eos_token_id=1,
+        hidden_size=32,
+        image_token_index=127,
+        pad_token_id=0,
+        projection_dim=32,
+        text_config={
+            "model_type": "gemma",
+            "hidden_size": 32,
+            "intermediate_size": 64,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+            "head_dim": 16,
+            "vocab_size": 128,
+            "max_position_embeddings": 128,
+            "hidden_activation": "gelu_pytorch_tanh",
+            "use_adarms": False,
+            "adarms_cond_dim": None,
+            "num_image_tokens": 4,
+        },
+        vision_config={
+            "model_type": "siglip_vision_model",
+            "hidden_size": 16,
+            "intermediate_size": 32,
+            "num_attention_heads": 2,
+            "num_hidden_layers": 2,
+            "num_image_tokens": 4,
+            "patch_size": 14,
+            "projection_dim": 32,
+            "vision_use_head": False,
+            "image_size": 28,
+        },
+    )
+    cfg.gemma_expert_config = CONFIG_MAPPING["gemma"](
+        hidden_size=16,
+        intermediate_size=32,
+        num_hidden_layers=2,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=8,
+        vocab_size=128,
+        max_position_embeddings=128,
+        hidden_activation="gelu_pytorch_tanh",
+        use_adarms=True,
+        adarms_cond_dim=16,
+    )
+    return cfg
+
+
+_TINY_GEMMA3 = {
+    "text_config": {
+        "model_type": "gemma3_text",
+        "hidden_size": 32,
+        "intermediate_size": 64,
+        "num_hidden_layers": 2,
+        "num_attention_heads": 2,
+        "num_key_value_heads": 1,
+        "head_dim": 16,
+        "sliding_window": 2,
+        "rope_theta": 1_000_000.0,
+        "rope_local_base_freq": 10_000.0,
+        "query_pre_attn_scalar": 16,
+        "rms_norm_eps": 1e-6,
+        "vocab_size": 128,
+        "max_position_embeddings": 512,
+        "attention_bias": False,
+        "attention_dropout": 0.0,
+        "hidden_activation": "gelu_pytorch_tanh",
+        "sliding_window_pattern": 2,
+        "torch_dtype": "float32",
+        "layer_types": ["sliding_attention", "full_attention"],
+    },
+    "vision_config": {
+        "model_type": "siglip_vision_model",
+        "hidden_size": 16,
+        "intermediate_size": 32,
+        "num_attention_heads": 2,
+        "num_hidden_layers": 2,
+        "patch_size": 14,
+        "image_size": 448,
+        "projection_dim": 32,
+        "projector_hidden_act": "gelu_fast",
+        "vision_use_head": False,
+        "torch_dtype": "float32",
+        "layer_norm_eps": 1e-6,
+    },
+    "image_token_index": 127,
+    "mm_tokens_per_image": 4,
+    "boi_token_index": 125,
+    "eoi_token_index": 126,
+}
+
+_TINY_EXPERT = {
+    "attention_bias": False,
+    "attention_dropout": 0.0,
+    "head_dim": 16,
+    "hidden_activation": "gelu_pytorch_tanh",
+    "hidden_size": 16,
+    "intermediate_size": 32,
+    "max_position_embeddings": 512,
+    "num_attention_heads": 2,
+    "num_hidden_layers": 2,
+    "num_key_value_heads": 1,
+    "rms_norm_eps": 1e-6,
+    "rope_theta": 10_000.0,
+    "use_adarms": True,
+    "adarms_cond_dim": 16,
+    "vocab_size": 128,
+}
+
+
+def _build_pi0_wrapper():
+    cfg = _tiny_paligemma_sub_configs(
+        PI0WithExpertConfig(
+            freeze_vision_encoder=False,
+            train_expert_only=False,
+            train_state_action_representation_only=True,
+            dropout=0.1,
+        )
+    )
+    return PI0WithExpertModel(cfg)
+
+
+def _build_pi05_wrapper():
+    cfg = _tiny_paligemma_sub_configs(
+        PI05WithExpertConfig(
+            freeze_vision_encoder=False,
+            train_expert_only=False,
+            train_state_action_representation_only=True,
+            discrete_action_vocab_size=16,
+            dropout=0.1,
+        )
+    )
+    return PI05WithExpertModel(cfg)
+
+
+def _build_pi06_wrapper():
+    return PI06WithExpertModel(
+        PI06WithExpertConfig(
+            gemma3_config=_TINY_GEMMA3,
+            gemma_expert_config=_TINY_EXPERT,
+            discrete_action_vocab_size=32,
+            freeze_vision_encoder=False,
+            train_expert_only=False,
+            train_state_action_representation_only=True,
+            dropout=0.1,
+        )
+    )
+
+
+def _build_pi07_wrapper():
+    return PI07WithExpertModel(
+        PI07WithExpertConfig(
+            gemma3_config=_TINY_GEMMA3,
+            gemma_expert_config=_TINY_EXPERT,
+            discrete_action_vocab_size=32,
+            freeze_vision_encoder=False,
+            train_expert_only=False,
+            train_state_action_representation_only=True,
+            dropout=0.1,
+        )
+    )
+
+
+#: (label, builder, whether the wrapper owns a discrete-action pathway).
+WRAPPERS = [
+    ("pi0", _build_pi0_wrapper, False),
+    ("pi05", _build_pi05_wrapper, True),
+    ("pi06", _build_pi06_wrapper, True),
+    ("pi07", _build_pi07_wrapper, True),
+]
+WRAPPER_IDS = [label for label, _, _ in WRAPPERS]
+
+
+# --------------------------------------------------------------------------- wrapper half
+
+
+@pytest.mark.parametrize(("label", "build", "has_discrete"), WRAPPERS, ids=WRAPPER_IDS)
+def test_wrapper_trains_only_the_discrete_action_representation(label, build, has_discrete):
+    """The VLM, the vision pathway (tower *and* multimodal projector) and the
+    action expert are all frozen; only the discrete-action embedding + head remain."""
+    model = build()
+
+    trainable = {n for n, p in model.named_parameters() if p.requires_grad}
+
+    assert trainable == (DISCRETE_PARAMS if has_discrete else set())
+
+
+@pytest.mark.parametrize(("label", "build", "has_discrete"), WRAPPERS, ids=WRAPPER_IDS)
+def test_wrapper_pins_the_frozen_trunk_to_eval_before_any_train_call(label, build, has_discrete):
+    """``__init__`` leaves modules in training mode. The frozen trunk must already
+    be in eval when the constructor returns — an entry point that runs a forward
+    without calling ``train()``/``eval()`` first would otherwise get dropout noise
+    through a trunk that cannot learn from it."""
+    model = build()
+
+    leaking = [n for n, m in model.named_modules() if isinstance(m, nn.Dropout) and m.training]
+
+    assert leaking == []
+
+
+@pytest.mark.parametrize(("label", "build", "has_discrete"), WRAPPERS, ids=WRAPPER_IDS)
+def test_wrapper_keeps_the_trunk_in_eval_across_train_calls(label, build, has_discrete):
+    """``update_policy`` calls ``policy.train()`` every step, so the ``train()``
+    override — not just ``set_requires_grad`` — has to re-pin the trunk."""
+    model = build()
+
+    model.train(True)
+
+    leaking = [n for n, m in model.named_modules() if isinstance(m, nn.Dropout) and m.training]
+    assert leaking == []
+    if has_discrete:
+        assert model.discrete_action_embedding.training
+        assert model.da_head.training
+
+
+@pytest.mark.parametrize(("label", "build", "has_discrete"), WRAPPERS, ids=WRAPPER_IDS)
+def test_wrapper_freezes_the_multimodal_projector(label, build, has_discrete):
+    """``freeze_vision_encoder`` freezes only the tower, so the projector is the
+    classic miss. These wrappers are built with ``freeze_vision_encoder=False``,
+    which makes the check meaningful: nothing but the flag can be freezing it."""
+    model = build()
+
+    projector_params = [
+        p for n, p in model.named_parameters() if "multi_modal_projector" in n or "mm_input" in n
+    ]
+
+    assert projector_params, f"{label}: no projector parameters found — test is not checking anything"
+    assert not any(p.requires_grad for p in projector_params)
+
+
+@pytest.mark.parametrize(("label", "build", "has_discrete"), WRAPPERS, ids=WRAPPER_IDS)
+def test_wrapper_freezes_the_language_model_head(label, build, has_discrete):
+    """The VLM's ``lm_head`` is tied to the token embedding table and is never the
+    discrete-action head. Freezing ``self.gemma3.model`` instead of ``self.gemma3``
+    (or ``backbone.model`` instead of ``backbone``) would leave it trainable."""
+    model = build()
+
+    lm_head_params = [p for n, p in model.named_parameters() if "lm_head" in n]
+
+    assert not any(p.requires_grad for p in lm_head_params)
+
+
+def test_flag_off_leaves_the_wrapper_untouched():
+    """The no-op guarantee: with the flag off, the trainable set is whatever it was
+    before this flag existed."""
+    cfg = _tiny_paligemma_sub_configs(
+        PI05WithExpertConfig(
+            freeze_vision_encoder=False,
+            train_expert_only=False,
+            train_state_action_representation_only=False,
+            discrete_action_vocab_size=16,
+            dropout=0.1,
+        )
+    )
+    model = PI05WithExpertModel(cfg)
+
+    assert all(p.requires_grad for p in model.parameters())
+
+
+# --------------------------------------------------------------------------- outer half
+
+
+class _StubTokenizer:
+    """Minimal stand-in for the PaliGemma tokenizer.
+
+    ``PI05FlowMatching.__init__`` otherwise calls
+    ``AutoTokenizer.from_pretrained("google/paligemma-3b-pt-224")``, which is a
+    live-Hub fetch — that would force these tests onto the ``network`` marker and
+    off the gating CPU run. Only ``ensure_loc_tokens`` touches the tokenizer during
+    construction, and it needs just ``__len__`` and ``add_tokens``.
+    """
+
+    def __init__(self):
+        self._len = 257_024
+
+    def __len__(self):
+        return self._len
+
+    def add_tokens(self, tokens, special_tokens=False):  # noqa: ARG002
+        # PaliGemma already reserves the <locNNNN> ids, so a real tokenizer adds 0.
+        return 0
+
+
+@pytest.fixture
+def build_pi05_flow_matching(monkeypatch):
+    """Build a real ``PI05FlowMatching`` with tiny sub-configs.
+
+    Without this the module builds the production 3B PaliGemma — ~65s per
+    construction, which is why the rest of the pi05 CPU suite uses
+    ``object.__new__(PI05FlowMatching)`` shells instead. Patching the config class
+    the module resolves at construction time keeps the real wiring (so the flag's
+    plumbing is genuinely exercised) while making the build cheap.
+    """
+
+    def _tiny_config(**kwargs):
+        return _tiny_paligemma_sub_configs(PI05WithExpertConfig(**kwargs))
+
+    monkeypatch.setattr(modeling_pi05, "PaliGemmaWithExpertConfig", _tiny_config)
+
+    def _build(**overrides):
+        # Continuous state by default so `state_proj` exists; the discrete-state
+        # case overrides it to assert the opposite.
+        overrides.setdefault("state_type", "continuous")
+        cfg = PI05Config(**overrides)
+        return PI05FlowMatching(cfg, discrete_action_vocab_size=16, language_tokenizer=_StubTokenizer())
+
+    return _build
+
+
+def test_policy_trains_exactly_the_state_action_representation(build_pi05_flow_matching):
+    """The whole contract, on a real policy: both halves together."""
+    model = build_pi05_flow_matching(train_state_action_representation_only=True)
+
+    trainable = sorted(n for n, p in model.named_parameters() if p.requires_grad)
+
+    assert trainable == [
+        "action_in_proj.bias",
+        "action_in_proj.weight",
+        "action_out_proj.bias",
+        "action_out_proj.weight",
+        "paligemma_with_expert.da_head.bias",
+        "paligemma_with_expert.da_head.weight",
+        "paligemma_with_expert.discrete_action_embedding.weight",
+        "state_proj.bias",
+        "state_proj.weight",
+    ]
+
+
+def test_policy_freezes_the_time_mlps(build_pi05_flow_matching):
+    """The time MLPs are hidden-size-only and condition the frozen expert; they are
+    not part of the state/action representation. This is the line
+    ``per_group_projection`` already draws."""
+    model = build_pi05_flow_matching(train_state_action_representation_only=True)
+
+    assert not any(p.requires_grad for p in model.time_mlp_in.parameters())
+    assert not any(p.requires_grad for p in model.time_mlp_out.parameters())
+
+
+def test_policy_freezes_the_modality_embeddings_when_enabled(build_pi05_flow_matching):
+    model = build_pi05_flow_matching(train_state_action_representation_only=True, use_modality_embedding=True)
+
+    assert not any(p.requires_grad for p in model.modality_embedding.parameters())
+    assert not any(p.requires_grad for p in model.action_modality_embedding.parameters())
+
+
+def test_policy_flag_off_is_a_no_op(build_pi05_flow_matching):
+    """With the flag off, everything this mode would freeze is still trainable.
+
+    Checked against the LLM backbone and the expert rather than the vision tower:
+    ``freeze_vision_encoder`` defaults to True, so the tower is frozen either way
+    and would make this assertion pass for the wrong reason.
+    """
+    model = build_pi05_flow_matching()
+
+    trainable = {n for n, p in model.named_parameters() if p.requires_grad}
+
+    assert "time_mlp_in.weight" in trainable
+    assert any(n.startswith("paligemma_with_expert.gemma_expert.") for n in trainable)
+    assert any(n.startswith("paligemma_with_expert.paligemma.model.language_model.") for n in trainable)
+
+
+def test_policy_backward_reaches_only_the_representation_params(build_pi05_flow_matching):
+    """A real gradient step: the frozen trunk transmits gradient to the trainable
+    projections without accumulating any of its own."""
+    model = build_pi05_flow_matching(train_state_action_representation_only=True)
+    model.train(True)
+
+    actions = torch.randn(2, model.config.chunk_size, model.config.max_action_dim)
+    model.action_out_proj(model.action_in_proj(actions)).sum().backward()
+
+    assert model.action_in_proj.weight.grad is not None
+    assert model.action_out_proj.weight.grad is not None
+    assert model.time_mlp_in.weight.grad is None
+    assert all(p.grad is None for p in model.paligemma_with_expert.paligemma.parameters())
+
+
+# --------------------------------------------------------------------------- config surface
+
+
+def test_pi05_discrete_state_warns_that_there_is_no_state_proj(caplog):
+    with caplog.at_level(logging.WARNING):
+        PI05Config(train_state_action_representation_only=True, state_type="discrete")
+
+    assert "no state_proj to train" in caplog.text
+
+
+def test_pi05_discrete_state_has_no_state_proj_to_train(build_pi05_flow_matching):
+    """pi06 and discrete-state pi05 have no ``state_proj`` at all: the mode still
+    works, it just trains one projection fewer."""
+    model = build_pi05_flow_matching(train_state_action_representation_only=True, state_type="discrete")
+
+    trainable = sorted(n for n, p in model.named_parameters() if p.requires_grad)
+
+    assert not any(n.startswith("state_proj") for n in trainable)
+    assert "action_in_proj.weight" in trainable
+    assert "paligemma_with_expert.discrete_action_embedding.weight" in trainable
+
+
+# ------------------------------------------------------- pi07's two-sources-of-truth hazard
+
+
+def _pi07_config(**overrides):
+    return make_policy_config("pi07_low_level", **overrides)
+
+
+def test_pi07_pushes_the_flag_into_vlm_config():
+    """pi07 is the only policy whose with-expert config is a serialized *field*, so
+    the flag has to reach ``vlm_config`` — ``Gemma3WithExpertModel.set_requires_grad``
+    reads it from there, and a missing push-down is a silent no-op on the VLM side."""
+    cfg = _pi07_config(train_state_action_representation_only=True)
+
+    assert cfg.vlm_config.train_state_action_representation_only is True
+
+
+def test_pi07_reloading_an_adapter_run_config_can_clear_the_flag():
+    """Regression: the push-down must be two-way.
+
+    ``vlm_config`` is serialized into the saved config.json, so after an adapter run
+    it carries the flag. Reloading that checkpoint to fully finetune —
+    ``--policy.train_state_action_representation_only=false`` — must clear BOTH
+    halves. A True-only push-down would leave the VLM and expert frozen while the
+    outer projections unfroze: a mode nobody asked for, with no error.
+    """
+    trained = _pi07_config(train_state_action_representation_only=True)
+    payload = draccus.encode(trained)
+    assert payload["vlm_config"]["train_state_action_representation_only"] is True
+
+    payload["train_state_action_representation_only"] = False
+    reloaded = draccus.decode(type(trained), payload)
+
+    assert reloaded.train_state_action_representation_only is False
+    assert reloaded.vlm_config.train_state_action_representation_only is False
+
+
+def test_pi07_inner_only_override_is_cleared_with_a_warning(caplog):
+    """Setting only ``--policy.vlm_config.train_state_action_representation_only=true``
+    would freeze the trunk while leaving every outer parameter trainable. The
+    policy-level flag wins, and the override is reported rather than silently dropped."""
+    with caplog.at_level(logging.WARNING):
+        cfg = _pi07_config(
+            vlm_config=PI07WithExpertConfig(
+                freeze_vision_encoder=True,
+                train_expert_only=False,
+                train_state_action_representation_only=True,
+            )
+        )
+
+    assert cfg.vlm_config.train_state_action_representation_only is False
+    assert "is cleared because the policy-level" in caplog.text
+
+
+def test_pi07_normal_push_down_is_quiet(caplog):
+    """The ordinary False -> True push-down must not log — a warning on every
+    enabling run trains readers to ignore it."""
+    with caplog.at_level(logging.WARNING):
+        _pi07_config(train_state_action_representation_only=True)
+
+    assert "is cleared because the policy-level" not in caplog.text
+
+
+def test_pi07_rejects_conflicting_vlm_config_modes():
+    """The sibling "train only X" flags live on ``vlm_config`` for pi07, so the
+    shared validator (which reads the policy config) cannot see them."""
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        _pi07_config(
+            train_state_action_representation_only=True,
+            # `freeze_vision_encoder=True` because the wrapper config independently
+            # rejects unfreezing the tower under `train_expert_only`.
+            vlm_config=PI07WithExpertConfig(freeze_vision_encoder=True, train_expert_only=True),
+        )

--- a/tests/policies/test_state_action_representation_only_registry.py
+++ b/tests/policies/test_state_action_representation_only_registry.py
@@ -1,0 +1,199 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Registry-wide invariants for ``train_state_action_representation_only``.
+
+The flag has to be plumbed through every policy that has a state/action
+representation to train, and must be *absent* from the policies that do not
+(the two high-level planners and ``value`` own no state/action projections and
+no live discrete-action modules, so the flag there would silently train nothing
+and produce a flat loss curve with no error).
+
+That "everywhere or nowhere, and we know which" property is exactly what a
+hand-maintained per-policy list gets wrong over time: ``train_vision_encoder_only``
+reached the pi07_paligemma planner but not the pi07 one, and nothing failed. These
+tests pin the capability set by *set equality* so drift in either direction fails.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import warnings
+from dataclasses import fields
+from pathlib import Path
+
+import draccus
+import pytest
+
+from opentau.policies.factory import make_policy_config
+
+FLAG = "train_state_action_representation_only"
+
+#: Every policy type ``make_policy_config`` accepts. Deliberately NOT derived from
+#: ``opentau.available_policies``, which omits ``pi07_paligemma_low_level``,
+#: ``pi07_paligemma_high_level_planner`` and ``pi05_continuous_state`` — iterating
+#: that list would let the whole pi07_paligemma family escape this sweep.
+ALL_POLICY_TYPES = frozenset(
+    {
+        "pi0",
+        "pi05",
+        "pi05_continuous_state",
+        "pi05_mem",
+        "pi06",
+        "pi07_paligemma_high_level_planner",
+        "pi07_paligemma_low_level",
+        "pi07_high_level",
+        "pi07_low_level",
+        "cosmos3",
+        "cosmos3_nano",
+        "value",
+    }
+)
+
+#: Policies that own a state/action representation worth training on its own:
+#: state/action projections and/or a discrete-action embedding + head.
+EXPECTED_CAPABLE = frozenset(
+    {
+        "pi0",  # projections only — no discrete-action pathway
+        "pi05",
+        "pi05_continuous_state",
+        "pi05_mem",
+        "pi06",  # no state_proj (discrete state), but has the rest
+        "pi07_low_level",
+        "pi07_paligemma_low_level",
+        "cosmos3",  # projections only — no discrete-action pathway
+        "cosmos3_nano",
+    }
+)
+
+#: Policies where the flag must NOT exist: no projections, no live discrete modules.
+EXPECTED_INCAPABLE = ALL_POLICY_TYPES - EXPECTED_CAPABLE
+
+
+def _config_for(policy_type: str):
+    with warnings.catch_warnings():
+        # pi05_continuous_state is deprecated but still routable.
+        warnings.simplefilter("ignore", DeprecationWarning)
+        return make_policy_config(policy_type)
+
+
+def test_factory_branch_list_is_complete():
+    """``ALL_POLICY_TYPES`` must equal the factory's actual ``policy_type == "..."``
+    branches.
+
+    The load-bearing direction is *new* policy types: a policy added to the factory
+    but not to ``ALL_POLICY_TYPES`` would never be swept by the set-equality test
+    below, so the flag could be forgotten on it silently. Parsing the comparisons
+    (rather than every string literal in the function) is what makes that direction
+    detectable.
+    """
+    tree = ast.parse(inspect.getsource(make_policy_config).lstrip())
+    branch_types = {
+        comparator.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Compare) and isinstance(node.left, ast.Name) and node.left.id == "policy_type"
+        for comparator in node.comparators
+        if isinstance(comparator, ast.Constant) and isinstance(comparator.value, str)
+    }
+
+    assert branch_types == set(ALL_POLICY_TYPES), (
+        f"policy types in the factory but not in ALL_POLICY_TYPES: "
+        f"{sorted(branch_types - ALL_POLICY_TYPES)}; "
+        f"in ALL_POLICY_TYPES but not in the factory: {sorted(ALL_POLICY_TYPES - branch_types)}"
+    )
+
+
+def test_exactly_the_capable_policies_carry_the_flag():
+    """Set equality in both directions: no capable policy is missing the flag, and
+    no incapable policy grew one."""
+    carrying = {t for t in ALL_POLICY_TYPES if FLAG in {f.name for f in fields(_config_for(t))}}
+
+    assert carrying == set(EXPECTED_CAPABLE), (
+        f"missing the flag: {sorted(EXPECTED_CAPABLE - carrying)}; "
+        f"unexpectedly carrying it: {sorted(carrying - EXPECTED_CAPABLE)}"
+    )
+
+
+@pytest.mark.parametrize("policy_type", sorted(EXPECTED_CAPABLE))
+def test_flag_defaults_to_false(policy_type):
+    """Default-off is the no-op guarantee: an existing config must behave exactly
+    as it did before this flag existed."""
+    assert getattr(_config_for(policy_type), FLAG) is False
+
+
+@pytest.mark.parametrize("policy_type", sorted(EXPECTED_CAPABLE))
+def test_flag_can_be_enabled(policy_type):
+    kwargs = {FLAG: True}
+    if policy_type in ("cosmos3", "cosmos3_nano"):
+        # cosmos3 defaults train_expert_only=True, which is mutually exclusive.
+        kwargs["train_expert_only"] = False
+    assert getattr(_config_for(policy_type).__class__(**kwargs), FLAG) is True
+
+
+@pytest.mark.parametrize("policy_type", sorted(EXPECTED_INCAPABLE))
+def test_incapable_policies_reject_the_flag(policy_type):
+    """A user who sets the flag on a planner or the value policy must get an error,
+    not a run that silently trains nothing."""
+    with pytest.raises(TypeError):
+        _config_for(policy_type).__class__(**{FLAG: True})
+
+
+@pytest.mark.parametrize("policy_type", sorted(EXPECTED_CAPABLE))
+def test_draccus_round_trips_the_flag(policy_type):
+    kwargs = {FLAG: True}
+    if policy_type in ("cosmos3", "cosmos3_nano"):
+        kwargs["train_expert_only"] = False
+    cfg = _config_for(policy_type).__class__(**kwargs)
+
+    reparsed = draccus.decode(type(cfg), draccus.encode(cfg))
+
+    assert getattr(reparsed, FLAG) is True
+
+
+@pytest.mark.parametrize("policy_type", sorted(EXPECTED_CAPABLE))
+def test_legacy_config_without_the_field_decodes_to_false(policy_type):
+    """A checkpoint config written before this flag existed must still load, and
+    must load with the flag off."""
+    cfg = _config_for(policy_type)
+    payload = draccus.encode(cfg)
+    payload.pop(FLAG, None)
+
+    reparsed = draccus.decode(type(cfg), payload)
+
+    assert getattr(reparsed, FLAG) is False
+
+
+def test_every_modeling_file_with_a_vision_only_freeze_also_handles_this_flag():
+    """AST completeness check, in the style of
+    ``tests/policies/test_from_pretrained_revision_overrides.py``.
+
+    Any modeling module that calls ``freeze_policy_level_params_for_vision_only``
+    owns policy-level projections, and therefore must also call this flag's helper.
+    A new policy that copies the vision-only freeze but forgets this one fails here
+    rather than silently training its whole trunk.
+    """
+    root = Path(__file__).resolve().parents[2] / "src" / "opentau" / "policies"
+    offenders = []
+    for path in sorted(root.rglob("modeling_*.py")):
+        source = path.read_text()
+        if "freeze_policy_level_params_for_vision_only(" not in source:
+            continue
+        if "freeze_policy_level_params_for_state_action_representation_only(" not in source:
+            offenders.append(str(path.relative_to(root)))
+
+    assert not offenders, (
+        "these modeling files freeze policy-level params for train_vision_encoder_only but "
+        f"never handle {FLAG}: {offenders}"
+    )


### PR DESCRIPTION
## What this does

Adds an opt-in finetuning mode, `policy.train_state_action_representation_only`, for adapting a **generic VLA checkpoint to a new dataset** by training only the parameters that are actually dataset-specific, and freezing everything else.

**Trainable**
1. The discrete-action representation — `discrete_action_embedding` (input table) **and** `da_head` (logits over the FAST action vocabulary), on every policy that supports knowledge insulation. They are untied but are both pure functions of the fitted FAST vocabulary and are invalidated by the same event (a tokenizer re-fit), so they move as one unit — which is how every existing freeze flag already treats them.
2. The state/action projections — `state_proj`, `action_in_proj`, `action_out_proj`. These are the only outer projections whose shape is a function of the robot (`max_state_dim` / `max_action_dim`) rather than of the architecture.

**Frozen**: the VLM backbone (and its tied `lm_head`), the vision/video encoder **and** the multimodal projector, the action expert — plus `time_mlp_in/out` (pi0's `action_time_mlp_*`, cosmos3's `adarms_proj`), the optional modality embeddings, and pi05_mem's RLDX `motion_module`.

The time MLPs are excluded deliberately: they are hidden-size-to-hidden-size, are fed a sinusoidal embedding of flow-matching time alone, and condition the (frozen) expert. This is the same line `per_group_projection` already draws when it gives per-`(robot_type, control_mode)` copies to exactly those three projections and notes that "time_mlp_in/out stay shared".

### Where it applies

Declared on the nine policy types that have such a representation: `pi0`, `pi05` (+ `pi05_continuous_state`), `pi05_mem`, `pi06`, `pi07_low_level`, `pi07_paligemma_low_level`, `cosmos3` (+ `cosmos3_nano`).

- `pi0` and `cosmos3` have no discrete-action pathway, so the mode degenerates to "train the projections only". That is still useful, so it is allowed — with a warning naming the empty bucket.
- `pi06` (and `pi05` with `state_type="discrete"`) bin state into text tokens and have no `state_proj` at all, so there is one fewer projection to train. Also warned.
- The two high-level planners and `value` do **not** declare the field. They own no projections and no live discrete-action modules, so the flag there would train nothing and produce a flat loss curve with no error. A registry-wide test pins that set by equality in both directions.

### Notable implementation points

- **Default-deny.** Both halves freeze *everything* and then re-enable an explicit allowlist resolved **by module object, never by parameter name**. Name matching is unsafe here: `Normalize`/`Unnormalize` register per-dataset statistics as `nn.Parameter(requires_grad=False)`, so they appear in `named_parameters()` as `normalize_*.buffer_state` / `buffer_actions` — any pattern matching `state` or `action` would turn normalization statistics into learned parameters, and the optimizer factory selects on `requires_grad` alone. Default-deny also freezes the `multi_modal_projector` for free, which `freeze_vision_encoder` (tower only) does not.
- **`config.dropout` is a no-op under this flag.** The frozen trunk is pinned to `eval()`, including each wrapper's own `self.dropout` which fires inside the decoder loop. With only an embedding table and one linear head training, trunk dropout is pure variance that no frozen weight can absorb.
- **No `motion_module` carve-out.** `freeze_policy_level_params_for_vision_only` keeps pi05_mem's RLDX temporal block trainable by a name match. The new helper deliberately does not: it is the one module a generic checkpoint does not carry, so inheriting the carve-out would silently train a freshly-initialized zero-gated block in a run whose premise is that only the dataset-facing adapters move.
- **cosmos3 `run_prefix`.** Its backbone forward is gated by `torch.no_grad()` keyed on `train_expert_only`. This mode freezes the backbone too, so the predicate is extended — otherwise the tower would build and retain a full activation graph for a backward that never reaches it (no crash, just an order-of-magnitude activation-memory bill). `train_vision_encoder_only` is explicitly kept **out** of that predicate, for the opposite reason; the docstring now explains both sides.
- **pi07 plumbing.** pi07 is the only policy whose with-expert config is a serialized *field*, so the flag is declared top-level and pushed into `vlm_config` **in both directions**. A True-only push-down would leave two silent half-frozen states — most importantly, reloading an adapter-trained checkpoint with `--policy.train_state_action_representation_only=false` to fully finetune would clear the policy-level flag while the serialized `vlm_config` one stayed True, freezing the VLM and expert while the outer projections unfroze.

Knowledge insulation splits the trainable set across two losses (`state_proj` + the discrete modules are reachable only from CE; `action_in/out_proj` only from MSE). That is a warning, not an error, so a deliberate CE-only or MSE-only run stays possible.

Default `False`; every new code path is flag-gated, so the flag off is a no-op.

## How it was tested

**New tests (95, ~0.4s)**
- `tests/policies/test_state_action_representation_only_helper.py` — the four helpers against hand-rolled fakes: the trainable set, the projector freeze, the time-MLP/modality-embedding/`motion_module` exclusions, the normalization-buffer name hazard, `train()`/`eval()` pinning, and the config validator.
- `tests/policies/test_state_action_representation_only_policies.py` — the **real** wrappers (pi0, pi05, pi06, pi07) and a real `PI05FlowMatching`: observed trainable set, no `nn.Dropout` left training after `__init__` or `train(True)`, `lm_head` and projector frozen, a backward that reaches only the representation params, and pi07's two-sources-of-truth regressions.
- `tests/policies/test_state_action_representation_only_registry.py` — registry-wide invariants. The capable set is pinned by **set equality** (drift in either direction fails), the factory's branch list is parsed by AST so a policy added later cannot escape the sweep, and an AST completeness check requires every modeling file that freezes policy-level params for `train_vision_encoder_only` to handle this flag too. That last one is what would have caught the analogous `train_vision_encoder_only` gap.

**CPU suite** — `pytest -m "not gpu and not network" -n auto tests/policies/ tests/configs/ tests/test_available.py` → **1122 passed, 2 skipped**.

**GPU suite** — run on a GPU dev box, `pytest -m "gpu" -n 0` over `test_pi05.py`, `test_pi06.py`, `test_pi07_low_level.py`, `test_pi07_paligemma_low_level.py`, `test_pi05_mem_gpu.py`, `test_knowledge_insulation.py`, `test_cosmos3_gpu.py`, `test_cosmos3_nano_gpu.py`, `test_policies.py` → **21 passed, 8 skipped, 0 failed**.

**Determinism (CLAUDE.md rule 3)** — `configs/dev/ci_config.json` run twice on GPU at `seed=1000`, 25 steps: the per-step `total_loss` / `mse_loss` / `ce_loss` / `lr` / `grad_norm` series is **bit-identical** (same md5 over the extracted series).

**No-op verification** — the whole diff removes only 17 lines, of which exactly two are executable: cosmos3's `no_grad` predicate and its paired KV `.detach()`, where `backbone_is_frozen = train_expert_only or <new flag>` reduces to `train_expert_only` when the flag is off. Everything else is pure addition inside `if <flag>:` blocks, config fields defaulting `False`, docstrings and imports.

## How to checkout & try? (for the reviewer)

```bash
git fetch origin claude/vla-dataset-params-training-06de1e
git checkout claude/vla-dataset-params-training-06de1e
```

```bash
pytest -sx tests/policies/test_state_action_representation_only_helper.py \
           tests/policies/test_state_action_representation_only_policies.py \
           tests/policies/test_state_action_representation_only_registry.py
```

Inspect the trainable set directly:

```bash
python -c "
from opentau.policies.pi05.configuration_pi05 import PI05Config
from opentau.policies.pi05.modeling_pi05 import PI05FlowMatching
cfg = PI05Config(train_state_action_representation_only=True, state_type='continuous')
m = PI05FlowMatching(cfg, discrete_action_vocab_size=16)
print(sorted(n for n, p in m.named_parameters() if p.requires_grad))
"
```

Or enable it on any training config:

```bash
opentau-train --config_path=configs/examples/pi05_training_config.json \
  --policy.train_state_action_representation_only=true
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [x] My PR includes policy-related changes.
  - [x] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
