### PR TITLE
fix(datasets): make the train/val split identical on every rank

### DIFF
--- a/src/opentau/datasets/factory.py
+++ b/src/opentau/datasets/factory.py
@@ -360,11 +360,13 @@ def val_split_generator(train_cfg: TrainPipelineConfig) -> torch.Generator:
       the resume boundary and across runs with different world sizes.
     * **Resume** reproduces the same split as long as those three inputs are
       unchanged. ``--config_path`` points at the checkpoint's ``train_config.json``
-      on resume, so ``seed`` and ``val_split_ratio`` carry over automatically —
-      but a CLI override of either, or a dataset whose length changed since the
-      checkpoint (re-uploaded episodes, a changed ``episodes`` /
-      ``excluded_episodes`` filter), silently re-partitions the data.
-      :func:`warn_if_resumed_split_differs` warns about the config half of that.
+      on resume, so they carry over automatically — but a CLI override of
+      ``seed``, of a ``val_split_ratio``, or of the fields that decide how many
+      frames a dataset yields (``episodes``, ``excluded_episodes``, ``revision``)
+      silently re-partitions the data. :func:`warn_if_resumed_split_differs`
+      catches all of those. The one case it cannot catch is an out-of-band
+      length change — the same repo at the same revision re-uploaded with more
+      episodes — since the checkpoint records no length to compare against.
     * **Mixture composition is irrelevant**: every dataset draws from a
       generator seeded the same way, so adding or reordering datasets does not
       reshuffle the splits of the others. Two datasets of equal length get the
@@ -384,20 +386,60 @@ def val_split_generator(train_cfg: TrainPipelineConfig) -> torch.Generator:
     return torch.Generator().manual_seed(int(seed))
 
 
-def _split_determining_fields(cfg: TrainPipelineConfig) -> dict[str, Any]:
-    """Return the config values the train/val split depends on.
+def _split_determining_fields(cfg_dict: dict[str, Any]) -> dict[str, Any]:
+    """Extract the values the train/val split depends on from a *serialized* config.
 
-    Kept next to :func:`val_split_generator` so a new split-determining field is
-    added in one place rather than being silently omitted from the resume check.
+    Takes an encoded config dict rather than a ``TrainPipelineConfig`` so that
+    the live run and the checkpoint's ``train_config.json`` are read by the same
+    code. Two separate extractors would drift, and a key present on only one
+    side is silently dropped from the comparison — i.e. it fails open, which for
+    a diagnostic is indistinguishable from a healthy resume.
+
+    Covers the config half of all three inputs in the split contract (see
+    :func:`val_split_generator`):
+
+    * ``seed`` directly;
+    * the **effective** ``val_split_ratio`` per dataset, resolving the
+      ``None``-inherits-the-mixture-default rule the way ``make_dataset`` does,
+      so a ratio moving between ``None`` and an explicit value equal to the
+      default is correctly seen as no change;
+    * the fields that determine ``len(dataset)`` without changing the dataset's
+      identity — ``episodes`` / ``excluded_episodes`` select and drop episodes,
+      and ``revision`` pins which version of the repo is read. ``repo_id`` comes
+      along so that the positional per-dataset comparison is only made between
+      like and like.
+
+    Args:
+        cfg_dict: A ``TrainPipelineConfig`` encoded via ``to_dict()``, or a
+            ``train_config.json`` parsed from a checkpoint.
+
+    Returns:
+        A flat ``{field path: value}`` mapping, ready to diff against another
+        config's mapping.
     """
-    return {
-        "seed": cfg.seed,
-        "dataset_mixture.val_split_ratio": cfg.dataset_mixture.val_split_ratio,
-        **{
-            f"dataset_mixture.datasets[{i}].val_split_ratio": ds.val_split_ratio
-            for i, ds in enumerate(cfg.dataset_mixture.datasets)
-        },
-    }
+    mixture = cfg_dict.get("dataset_mixture") or {}
+    default_ratio = mixture.get("val_split_ratio")
+
+    fields: dict[str, Any] = {"seed": cfg_dict.get("seed")}
+    for i, ds in enumerate(mixture.get("datasets") or []):
+        ratio = ds.get("val_split_ratio")
+        # The mixture-wide default is folded in here rather than compared on its
+        # own: changing it is a no-op for any dataset that overrides it.
+        fields[f"datasets[{i}].val_split_ratio"] = default_ratio if ratio is None else ratio
+        for key in ("repo_id", "revision", "episodes", "excluded_episodes"):
+            fields[f"datasets[{i}].{key}"] = ds.get(key)
+    return fields
+
+
+def _describe_drift(field: str, before: Any, after: Any) -> str:
+    """Render one drifted field for the warning, keeping episode lists readable."""
+
+    def fmt(value: Any) -> str:
+        if isinstance(value, (list, tuple)) and len(value) > 4:
+            return f"[{len(value)} items]"
+        return repr(value)
+
+    return f"{field}: {fmt(before)} -> {fmt(after)}"
 
 
 def warn_if_resumed_split_differs(cfg: TrainPipelineConfig) -> None:
@@ -410,10 +452,13 @@ def warn_if_resumed_split_differs(cfg: TrainPipelineConfig) -> None:
     frames the checkpoint was trained on, and its ``running_best`` numbers are
     not comparable to the pre-resume ones.
 
-    Only the *config* half of the contract is checkable here: a dataset whose
-    length changed since the checkpoint also re-partitions the data, and that is
-    not recorded anywhere in the checkpoint. See :func:`val_split_generator` for
-    the full contract.
+    Checks the *config* half of the contract, which includes the config-visible
+    determinants of ``len(dataset)`` — ``episodes``, ``excluded_episodes`` and
+    ``revision`` are all serialized into the checkpoint, so overriding them on
+    resume is caught. What remains undetectable is an **out-of-band** length
+    change: the same ``repo_id`` at the same ``revision`` re-uploaded with more
+    episodes. Nothing in the checkpoint records the length it observed, so that
+    case is documented on :func:`val_split_generator` rather than warned about.
 
     No-ops when not resuming, when validation is off, or when the checkpoint's
     ``train_config.json`` is missing or unreadable — a best-effort diagnostic
@@ -440,22 +485,15 @@ def warn_if_resumed_split_differs(cfg: TrainPipelineConfig) -> None:
         logger.debug("Could not read %s for the val-split drift check: %s", saved_path, exc)
         return
 
-    saved_datasets = saved.get("dataset_mixture", {}).get("datasets", [])
-    saved_fields = {
-        "seed": saved.get("seed"),
-        "dataset_mixture.val_split_ratio": saved.get("dataset_mixture", {}).get("val_split_ratio"),
-        **{
-            f"dataset_mixture.datasets[{i}].val_split_ratio": ds.get("val_split_ratio")
-            for i, ds in enumerate(saved_datasets)
-        },
-    }
-
-    current_fields = _split_determining_fields(cfg)
-    drifted = {
-        key: (saved_fields[key], value)
+    saved_fields = _split_determining_fields(saved)
+    current_fields = _split_determining_fields(cfg.to_dict())
+    # Intersect on keys: a mixture that gained or lost a dataset changes far more
+    # than the split, and comparing shifted positions would only add noise.
+    drifted = [
+        _describe_drift(key, saved_fields[key], value)
         for key, value in current_fields.items()
         if key in saved_fields and saved_fields[key] != value
-    }
+    ]
     if drifted:
         logger.warning(
             "Resuming with train/val split settings that differ from the checkpoint at %s: %s. "
@@ -464,7 +502,7 @@ def warn_if_resumed_split_differs(cfg: TrainPipelineConfig) -> None:
             "against — its Validation/* metrics and `running_best` are not comparable to the "
             "pre-resume ones, and frames held out before are now trained on.",
             cfg.checkpoint_path,
-            ", ".join(f"{k}: {before!r} -> {after!r}" for k, (before, after) in sorted(drifted.items())),
+            ", ".join(sorted(drifted)),
         )
 
 

--- a/src/opentau/datasets/factory.py
+++ b/src/opentau/datasets/factory.py
@@ -46,6 +46,10 @@ Functions:
         TrainPipelineConfig containing multiple dataset configurations.
     resolve_delta_timestamps: Resolves delta timestamps configuration based
         on TrainPipelineConfig settings, mapping features to temporal groups.
+    val_split_generator: Builds the rank-independent RNG that partitions a
+        dataset into its train and validation halves.
+    warn_if_resumed_split_differs: Warns when a resumed run's config would
+        partition the data differently than the checkpoint it resumes from.
 
 Constants:
     IMAGENET_STATS: ImageNet normalization statistics (mean, std, min, max)
@@ -61,9 +65,10 @@ Example:
 """
 
 import copy
+import json
 import logging
 from pathlib import Path
-from typing import List, Optional, Tuple, Union
+from typing import Any, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
@@ -75,6 +80,7 @@ import opentau.datasets.vqa.dummy  # noqa: F401
 import opentau.datasets.vqa.vsr  # noqa: F401
 from opentau import available_vqa_datasets
 from opentau.configs.default import DatasetConfig
+from opentau.configs.policies import TRAIN_CONFIG_NAME
 from opentau.configs.train import TrainPipelineConfig
 from opentau.datasets.action_indexing import resolve_delta_map
 from opentau.datasets.dataset_mixture import WeightedDatasetMixture
@@ -91,6 +97,9 @@ from opentau.datasets.lerobot_dataset import (
 from opentau.datasets.standard_data_format_mapping import DATA_FEATURES_NAME_MAPPING, feature_mapping_key
 from opentau.datasets.transforms import ImageTransforms
 from opentau.datasets.utils import DeltaTimestampInfo
+from opentau.utils.accelerate_utils import get_proc_accelerator
+
+logger = logging.getLogger(__name__)
 
 IMAGENET_STATS = {
     "min": [[[0.0]], [[0.0]], [[0.0]]],  # (c,1,1)
@@ -313,6 +322,152 @@ def resolve_delta_timestamps(
     return dt_mean, {}, {}, {}
 
 
+# Fallback base seed for the train/val split when `cfg.seed is None`. The split
+# must be identical on every rank, so it cannot fall back to the global RNG:
+# without `cfg.seed`, `train.py` never calls `set_seed` at all and each process
+# starts from its own entropy-derived torch seed. An arbitrary but fixed
+# constant keeps the split reproducible in that case too.
+DEFAULT_VAL_SPLIT_SEED = 8_675_309
+
+
+def val_split_generator(train_cfg: TrainPipelineConfig) -> torch.Generator:
+    """Build the rank-independent RNG that partitions a dataset into train/val.
+
+    The train/val split **must** be identical on every rank. Each rank builds
+    its own copy of the dataset and its own ``Subset`` views, so if the ranks
+    disagree on the partition, one rank's validation frames are another rank's
+    training frames — the gathered ``Validation/*`` metrics are then measured
+    partly on memorized data and are optimistically biased, and the
+    ``running_best`` checkpoint selection is driven by that contaminated number.
+
+    Taking the split off the *global* torch RNG does exactly that, because
+    :func:`opentau.utils.random_utils.set_seed` deliberately offsets the seed by
+    ``process_index * 12345`` so that per-sample draws (augmentation, dropout,
+    prompt substitution) are decorrelated across ranks. That offset is correct
+    for per-sample draws and is intentionally left alone; the split is simply
+    moved off the global RNG onto this dedicated, rank-independent generator.
+
+    Stability contract — the split is a pure function of exactly three inputs:
+
+    * ``train_cfg.seed`` (never ``process_index``, never ``num_processes``),
+    * ``len(dataset)``,
+    * the effective ``val_split_ratio`` for that dataset.
+
+    Consequences that are deliberate:
+
+    * **World-size change** (resuming on 4 GPUs instead of 8, or vice versa)
+      leaves the split untouched, so validation numbers stay comparable across
+      the resume boundary and across runs with different world sizes.
+    * **Resume** reproduces the same split as long as those three inputs are
+      unchanged. ``--config_path`` points at the checkpoint's ``train_config.json``
+      on resume, so ``seed`` and ``val_split_ratio`` carry over automatically —
+      but a CLI override of either, or a dataset whose length changed since the
+      checkpoint (re-uploaded episodes, a changed ``episodes`` /
+      ``excluded_episodes`` filter), silently re-partitions the data.
+      :func:`warn_if_resumed_split_differs` warns about the config half of that.
+    * **Mixture composition is irrelevant**: every dataset draws from a
+      generator seeded the same way, so adding or reordering datasets does not
+      reshuffle the splits of the others. Two datasets of equal length get the
+      same permutation, which is harmless (frame *i* of one dataset has nothing
+      to do with frame *i* of another) and is in fact what you want when the
+      same underlying data is listed twice under different configs — the shared
+      permutation keeps the val frames aligned instead of leaking each entry's
+      val half into the other's train half.
+
+    Args:
+        train_cfg: The training config supplying the base ``seed``.
+
+    Returns:
+        A fresh ``torch.Generator`` seeded identically on every rank.
+    """
+    seed = train_cfg.seed if train_cfg.seed is not None else DEFAULT_VAL_SPLIT_SEED
+    return torch.Generator().manual_seed(int(seed))
+
+
+def _split_determining_fields(cfg: TrainPipelineConfig) -> dict[str, Any]:
+    """Return the config values the train/val split depends on.
+
+    Kept next to :func:`val_split_generator` so a new split-determining field is
+    added in one place rather than being silently omitted from the resume check.
+    """
+    return {
+        "seed": cfg.seed,
+        "dataset_mixture.val_split_ratio": cfg.dataset_mixture.val_split_ratio,
+        **{
+            f"dataset_mixture.datasets[{i}].val_split_ratio": ds.val_split_ratio
+            for i, ds in enumerate(cfg.dataset_mixture.datasets)
+        },
+    }
+
+
+def warn_if_resumed_split_differs(cfg: TrainPipelineConfig) -> None:
+    """Warn when a resumed run would partition its data differently than before.
+
+    On resume the whole train config is loaded from the checkpoint's
+    ``train_config.json`` and CLI overrides are layered on top, so a stray
+    ``--seed=...`` or ``--dataset_mixture.val_split_ratio=...`` silently
+    re-partitions every dataset. The resumed run then reports validation on
+    frames the checkpoint was trained on, and its ``running_best`` numbers are
+    not comparable to the pre-resume ones.
+
+    Only the *config* half of the contract is checkable here: a dataset whose
+    length changed since the checkpoint also re-partitions the data, and that is
+    not recorded anywhere in the checkpoint. See :func:`val_split_generator` for
+    the full contract.
+
+    No-ops when not resuming, when validation is off, or when the checkpoint's
+    ``train_config.json`` is missing or unreadable — a best-effort diagnostic
+    must never be the thing that fails a resume. Every rank runs this (the
+    dataset is built on all of them), so the message is emitted on the main
+    process only rather than once per GPU.
+
+    Args:
+        cfg: The resolved training config for the run being started.
+    """
+    if not cfg.resume or cfg.val_freq <= 0 or cfg.checkpoint_path is None:
+        return
+
+    # None outside a training run (tests, offline scripts) — warn in that case.
+    accelerator = get_proc_accelerator()
+    if accelerator is not None and not accelerator.is_main_process:
+        return
+
+    saved_path = Path(cfg.checkpoint_path) / TRAIN_CONFIG_NAME
+    try:
+        with open(saved_path) as f:
+            saved = json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.debug("Could not read %s for the val-split drift check: %s", saved_path, exc)
+        return
+
+    saved_datasets = saved.get("dataset_mixture", {}).get("datasets", [])
+    saved_fields = {
+        "seed": saved.get("seed"),
+        "dataset_mixture.val_split_ratio": saved.get("dataset_mixture", {}).get("val_split_ratio"),
+        **{
+            f"dataset_mixture.datasets[{i}].val_split_ratio": ds.get("val_split_ratio")
+            for i, ds in enumerate(saved_datasets)
+        },
+    }
+
+    current_fields = _split_determining_fields(cfg)
+    drifted = {
+        key: (saved_fields[key], value)
+        for key, value in current_fields.items()
+        if key in saved_fields and saved_fields[key] != value
+    }
+    if drifted:
+        logger.warning(
+            "Resuming with train/val split settings that differ from the checkpoint at %s: %s. "
+            "The split is a pure function of (seed, dataset length, val_split_ratio), so the "
+            "resumed run validates on a different subset than the checkpoint was trained "
+            "against — its Validation/* metrics and `running_best` are not comparable to the "
+            "pre-resume ones, and frames held out before are now trained on.",
+            cfg.checkpoint_path,
+            ", ".join(f"{k}: {before!r} -> {after!r}" for k, (before, after) in sorted(drifted.items())),
+        )
+
+
 def _subset_meta(meta: LeRobotDatasetMetadata) -> LeRobotDatasetMetadata:
     """Per-subset metadata copy that shares read-only per-episode structures.
 
@@ -352,6 +507,10 @@ def make_dataset(
     The validation dataset is created by splitting the train dataset into train and validation sets based on the
     effective split ratio: the per-dataset `cfg.val_split_ratio` when set, otherwise the mixture-wide
     `train_cfg.dataset_mixture.val_split_ratio` (the per-dataset value `None` inherits the mixture default).
+
+    The split is drawn from a dedicated, rank-independent generator rather than the global torch RNG
+    (which `set_seed` offsets per process), so every rank partitions the dataset identically and the
+    validation half is held out from *all* ranks' training data. See `val_split_generator`.
 
     Args:
         cfg (DatasetConfig): A DatasetConfig used to create a LeRobotDataset.
@@ -451,7 +610,15 @@ def make_dataset(
         )
         val_size = int(len(dataset) * effective_val_split)
         train_size = len(dataset) - val_size
-        train_dataset, val_dataset = torch.utils.data.random_split(dataset, [train_size, val_size])
+        # Explicit, rank-independent generator: the global torch RNG is seeded
+        # per-rank on purpose (`set_seed(..., accelerator=...)` offsets by
+        # `process_index * 12345`), so splitting off it gives every rank a
+        # different partition and the reported validation metrics end up
+        # measured on other ranks' training frames. See `val_split_generator`
+        # for the full stability contract.
+        train_dataset, val_dataset = torch.utils.data.random_split(
+            dataset, [train_size, val_size], generator=val_split_generator(train_cfg)
+        )
         # Share the large, read-only per-episode metadata (`episodes`,
         # `episodes_stats`) across the two halves; deep-copy only the small
         # aggregated `stats`. A blanket `deepcopy(meta)` here is tens of GB of
@@ -475,9 +642,6 @@ def make_dataset(
         return train_dataset, val_dataset  # type: ignore[return-value]
 
     return dataset
-
-
-logger = logging.getLogger(__name__)
 
 
 def _resolve_weights(
@@ -555,6 +719,8 @@ def make_dataset_mixture(
     Returns:
         WeightedDatasetMixture or Tuple[WeightedDatasetMixture, WeightedDatasetMixture]: An instance of WeightedDatasetMixture containing the datasets, or a tuple of (train_mixture, val_mixture) if val_freq > 0.
     """
+    warn_if_resumed_split_differs(cfg)
+
     datasets = []
     val_datasets = []
     for dataset_cfg in cfg.dataset_mixture.datasets:

--- a/src/opentau/utils/random_utils.py
+++ b/src/opentau/utils/random_utils.py
@@ -211,6 +211,18 @@ def set_seed(seed, accelerator: accelerate.Accelerator = None) -> None:
         accelerator: Optional Accelerator instance. If provided, each process
             gets a different seed offset to ensure reproducibility in distributed
             settings.
+
+    Note:
+        The per-process offset is intentional: it decorrelates the *per-sample*
+        draws (image augmentation, optional-key dropout, prompt substitution)
+        across ranks, so the global batch is not eight copies of the same
+        augmentation stream. The consequence is that **the global RNG is
+        rank-dependent by construction**, so any decision that must agree across
+        ranks — a dataset-level partition, a branch that fires a collective —
+        must never be taken off it. Use an explicit generator seeded from
+        ``cfg.seed`` alone; see
+        :func:`opentau.datasets.factory.val_split_generator` for the train/val
+        split, which regressed exactly this way.
     """
     # before setting the seed, we check if we are using an accelerator and ensure every process gets a different seed
     if seed is not None and accelerator is not None:

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -961,6 +961,302 @@ def test_make_dataset_per_dataset_val_split_ratio_zero_opts_out(train_pipeline_c
         cleanup()
 
 
+def _val_indices_for_rank(train_pipeline_config, rank, num_processes=8, dataset_len=5000, after_seed=None):
+    """Run `make_dataset`'s split the way rank `rank` of an 8-rank job would.
+
+    Mirrors the production ordering in `scripts/train.py`: `set_seed(cfg.seed,
+    accelerator=accelerator)` — which offsets the global RNG by
+    `process_index * 12345` — immediately followed by dataset construction,
+    including train.py's `if cfg.seed is not None` guard. When `cfg.seed` is
+    None nothing seeds the global RNG, so each real process would be running on
+    its own entropy-derived state; that is emulated here with an arbitrary
+    per-rank seed.
+
+    `after_seed` is an optional no-arg callable run between the seeding and the
+    dataset construction, standing in for everything in `train.py` that consumes
+    the global RNG in that window.
+
+    Returns the val `Subset`'s index list.
+    """
+    from opentau.utils.random_utils import set_seed
+
+    dataset_cfg = train_pipeline_config.dataset_mixture.datasets[0]
+    cleanup = _register_mapping(dataset_cfg.repo_id)
+    try:
+        if train_pipeline_config.seed is not None:
+            set_seed(
+                train_pipeline_config.seed,
+                accelerator=MagicMock(process_index=rank, num_processes=num_processes),
+            )
+        else:
+            torch.manual_seed(0xC0FFEE + rank)
+        if after_seed is not None:
+            after_seed()
+        with (
+            patch("opentau.datasets.factory.LeRobotDatasetMetadata") as mock_meta_cls,
+            patch("opentau.datasets.factory.LeRobotDataset") as mock_ds_cls,
+        ):
+            mock_meta_cls.return_value = MagicMock(features=[])
+            mock_ds = MagicMock(meta=MagicMock(info={}, stats={}, camera_keys=[]))
+            mock_ds.__len__.return_value = dataset_len
+            mock_ds.shallow_copy_with_dropout.return_value = mock_ds
+            mock_ds_cls.return_value = mock_ds
+
+            _, val_dataset = make_dataset(dataset_cfg, train_pipeline_config)
+        return list(val_dataset.indices)
+    finally:
+        cleanup()
+
+
+@pytest.mark.parametrize("seed", [1000, None])
+def test_val_split_is_identical_across_ranks(train_pipeline_config, seed):
+    """The train/val split must be byte-identical on every rank.
+
+    Regression test. `set_seed(seed, accelerator=...)` offsets the global torch
+    RNG by `process_index * 12345` on purpose, to decorrelate per-sample draws
+    (augmentation, optional-key dropout, prompt substitution) across ranks. The
+    split used to be taken off that same global RNG with no explicit generator,
+    so each rank partitioned the dataset differently: every rank held out a
+    *different* 2%, and each rank's validation frames sat in some other rank's
+    training set. The gathered `Validation/*` metrics were therefore measured on
+    partly-memorized data (optimistically biased), and `running_best` checkpoint
+    selection was driven by that contaminated number.
+
+    The `seed=None` case matters just as much: `train.py` then never calls
+    `set_seed` at all, so each process would otherwise split off its own
+    entropy-seeded RNG — the same bug by a different route.
+    """
+    train_pipeline_config.seed = seed
+    train_pipeline_config.dataset_mixture.val_split_ratio = 0.02
+    train_pipeline_config.val_freq = 1
+
+    per_rank = {rank: _val_indices_for_rank(train_pipeline_config, rank) for rank in range(8)}
+
+    assert len(per_rank[0]) == 100  # int(5000 * 0.02); a non-trivial split, not an empty one
+    for rank, indices in per_rank.items():
+        assert indices == per_rank[0], f"rank {rank} split differs from rank 0"
+
+
+def test_val_split_is_independent_of_world_size(train_pipeline_config):
+    """Resuming on a different number of GPUs must not re-partition the data.
+
+    Checkpoint selection (`running_best`) compares validation numbers across the
+    resume boundary, so the split has to be a function of `cfg.seed` alone — not
+    of `num_processes`.
+    """
+    train_pipeline_config.seed = 1000
+    train_pipeline_config.dataset_mixture.val_split_ratio = 0.02
+    train_pipeline_config.val_freq = 1
+
+    eight_gpu = _val_indices_for_rank(train_pipeline_config, rank=0, num_processes=8)
+    four_gpu = _val_indices_for_rank(train_pipeline_config, rank=3, num_processes=4)
+    single_gpu = _val_indices_for_rank(train_pipeline_config, rank=0, num_processes=1)
+
+    assert eight_gpu == four_gpu == single_gpu
+
+
+def test_val_split_is_independent_of_prior_global_rng_consumption(train_pipeline_config):
+    """The split must not depend on how much global RNG ran before it.
+
+    Guards the fix against a subtler re-regression than the rank offset: with an
+    implicit generator the partition also shifts whenever an unrelated change
+    adds or removes a draw earlier in the process (model init, a new transform),
+    silently invalidating comparisons against every previously-trained
+    checkpoint. An explicit generator makes the split reproducible regardless.
+    """
+    train_pipeline_config.seed = 1000
+    train_pipeline_config.dataset_mixture.val_split_ratio = 0.02
+    train_pipeline_config.val_freq = 1
+
+    baseline = _val_indices_for_rank(train_pipeline_config, rank=0)
+    perturbed = _val_indices_for_rank(
+        train_pipeline_config,
+        rank=0,
+        # Runs after `set_seed` and before the split, exactly where an added
+        # model-init or transform draw would land.
+        after_seed=lambda: torch.rand(12345),
+    )
+
+    assert perturbed == baseline
+
+
+def test_val_split_changes_with_seed(train_pipeline_config):
+    """`cfg.seed` must actually reach the split generator.
+
+    Without this, a generator hard-coded to a constant would satisfy every
+    cross-rank assertion above while quietly ignoring the run's seed, making the
+    split unchangeable and every run's held-out set identical.
+    """
+    train_pipeline_config.dataset_mixture.val_split_ratio = 0.02
+    train_pipeline_config.val_freq = 1
+
+    train_pipeline_config.seed = 1000
+    first = _val_indices_for_rank(train_pipeline_config, rank=0)
+    train_pipeline_config.seed = 2000
+    second = _val_indices_for_rank(train_pipeline_config, rank=0)
+
+    assert first != second
+
+
+def test_val_split_generator_ignores_process_index(train_pipeline_config):
+    """`val_split_generator` derives its seed from `cfg.seed` only.
+
+    Pins the invariant at the source, so a future "make the split depend on the
+    rank/world size" edit fails here rather than only in the end-to-end tests.
+    """
+    from opentau.datasets.factory import DEFAULT_VAL_SPLIT_SEED, val_split_generator
+
+    train_pipeline_config.seed = 1000
+    assert val_split_generator(train_pipeline_config).initial_seed() == 1000
+
+    train_pipeline_config.seed = None
+    assert val_split_generator(train_pipeline_config).initial_seed() == DEFAULT_VAL_SPLIT_SEED
+
+
+def _write_checkpoint_train_config(tmp_path, cfg_dict):
+    from opentau.configs.policies import TRAIN_CONFIG_NAME
+
+    (tmp_path / TRAIN_CONFIG_NAME).write_text(json.dumps(cfg_dict))
+    return tmp_path
+
+
+def test_warn_if_resumed_split_differs_flags_a_changed_seed(train_pipeline_config, tmp_path, caplog):
+    """A CLI `--seed` override on resume silently re-partitions every dataset.
+
+    On resume the train config is loaded from the checkpoint's
+    `train_config.json` and CLI overrides are layered on top, so the split
+    inputs can drift without the user noticing. The resumed run then validates
+    on frames the checkpoint trained on.
+    """
+    from opentau.datasets.factory import warn_if_resumed_split_differs
+
+    train_pipeline_config.seed = 2000
+    train_pipeline_config.val_freq = 1
+    train_pipeline_config.resume = True
+    train_pipeline_config.checkpoint_path = _write_checkpoint_train_config(
+        tmp_path, {"seed": 1000, "dataset_mixture": {"val_split_ratio": 0.02, "datasets": []}}
+    )
+
+    with caplog.at_level(logging.WARNING, logger="opentau.datasets.factory"):
+        warn_if_resumed_split_differs(train_pipeline_config)
+
+    assert "seed: 1000 -> 2000" in caplog.text
+
+
+def test_warn_if_resumed_split_differs_is_quiet_when_split_is_unchanged(
+    train_pipeline_config, tmp_path, caplog
+):
+    """An ordinary resume must not warn — otherwise the warning is noise."""
+    from opentau.datasets.factory import warn_if_resumed_split_differs
+
+    train_pipeline_config.seed = 1000
+    train_pipeline_config.val_freq = 1
+    train_pipeline_config.resume = True
+    train_pipeline_config.dataset_mixture.val_split_ratio = 0.02
+    saved = {
+        "seed": 1000,
+        "dataset_mixture": {
+            "val_split_ratio": 0.02,
+            "datasets": [
+                {"val_split_ratio": ds.val_split_ratio}
+                for ds in train_pipeline_config.dataset_mixture.datasets
+            ],
+        },
+    }
+    train_pipeline_config.checkpoint_path = _write_checkpoint_train_config(tmp_path, saved)
+
+    with caplog.at_level(logging.WARNING, logger="opentau.datasets.factory"):
+        warn_if_resumed_split_differs(train_pipeline_config)
+
+    assert caplog.text == ""
+
+
+def test_warn_if_resumed_split_differs_reads_a_real_saved_train_config(
+    train_pipeline_config, tmp_path, caplog
+):
+    """Round-trip against a config written by `save_pretrained`, not a hand-built dict.
+
+    The drift check reads `seed`, `dataset_mixture.val_split_ratio` and
+    `dataset_mixture.datasets[i].val_split_ratio` out of the checkpoint's
+    serialized `train_config.json`. If the serialization ever nests those
+    differently, every lookup returns `None` and the check goes permanently
+    silent — a warning that never fires looks exactly like a healthy resume.
+    """
+    from opentau.datasets.factory import warn_if_resumed_split_differs
+
+    train_pipeline_config.seed = 1000
+    train_pipeline_config.val_freq = 1
+    train_pipeline_config.save_pretrained(tmp_path)
+
+    train_pipeline_config.resume = True
+    train_pipeline_config.checkpoint_path = tmp_path
+
+    # Unchanged config round-tripped through the real serializer: no warning.
+    with caplog.at_level(logging.WARNING, logger="opentau.datasets.factory"):
+        warn_if_resumed_split_differs(train_pipeline_config)
+    assert caplog.text == ""
+
+    # Now drift a per-dataset ratio, which lives at the deepest of the three paths.
+    train_pipeline_config.dataset_mixture.datasets[0].val_split_ratio = 0.5
+    with caplog.at_level(logging.WARNING, logger="opentau.datasets.factory"):
+        warn_if_resumed_split_differs(train_pipeline_config)
+    assert "dataset_mixture.datasets[0].val_split_ratio" in caplog.text
+
+
+def test_warn_if_resumed_split_differs_warns_once_not_once_per_rank(train_pipeline_config, tmp_path, caplog):
+    """Every rank builds the dataset, so the warning is main-process only."""
+    from opentau.datasets.factory import warn_if_resumed_split_differs
+
+    train_pipeline_config.seed = 2000
+    train_pipeline_config.val_freq = 1
+    train_pipeline_config.resume = True
+    train_pipeline_config.checkpoint_path = _write_checkpoint_train_config(
+        tmp_path, {"seed": 1000, "dataset_mixture": {"val_split_ratio": 0.02, "datasets": []}}
+    )
+
+    with (
+        patch(
+            "opentau.datasets.factory.get_proc_accelerator",
+            return_value=MagicMock(is_main_process=False),
+        ),
+        caplog.at_level(logging.WARNING, logger="opentau.datasets.factory"),
+    ):
+        warn_if_resumed_split_differs(train_pipeline_config)
+
+    assert caplog.text == ""
+
+
+@pytest.mark.parametrize(
+    ("resume", "val_freq", "write_config"),
+    [
+        (False, 1, True),  # not resuming: nothing to compare against
+        (True, 0, True),  # validation disabled: no split is taken
+        (True, 1, False),  # checkpoint has no train_config.json
+    ],
+)
+def test_warn_if_resumed_split_differs_no_ops(
+    train_pipeline_config, tmp_path, caplog, resume, val_freq, write_config
+):
+    """A best-effort diagnostic must stay silent — and must never raise — when it
+    has nothing to say or nothing to read.
+    """
+    from opentau.datasets.factory import warn_if_resumed_split_differs
+
+    train_pipeline_config.seed = 2000  # would drift, if the check ran at all
+    train_pipeline_config.resume = resume
+    train_pipeline_config.val_freq = val_freq
+    train_pipeline_config.checkpoint_path = (
+        _write_checkpoint_train_config(tmp_path, {"seed": 1000, "dataset_mixture": {}})
+        if write_config
+        else tmp_path
+    )
+
+    with caplog.at_level(logging.WARNING, logger="opentau.datasets.factory"):
+        warn_if_resumed_split_differs(train_pipeline_config)
+
+    assert caplog.text == ""
+
+
 def test_subset_meta_shares_episode_metadata_but_isolates_stats():
     """`_subset_meta` shares the large read-only per-episode metadata by reference
     while giving each subset an independent aggregated `stats`.

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -1151,24 +1151,98 @@ def test_warn_if_resumed_split_differs_is_quiet_when_split_is_unchanged(
 
     train_pipeline_config.seed = 1000
     train_pipeline_config.val_freq = 1
-    train_pipeline_config.resume = True
     train_pipeline_config.dataset_mixture.val_split_ratio = 0.02
-    saved = {
-        "seed": 1000,
-        "dataset_mixture": {
-            "val_split_ratio": 0.02,
-            "datasets": [
-                {"val_split_ratio": ds.val_split_ratio}
-                for ds in train_pipeline_config.dataset_mixture.datasets
-            ],
-        },
-    }
-    train_pipeline_config.checkpoint_path = _write_checkpoint_train_config(tmp_path, saved)
+    train_pipeline_config.save_pretrained(tmp_path)
+
+    train_pipeline_config.resume = True
+    train_pipeline_config.checkpoint_path = tmp_path
 
     with caplog.at_level(logging.WARNING, logger="opentau.datasets.factory"):
         warn_if_resumed_split_differs(train_pipeline_config)
 
     assert caplog.text == ""
+
+
+def test_warn_if_resumed_split_differs_flags_a_changed_episode_filter(
+    train_pipeline_config, tmp_path, caplog
+):
+    """`episodes` / `excluded_episodes` decide `len(dataset)` — the split's third input.
+
+    They are serialized into the checkpoint, so overriding one on resume is
+    detectable and must be caught: it changes both the val size and the whole
+    permutation while `seed` and `val_split_ratio` look untouched.
+    """
+    from opentau.datasets.factory import warn_if_resumed_split_differs
+
+    train_pipeline_config.seed = 1000
+    train_pipeline_config.val_freq = 1
+    train_pipeline_config.save_pretrained(tmp_path)
+
+    train_pipeline_config.resume = True
+    train_pipeline_config.checkpoint_path = tmp_path
+    train_pipeline_config.dataset_mixture.datasets[0].excluded_episodes = [3, 7]
+
+    with caplog.at_level(logging.WARNING, logger="opentau.datasets.factory"):
+        warn_if_resumed_split_differs(train_pipeline_config)
+
+    assert "datasets[0].excluded_episodes" in caplog.text
+
+
+def test_warn_if_resumed_split_differs_compares_effective_not_raw_ratios(
+    train_pipeline_config, tmp_path, caplog
+):
+    """A per-dataset `None` and an explicit value equal to the mixture default are
+    the same split, and must not warn.
+
+    `make_dataset` resolves `None` to the mixture-wide default, so comparing raw
+    values reports drift where the effective ratio is identical. A diagnostic
+    that cries wolf gets tuned out, which costs exactly the real detection it
+    exists for.
+    """
+    from opentau.datasets.factory import warn_if_resumed_split_differs
+
+    train_pipeline_config.seed = 1000
+    train_pipeline_config.val_freq = 1
+    train_pipeline_config.dataset_mixture.val_split_ratio = 0.02
+    train_pipeline_config.dataset_mixture.datasets[0].val_split_ratio = None  # inherit
+    train_pipeline_config.save_pretrained(tmp_path)
+
+    train_pipeline_config.resume = True
+    train_pipeline_config.checkpoint_path = tmp_path
+    # Spell out the value it was already inheriting: same effective split.
+    train_pipeline_config.dataset_mixture.datasets[0].val_split_ratio = 0.02
+
+    with caplog.at_level(logging.WARNING, logger="opentau.datasets.factory"):
+        warn_if_resumed_split_differs(train_pipeline_config)
+
+    assert caplog.text == ""
+
+    # ...but a genuinely different effective ratio still warns.
+    train_pipeline_config.dataset_mixture.datasets[0].val_split_ratio = 0.2
+    with caplog.at_level(logging.WARNING, logger="opentau.datasets.factory"):
+        warn_if_resumed_split_differs(train_pipeline_config)
+
+    assert "datasets[0].val_split_ratio: 0.02 -> 0.2" in caplog.text
+
+
+def test_warn_if_resumed_split_differs_summarizes_long_episode_lists(train_pipeline_config, tmp_path, caplog):
+    """Episode lists can hold thousands of entries; the warning must stay readable."""
+    from opentau.datasets.factory import warn_if_resumed_split_differs
+
+    train_pipeline_config.seed = 1000
+    train_pipeline_config.val_freq = 1
+    train_pipeline_config.dataset_mixture.datasets[0].episodes = list(range(500))
+    train_pipeline_config.save_pretrained(tmp_path)
+
+    train_pipeline_config.resume = True
+    train_pipeline_config.checkpoint_path = tmp_path
+    train_pipeline_config.dataset_mixture.datasets[0].episodes = list(range(400))
+
+    with caplog.at_level(logging.WARNING, logger="opentau.datasets.factory"):
+        warn_if_resumed_split_differs(train_pipeline_config)
+
+    assert "datasets[0].episodes: [500 items] -> [400 items]" in caplog.text
+    assert "499" not in caplog.text  # the lists themselves are not dumped
 
 
 def test_warn_if_resumed_split_differs_reads_a_real_saved_train_config(
@@ -1200,7 +1274,7 @@ def test_warn_if_resumed_split_differs_reads_a_real_saved_train_config(
     train_pipeline_config.dataset_mixture.datasets[0].val_split_ratio = 0.5
     with caplog.at_level(logging.WARNING, logger="opentau.datasets.factory"):
         warn_if_resumed_split_differs(train_pipeline_config)
-    assert "dataset_mixture.datasets[0].val_split_ratio" in caplog.text
+    assert "datasets[0].val_split_ratio" in caplog.text
 
 
 def test_warn_if_resumed_split_differs_warns_once_not_once_per_rank(train_pipeline_config, tmp_path, caplog):


### PR DESCRIPTION
## What this does

Fixes a silent validation-data leak: **the train/validation split was different on every rank, so the reported validation metrics were measured on data the model had been trained on.**

Two things combined:

1. `utils/random_utils.py::set_seed(seed, accelerator=...)` deliberately offsets the seed per process — `seed += accelerator.process_index * 12345` — so that per-sample draws (image augmentation, optional-key dropout, prompt substitution) are decorrelated across ranks. This is correct and intentional.
2. `datasets/factory.py::make_dataset` took the train/val `random_split` off that same **global** RNG with no explicit generator.

`scripts/train.py` calls `set_seed(cfg.seed, accelerator=accelerator)` and then `make_dataset_mixture(cfg)` on *every* rank, unguarded, so each rank drew a different `randperm` and partitioned the dataset differently.

Because every rank builds its own `Subset` views, each rank's validation frames landed in some other rank's training set. Simulating 8 ranks over a 353,222-frame dataset at a 2% val ratio:

```python
import random, numpy as np, torch

N, val_size = 353222, 7064
sets = {}
for rank in range(8):
    s = 1234 + rank * 12345
    random.seed(s); np.random.seed(s); torch.manual_seed(s)
    _, va = torch.utils.data.random_split(range(N), [N - val_size, val_size])
    sets[rank] = set(va.indices)

len(sets[0] & sets[1])            # 143 — pure chance
len(set.union(*sets.values()))    # 52818 (15% of the dataset)
len(set.intersection(*sets.values()))  # 0
```

The intersection is empty, so **100% of the frames behind the reported `Validation/*` metrics were in at least one rank's training set**. Consequences: validation loss was optimistically biased (partly-memorized frames), `running_best` checkpoint selection was driven by that contaminated metric, and val numbers were not comparable across runs with different world sizes.

### The fix

Scoped to the split — the per-rank offset in `set_seed` is left alone, since it is load-bearing elsewhere. `random_split` now takes an explicit, rank-independent generator seeded from `cfg.seed` only (`val_split_generator`).

The split is now a pure function of exactly three inputs: `cfg.seed`, `len(dataset)`, and the effective `val_split_ratio`. It is independent of `process_index`, `num_processes`, mixture composition, and how much global RNG ran beforehand. Deliberate consequences, documented on `val_split_generator`:

- **World-size change** (resuming on 4 GPUs instead of 8) leaves the split untouched, so validation stays comparable across the resume boundary.
- **Resume** reproduces the same split as long as those three inputs are unchanged. `--config_path` points at the checkpoint's `train_config.json` on resume, so they carry over automatically — but a CLI override re-partitions the data silently, and `warn_if_resumed_split_differs` warns on exactly that. It covers all three inputs: `seed`, the *effective* `val_split_ratio` per dataset (resolving the `None`-inherits-the-mixture-default rule the way `make_dataset` does), and the config-visible determinants of `len(dataset)` — `episodes`, `excluded_episodes` and `revision`, which are all serialized into the checkpoint. The one case it cannot catch is an **out-of-band** length change: the same `repo_id` at the same `revision` re-uploaded with more episodes. Nothing in the checkpoint records the length actually observed, so that is documented on `val_split_generator` rather than detected; recording it would mean touching the checkpoint format, which belongs in its own change.
- **Mixture composition is irrelevant** — adding or reordering datasets does not reshuffle the others' splits. Two datasets of equal length get the same permutation, which is what you want when the same underlying data is listed twice under different configs: the shared permutation keeps the val frames aligned instead of leaking each entry's val half into the other's train half.
- **`cfg.seed = None`** is covered too. `train.py` never calls `set_seed` in that case, so each process would otherwise split off its own entropy-seeded RNG — the same bug by a different route. A fixed `DEFAULT_VAL_SPLIT_SEED` handles it.

I swept the rest of the data path for the same class of problem (a dataset-level partition or cross-rank-consistent decision taken off the global RNG). This `random_split` was the only instance:

- `datasets/compute_stats.py::sample_indices` — deterministic `np.linspace`, no RNG.
- `datasets/delta_action_stats.py` row cap — uniform stride, no RNG.
- `datasets/dataset_mixture.py::HierarchicalSampler` — already uses an explicit generator; samples **with replacement**, so it carries no partition invariant, and per-rank divergence there is the ordinary data-sharding path rather than a leak.
- `datasets/sampler.py::EpisodeAwareSampler` — `torch.randperm` off the global RNG, but it is not wired into the training path (only tests reference it). Left alone rather than changed speculatively.
- The per-sample draws in `lerobot_dataset.py` (subgoal dropout, prompt substitution, segment offsets) are exactly what the per-rank offset exists to decorrelate — correct as-is.

Also added a `Note:` to `set_seed`'s docstring recording that the global RNG is rank-dependent by construction, so cross-rank-consistent decisions must never be taken off it.

## How it was tested

Added 19 tests in `tests/datasets/test_datasets.py`, next to the existing dataset-factory val-split tests. They drive the real `make_dataset` through the production ordering (`set_seed(cfg.seed, accelerator=...)` → build dataset), simulating `process_index` values in one process.

**Four fail on the pre-fix code and pass after it** — verified by reverting just the `generator=` argument and re-running:

```
FAILED test_val_split_is_identical_across_ranks[1000]
FAILED test_val_split_is_identical_across_ranks[None]
FAILED test_val_split_is_independent_of_world_size
FAILED test_val_split_is_independent_of_prior_global_rng_consumption
```

- `test_val_split_is_identical_across_ranks` — parameterized over `seed=1000` and `seed=None`; asserts the val index lists of 8 simulated ranks are all equal to rank 0's.
- `test_val_split_is_independent_of_world_size` — the split at world sizes 8, 4 and 1 is the same.
- `test_val_split_is_independent_of_prior_global_rng_consumption` — an unrelated `torch.rand(12345)` between the seeding and the split does not move it.
- `test_val_split_changes_with_seed` — mutation-killer: a generator hard-coded to a constant would satisfy every cross-rank assertion above while silently ignoring the run's seed.
- `test_val_split_generator_ignores_process_index` — pins the invariant at the source, including the `seed=None` fallback.
- Eight tests over `warn_if_resumed_split_differs`: it fires on a changed seed and on a changed `excluded_episodes`, stays quiet on an ordinary resume, is main-process-only (it runs on every rank), and no-ops without raising when not resuming / validation is off / the checkpoint has no `train_config.json`.
- `test_warn_if_resumed_split_differs_compares_effective_not_raw_ratios` — a per-dataset ratio moving between `None` and an explicit value equal to the mixture default is the same split and must stay silent, while a genuinely different ratio still warns. A diagnostic that cries wolf gets tuned out, which costs exactly the real detection it exists for.
- `test_warn_if_resumed_split_differs_reads_a_real_saved_train_config` — round-trips through the actual `save_pretrained` serializer rather than a hand-built dict, so a change to how the config nests those fields can't make the warning go permanently silent (a warning that never fires looks exactly like a healthy resume).

The three drift-check tests added in the second commit were likewise verified against the previous behavior: reverting just the effective-ratio resolution and the length-determining field list fails all three.

Full runs:

```
uv run pre-commit run --files <changed files>          # clean
uv run pytest -m "not gpu and not network" -n auto tests/datasets/
  → 701 passed, 7 skipped
uv run pytest -m "not gpu and not network" -n auto tests/utils tests/configs tests/scripts
  → 611 passed, 4 skipped
```

(`tests/utils/test_libero_utils.py` fails to import locally on `ModuleNotFoundError: No module named 'robosuite'` — pre-existing, reproduced on a clean checkout of `main`; this environment lacks the `libero` extra that CI installs.)

No GPU tests: this is a `datasets`-scoped fix and touches no policy, optimizer, sampler or training-loop code, so the policy/GPU checklist boxes stay unchecked.

## How to checkout & try? (for the reviewer)

The regression tests:

```bash
pytest -sx tests/datasets/test_datasets.py -k "val_split or resumed_split"
```

To watch them catch the original bug, revert just the generator argument in `src/opentau/datasets/factory.py` — change

```python
train_dataset, val_dataset = torch.utils.data.random_split(
    dataset, [train_size, val_size], generator=val_split_generator(train_cfg)
)
```

back to `torch.utils.data.random_split(dataset, [train_size, val_size])`, then re-run the command above: four tests fail.

The standalone repro of the underlying behavior, no OpenTau needed:

```bash
python -c "
import random, numpy as np, torch
N, val_size = 353222, 7064
sets = {}
for rank in range(8):
    s = 1234 + rank * 12345
    random.seed(s); np.random.seed(s); torch.manual_seed(s)
    _, va = torch.utils.data.random_split(range(N), [N - val_size, val_size])
    sets[rank] = set(va.indices)
print('rank0 & rank1 overlap:', len(sets[0] & sets[1]))
print('union:', len(set.union(*sets.values())))
print('intersection:', len(set.intersection(*sets.values())))
"
```

Full dataset suite:

```bash
pytest -m "not gpu and not network" -n auto tests/datasets/
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
