### PR TITLE
fix(datasets): seed the training sampler from cfg.seed

### DIFF
--- a/src/opentau/datasets/dataset_mixture.py
+++ b/src/opentau/datasets/dataset_mixture.py
@@ -777,14 +777,18 @@ class HierarchicalSampler(Sampler[int]):
     samples uniformly within that dataset. This avoids multinomial over a huge number of categories (over 2^24)
     by operating at the dataset level.
 
-    Seeding, in order of precedence: an explicit ``generator``, else ``seed``
-    applied to a fresh generator, else a bare ``torch.Generator()``. That last
-    fallback is **not** unseeded — PyTorch default-constructs generators with a
-    fixed constant — so it is deterministic and identical in every process, but
-    it is a PyTorch implementation detail rather than a documented guarantee and
-    it ignores the run's seed entirely. Callers on the training path pass
-    ``seed=cfg.seed`` so the sample stream is reproducible *and* controlled by
-    the run's own seed; see ``WeightedDatasetMixture.get_dataloader``.
+    Seeding. ``generator`` supplies the RNG *object* and ``seed`` sets its
+    state, so when both are given **``seed`` wins** — it is applied to the
+    passed-in generator via ``manual_seed``, re-seeding the caller's object
+    **in place**. Passing only ``generator`` uses it as-is; passing only
+    ``seed`` applies it to a fresh generator; passing neither leaves a bare
+    ``torch.Generator()``. That last fallback is **not** unseeded — PyTorch
+    default-constructs generators with a fixed constant — so it is
+    deterministic and identical in every process, but it is a PyTorch
+    implementation detail rather than a documented guarantee and it ignores the
+    run's seed entirely. Callers on the training path pass ``seed=cfg.seed`` so
+    the sample stream is reproducible *and* controlled by the run's own seed;
+    see ``WeightedDatasetMixture.get_dataloader``.
 
     Whatever the source, the seed must be **rank-independent**: `accelerate`
     shards this stream by having every rank iterate it and keep the batches at

--- a/src/opentau/datasets/dataset_mixture.py
+++ b/src/opentau/datasets/dataset_mixture.py
@@ -776,6 +776,29 @@ class HierarchicalSampler(Sampler[int]):
     r"""With-replacement sampler for a ConcatDataset that first samples a dataset according to `dataset_probs`, and then
     samples uniformly within that dataset. This avoids multinomial over a huge number of categories (over 2^24)
     by operating at the dataset level.
+
+    Seeding, in order of precedence: an explicit ``generator``, else ``seed``
+    applied to a fresh generator, else a bare ``torch.Generator()``. That last
+    fallback is **not** unseeded — PyTorch default-constructs generators with a
+    fixed constant — so it is deterministic and identical in every process, but
+    it is a PyTorch implementation detail rather than a documented guarantee and
+    it ignores the run's seed entirely. Callers on the training path pass
+    ``seed=cfg.seed`` so the sample stream is reproducible *and* controlled by
+    the run's own seed; see ``WeightedDatasetMixture.get_dataloader``.
+
+    Whatever the source, the seed must be **rank-independent**: `accelerate`
+    shards this stream by having every rank iterate it and keep the batches at
+    its own offset, which only partitions the data while the ranks agree on the
+    sequence.
+
+    Note:
+        The sampler's position is not checkpointed. `accelerate.save_state`
+        persists sampler state only for its own ``SeedableRandomSampler``, so a
+        resumed run rebuilds this sampler and restarts the stream from the
+        beginning rather than continuing it. Sampling is i.i.d. with
+        replacement, so the resumed run is still drawing from the right
+        distribution — but it replays the sample sequence the run already
+        consumed before the interruption instead of seeing fresh draws.
     """
 
     def __init__(
@@ -1122,10 +1145,18 @@ class WeightedDatasetMixture:
 
         # Hierarchical sampling: choose dataset by weight, then uniform within it (both with replacement)
         ds_lengths = [len(ds) for ds in self.datasets]
+        # `cfg.seed` verbatim — never `process_index`. Under `accelerate.prepare`
+        # with the default `dispatch_batches=False`, every rank iterates this
+        # whole stream and keeps the batches at its own offset, so the global
+        # batch is a partition of one shared sequence only while the ranks agree
+        # on it. A rank-dependent seed here would silently make ranks re-draw
+        # each other's samples within a step (see `factory.val_split_generator`
+        # for the same contract on the train/val split).
         sampler = HierarchicalSampler(
             dataset_lengths=ds_lengths,
             dataset_probs=self.dataset_weights,
             num_samples=num_samples_per_epoch,
+            seed=self.cfg.seed,
         )
 
         dataloader = DataLoader(

--- a/tests/datasets/test_dataset_mixture.py
+++ b/tests/datasets/test_dataset_mixture.py
@@ -324,8 +324,8 @@ class TestHierarchicalSamplerSeeding:
         )
         assert self._stream(seed=None) == list(legacy)
 
-    def test_explicit_generator_wins_over_seed(self):
-        """`generator` takes precedence, so a caller can supply its own RNG."""
+    def test_explicit_generator_alone_drives_the_stream(self):
+        """A caller can supply its own RNG instead of a seed."""
         gen = torch.Generator().manual_seed(7)
         sampler = HierarchicalSampler(
             dataset_lengths=self.LENGTHS,
@@ -334,6 +334,30 @@ class TestHierarchicalSamplerSeeding:
             generator=gen,
         )
         assert list(sampler) == self._stream(seed=7)
+
+    def test_seed_beats_generator_and_reseeds_it_in_place(self):
+        """When both are passed, `seed` wins -- and it mutates the caller's generator.
+
+        `__init__` adopts `generator` as the RNG object and then applies
+        `manual_seed(seed)` to it, so `seed` overrides the generator's state
+        rather than the other way round, and the caller's object is re-seeded as
+        a side effect. Pinned because it is the surprising direction: a reader
+        reasonably expects an explicitly-constructed generator to win, and a
+        future refactor could silently flip it.
+        """
+        caller_gen = torch.Generator().manual_seed(7)
+        sampler = HierarchicalSampler(
+            dataset_lengths=self.LENGTHS,
+            dataset_probs=self.PROBS,
+            num_samples=128,
+            generator=caller_gen,
+            seed=1000,
+        )
+
+        stream = list(sampler)
+        assert stream == self._stream(seed=1000)  # seed wins...
+        assert stream != self._stream(seed=7)  # ...not the generator's own state
+        assert caller_gen.initial_seed() == 1000  # re-seeded in place
 
 
 class TestResolveMixtureDeltaMap:

--- a/tests/datasets/test_dataset_mixture.py
+++ b/tests/datasets/test_dataset_mixture.py
@@ -17,7 +17,7 @@
 
 import logging
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
@@ -26,6 +26,7 @@ import torch
 from opentau.configs.default import DatasetConfig, DatasetMixtureConfig
 from opentau.datasets.dataset_mixture import (
     DatasetMixtureMetadata,
+    HierarchicalSampler,
     WeightedDatasetMixture,
     pad_vector,
 )
@@ -263,6 +264,78 @@ class TestDatasetMixtureMetadata:
         )
 
 
+class TestHierarchicalSamplerSeeding:
+    """Seeding contract of the training sampler, in isolation (no full mixture build)."""
+
+    LENGTHS = [1000, 3000]
+    PROBS = [0.7, 0.3]
+
+    def _stream(self, seed=None, n=128):
+        sampler = HierarchicalSampler(
+            dataset_lengths=self.LENGTHS,
+            dataset_probs=self.PROBS,
+            num_samples=n,
+            seed=seed,
+        )
+        return list(sampler)
+
+    def test_same_seed_reproduces_the_stream(self):
+        """A seeded run must be replayable."""
+        assert self._stream(seed=1000) == self._stream(seed=1000)
+
+    def test_different_seeds_give_different_streams(self):
+        """The point of threading `cfg.seed` through: a seed sweep must actually
+        vary the data order, not just model init and augmentation."""
+        assert self._stream(seed=1000) != self._stream(seed=2000)
+
+    def test_stream_ignores_the_global_rng(self):
+        """The sampler must not read the global RNG.
+
+        `set_seed(seed, accelerator=...)` offsets the global torch RNG by
+        `process_index * 12345`, so a sampler that consulted it would hand each
+        rank a different stream. `accelerate` shards by having every rank walk
+        the whole stream and keep the batches at its own offset, which only
+        partitions the data while the ranks agree on the sequence -- otherwise
+        ranks silently re-draw each other's samples within a step.
+        """
+        from opentau.utils.random_utils import set_seed
+
+        streams = []
+        for rank in range(4):
+            set_seed(1000, accelerator=MagicMock(process_index=rank))
+            streams.append(self._stream(seed=1000))
+
+        for rank, stream in enumerate(streams):
+            assert stream == streams[0], f"rank {rank} stream differs from rank 0"
+
+    def test_seed_none_preserves_the_legacy_default_generator_stream(self):
+        """`seed=None` must stay bit-compatible with the pre-change behavior.
+
+        `cfg.seed` is optional; when it is unset the sampler falls back to a bare
+        `torch.Generator()`, which is what every run used before the seed was
+        threaded through. Pinning it keeps a `seed=None` run's data order
+        unchanged by this fix.
+        """
+        legacy = HierarchicalSampler(
+            dataset_lengths=self.LENGTHS,
+            dataset_probs=self.PROBS,
+            num_samples=128,
+            generator=torch.Generator(),  # exactly the old fallback
+        )
+        assert self._stream(seed=None) == list(legacy)
+
+    def test_explicit_generator_wins_over_seed(self):
+        """`generator` takes precedence, so a caller can supply its own RNG."""
+        gen = torch.Generator().manual_seed(7)
+        sampler = HierarchicalSampler(
+            dataset_lengths=self.LENGTHS,
+            dataset_probs=self.PROBS,
+            num_samples=128,
+            generator=gen,
+        )
+        assert list(sampler) == self._stream(seed=7)
+
+
 class TestResolveMixtureDeltaMap:
     """Unit-test the delta-map uniformity resolution in isolation (no full mixture build)."""
 
@@ -478,6 +551,25 @@ class TestWeightedDatasetMixture:
         assert dataloader is not None
         assert dataloader.batch_size == train_pipeline_config.batch_size
         assert dataloader.num_workers == train_pipeline_config.num_workers
+
+    def test_get_dataloader_seeds_the_sampler_from_cfg_seed(self, train_pipeline_config, datasets_factory):
+        """`cfg.seed` must actually reach the training sampler.
+
+        `HierarchicalSampler` was constructed with neither `seed` nor
+        `generator`, so it fell back to a bare `torch.Generator()`. That is not
+        unseeded -- PyTorch default-constructs generators with a fixed constant
+        -- so the stream was deterministic, but identical for every run of a
+        given mixture regardless of `cfg.seed`: a seed sweep varied model init
+        and augmentation while feeding all its runs the same samples in the same
+        order. It also rested on a PyTorch implementation detail, so a change to
+        that constant would have silently shifted every run's data order.
+        """
+        train_pipeline_config.seed = 4242
+        mixture = WeightedDatasetMixture(train_pipeline_config, datasets_factory(2), [0.7, 0.3], 30.0)
+
+        sampler = mixture.get_dataloader().sampler
+
+        assert sampler._gen.initial_seed() == 4242
 
     def test_get_combined_val_dataloader(self, train_pipeline_config, datasets_factory):
         """One deterministic sequential loader over the whole mixture (the


### PR DESCRIPTION
## What this does

Follow-up to #498, from the RNG sweep that PR prompted. `WeightedDatasetMixture.get_dataloader` constructed `HierarchicalSampler` with neither `seed` nor `generator`:

```python
sampler = HierarchicalSampler(
    dataset_lengths=ds_lengths,
    dataset_probs=self.dataset_weights,
    num_samples=num_samples_per_epoch,
)
```

despite the sampler declaring both as supported keyword-only parameters. It therefore fell back to a bare `torch.Generator()`.

**That fallback is not unseeded, and this is not a correctness bug.** PyTorch default-constructs generators with a fixed constant — verified identical across separate processes:

```bash
for i in 1 2 3; do python -c "import torch; print(torch.Generator().initial_seed())"; done
# 67280421310721
# 67280421310721
# 67280421310721
```

So the stream was deterministic and identical on every rank. Unlike the train/val split in #498, there was no cross-rank divergence and no data leak. Two things were wrong anyway:

1. **`cfg.seed` never reached the sampler.** Every run of a given mixture drew the same samples in the same order regardless of seed, so a seed sweep varied only model init and augmentation draws while feeding all its runs identical data in identical order. That is not what `seed: Random seed used for training (model initialization, dataset shuffling)` in `configs/train.py` advertises.
2. **The data order rested on a PyTorch implementation detail.** `torch.Generator()`'s default seed is not a documented guarantee; if it ever changed, every run's data order would shift silently.

### The fix

Pass `seed=self.cfg.seed`. It is the raw config value, so it stays **rank-independent** — which matters here for the same reason it does for the split. `accelerate.prepare` shards with the default `dispatch_batches=False`: every rank iterates the whole sampler stream and keeps the batches at its own offset, so the global batch is a partition of one shared sequence only while the ranks agree on it. A rank-dependent seed would make ranks re-draw each other's samples within a step. The class docstring now states that contract.

`cfg.seed = None` keeps today's behavior exactly — `HierarchicalSampler` already treats `seed=None` as "leave the default generator alone" — and that is pinned by a test comparing against an explicit bare `torch.Generator()`, so a `seed=None` run's data order is bit-unchanged by this PR.

### Behavioral change to be aware of

For any run with `cfg.seed` set, **the training data order changes**. Sampling is i.i.d. with replacement from the same weighted distribution, so this is a different draw from the same distribution rather than a distributional change — but two runs of the same config across this commit will not be step-for-step comparable, and a run resumed across it will not continue its previous stream.

### Also documented, not changed

While confirming the resume story I found that the sampler's position is never checkpointed: `accelerate.checkpointing` persists sampler state only when the sampler is its own `SeedableRandomSampler`, and `train.py` uses neither `skip_first_batches` nor `set_epoch`. A resumed run therefore rebuilds the sampler and **restarts the stream from the beginning** rather than continuing it — it replays the sample sequence already consumed before the interruption. Sampling with replacement means it is still drawing from the right distribution, so this is a data-diversity issue rather than a correctness one.

That behavior is identical before and after this PR — this change only alters *which* stream gets replayed. Fixing it is a separate design decision (skip-ahead on resume, or an epoch/step-derived seed), so this PR records it in the `HierarchicalSampler` docstring instead of quietly changing it.

## How it was tested

New `TestHierarchicalSamplerSeeding` in `tests/datasets/test_dataset_mixture.py`, unit-testing the seeding contract with no mixture build, plus one test on the wiring:

- `test_get_dataloader_seeds_the_sampler_from_cfg_seed` — the mutation-killer for this change: asserts `cfg.seed` reaches the sampler's generator. Verified it **fails** when the `seed=self.cfg.seed` line is reverted.
- `test_same_seed_reproduces_the_stream` / `test_different_seeds_give_different_streams` — a seeded run is replayable, and a seed sweep actually varies the data order.
- `test_stream_ignores_the_global_rng` — runs `set_seed(1000, accelerator=...)` at four simulated `process_index` values (the `process_index * 12345` offset) and asserts the stream is unchanged, pinning rank-independence at the source.
- `test_seed_none_preserves_the_legacy_default_generator_stream` — `seed=None` is bit-compatible with the pre-change bare `torch.Generator()`, so unseeded runs are unaffected.
- `test_explicit_generator_wins_over_seed` — precedence order.

Full runs:

```
uv run pre-commit run --files <changed files>          # clean
uv run pytest -m "not gpu and not network" -n auto tests/datasets/
  → 707 passed, 7 skipped
uv run pytest -m "not gpu and not network" -n auto tests/scripts tests/configs
  → 451 passed
```

No GPU tests: this touches only `datasets/`, no policy, optimizer or training-loop code, so the policy/GPU checklist boxes stay unchecked.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/datasets/test_dataset_mixture.py -k "HierarchicalSamplerSeeding or seeds_the_sampler"
```

To see the original behavior, revert the one line — drop `seed=self.cfg.seed` from the `HierarchicalSampler(...)` call in `src/opentau/datasets/dataset_mixture.py` — and re-run: `test_get_dataloader_seeds_the_sampler_from_cfg_seed` fails while the rest still pass, since the sampler always supported seeding and only the caller was not using it.

Confirm the default-generator constant that the old behavior depended on:

```bash
python -c "import torch; print(torch.Generator().initial_seed())"
```

Full dataset suite:

```bash
pytest -m "not gpu and not network" -n auto tests/datasets/
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
