### PR TITLE
fix(datasets): skip quantile aggregation on partial coverage

### DIFF
--- a/src/opentau/datasets/compute_stats.py
+++ b/src/opentau/datasets/compute_stats.py
@@ -362,8 +362,8 @@ def aggregate_feature_stats(
 
     Args:
         stats_ft_list: List of statistics dictionaries for the same feature.
-        weights: Optional weights for each statistics entry. If None, uses
-            count values as weights.
+        weights: Optional weights for each statistics entry, parallel to
+            ``stats_ft_list``. If None, uses count values as weights.
         contributor_names: Optional names parallel to ``stats_ft_list``, used
             only to name the offenders in the partial-quantile-coverage
             warning. Without it the warning falls back to list indices.
@@ -375,8 +375,20 @@ def aggregate_feature_stats(
         any quantile every contributor carries.
 
     Raises:
-        ValueError: If ``contributor_names`` is not parallel to ``stats_ft_list``.
+        ValueError: If ``weights`` or ``contributor_names`` is not parallel to
+            ``stats_ft_list``.
     """
+    # `weights` replaces the per-contributor `count`, so a misaligned list is not
+    # a broadcast error you'd notice — with a single-entry `stats_ft_list` numpy
+    # happily broadcasts the extra weights and inflates `count` (and skews every
+    # weighted stat) silently. Reject it here as well as in `aggregate_stats`,
+    # whose own check runs before the per-feature filter and so catches a
+    # different misalignment.
+    if weights is not None and len(weights) != len(stats_ft_list):
+        raise ValueError(
+            f"weights ({len(weights)}) must be parallel to stats_ft_list ({len(stats_ft_list)}); "
+            "a misaligned list silently inflates 'count' and skews every weighted stat."
+        )
     if contributor_names is not None and len(contributor_names) != len(stats_ft_list):
         raise ValueError(
             f"contributor_names ({len(contributor_names)}) must be parallel to stats_ft_list "

--- a/src/opentau/datasets/compute_stats.py
+++ b/src/opentau/datasets/compute_stats.py
@@ -71,12 +71,25 @@ Example:
         >>> aggregated = aggregate_stats(stats_list, weights=weights)
 """
 
+import logging
 import warnings
 from typing import Optional
 
 import numpy as np
 
 from opentau.datasets.utils import load_image_as_numpy
+
+# Quantile stats a contributor may carry, in the order they are aggregated.
+# `q01`/`q99` are the pair QUANTILE normalization reads; the inner three are
+# carried through for diagnostics (`scripts/diagnose_norm_distribution.py`) and
+# for future conventions. Datasets whose stats predate quantile support carry
+# none of them, and the fleet migration that adds them is incremental — hence
+# the partial-coverage handling in `aggregate_feature_stats`.
+QUANTILE_STAT_NAMES: tuple[str, ...] = ("q01", "q10", "q50", "q90", "q99")
+
+# Cap on how many contributors a partial-coverage warning names, so a
+# 30-dataset mixture missing quantiles everywhere doesn't produce a wall of log.
+_MAX_NAMED_CONTRIBUTORS = 10
 
 
 def estimate_num_samples(
@@ -279,8 +292,48 @@ def _assert_type_and_shape(stats_list: list[dict[str, dict]]) -> None:
                     raise ValueError(f"Shape of '{k}' must be (3,1,1), but is {v.shape} instead.")
 
 
+def _describe_contributors(indices: tuple[int, ...], contributor_names: Optional[list[str]]) -> str:
+    """Render the offending contributors for a log line: names when known, else indices."""
+    shown = list(indices[:_MAX_NAMED_CONTRIBUTORS])
+    suffix = f", ... and {len(indices) - len(shown)} more" if len(indices) > len(shown) else ""
+    if contributor_names:
+        return f"{[str(contributor_names[i]) for i in shown]}{suffix}"
+    return f"indices {shown}{suffix}"
+
+
+def _warn_dropped_quantiles(
+    dropped: dict[tuple[int, ...], list[str]],
+    num_contributors: int,
+    contributor_names: Optional[list[str]],
+    context: Optional[str],
+) -> None:
+    """Log one warning per distinct set of contributors missing quantile stats.
+
+    Grouping by the missing set keeps the common case — one unmigrated dataset
+    that carries none of the five quantiles — to a single line instead of five.
+    """
+    where = f" [{context}]" if context else ""
+    for indices, q_names in dropped.items():
+        logging.warning(
+            "aggregate_feature_stats%s: dropping %s from the aggregated stats because "
+            "%d/%d contributors are missing them: %s. Quantiles are never backfilled from "
+            "min/max (that would pool two different scales into one buffer), so the aggregate "
+            "carries no quantiles at all. MEAN_STD / MIN_MAX normalization is unaffected; "
+            "QUANTILE normalization over these stats will fail until the listed contributors' "
+            "stats are recomputed with quantiles.",
+            where,
+            sorted(q_names),
+            len(indices),
+            num_contributors,
+            _describe_contributors(indices, contributor_names),
+        )
+
+
 def aggregate_feature_stats(
-    stats_ft_list: list[dict[str, dict]], weights: Optional[list[float]] = None
+    stats_ft_list: list[dict[str, dict]],
+    weights: Optional[list[float]] = None,
+    contributor_names: Optional[list[str]] = None,
+    context: Optional[str] = None,
 ) -> dict[str, dict[str, np.ndarray]]:
     """Aggregate statistics for a single feature across multiple episodes/datasets.
 
@@ -301,14 +354,35 @@ def aggregate_feature_stats(
     ``std``). ``count`` is unconditional: the sum of contributors' counts, not a
     per-dim effective contributor count.
 
+    Quantiles (:data:`QUANTILE_STAT_NAMES`) are aggregated only when *every*
+    contributor carries them. Partial coverage drops that quantile from the
+    output and logs a warning naming the contributors that lack it — it is never
+    backfilled from ``min``/``max``. See the inline comment at the quantile loop
+    for why the drop is preferred over raising.
+
     Args:
         stats_ft_list: List of statistics dictionaries for the same feature.
         weights: Optional weights for each statistics entry. If None, uses
             count values as weights.
+        contributor_names: Optional names parallel to ``stats_ft_list``, used
+            only to name the offenders in the partial-quantile-coverage
+            warning. Without it the warning falls back to list indices.
+        context: Optional label prefixed to that warning (e.g. the norm head
+            and feature the contributors are being pooled for).
 
     Returns:
-        Aggregated statistics dictionary with min, max, mean, std, and count.
+        Aggregated statistics dictionary with min, max, mean, std, count, and
+        any quantile every contributor carries.
+
+    Raises:
+        ValueError: If ``contributor_names`` is not parallel to ``stats_ft_list``.
     """
+    if contributor_names is not None and len(contributor_names) != len(stats_ft_list):
+        raise ValueError(
+            f"contributor_names ({len(contributor_names)}) must be parallel to stats_ft_list "
+            f"({len(stats_ft_list)}); a misaligned list would name the wrong dataset in the "
+            "partial-quantile-coverage warning."
+        )
     means = np.stack([s["mean"] for s in stats_ft_list])
     variances = np.stack([s["std"] ** 2 for s in stats_ft_list])
     mins = np.stack([s["min"] for s in stats_ft_list])
@@ -362,30 +436,31 @@ def aggregate_feature_stats(
         "count": total_count,
     }
 
-    # q01/q99 for QUANTILE normalization. Exact pooled quantiles are not
-    # recoverable from per-contributor quantiles, so use the count-weighted mean
-    # of the contributors' quantiles — a standard approximation that stays
-    # robust to a single contributor's extremes (unlike pooled min/max).
-    # Non-finite entries are masked per dim like the mean.
+    # Quantiles for QUANTILE normalization (and for diagnostics). Exact pooled
+    # quantiles are not recoverable from per-contributor quantiles, so use the
+    # count-weighted mean of the contributors' quantiles — a standard
+    # approximation that stays robust to a single contributor's extremes
+    # (unlike pooled min/max). Non-finite entries are masked per dim like the
+    # mean.
     #
-    # All-or-none: a contributor without the quantile is NOT backfilled from its
+    # All-or-skip: a contributor without the quantile is NOT backfilled from its
     # same-side extreme. Mixing a true q01 with a min pools two different
     # scales into one buffer, silently widening the band by however far the
     # extreme sits outside the 1st percentile — precisely the outlier
-    # sensitivity QUANTILE exists to avoid. Recompute the offending dataset's
-    # stats instead.
-    for q_name in ("q01", "q99"):
+    # sensitivity QUANTILE exists to avoid. Partial coverage therefore drops the
+    # quantile from the aggregate entirely (with a warning) rather than raising:
+    # the fleet's quantile migration is incremental, so a mixture that pairs a
+    # migrated dataset with an unmigrated one is a normal transient state, and
+    # every non-QUANTILE job over that mixture is unaffected by the gap.
+    dropped_quantiles: dict[tuple[int, ...], list[str]] = {}
+    for q_name in QUANTILE_STAT_NAMES:
         have = [q_name in s for s in stats_ft_list]
         if not any(have):
             continue
         if not all(have):
-            missing = [i for i, h in enumerate(have) if not h]
-            raise KeyError(
-                f"aggregate_feature_stats: {len(missing)}/{len(stats_ft_list)} contributors are "
-                f"missing '{q_name}' (indices {missing[:10]}), but the rest have it. Quantiles "
-                "are not backfilled from min/max because that would pool two different scales "
-                "into one buffer. Recompute stats for the listed contributors."
-            )
+            missing = tuple(i for i, h in enumerate(have) if not h)
+            dropped_quantiles.setdefault(missing, []).append(q_name)
+            continue
         q_vals = np.stack([s[q_name] for s in stats_ft_list])
         q_bad = ~np.isfinite(q_vals)
         q_weights = np.where(q_bad, 0.0, counts).astype(np.float64)
@@ -398,11 +473,17 @@ def aggregate_feature_stats(
             where=q_weight_sum > 0,
         )
 
+    if dropped_quantiles:
+        _warn_dropped_quantiles(dropped_quantiles, len(stats_ft_list), contributor_names, context)
+
     return aggregated
 
 
 def aggregate_stats(
-    stats_list: list[dict[str, dict]], weights: Optional[list[float]] = None
+    stats_list: list[dict[str, dict]],
+    weights: Optional[list[float]] = None,
+    contributor_names: Optional[list[str]] = None,
+    context: Optional[str] = None,
 ) -> dict[str, dict[str, np.ndarray]]:
     """Aggregate stats from multiple compute_stats outputs into a single set of stats.
 
@@ -413,15 +494,44 @@ def aggregate_stats(
     - new_max = max(max_dataset_0, max_dataset_1, ...)
     - new_mean = (mean of all data, weighted by counts)
     - new_std = (std of all data)
+
+    Args:
+        stats_list: One stats dict (feature -> stat -> array) per contributor.
+        weights: Optional per-contributor weights; ``None`` uses each entry's
+            ``count``.
+        contributor_names: Optional names parallel to ``stats_list``, forwarded
+            to :func:`aggregate_feature_stats` so a partial-quantile-coverage
+            warning names the offending datasets instead of bare indices.
+        context: Optional label prefixed to those warnings; the feature key is
+            appended automatically.
+
+    Raises:
+        ValueError: If ``contributor_names``/``weights`` are not parallel to
+            ``stats_list``.
     """
 
     _assert_type_and_shape(stats_list)
+
+    for label, parallel in (("contributor_names", contributor_names), ("weights", weights)):
+        if parallel is not None and len(parallel) != len(stats_list):
+            raise ValueError(f"{label} ({len(parallel)}) must be parallel to stats_list ({len(stats_list)}).")
 
     data_keys = {key for stats in stats_list for key in stats}
     aggregated_stats = {key: {} for key in data_keys}
 
     for key in data_keys:
-        stats_with_key = [stats[key] for stats in stats_list if key in stats]
-        aggregated_stats[key] = aggregate_feature_stats(stats_with_key, weights)
+        # A feature absent from some contributors narrows the contributor set
+        # for that feature only; `weights` and `contributor_names` are indexed
+        # by the same positions so every parallel list stays aligned with it.
+        present = [i for i, stats in enumerate(stats_list) if key in stats]
+        stats_with_key = [stats_list[i][key] for i in present]
+        weights_with_key = [weights[i] for i in present] if weights is not None else None
+        names_with_key = [contributor_names[i] for i in present] if contributor_names is not None else None
+        aggregated_stats[key] = aggregate_feature_stats(
+            stats_with_key,
+            weights_with_key,
+            contributor_names=names_with_key,
+            context=f"{context}, feature {key!r}" if context else f"feature {key!r}",
+        )
 
     return aggregated_stats

--- a/src/opentau/datasets/dataset_mixture.py
+++ b/src/opentau/datasets/dataset_mixture.py
@@ -512,7 +512,17 @@ class DatasetMixtureMetadata:
             member_weights = [
                 float(getattr(metadatas[i], "info", {}).get("total_frames", 1) or 1) for i in member_indices
             ]
-            per_norm_key_stats.append(aggregate_stats(member_stats, weights=member_weights))
+            # Names + head label so a partial-quantile head (some members
+            # migrated to q01/q10/q50/q90/q99, some not) warns with the
+            # unmigrated dataset's repo id rather than a bare list index.
+            per_norm_key_stats.append(
+                aggregate_stats(
+                    member_stats,
+                    weights=member_weights,
+                    contributor_names=[self.dataset_names[i] for i in member_indices],
+                    context=f"norm head {k!r}",
+                )
+            )
 
         # One aggregated warning for fallback datasets, capped at 10 names
         # so a 30-dataset mixture without tags doesn't spam the log.
@@ -570,9 +580,11 @@ class DatasetMixtureMetadata:
         # `per_dataset_stats[1]` lacked actions — the BPE codec would then
         # fit a weighted mean using dataset 0's weight applied to dataset 2's
         # action distribution.
-        filtered: list[tuple[dict[str, np.ndarray], float]] = [
-            ({"actions": s["actions"]}, w)
-            for s, w in zip(self.per_dataset_stats, self._dataset_weights, strict=True)
+        filtered: list[tuple[dict[str, np.ndarray], float, str]] = [
+            ({"actions": s["actions"]}, w, name)
+            for s, w, name in zip(
+                self.per_dataset_stats, self._dataset_weights, self.dataset_names, strict=True
+            )
             if "actions" in s
         ]
         if not filtered:
@@ -580,8 +592,10 @@ class DatasetMixtureMetadata:
                 "No dataset in the mixture exposes 'actions' stats; aggregated_action_stats() is undefined."
             )
         agg = aggregate_stats(
-            [s for s, _ in filtered],
-            weights=[w for _, w in filtered],
+            [s for s, _, _ in filtered],
+            weights=[w for _, w, _ in filtered],
+            contributor_names=[name for _, _, name in filtered],
+            context="mixture-wide action stats",
         )
         return agg["actions"]
 

--- a/src/opentau/datasets/delta_action_stats.py
+++ b/src/opentau/datasets/delta_action_stats.py
@@ -550,9 +550,10 @@ def _merge_running(parts: list[dict[str, dict[str, np.ndarray]]]) -> dict[str, d
     """Combine per-file statistics into one set via the existing weighted aggregator.
 
     Reuses :func:`opentau.datasets.compute_stats.aggregate_feature_stats` so pooling here obeys
-    the same weighted-mean/variance rules as every other stats path — including the all-or-none
-    quantile requirement, which holds trivially since every part is produced by
-    :class:`RunningStats`.
+    the same weighted-mean/variance rules as every other stats path — including the all-or-skip
+    quantile requirement (partial coverage drops the quantile rather than backfilling it), which
+    never triggers here since every part is produced by :class:`RunningStats` and so carries the
+    same quantile keys.
 
     Parity note: mean/std/min/max merge exactly. The **quantiles** are pooled as the
     count-weighted mean of the per-file q01/q99 — the same approximation OpenTau already uses for

--- a/src/opentau/policies/normalize.py
+++ b/src/opentau/policies/normalize.py
@@ -241,6 +241,11 @@ def resolve_stat_row(
     converted from v2.1) must have their stats recomputed, or be loaded through
     the delta-action stats pass, which computes quantiles for every dim.
 
+    A row can also lack quantiles because it is an *aggregated* norm head whose
+    member datasets disagree: ``aggregate_feature_stats`` drops a quantile the
+    whole head cannot cover rather than backfilling it from min/max, so one
+    unmigrated dataset removes quantiles from every dataset sharing its head.
+
     Raises:
         KeyError: If the feature is missing, or the stat is missing.
     """
@@ -250,10 +255,13 @@ def resolve_stat_row(
     if name in feat_stats:
         return feat_stats[name]
     hint = ""
-    if name in ("q01", "q99"):
+    if name.startswith("q") and name[1:].isdigit():
         hint = (
             " QUANTILE normalization requires quantile stats; recompute this dataset's stats "
-            "(or switch its normalization_mapping to MIN_MAX / MEAN_STD)."
+            "(or switch its normalization_mapping to MIN_MAX / MEAN_STD). If this row is an "
+            "aggregated norm head, the datasets that lack quantiles are named in the earlier "
+            "'aggregate_feature_stats ...: dropping ...' warning — recomputing those is enough "
+            "to restore quantiles for the whole head."
         )
     raise KeyError(f"stats['{key}'] is missing stat '{name}'. Available stats: {list(feat_stats)}.{hint}")
 
@@ -273,11 +281,24 @@ def _stat_to_float32_tensor(value: np.ndarray | Tensor) -> Tensor:
     raise ValueError(f"np.ndarray or torch.Tensor expected, but type is '{type(value)}' instead.")
 
 
+def row_label(dataset_names: list[str] | None, index: int) -> str:
+    """``per_dataset_stats[2] ('so101|joint_position')`` — index plus name when known.
+
+    The row identifier is what an operator needs to act on a stats error: for a
+    mixture it is the norm-head key, whose member datasets are listed in the
+    ``Norm-head aggregation`` log line emitted at mixture build time.
+    """
+    if dataset_names is not None and 0 <= index < len(dataset_names):
+        return f"per_dataset_stats[{index}] ('{dataset_names[index]}')"
+    return f"per_dataset_stats[{index}]"
+
+
 def create_stats_buffers(
     features: dict[str, PolicyFeature],
     norm_map: dict[str, NormalizationMode],
     per_dataset_stats: list[dict[str, dict[str, Tensor | np.ndarray]]] | None = None,
     num_datasets: int | None = None,
+    dataset_names: list[str] | None = None,
 ) -> dict[str, dict[str, nn.ParameterDict]]:
     """Create per-feature stat buffers shaped ``(D, *feat_shape)``.
 
@@ -291,6 +312,9 @@ def create_stats_buffers(
             or ``_inject_stats`` overwrites them.
         num_datasets: Required when ``per_dataset_stats is None``; ignored
             otherwise. Sets the leading dim of the inf-init buffers.
+        dataset_names: Optional row identifiers parallel to
+            ``per_dataset_stats``, used only to name the offending row when a
+            stat is missing or misshapen.
 
     Returns:
         dict feature_name -> nn.ParameterDict({"mean": param, "std": param}) etc.
@@ -343,15 +367,15 @@ def create_stats_buffers(
             else:
                 rows = []
                 for i, ds_stats in enumerate(per_dataset_stats):
+                    label = row_label(dataset_names, i)
                     try:
                         value = resolve_stat_row(ds_stats, key, name)
                     except KeyError as e:
-                        raise KeyError(f"per_dataset_stats[{i}]: {e.args[0]}") from None
+                        raise KeyError(f"{label}: {e.args[0]}") from None
                     row = _stat_to_float32_tensor(value)
                     if tuple(row.shape) != shape:
                         raise ValueError(
-                            f"per_dataset_stats[{i}]['{key}']['{name}'] has shape "
-                            f"{tuple(row.shape)}, expected {shape}."
+                            f"{label}['{key}']['{name}'] has shape {tuple(row.shape)}, expected {shape}."
                         )
                     rows.append(row)
                 tensor = torch.stack(rows, dim=0)
@@ -460,7 +484,11 @@ class Normalize(nn.Module):
                 f"{len(per_dataset_stats)} vs {len(dataset_names)}."
             )
         stats_buffers = create_stats_buffers(
-            features, norm_map, per_dataset_stats=per_dataset_stats, num_datasets=num_datasets
+            features,
+            norm_map,
+            per_dataset_stats=per_dataset_stats,
+            num_datasets=num_datasets,
+            dataset_names=dataset_names,
         )
         for key, buffer in stats_buffers.items():
             setattr(self, "buffer_" + key.replace(".", "_"), buffer)
@@ -623,7 +651,11 @@ class Unnormalize(nn.Module):
                 f"{len(per_dataset_stats)} vs {len(dataset_names)}."
             )
         stats_buffers = create_stats_buffers(
-            features, norm_map, per_dataset_stats=per_dataset_stats, num_datasets=num_datasets
+            features,
+            norm_map,
+            per_dataset_stats=per_dataset_stats,
+            num_datasets=num_datasets,
+            dataset_names=dataset_names,
         )
         for key, buffer in stats_buffers.items():
             setattr(self, "buffer_" + key.replace(".", "_"), buffer)

--- a/src/opentau/policies/pretrained.py
+++ b/src/opentau/policies/pretrained.py
@@ -857,6 +857,7 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
         from opentau.policies.normalize import (
             _stat_to_float32_tensor,
             resolve_stat_row,
+            row_label,
             stat_names_for_mode,
         )
 
@@ -879,6 +880,12 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
                     "have the same length."
                 )
 
+        # Row identity (norm-head name when known) so a stats gap — e.g. a
+        # QUANTILE policy over a head whose aggregate dropped quantiles — names
+        # the offending row instead of failing with a bare stat name, matching
+        # `create_stats_buffers`.
+        names_for_rows = dataset_names or getattr(self.config, "dataset_names", None)
+
         for module_attr in NORM_MODULE_NAMES:
             module = getattr(self, module_attr, None)
             if module is None:
@@ -893,10 +900,12 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
                     continue
                 stat_names = stat_names_for_mode(norm_mode)
                 for stat in stat_names:
-                    rows = [
-                        _stat_to_float32_tensor(resolve_stat_row(s, feature_key, stat))
-                        for s in per_dataset_stats
-                    ]
+                    rows = []
+                    for i, s in enumerate(per_dataset_stats):
+                        try:
+                            rows.append(_stat_to_float32_tensor(resolve_stat_row(s, feature_key, stat)))
+                        except KeyError as e:
+                            raise KeyError(f"{row_label(names_for_rows, i)}: {e.args[0]}") from None
                     new_tensor = torch.stack(rows, dim=0).to(
                         device=buffer[stat].device, dtype=buffer[stat].dtype
                     )

--- a/tests/datasets/test_compute_stats.py
+++ b/tests/datasets/test_compute_stats.py
@@ -577,19 +577,33 @@ def test_aggregate_feature_stats_partial_quantiles_falls_back_to_indices(caplog)
     assert "indices [1]" in message
 
 
-def test_aggregate_feature_stats_rejects_misaligned_contributor_names():
-    """A names list that isn't parallel would name the wrong dataset — reject it up front."""
+@pytest.mark.parametrize("kwargs", [{"contributor_names": ["only-one"]}, {"weights": [1.0]}])
+def test_aggregate_feature_stats_rejects_misaligned_parallel_args(kwargs):
+    """A non-parallel `weights`/`contributor_names` list is rejected, not silently broadcast.
+
+    Both fail quietly rather than loudly: a short names list names the wrong dataset, and a
+    misaligned `weights` list (which *replaces* `count`) broadcasts against the stats stack and
+    inflates `count` while skewing every weighted stat — the same silent-misalignment class this
+    change fixes one level up in `aggregate_stats`.
+    """
     with pytest.raises(ValueError, match="parallel"):
-        aggregate_feature_stats([_base_stats(), _base_stats()], contributor_names=["only-one"])
+        aggregate_feature_stats([_base_stats(), _base_stats()], **kwargs)
 
 
-def test_aggregate_stats_names_the_offending_dataset_per_feature(caplog):
-    """`aggregate_stats` forwards names/context per feature, keeping both aligned to the filter.
+def test_aggregate_stats_filters_names_and_weights_with_the_feature(caplog):
+    """`aggregate_stats` narrows names *and* weights to the contributors a feature actually has.
 
     `state` is present on both contributors while `actions` is present on only one, so the two
-    features aggregate over different contributor subsets. The names (and weights) must be
-    filtered by the same positions, or the warning would accuse whichever dataset happens to sit
-    at that index in the unfiltered list.
+    features aggregate over different contributor subsets. Both parallel lists must be indexed by
+    the same positions as the stats:
+
+    - names: an unfiltered list accuses whichever dataset sits at that index in the full list;
+    - weights: an unfiltered list is broadcast against the shorter stats stack, so `actions`
+      reports the whole mixture's weight (4.0) instead of its single contributor's (1.0) — and
+      every weighted stat is pooled against that inflated denominator.
+
+    The `count` assertions are what pin the weights half; the quantile/warning assertions alone
+    pass either way, since both contributors' means are identical here.
     """
     migrated = {"state": _with_quantiles(count=10, scale=1.0), "actions": _with_quantiles(10, 1.0)}
     legacy = {"state": _base_stats(count=10)}
@@ -601,6 +615,10 @@ def test_aggregate_stats_names_the_offending_dataset_per_feature(caplog):
             contributor_names=["TensorAuto/migrated", "TensorAuto/legacy"],
             context="norm head 'so101|joint_position'",
         )
+
+    # Weights follow the filter: `state` pools both (1.0 + 3.0), `actions` only the one it has.
+    np.testing.assert_allclose(agg["state"]["count"], 4.0)
+    np.testing.assert_allclose(agg["actions"]["count"], 1.0)
 
     # `actions` has a single contributor, so its quantiles survive; `state` loses them.
     assert set(QUANTILE_STAT_NAMES) <= set(agg["actions"])

--- a/tests/datasets/test_compute_stats.py
+++ b/tests/datasets/test_compute_stats.py
@@ -14,12 +14,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import logging
 from unittest.mock import patch
 
 import numpy as np
 import pytest
 
 from opentau.datasets.compute_stats import (
+    QUANTILE_STAT_NAMES,
     _assert_type_and_shape,
     aggregate_feature_stats,
     aggregate_stats,
@@ -422,6 +424,25 @@ def test_aggregate_stats():
         np.testing.assert_allclose(results[fkey]["count"], expected_agg_stats[fkey]["count"])
 
 
+def _base_stats(count: int = 10) -> dict[str, np.ndarray]:
+    """Non-quantile stats every contributor in the quantile tests shares."""
+    return {
+        "min": np.array([-8.0]),
+        "max": np.array([8.0]),
+        "mean": np.array([0.0]),
+        "std": np.array([1.0]),
+        "count": np.array([count]),
+    }
+
+
+def _with_quantiles(count: int, scale: float) -> dict[str, np.ndarray]:
+    """`_base_stats` plus the full quantile set, spread symmetrically around 0."""
+    stats = _base_stats(count)
+    for q_name, offset in zip(QUANTILE_STAT_NAMES, (-2.0, -1.0, 0.0, 1.0, 2.0), strict=True):
+        stats[q_name] = np.array([offset * scale])
+    return stats
+
+
 def test_aggregate_feature_stats_quantiles_weighted_mean():
     """q01/q99 aggregate as the count-weighted mean of contributor quantiles."""
     stats_ft = [
@@ -450,47 +471,141 @@ def test_aggregate_feature_stats_quantiles_weighted_mean():
     np.testing.assert_allclose(agg["q99"], [6.0])
 
 
-def test_aggregate_feature_stats_partial_quantiles_raises():
-    """Mixing contributors with and without quantiles is an error, not a min/max backfill.
+def test_aggregate_feature_stats_full_quantile_set_aggregates(caplog):
+    """(a) Every contributor has every quantile -> all five land in the aggregate, no warning.
 
-    Backfilling a missing q01 from that contributor's `min` pools two different scales into one
-    buffer: `min` sits however far outside the 1st percentile the tail reaches, so the pooled
-    band silently widens by an amount driven purely by outliers — exactly the sensitivity
-    QUANTILE exists to remove.
+    Pins the inner quantiles too: the loop used to cover only q01/q99, so q10/q50/q90 — which
+    fleet stats now carry and `_to_standard_data_format` already pads — were silently dropped
+    from every aggregated norm head.
     """
-    stats_ft = [
-        {
-            "min": np.array([-8.0]),
-            "max": np.array([8.0]),
-            "mean": np.array([0.0]),
-            "std": np.array([1.0]),
-            "count": np.array([10]),
-            "q01": np.array([-2.0]),
-            "q99": np.array([2.0]),
-        },
-        {
-            # no quantiles (stats predating quantile support)
-            "min": np.array([-4.0]),
-            "max": np.array([4.0]),
-            "mean": np.array([0.0]),
-            "std": np.array([1.0]),
-            "count": np.array([10]),
-        },
-    ]
-    with pytest.raises(KeyError, match="missing 'q01'"):
-        aggregate_feature_stats(stats_ft)
+    stats_ft = [_with_quantiles(count=10, scale=1.0), _with_quantiles(count=30, scale=2.0)]
+    with caplog.at_level(logging.WARNING):
+        agg = aggregate_feature_stats(stats_ft)
+    assert set(QUANTILE_STAT_NAMES) <= set(agg)
+    # count-weighted 10:30 of scale 1 and 2 -> effective scale 1.75
+    np.testing.assert_allclose(agg["q01"], [-3.5])
+    np.testing.assert_allclose(agg["q10"], [-1.75])
+    np.testing.assert_allclose(agg["q50"], [0.0])
+    np.testing.assert_allclose(agg["q90"], [1.75])
+    np.testing.assert_allclose(agg["q99"], [3.5])
+    assert not [r for r in caplog.records if "dropping" in r.getMessage()]
 
 
-def test_aggregate_feature_stats_no_quantiles_no_keys():
-    """When no contributor has quantiles, the aggregate has no quantile keys."""
-    stats_ft = [
-        {
-            "min": np.array([0.0]),
-            "max": np.array([1.0]),
-            "mean": np.array([0.5]),
-            "std": np.array([0.1]),
-            "count": np.array([5]),
-        }
-    ]
-    agg = aggregate_feature_stats(stats_ft)
-    assert "q01" not in agg and "q99" not in agg
+def test_aggregate_feature_stats_no_quantiles_no_keys(caplog):
+    """(b) No contributor has quantiles -> keys absent, and no warning noise.
+
+    The overwhelmingly common case today (nothing in the mixture is migrated yet); warning on it
+    would fire on nearly every job and train operators to ignore the message that matters.
+    """
+    stats_ft = [_base_stats(count=5), _base_stats(count=7)]
+    with caplog.at_level(logging.WARNING):
+        agg = aggregate_feature_stats(stats_ft)
+    assert not set(QUANTILE_STAT_NAMES) & set(agg)
+    assert caplog.records == []
+
+
+@pytest.mark.parametrize("migrated_index", [0, 1])
+def test_aggregate_feature_stats_partial_quantiles_skips_and_warns(migrated_index, caplog):
+    """(c) Partial coverage in BOTH directions -> quantiles dropped, warned, never raised.
+
+    The failure this replaces was symmetric: the old KeyError fired whether the migrated dataset
+    came first or second, killing any job whose mixture straddled the incremental fleet migration
+    before it even loaded a checkpoint. Parametrizing the position is what makes this a pin —
+    a fix that only handled "new dataset last" would pass a single-ordering test.
+
+    Backfilling is still refused: `min` sits however far outside the 1st percentile the tail
+    reaches, so pooling it with a true q01 would widen the band by an outlier-driven amount —
+    exactly the sensitivity QUANTILE exists to remove. Declining to publish a quantile at all is
+    the only safe option, and non-QUANTILE jobs over the same mixture are unaffected.
+    """
+    stats_ft = [_base_stats(count=10), _base_stats(count=10)]
+    stats_ft[migrated_index] = _with_quantiles(count=10, scale=1.0)
+    unmigrated_index = 1 - migrated_index
+
+    with caplog.at_level(logging.WARNING):
+        agg = aggregate_feature_stats(
+            stats_ft, contributor_names=["TensorAuto/migrated", "TensorAuto/legacy"]
+        )
+
+    # No exception, and the non-quantile stats still aggregate normally.
+    assert not set(QUANTILE_STAT_NAMES) & set(agg)
+    np.testing.assert_allclose(agg["mean"], [0.0])
+    np.testing.assert_allclose(agg["count"], [20])
+
+    # Exactly one warning, naming the unmigrated contributor and every dropped quantile.
+    warnings_logged = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings_logged) == 1
+    message = warnings_logged[0]
+    assert ["TensorAuto/migrated", "TensorAuto/legacy"][unmigrated_index] in message
+    assert ["TensorAuto/migrated", "TensorAuto/legacy"][migrated_index] not in message
+    for q_name in QUANTILE_STAT_NAMES:
+        assert q_name in message
+    assert "1/2 contributors" in message
+
+
+def test_aggregate_feature_stats_partial_quantiles_groups_by_missing_set(caplog):
+    """Quantiles missing from *different* contributors warn separately, not as one blurred line.
+
+    A dataset migrated to q01/q99 only, alongside one with the full set, drops q10/q50/q90 for a
+    different reason than a dataset with no quantiles at all drops q01/q99 — telling the operator
+    which recompute fixes which gap requires keeping the two groups apart.
+    """
+    full = _with_quantiles(count=10, scale=1.0)
+    outer_only = _base_stats(count=10) | {"q01": np.array([-2.0]), "q99": np.array([2.0])}
+    none_at_all = _base_stats(count=10)
+
+    with caplog.at_level(logging.WARNING):
+        agg = aggregate_feature_stats(
+            [full, outer_only, none_at_all], contributor_names=["full", "outer_only", "none_at_all"]
+        )
+
+    assert not set(QUANTILE_STAT_NAMES) & set(agg)
+    messages = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(messages) == 2
+    # q01/q99 are missing from one contributor; q10/q50/q90 from two.
+    outer = next(m for m in messages if "'q01'" in m)
+    inner = next(m for m in messages if "'q10'" in m)
+    assert "1/3 contributors" in outer and "none_at_all" in outer and "outer_only" not in outer
+    assert "2/3 contributors" in inner and "none_at_all" in inner and "outer_only" in inner
+
+
+def test_aggregate_feature_stats_partial_quantiles_falls_back_to_indices(caplog):
+    """Without contributor names the warning still points somewhere: the list index."""
+    with caplog.at_level(logging.WARNING):
+        aggregate_feature_stats([_with_quantiles(count=10, scale=1.0), _base_stats(count=10)])
+    message = next(r.getMessage() for r in caplog.records if r.levelno == logging.WARNING)
+    assert "indices [1]" in message
+
+
+def test_aggregate_feature_stats_rejects_misaligned_contributor_names():
+    """A names list that isn't parallel would name the wrong dataset — reject it up front."""
+    with pytest.raises(ValueError, match="parallel"):
+        aggregate_feature_stats([_base_stats(), _base_stats()], contributor_names=["only-one"])
+
+
+def test_aggregate_stats_names_the_offending_dataset_per_feature(caplog):
+    """`aggregate_stats` forwards names/context per feature, keeping both aligned to the filter.
+
+    `state` is present on both contributors while `actions` is present on only one, so the two
+    features aggregate over different contributor subsets. The names (and weights) must be
+    filtered by the same positions, or the warning would accuse whichever dataset happens to sit
+    at that index in the unfiltered list.
+    """
+    migrated = {"state": _with_quantiles(count=10, scale=1.0), "actions": _with_quantiles(10, 1.0)}
+    legacy = {"state": _base_stats(count=10)}
+
+    with caplog.at_level(logging.WARNING):
+        agg = aggregate_stats(
+            [migrated, legacy],
+            weights=[1.0, 3.0],
+            contributor_names=["TensorAuto/migrated", "TensorAuto/legacy"],
+            context="norm head 'so101|joint_position'",
+        )
+
+    # `actions` has a single contributor, so its quantiles survive; `state` loses them.
+    assert set(QUANTILE_STAT_NAMES) <= set(agg["actions"])
+    assert not set(QUANTILE_STAT_NAMES) & set(agg["state"])
+    messages = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(messages) == 1
+    assert "TensorAuto/legacy" in messages[0]
+    assert "norm head 'so101|joint_position'" in messages[0] and "feature 'state'" in messages[0]

--- a/tests/datasets/test_norm_key_aggregation.py
+++ b/tests/datasets/test_norm_key_aggregation.py
@@ -23,6 +23,7 @@ from types import SimpleNamespace
 import numpy as np
 import pytest
 
+from opentau.datasets.compute_stats import QUANTILE_STAT_NAMES
 from opentau.datasets.dataset_mixture import DatasetMixtureMetadata, compute_norm_key
 from opentau.datasets.standard_data_format_mapping import DATA_FEATURES_NAME_MAPPING
 
@@ -223,6 +224,55 @@ class TestDatasetMixtureMetadataNormAggregation:
         ]
         assert len(fallback_warnings) == 1
         assert "repo/b" in fallback_warnings[0].getMessage()
+
+    @pytest.mark.parametrize("migrated_repo", ["repo/a", "repo/b"])
+    def test_partial_quantile_coverage_in_a_head_warns_and_keeps_building(self, migrated_repo, caplog):
+        """A head straddling the fleet's incremental quantile migration must still build.
+
+        This is the end-to-end shape of the breakage: `aggregate_stats` used to raise, so the
+        first mixture pairing a migrated dataset with an unmigrated one killed the training job
+        at startup — before the checkpoint was even loaded, and regardless of whether the job
+        used QUANTILE normalization at all. The failure was symmetric in the ordering, so both
+        directions are exercised here.
+        """
+        repos = ["repo/a", "repo/b"]
+        _patch_name_mapping(repos)
+        cfg = _make_cfg(max_state_dim=8, max_action_dim=8)
+        metadatas = []
+        for repo_id, value in zip(repos, (1.0, 3.0), strict=True):
+            stats = _make_stats(6, 7, value=value, count=100)
+            if repo_id == migrated_repo:
+                for feature, dim in (("state", 6), ("actions", 7)):
+                    for q_name, offset in zip(QUANTILE_STAT_NAMES, (-2, -1, 0, 1, 2), strict=True):
+                        stats[feature][q_name] = np.full((dim,), float(offset), dtype=np.float32)
+            metadatas.append(
+                _make_metadata(
+                    repo_id,
+                    info={"robot_type": "franka", "control_mode": "joint", "total_frames": 100},
+                    stats=stats,
+                )
+            )
+
+        with caplog.at_level(logging.WARNING):
+            meta = DatasetMixtureMetadata(cfg, metadatas, dataset_weights=[0.5, 0.5], dataset_names=repos)
+
+        # One head, built successfully, with the ordinary stats still pooled.
+        assert meta.norm_keys == ["franka::joint"]
+        head = meta.per_norm_key_stats[0]
+        np.testing.assert_allclose(head["state"]["mean"][0], 2.0, atol=1e-6)
+        # ... and no quantiles, because the head cannot cover them for every member.
+        for feature in ("state", "actions"):
+            assert not set(QUANTILE_STAT_NAMES) & set(head[feature])
+
+        # The warning names the unmigrated repo and the head it belongs to — the two facts an
+        # operator needs to know which dataset to recompute.
+        unmigrated_repo = next(r for r in repos if r != migrated_repo)
+        dropped = [r.getMessage() for r in caplog.records if "dropping" in r.getMessage()]
+        assert len(dropped) == 2  # one per pooled feature (state, actions); cameras have no quantiles
+        for message in dropped:
+            assert unmigrated_repo in message
+            assert migrated_repo not in message
+            assert "norm head 'franka::joint'" in message
 
     def test_pooled_stats_closed_form(self):
         """Pooled mean/variance per the Chan-style weighted formula."""

--- a/tests/policies/test_normalize_per_dataset.py
+++ b/tests/policies/test_normalize_per_dataset.py
@@ -654,6 +654,40 @@ def test_quantile_missing_all_raises():
         Normalize(features, norm_map, per_dataset_stats=stats)
 
 
+def test_quantile_error_names_the_offending_row_and_the_aggregate_drop():
+    """The QUANTILE error must name the row and explain how it lost its quantiles.
+
+    A head loses quantiles two ways: its own dataset never had them, or it is an *aggregate*
+    whose members disagree — since #503-era fleet migration, `aggregate_feature_stats` drops a
+    quantile the whole head cannot cover instead of raising. Both land here as the same missing
+    key, so an operator staring at `per_dataset_stats[1]` alone cannot tell which datasets to
+    recompute. The row name (the norm-head key) plus the pointer to the aggregation warning that
+    names the members is what makes the failure actionable.
+    """
+    features = {"action": PolicyFeature(type=FeatureType.ACTION, shape=(3,))}
+    norm_map = {"ACTION": NormalizationMode.QUANTILE}
+    stats = _build_quantile_stats(2)
+    del stats[1]["action"]["q01"]
+    del stats[1]["action"]["q99"]
+
+    with pytest.raises(KeyError) as excinfo:
+        Normalize(
+            features,
+            norm_map,
+            per_dataset_stats=stats,
+            dataset_names=["franka::joint", "so101::joint_position"],
+        )
+    message = excinfo.value.args[0]
+    assert "per_dataset_stats[1] ('so101::joint_position')" in message
+    assert "franka::joint" not in message
+    assert "aggregate_feature_stats" in message and "dropping" in message
+
+    # Without names the row is still identified positionally, and the hint still fires.
+    with pytest.raises(KeyError) as unnamed:
+        Normalize(features, norm_map, per_dataset_stats=stats)
+    assert "per_dataset_stats[1]:" in unnamed.value.args[0]
+
+
 def test_quantile_does_not_clamp():
     """Out-of-band values extend beyond [-1, 1] rather than saturating.
 


### PR DESCRIPTION
## What this does

(🐛 Bug) Partial quantile coverage across the contributors of an aggregated norm head no longer raises — it drops the quantile and warns.

`aggregate_feature_stats` pools stats for every dataset sharing a normalization head (`WeightedDatasetMixture` → `aggregate_stats`, `datasets/dataset_mixture.py`). Until now, a head whose contributors *disagreed* about carrying `q01`/`q99` raised:

```
KeyError: aggregate_feature_stats: 1/2 contributors are missing 'q01' (indices [1]), but the rest have it.
```

Datasets are being migrated incrementally to carry `q01/q10/q50/q90/q99`, so the first mixture that pairs a migrated dataset with an unmigrated one died at startup — before the checkpoint was even loaded, and regardless of whether the job used QUANTILE normalization at all. The failure was symmetric: it fired whether the new dataset was the one *with* quantiles or the one without. An additive metadata improvement became a hard breakage for unrelated jobs.

Now partial coverage behaves like the "nobody has it" case — the quantile is simply absent from the aggregate — plus one `logging.warning` naming how many contributors were missing it and which ones. **The no-backfill principle is unchanged:** a quantile is still never synthesized from a min/max (that would pool two different scales into one buffer, widening the band by however far the extreme sits outside the 1st percentile — exactly the outlier sensitivity QUANTILE exists to remove). We just decline to publish an aggregate quantile at all.

Also in this PR:

- **`q10`/`q50`/`q90` are aggregated too.** The loop covered only `q01`/`q99`, so the three inner quantiles — which fleet stats now carry, and which `_to_standard_data_format` already indexes and pads — were silently dropped from every aggregated head. They now aggregate when all contributors have them and are skipped-with-warning when coverage is partial, consistent with `q01`/`q99`. Names live in one place: `compute_stats.QUANTILE_STAT_NAMES`.
- **`aggregate_stats` keeps `weights` and `contributor_names` aligned with its per-feature contributor filter.** A feature absent from some contributors narrows the contributor set for that feature only; `weights` used to be forwarded unfiltered, so numpy broadcast it against the shorter stats stack — inflating `count` and skewing every weighted stat against that denominator. Both parallel lists are now indexed by the same positions, and a non-parallel list is rejected in `aggregate_stats` (before the filter) and in `aggregate_feature_stats` (for direct callers).
- **Stats-resolution errors name the offending row.** `Normalize`/`Unnormalize` deliberately do *not* fall back to min/max in QUANTILE mode, and that is unchanged — but a head can now legitimately arrive without quantiles, so `create_stats_buffers` (and the `_inject_stats` path, which had no row context at all) now report `per_dataset_stats[1] ('franka::joint')` instead of a bare index, and the hint explains that an aggregated head loses quantiles when its members disagree and points at the warning that names them. Combined with the mixture's existing `Norm-head aggregation` INFO summary, an operator reading the log sees head → member datasets → which member to recompute.

What a QUANTILE-mode policy does when a head legitimately has no quantiles: it still fails loudly at `Normalize` construction (`KeyError`), it does not silently degrade to min-max scaling. Only the message improved. `scripts/diagnose_norm_distribution.py` already mirrors that rule and needed no change.

## How it was tested

Added to `tests/datasets/test_compute_stats.py`:

- `test_aggregate_feature_stats_full_quantile_set_aggregates` — (a) all contributors have every quantile → all five land in the aggregate with the right count-weighted values, no warning. Pins `q10`/`q50`/`q90`, which the old loop never produced.
- `test_aggregate_feature_stats_no_quantiles_no_keys` — (b) nobody has them → keys absent and `caplog.records == []`, so the common all-legacy mixture stays quiet.
- `test_aggregate_feature_stats_partial_quantiles_skips_and_warns[0|1]` — (c) partial coverage, parametrized over **which** contributor is the migrated one, so a fix that only handled "new dataset last" fails. Asserts no exception, quantiles absent, mean/count still pooled, exactly one warning naming the unmigrated contributor and not the migrated one.
- `test_aggregate_feature_stats_partial_quantiles_groups_by_missing_set` — a q01/q99-only dataset alongside a full one and a legacy one warns in two groups, not one blurred line.
- `test_aggregate_feature_stats_partial_quantiles_falls_back_to_indices` and `test_aggregate_feature_stats_rejects_misaligned_parallel_args` (parametrized over `weights` and `contributor_names`).
- `test_aggregate_stats_filters_names_and_weights_with_the_feature` — the two features have different contributor subsets, so an unfiltered parallel list misbehaves: names accuse the wrong dataset, and weights make `actions` report the whole mixture's weight. The `count` assertions are what pin the weights half — the names/quantile assertions alone pass either way, which is why they were not sufficient on their own.

Added to `tests/datasets/test_norm_key_aggregation.py`:

- `test_partial_quantile_coverage_in_a_head_warns_and_keeps_building[repo/a|repo/b]` — the end-to-end shape of the breakage: a real `DatasetMixtureMetadata` head with one migrated and one unmigrated member builds successfully, pools mean/std as usual, carries no quantiles, and warns per feature naming the unmigrated repo and the head key. Parametrized over both orderings.

Added to `tests/policies/test_normalize_per_dataset.py`:

- `test_quantile_error_names_the_offending_row_and_the_aggregate_drop` — the QUANTILE `KeyError` names the row (`per_dataset_stats[1] ('so101::joint_position')`), does not name the healthy row, and carries the aggregate-drop hint; the unnamed construction still identifies the row positionally.

Verification that the new tests are real pins, not decoration: with the quantile loop reverted to the old `("q01", "q99")` + raise, 5 of the 7 new `test_compute_stats.py` quantile tests fail (the two that pass are the pre-existing weighted-mean test and requirement (b), which is unchanged behavior by design).

Ran, in order:

```
uv run pre-commit run --all-files          # clean
uv run pytest -m "not gpu and not network" -n auto tests/datasets/ tests/policies/ tests/scripts/    # 1966 passed, 9 skipped
```

GPU pytests were **not** run: this change touches no model math, no training loop, no optimizer and no sampler. The two files under `src/opentau/policies/` (`normalize.py`, `pretrained.py`) change only error-message text plus one optional keyword used solely to build that text — no numerics, no forward path. Both policy checklist boxes are therefore left unchecked.

## How to checkout & try? (for the reviewer)

```bash
git checkout claude/nostalgic-matsumoto-08d090
```

```bash
uv run pytest -sx tests/datasets/test_compute_stats.py -k quantile
```

```bash
uv run pytest -sx tests/datasets/test_norm_key_aggregation.py -k partial_quantile
```

```bash
uv run pytest -sx "tests/policies/test_normalize_per_dataset.py::test_quantile_error_names_the_offending_row_and_the_aggregate_drop"
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
