### PR TITLE
docs(scripts): fix stale module path in RoboCasa server docstring

### DIFF
--- a/src/opentau/scripts/robocasa/server.py
+++ b/src/opentau/scripts/robocasa/server.py
@@ -14,8 +14,8 @@
 
 """Policy WebSocket server for RoboCasa ``client.py`` / ``client_async.py`` with OpenTau loading.
 
-Implements the same wire protocol as ``robocasa_server``, plus **batched** messages for
-``robocasa.scripts.client_async``:
+Implements the single-observation wire protocol used by ``robocasa.scripts.client``, plus
+**batched** messages for ``robocasa.scripts.client_async``:
 
     Single request:
 
@@ -36,7 +36,7 @@ full predicted chunk per environment: shape ``(n_action_steps, action_dim)`` (tr
 
 Run::
 
-    python -m opentau.scripts.robocasa_server_async \\
+    python -m opentau.scripts.robocasa.server \\
         --config_path /path/to/train_config.json \\
         --robocasa_action_dim 16 --robocasa_port 8765
 


### PR DESCRIPTION
## What this does

Docs-only fix to the module docstring of `src/opentau/scripts/robocasa/server.py`. Label: (📝 Documentation).

The `Run::` block advertised a module path that does not exist:

```bash
python -m opentau.scripts.robocasa_server_async \
    --config_path /path/to/train_config.json \
    --robocasa_action_dim 16 --robocasa_port 8765
```

There is no `opentau/scripts/robocasa_server_async.py`. The server lives at `src/opentau/scripts/robocasa/server.py`, so the invocation is `python -m opentau.scripts.robocasa.server` — which is already what `docs/source/tutorials/robocasa.rst` documents (lines 151 and 176). Anyone copy-pasting the docstring got `No module named opentau.scripts.robocasa_server_async`.

Two other names in the same docstring were checked before touching them:

- **`robocasa_server`** (line 17, "Implements the same wire protocol as ...") — also stale. No module by that name exists in this tree, and `git log --all` shows no file ever named that; the docstring shipped with both names already wrong when the server was added in #151. It now names the actual counterpart it shares a protocol with: `robocasa.scripts.client`, the single-observation reference client. This matches the request/response sections immediately below it and the tutorial's "Requests" section.
- **`robocasa.scripts.client` / `robocasa.scripts.client_async`** (lines 15, 18, 25) — **correct, left untouched.** These refer to the external RoboCasa reference rollout clients, which the tutorial explicitly documents as living "Outside this repo" (`docs/source/tutorials/robocasa.rst:96-100`), not to any OpenTau module.

Repo-wide grep confirms `robocasa_server` had exactly two occurrences, both in this file's docstring; nothing in `docs/`, `README.md`, `configs/`, or `.github/workflows/` referenced it. No behaviour change — the diff is 3 lines of prose.

## How it was tested

- **Verified the corrected command actually runs** (the point of the fix) — it resolves and prints usage rather than `ModuleNotFoundError`:
  ```
  $ python -m opentau.scripts.robocasa.server --help
  usage: server.py [-h] [--config_path str] [--dataset_mixture str] ...
  ```
- **Verified the stale names are gone repo-wide:** `grep -rn "robocasa_server" .` returns no hits.
- `pre-commit run --all-files` — all hooks pass, no files rewritten.
- `pytest -m "not gpu and not network" -n auto` — **2594 passed, 13 skipped, 1 failed**. The one failure is `tests/utils/test_libero_utils.py::test_libero2torch`, which is **pre-existing and unrelated**: it is a `FileNotFoundError` for a LIBERO `.pruned_init` asset under `/tmp/libero-assets/`, which CI downloads and my local checkout does not have. Confirmed pre-existing by stashing the change and re-running the same test on the clean tree — it fails identically there.
- No GPU or regression tests: this PR changes only a docstring, no policy or runtime code.

## How to checkout & try? (for the reviewer)

The stale path is gone and the documented one works:

```bash
grep -rn "robocasa_server" .
```

```bash
python -m opentau.scripts.robocasa.server --help
```

```bash
pytest -m "not gpu and not network" -n auto
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
