### PR TITLE
fix(configs): propagate max_action_dim to the policy config

### DIFF
--- a/src/opentau/configs/train.py
+++ b/src/opentau/configs/train.py
@@ -23,7 +23,7 @@ import datetime as dt
 import logging
 import os
 import sys
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 from pathlib import Path
 from typing import Type
 
@@ -67,6 +67,24 @@ def warn(*args, **kwargs):
         **kwargs: Arbitrary keyword arguments passed to print().
     """
     print("WARNING:", *args, **kwargs, file=sys.stderr)
+
+
+# Pipeline-level Standard Data Format field -> the policy-config field it drives.
+#
+# The dataloader is the source of truth for tensor widths: ``WeightedDatasetMixture``
+# pads every ``state``/``actions`` row to ``cfg.max_state_dim`` / ``cfg.max_action_dim``
+# and emits chunks of ``cfg.action_chunk`` (``datasets/dataset_mixture.py``,
+# ``datasets/lerobot_dataset.py``). The policy's projections are sized from its *own*
+# fields, so the pipeline values must be pushed onto the policy config or the model is
+# built for a shape the dataloader never produces. Consequently the pipeline value
+# always wins -- including over a value that came from a pretrained checkpoint, which is
+# why ``validate()`` re-applies this after reloading ``self.policy`` from
+# ``--policy.path``.
+PIPELINE_TO_POLICY_SHAPE_FIELDS: dict[str, str] = {
+    "max_state_dim": "max_state_dim",
+    "max_action_dim": "max_action_dim",
+    "action_chunk": "chunk_size",
+}
 
 
 @dataclass
@@ -235,13 +253,54 @@ class TrainPipelineConfig(HubMixin):
         )
 
         if self.policy:
-            self.policy.max_state_dim = self.max_state_dim
-            self.policy.max_action_state = self.max_action_dim
-            self.policy.chunk_size = self.action_chunk
+            self._propagate_shape_fields_to_policy()
         if self.job_name:
             warn(
                 "cfg.job_name is deprecated and ignored. Set cfg.wandb.project and/or cfg.wandb.name instead."
             )
+
+    def _propagate_shape_fields_to_policy(self):
+        """Force the policy config to agree with the pipeline's Standard Data Format.
+
+        Copies each entry of :data:`PIPELINE_TO_POLICY_SHAPE_FIELDS` from ``self`` onto
+        ``self.policy``. The three widths must move together: the dataloader shapes
+        ``state``, ``actions`` and the action chunk from the *pipeline* fields, so a
+        policy left on a different value is built for tensors it will never be fed.
+
+        Contract, verified by ``tests/configs/test_shape_field_propagation.py``:
+
+        - **The pipeline value always wins**, overwriting whatever the policy config
+          held -- including a width deserialized from a pretrained checkpoint. To train
+          a 6-DoF checkpoint, set the *pipeline* ``max_state_dim`` / ``max_action_dim`` /
+          ``action_chunk``; setting only ``policy.*`` is silently overridden.
+        - **A field the policy dataclass does not declare is skipped, never created.**
+          ``PreTrainedConfig`` subclasses are plain (unslotted) dataclasses, so a bare
+          ``setattr`` of an undeclared name succeeds and produces an attribute nothing
+          reads -- which is how ``max_action_state`` sat here undetected since the
+          initial commit, and how the high-level planners (no ``chunk_size``, no
+          ``max_action_dim``) were being given a junk ``chunk_size``.
+        - An override that actually *changes* a value is logged at WARNING, so the
+          checkpoint-says-6 / pipeline-says-32 case is visible rather than silent.
+        """
+        if self.policy is None:
+            return
+
+        declared = {f.name for f in fields(type(self.policy))}
+        for pipeline_field, policy_field in PIPELINE_TO_POLICY_SHAPE_FIELDS.items():
+            if policy_field not in declared:
+                continue
+            new_value = getattr(self, pipeline_field)
+            old_value = getattr(self.policy, policy_field, None)
+            if old_value != new_value:
+                logging.warning(
+                    f"Overriding policy.{policy_field}={old_value} with "
+                    f"{pipeline_field}={new_value} from the training config. The "
+                    "dataloader shapes every sample from the pipeline-level value, so "
+                    "it wins. If you meant to keep the policy's value (e.g. it came "
+                    f"from a pretrained checkpoint), set {pipeline_field}={old_value} "
+                    "at the top level of the training config instead."
+                )
+            setattr(self.policy, policy_field, new_value)
 
     def validate(self):
         """Validate and finalize the training configuration.
@@ -301,9 +360,10 @@ class TrainPipelineConfig(HubMixin):
             self.scheduler = self.policy.get_scheduler_preset()
 
         if self.policy:
-            self.policy.max_state_dim = self.max_state_dim
-            self.policy.max_action_state = self.max_action_dim
-            self.policy.chunk_size = self.action_chunk
+            # Re-applied here because the ``--policy.path`` / ``resume`` branches above
+            # may have replaced ``self.policy`` wholesale with a config deserialized
+            # from a checkpoint, carrying that checkpoint's widths.
+            self._propagate_shape_fields_to_policy()
 
             # The dataloader letterboxes every sample to ``self.resolution``
             # before the policy sees it; a differing policy-side

--- a/tests/configs/test_shape_field_propagation.py
+++ b/tests/configs/test_shape_field_propagation.py
@@ -1,0 +1,297 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pins the Standard-Data-Format width contract between the pipeline and the policy.
+
+``TrainPipelineConfig`` pushes ``max_state_dim`` / ``max_action_dim`` / ``action_chunk``
+onto the policy config, because the dataloader shapes every sample from the *pipeline*
+values while the policy sizes its projections from its *own* fields. The three must move
+together or the model is built for tensors it is never fed.
+
+Until this module existed nothing asserted that. The propagation had assigned to
+``policy.max_action_state`` -- a name no policy config declares -- since the initial
+commit, so ``max_action_dim`` never actually propagated while its two siblings did, and
+the resulting split was invisible to the suite.
+"""
+
+import ast
+import dataclasses
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from opentau.configs import parser
+from opentau.configs.policies import PreTrainedConfig
+from opentau.configs.train import PIPELINE_TO_POLICY_SHAPE_FIELDS, TrainPipelineConfig
+
+TRAIN_CONFIG_SOURCE = Path("src/opentau/configs/train.py")
+ARTIFACT_DIR = Path("tests/artifacts/configs")
+
+# Deliberately disagrees with every policy default (32 / 32 / 50) so a test that passes
+# only because both sides happen to hold the same number cannot exist here.
+PIPELINE_WIDTHS = {"max_state_dim": 7, "max_action_dim": 9, "action_chunk": 13}
+
+
+def _all_policy_configs():
+    """Every *production* policy config class, keyed by its ``policy.type`` choice.
+
+    Filtered to ``opentau.*`` classes because importing a test module that registers its
+    own ``PreTrainedConfig`` subclass would otherwise change this list depending on which
+    tests ran -- collection has to be identical across ``-n auto`` workers.
+    """
+    return sorted(
+        (name, cls)
+        for name, cls in PreTrainedConfig.get_known_choices().items()
+        if cls.__module__.startswith("opentau.")
+    )
+
+
+def _declared_fields(policy_config) -> set[str]:
+    return {f.name for f in dataclasses.fields(type(policy_config))}
+
+
+def _make_cfg(dataset_mixture_config, policy_config, **overrides):
+    kwargs = {
+        "dataset_mixture": dataset_mixture_config,
+        "policy": policy_config,
+        "batch_size": 8,
+        **PIPELINE_WIDTHS,
+        **overrides,
+    }
+    return TrainPipelineConfig(**kwargs)
+
+
+def test_all_three_widths_move_together(dataset_mixture_config, policy_config):
+    """The direct regression: ``max_action_dim`` must propagate like its siblings.
+
+    With the ``max_action_state`` typo in place, the two sibling assertions passed and
+    only the ``max_action_dim`` one failed -- which is exactly the production symptom.
+    """
+    cfg = _make_cfg(dataset_mixture_config, policy_config)
+
+    assert cfg.policy.max_state_dim == 7
+    assert cfg.policy.max_action_dim == 9
+    assert cfg.policy.chunk_size == 13
+
+
+def test_pipeline_width_wins_over_a_disagreeing_policy_width(dataset_mixture_config, policy_config):
+    """The conflict case: both sides are set, to *different* values. Pipeline wins.
+
+    Passing only one side would leave the outcome consistent with either precedence,
+    so the disagreement has to be constructed explicitly.
+    """
+    policy_config.max_state_dim = 21
+    policy_config.max_action_dim = 22
+    policy_config.chunk_size = 23
+
+    cfg = _make_cfg(dataset_mixture_config, policy_config)
+
+    assert (cfg.policy.max_state_dim, cfg.policy.max_action_dim, cfg.policy.chunk_size) == (
+        7,
+        9,
+        13,
+    ), "the pipeline-level widths must override the policy-level ones, not the reverse"
+
+
+def test_pipeline_width_wins_over_the_width_carried_by_a_pretrained_checkpoint(
+    dataset_mixture_config, tmp_path
+):
+    """``validate()`` re-applies the widths after ``--policy.path`` replaces the policy.
+
+    This is the reported failure: a 6-DoF checkpoint loaded under the default 32-wide
+    pipeline. The checkpoint's widths must not survive, because the dataloader is
+    already padding to the pipeline's.
+    """
+    checkpoint_policy = {
+        **json.loads((ARTIFACT_DIR / "train_config.json").read_text())["policy"],
+        # a 6-DoF arm, narrower than the pipeline defaults on every axis
+        "max_state_dim": 6,
+        "max_action_dim": 6,
+        "chunk_size": 8,
+        "n_action_steps": 8,  # PI0Config requires n_action_steps <= chunk_size
+    }
+    (tmp_path / "config.json").write_text(json.dumps(checkpoint_policy))
+
+    with patch.object(parser, "get_path_arg", return_value=tmp_path):
+        cfg = TrainPipelineConfig(
+            dataset_mixture=dataset_mixture_config,
+            policy=None,
+            output_dir=str(tmp_path / "run"),
+            job_name="test_run",
+            batch_size=8,
+            use_policy_training_preset=True,
+            **PIPELINE_WIDTHS,
+        )
+        cfg.validate()
+
+    assert cfg.policy.max_state_dim == 7
+    assert cfg.policy.max_action_dim == 9, (
+        "validate() must re-apply max_action_dim after the pretrained reload; "
+        "leaving the checkpoint's value is the bug this module exists for"
+    )
+    assert cfg.policy.chunk_size == 13
+
+
+@pytest.mark.parametrize("policy_type,policy_cls", _all_policy_configs())
+def test_propagation_never_creates_an_attribute_the_policy_does_not_declare(
+    dataset_mixture_config, policy_type, policy_cls
+):
+    """Undeclared targets must be skipped, not invented.
+
+    ``PreTrainedConfig`` subclasses are plain unslotted dataclasses, so ``setattr`` of a
+    misspelled or inapplicable name silently succeeds and nothing ever reads it. Swept
+    over the whole registry because the policies that lack a width differ per field:
+    the two high-level planners declare neither ``chunk_size`` nor ``max_action_dim``,
+    and ``value`` declares ``chunk_size`` but not ``max_action_dim``.
+    """
+    policy = policy_cls()
+    declared = _declared_fields(policy)
+    before = set(vars(policy))
+
+    cfg = _make_cfg(dataset_mixture_config, policy)
+
+    invented = set(vars(cfg.policy)) - before
+    assert not invented, f"{policy_type} gained undeclared attribute(s): {sorted(invented)}"
+
+    for pipeline_field, policy_field in PIPELINE_TO_POLICY_SHAPE_FIELDS.items():
+        if policy_field in declared:
+            assert getattr(cfg.policy, policy_field) == PIPELINE_WIDTHS[pipeline_field]
+        else:
+            assert not hasattr(cfg.policy, policy_field)
+
+
+def test_the_policies_that_lack_a_width_are_exactly_the_known_ones():
+    """Pins *why* the presence check is load-bearing, across the whole registry.
+
+    Without this, someone could delete the check, watch the suite stay green on the
+    policies that declare all three fields, and never learn that the planners and
+    ``value`` are the cases it exists for.
+    """
+    missing = {
+        policy_field: {
+            name
+            for name, cls in _all_policy_configs()
+            if policy_field not in {f.name for f in dataclasses.fields(cls)}
+        }
+        for policy_field in PIPELINE_TO_POLICY_SHAPE_FIELDS.values()
+    }
+
+    assert missing == {
+        "max_state_dim": set(),
+        "max_action_dim": {
+            "pi07_high_level",
+            "pi07_paligemma_high_level_planner",
+            "value",
+        },
+        "chunk_size": {"pi07_high_level", "pi07_paligemma_high_level_planner"},
+    }, (
+        f"registry width coverage changed: {missing}. A policy that newly declares one of "
+        "these fields will start receiving the pipeline value (check that is intended); "
+        "one that drops a field must not start collecting a junk attribute instead."
+    )
+
+
+def test_the_misspelled_target_is_gone_everywhere():
+    """``max_action_state`` is not a field of any policy config, so it must never be set.
+
+    Checked over attribute nodes rather than raw source text, so the prose above -- which
+    names the typo deliberately -- does not itself trip the assertion.
+    """
+    assert "max_action_state" not in PIPELINE_TO_POLICY_SHAPE_FIELDS.values()
+
+    touched = [
+        node.lineno
+        for node in ast.walk(_train_config_ast())
+        if isinstance(node, ast.Attribute) and node.attr == "max_action_state"
+    ]
+    assert not touched, f"train.py still references .max_action_state at line(s) {touched}"
+
+    for _, policy_cls in _all_policy_configs():
+        assert "max_action_state" not in {f.name for f in dataclasses.fields(policy_cls)}
+
+
+def test_overriding_a_differing_width_warns_and_an_agreeing_one_stays_quiet(
+    dataset_mixture_config, policy_config, caplog
+):
+    """The silent clobber is what made the reported bug hard to see."""
+    policy_config.max_action_dim = 6
+
+    with caplog.at_level("WARNING"):
+        cfg = _make_cfg(dataset_mixture_config, policy_config)
+    assert "policy.max_action_dim=6" in caplog.text
+
+    # A second pass now agrees on every width, so it must not re-warn.
+    caplog.clear()
+    with caplog.at_level("WARNING"):
+        cfg._propagate_shape_fields_to_policy()
+    assert "max_action_dim" not in caplog.text
+
+
+def _train_config_ast() -> ast.Module:
+    return ast.parse(TRAIN_CONFIG_SOURCE.read_text())
+
+
+def test_both_call_sites_go_through_the_single_helper():
+    """``__post_init__`` and ``validate()`` must not each hand-roll the propagation.
+
+    The typo survived partly because the block was duplicated: a reader fixing one copy
+    has no signal that a second exists. Pinning the call keeps them from drifting apart
+    again.
+    """
+    class_node = next(
+        n
+        for n in ast.walk(_train_config_ast())
+        if isinstance(n, ast.ClassDef) and n.name == "TrainPipelineConfig"
+    )
+    methods = {n.name: n for n in class_node.body if isinstance(n, ast.FunctionDef)}
+
+    for method in ("__post_init__", "validate"):
+        calls = {
+            node.func.attr
+            for node in ast.walk(methods[method])
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+        }
+        assert "_propagate_shape_fields_to_policy" in calls, (
+            f"{method}() must delegate the width propagation to the shared helper"
+        )
+
+
+def test_no_shape_width_is_assigned_to_the_policy_outside_the_helper():
+    """Guards the helper's presence check from being bypassed by a direct ``setattr``.
+
+    A bare ``self.policy.<width> = ...`` re-opens both failure modes at once: it can
+    invent an attribute on a policy that does not declare the field, and it can move one
+    width without its siblings.
+    """
+    guarded = set(PIPELINE_TO_POLICY_SHAPE_FIELDS.values())
+    offenders = []
+
+    for node in ast.walk(_train_config_ast()):
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if (
+                isinstance(target, ast.Attribute)
+                and target.attr in guarded
+                and isinstance(target.value, ast.Attribute)
+                and target.value.attr == "policy"
+            ):
+                offenders.append(f"line {target.lineno}: self.policy.{target.attr}")
+
+    assert not offenders, (
+        "assign policy widths only inside _propagate_shape_fields_to_policy(), which "
+        f"skips fields the policy does not declare; found: {offenders}"
+    )


### PR DESCRIPTION
## What this does

(🐛 Bug)

`TrainPipelineConfig` copies three Standard-Data-Format widths onto the policy config, but the middle one was misspelled:

```python
self.policy.max_state_dim = self.max_state_dim
self.policy.max_action_state = self.max_action_dim   # <-- not a field on any policy config
self.policy.chunk_size = self.action_chunk
```

`max_action_state` is not declared by any `PreTrainedConfig` subclass, and those subclasses are plain (unslotted) dataclasses — so the assignment silently created an attribute nothing reads, and `max_action_dim` never reached the policy. Its two siblings propagated normally, so the three widths that are supposed to move together did not.

Symptom: load a checkpoint whose policy config has `max_action_dim = 6` under a pipeline with the default `max_action_dim = 32`, and the state side gets forced to 32 while the action side stays at 6 — the model is half-built for one arm and half for another, with no error.

### Which side is authoritative

The pipeline is, and the fix restores that:

- The dataloader is what physically decides tensor widths — `WeightedDatasetMixture` pads every `state`/`actions` row to `cfg.max_state_dim` / `cfg.max_action_dim` and emits chunks of `cfg.action_chunk`. A policy left on a different value is built for tensors it is never fed.
- The block is duplicated in `validate()` *immediately after* the `--policy.path` / `resume` branches replace `self.policy` with a config deserialized from a checkpoint. Its only purpose is to re-clobber the checkpoint's widths, which is only coherent if the pipeline wins.
- Deleting the line instead would mean deleting the two working siblings too, changing the contract every current training run depends on.

`git log -S max_action_state` shows the typo dates to the initial commit and was never spelled correctly, so the assignment has been dead its whole life. **Every config under `configs/` already sets both sides to the same value**, so no shipped config changes behavior.

### Not just a one-character fix

Three registry policies do not declare `max_action_dim` (`pi07_high_level`, `pi07_paligemma_high_level_planner`, `value`), and two of those also lack `chunk_size`. So correcting the spelling alone would have created junk attributes on those instead — and the sibling `chunk_size` line **is already doing exactly that today** to both high-level planners.

Both call sites now delegate to one guarded helper, `_propagate_shape_fields_to_policy`, driven by a single `PIPELINE_TO_POLICY_SHAPE_FIELDS` mapping, which:

- skips a field the policy dataclass does not declare, rather than inventing it;
- logs at WARNING when an override actually changes a value, so a checkpoint/pipeline width disagreement is visible instead of silent.

Factoring the two copies into one helper also removes the duplication that let the typo survive — a reader fixing one copy previously had no signal that a second existed.

### Out of scope (flagged, not fixed)

Because `chunk_size` is copied by `setattr` after the policy's `__post_init__`, a pipeline `action_chunk` smaller than the policy's `n_action_steps` leaves the config in a state the policy's own validation rejects (`PI0Config(); action_chunk=10` → `chunk_size=10`, `n_action_steps=50`). That predates this PR and concerns `chunk_size`, which already propagated correctly, so it is left alone here. Every in-repo config sets `n_action_steps` explicitly and so avoids it.

## How it was tested

New `tests/configs/test_shape_field_propagation.py` (20 tests) — there was no test pinning this contract before, which is why the typo survived:

- `test_all_three_widths_move_together` — the direct regression.
- `test_pipeline_width_wins_over_a_disagreeing_policy_width` — sets both sides to *different* values and asserts which wins. Passing only one side would leave the result consistent with either precedence, so the conflict is constructed explicitly.
- `test_pipeline_width_wins_over_the_width_carried_by_a_pretrained_checkpoint` — drives the real `--policy.path` reload through `validate()` with a 6-DoF checkpoint config.
- `test_propagation_never_creates_an_attribute_the_policy_does_not_declare` — swept over the whole policy registry.
- `test_the_policies_that_lack_a_width_are_exactly_the_known_ones` — pins the sets, so a policy gaining or dropping a width forces the guard to be revisited.
- Two AST tests pinning that both call sites go through the helper and that no width is assigned to `self.policy` outside it, so the sites cannot drift apart again.

Each test was verified to be mutation-killing rather than merely green:

| mutation | result |
|---|---|
| restore the original `max_action_state` typo | 5 failed |
| drop the declared-field presence check | 4 failed (exactly the policies missing a field) |
| remove the `validate()` call site | 2 failed |

Full CPU suite: `pytest -m "not gpu and not network" -n auto` → **2613 passed, 13 skipped**, in 3m10s. Two failures (`test_libero_utils.py::test_libero2torch`, `test_utils_benchmark.py::test_exception_handling`) reproduce identically on the unmodified baseline — the first wants `LIBERO_CONFIG_PATH`, which CI sets.

`pre-commit run` clean on both files.

GPU tests were not run: this change is confined to training-config plumbing, touches no modeling code, and is fully exercised on CPU. Happy to run them if a reviewer disagrees.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/configs/test_shape_field_propagation.py
```

Watch the three widths move together, and the planner not collect a junk `chunk_size`:

```bash
python -c "
from opentau.configs.train import TrainPipelineConfig
from opentau.configs.default import DatasetMixtureConfig, DatasetConfig
from opentau.configs.policies import PreTrainedConfig
import opentau.policies
dm = DatasetMixtureConfig(datasets=[DatasetConfig(repo_id='m', root='/tmp/m')])
for t in ('pi05', 'pi07_high_level'):
    p = PreTrainedConfig.get_known_choices()[t]()
    c = TrainPipelineConfig(dataset_mixture=dm, policy=p, batch_size=8,
                            max_state_dim=7, max_action_dim=9, action_chunk=13)
    print(t, {f: getattr(c.policy, f, '<absent>')
              for f in ('max_state_dim', 'max_action_dim', 'chunk_size', 'max_action_state')})
"
```

On `main` this prints `max_action_dim: 32` for `pi05` (unpropagated), a junk `max_action_state: 9` on both, and a junk `chunk_size: 13` on the planner.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.
