### PR TITLE
fix(configs): re-check policy action horizon after action_chunk propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,25 @@ carry a concrete `config_version` (and an informational `opentau_version`).
   current working directory for a Hub checkpoint (which an `@<step>` suffix would
   have turned into a directory named after a git ref). Hub exports go to
   `<output_dir>/onnx/<spec>/`; local checkpoint dirs are unchanged.
+* **`action_chunk` is re-checked against the policy's execution horizon.**
+  `TrainPipelineConfig` copies its pipeline-level `action_chunk` onto
+  `policy.chunk_size` by `setattr`, which lands *after* the policy config's
+  `__post_init__` has run — so the policy's own `n_action_steps <= chunk_size`
+  invariant (and the shortened-horizon-vs-`max_delay`/`safety_buffer` pair) only
+  ever saw the `chunk_size` the policy *declared*, never the propagated one. A
+  config setting `action_chunk` and leaving `n_action_steps` at its default
+  therefore reached, silently, exactly the combination the very same policy
+  config rejects when it appears in JSON. Every in-repo config dodges it only by
+  setting the two equal by hand. The checks are now one shared
+  `PreTrainedConfig.validate_action_horizon` — replacing a copy in each of the
+  seven policy configs that carried it — called from both policy `__post_init__`
+  and the end of `_propagate_shape_fields_to_policy`, and the error names
+  `action_chunk` as the cause.
+  **A config with `n_action_steps > action_chunk` now fails at config time**; the
+  model always decoded only `chunk_size` actions, so set `n_action_steps` to
+  `action_chunk` (what such a run was effectively doing) to keep its behavior.
+  As a side effect of sharing the check, pi0 gains the `safety_buffer <=
+  chunk_size` bound its `max_delay` siblings already enforced.
 
 ### Migration notes
 

--- a/src/opentau/configs/policies.py
+++ b/src/opentau/configs/policies.py
@@ -28,7 +28,7 @@ import tempfile
 import warnings
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Type, TypeVar
+from typing import ClassVar, Type, TypeVar
 
 import draccus
 from huggingface_hub import hf_hub_download
@@ -434,6 +434,14 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):
     action_decoder_latency_lower: float = 0.0
     action_decoder_latency_upper: float = 0.0
 
+    #: Name of this policy's "keep executing past the current chunk" knob — the field a
+    #: shortened execution horizon (``n_action_steps < chunk_size``) cannot be combined
+    #: with. Every policy that models real-time inference delay calls it ``max_delay``;
+    #: pi0 predates that path and calls its overlap-refill knob ``safety_buffer``, so it
+    #: overrides this. Read by :py:meth:`validate_action_horizon`; a policy that names the
+    #: knob something else must override this or its knob silently stops being checked.
+    action_horizon_delay_field: ClassVar[str] = "max_delay"
+
     def __post_init__(self):
         """Initialize post-creation attributes.
 
@@ -625,6 +633,64 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):
         for resolution in self._bound_image_resolutions().values():
             return resolution
         return None
+
+    def validate_action_horizon(self) -> None:
+        """Check the invariants that tie ``n_action_steps`` (and the delay knob) to ``chunk_size``.
+
+        ``chunk_size`` is the trained prediction horizon — the number of actions the
+        model always decodes per invocation. ``n_action_steps`` is how many of them
+        ``select_action`` executes before re-querying, so it is bounded above by
+        ``chunk_size``, and a *shortened* horizon (``n_action_steps < chunk_size``)
+        cannot be combined with the knob that keeps actions flowing past the current
+        chunk (``max_delay``, or ``safety_buffer`` on pi0 — see
+        :py:attr:`action_horizon_delay_field`): the two would entangle the action-queue
+        refill logic.
+
+        Every policy config that declares an execution horizon calls this from its
+        ``__post_init__`` (``value`` and the high-level planners do not, since for them
+        it is the no-op described below), and
+        ``TrainPipelineConfig`` calls it again after copying its pipeline-level
+        ``action_chunk`` onto ``policy.chunk_size`` — that ``setattr`` lands *after*
+        ``__post_init__`` has run, so without the second call a propagated
+        ``chunk_size`` could contradict ``n_action_steps`` with nothing raising. The
+        checks live here rather than being copied into each config so the two callers
+        (and every policy) cannot drift apart.
+
+        No-op for policies that do not declare both fields (the high-level planners
+        declare neither; ``value`` has ``chunk_size`` but no execution horizon).
+
+        Raises:
+            ValueError: If ``n_action_steps`` exceeds ``chunk_size``, the delay knob
+                exceeds ``chunk_size``, or a shortened horizon is combined with a
+                non-zero delay knob.
+        """
+        chunk_size = getattr(self, "chunk_size", None)
+        n_action_steps = getattr(self, "n_action_steps", None)
+        if chunk_size is None or n_action_steps is None:
+            return
+
+        if n_action_steps > chunk_size:
+            raise ValueError(
+                "The chunk size is the upper bound for the number of action steps per model "
+                f"invocation. Got {n_action_steps} for `n_action_steps` and {chunk_size} for "
+                "`chunk_size`."
+            )
+
+        delay_field = self.action_horizon_delay_field
+        delay = getattr(self, delay_field, 0)
+        if delay > chunk_size:
+            raise ValueError(
+                f"`{delay_field}` must be less than or equal to the chunk size. Got {delay} for "
+                f"`{delay_field}` and {chunk_size} for `chunk_size`."
+            )
+
+        if n_action_steps < chunk_size and delay != 0:
+            raise ValueError(
+                "A shortened execution horizon (n_action_steps < chunk_size) is not yet supported "
+                f"together with a non-zero `{delay_field}`; they would entangle the action-queue "
+                f"refill logic. Got n_action_steps={n_action_steps}, chunk_size={chunk_size}, "
+                f"{delay_field}={delay}."
+            )
 
     def validate_input_resolution(self, *, strict: bool) -> None:
         """Check ``resize_imgs_with_padding`` against the bound image features.

--- a/src/opentau/configs/train.py
+++ b/src/opentau/configs/train.py
@@ -281,6 +281,20 @@ class TrainPipelineConfig(HubMixin):
           ``max_action_dim``) were being given a junk ``chunk_size``.
         - An override that actually *changes* a value is logged at WARNING, so the
           checkpoint-says-6 / pipeline-says-32 case is visible rather than silent.
+        - **The policy's own invariants keyed on these widths are re-checked** once
+          the copy is done, via
+          :py:meth:`~opentau.configs.policies.PreTrainedConfig.validate_action_horizon`.
+          The ``setattr`` loop lands *after* the policy config's ``__post_init__`` has
+          run, so ``n_action_steps <= chunk_size`` (and the delay-knob pair) would
+          otherwise only ever be checked against the ``chunk_size`` the policy
+          *declared*, never against the propagated ``action_chunk``: a config setting
+          ``action_chunk`` and leaving ``n_action_steps`` at its default reached,
+          silently, exactly the combination that same policy config rejects when it
+          appears in JSON.
+
+        Raises:
+            ValueError: If the propagated ``chunk_size`` contradicts the policy's own
+                execution-horizon fields.
         """
         if self.policy is None:
             return
@@ -301,6 +315,17 @@ class TrainPipelineConfig(HubMixin):
                     "at the top level of the training config instead."
                 )
             setattr(self.policy, policy_field, new_value)
+
+        try:
+            self.policy.validate_action_horizon()
+        except ValueError as e:
+            raise ValueError(
+                f"{e} `policy.chunk_size` was overwritten with the pipeline-level "
+                f"`action_chunk` ({self.action_chunk}), so the conflict is between `action_chunk` "
+                "and the policy fields it does not propagate. Bring the policy field(s) named "
+                "above into range of `action_chunk` (`n_action_steps` is normally set equal to "
+                "it), or change `action_chunk` — a policy-level `chunk_size` is ignored either way."
+            ) from e
 
     def validate(self):
         """Validate and finalize the training configuration.

--- a/src/opentau/policies/cosmos3/configuration_cosmos3.py
+++ b/src/opentau/policies/cosmos3/configuration_cosmos3.py
@@ -242,12 +242,7 @@ class Cosmos3Config(PreTrainedConfig):
         validate_state_action_representation_only_config(
             self, policy_name=self.type, has_discrete_actions=False
         )
-        if self.n_action_steps > self.chunk_size:
-            raise ValueError(
-                "The chunk size is the upper bound for the number of action steps per model "
-                f"invocation. Got {self.n_action_steps} for `n_action_steps` and {self.chunk_size} "
-                "for `chunk_size`."
-            )
+        self.validate_action_horizon()
         if self.n_obs_steps != 1:
             raise ValueError(
                 f"Multiple observation steps not handled yet. Got `n_obs_steps={self.n_obs_steps}`"
@@ -257,17 +252,6 @@ class Cosmos3Config(PreTrainedConfig):
             raise ValueError(
                 "cosmos3 supports attention_implementation in {'eager', 'sdpa'} only "
                 f"(MRoPE + QK-norm rule out 'flash_cuda'). Got '{self.attention_implementation}'."
-            )
-
-        if self.max_delay > self.chunk_size:
-            raise ValueError(
-                f"The max delay must be <= the chunk size. Got max_delay={self.max_delay} and "
-                f"chunk_size={self.chunk_size}."
-            )
-        if self.n_action_steps < self.chunk_size and self.max_delay != 0:
-            raise ValueError(
-                "A shortened execution horizon (n_action_steps < chunk_size) is not supported "
-                "together with real-time inference delay (max_delay > 0)."
             )
 
         # Hard concat-attention constraints vs the Qwen3-VL text tower. The exact

--- a/src/opentau/policies/pi0/configuration_pi0.py
+++ b/src/opentau/policies/pi0/configuration_pi0.py
@@ -22,7 +22,7 @@ optimization, scheduling, and data processing.
 """
 
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import ClassVar, Literal
 
 from opentau.configs.policies import PreTrainedConfig
 from opentau.configs.types import FeatureType, NormalizationMode, PolicyFeature
@@ -100,6 +100,11 @@ class PI0Config(PreTrainedConfig):
     chunk_size: int = 50
     n_action_steps: int = 50
     safety_buffer: int = 0
+
+    # pi0 predates the real-time-delay path; its "keep executing past the current
+    # chunk" knob is the overlap-refill `safety_buffer`, not `max_delay`. Tells
+    # `validate_action_horizon` which field to check against `chunk_size`.
+    action_horizon_delay_field: ClassVar[str] = "safety_buffer"
 
     normalization_mapping: dict[str, NormalizationMode] = field(
         default_factory=lambda: {
@@ -216,11 +221,7 @@ class PI0Config(PreTrainedConfig):
                 "the state projection is part of the state/action representation this mode trains, "
                 "so asking for it to be frozen at the same time is self-contradictory."
             )
-        if self.n_action_steps > self.chunk_size:
-            raise ValueError(
-                f"The chunk size is the upper bound for the number of action steps per model invocation. Got "
-                f"{self.n_action_steps} for `n_action_steps` and {self.chunk_size} for `chunk_size`."
-            )
+        self.validate_action_horizon()
         if self.n_obs_steps != 1:
             raise ValueError(
                 f"Multiple observation steps not handled yet. Got `nobs_steps={self.n_obs_steps}`"
@@ -232,15 +233,6 @@ class PI0Config(PreTrainedConfig):
                 "which builds the per-token block-ids the kernel requires. This policy does "
                 "not build them, so the kernel would hard-error at the first forward. "
                 "Use 'eager' or 'sdpa' instead."
-            )
-
-        if self.n_action_steps < self.chunk_size and self.safety_buffer != 0:
-            raise ValueError(
-                "A shortened execution horizon (n_action_steps < chunk_size) is not yet "
-                "supported together with a non-zero safety_buffer; they would entangle the "
-                "action-queue refill logic. Got "
-                f"n_action_steps={self.n_action_steps}, chunk_size={self.chunk_size}, "
-                f"safety_buffer={self.safety_buffer}."
             )
 
     def validate_features(self) -> None:

--- a/src/opentau/policies/pi05/configuration_pi05.py
+++ b/src/opentau/policies/pi05/configuration_pi05.py
@@ -267,11 +267,7 @@ class PI05Config(PreTrainedConfig):
                 "the frozen VLM embedding table), so the trainable set is the discrete-action "
                 "embedding + head and action_in_proj / action_out_proj only."
             )
-        if self.n_action_steps > self.chunk_size:
-            raise ValueError(
-                f"The chunk size is the upper bound for the number of action steps per model invocation. Got "
-                f"{self.n_action_steps} for `n_action_steps` and {self.chunk_size} for `chunk_size`."
-            )
+        self.validate_action_horizon()
         if self.n_obs_steps != 1:
             raise ValueError(
                 f"Multiple observation steps not handled yet. Got `nobs_steps={self.n_obs_steps}`"
@@ -302,20 +298,6 @@ class PI05Config(PreTrainedConfig):
                 "which builds the per-token block-ids the kernel requires. This policy does "
                 "not build them, so the kernel would hard-error at the first forward. "
                 "Use 'eager' or 'sdpa' instead."
-            )
-
-        if self.max_delay > self.chunk_size:
-            raise ValueError(
-                f"The max delay must be less than or equal to the chunk size. Got {self.max_delay} for `max_delay` and {self.chunk_size} for `chunk_size`."
-            )
-
-        if self.n_action_steps < self.chunk_size and self.max_delay != 0:
-            raise ValueError(
-                "A shortened execution horizon (n_action_steps < chunk_size) is not yet "
-                "supported together with real-time inference delay (max_delay > 0); they "
-                "would entangle the action-queue prefix logic. Got "
-                f"n_action_steps={self.n_action_steps}, chunk_size={self.chunk_size}, "
-                f"max_delay={self.max_delay}."
             )
 
     def validate_features(self) -> None:

--- a/src/opentau/policies/pi05_mem/configuration_pi05.py
+++ b/src/opentau/policies/pi05_mem/configuration_pi05.py
@@ -307,25 +307,7 @@ class PI05MemConfig(PreTrainedConfig):
                 "Use 'eager' or 'sdpa' instead."
             )
 
-        if self.n_action_steps > self.chunk_size:
-            raise ValueError(
-                f"The chunk size is the upper bound for the number of action steps per model invocation. Got "
-                f"{self.n_action_steps} for `n_action_steps` and {self.chunk_size} for `chunk_size`."
-            )
-
-        if self.max_delay > self.chunk_size:
-            raise ValueError(
-                f"The max delay must be less than or equal to the chunk size. Got {self.max_delay} for `max_delay` and {self.chunk_size} for `chunk_size`."
-            )
-
-        if self.n_action_steps < self.chunk_size and self.max_delay != 0:
-            raise ValueError(
-                "A shortened execution horizon (n_action_steps < chunk_size) is not yet "
-                "supported together with real-time inference delay (max_delay > 0); they "
-                "would entangle the action-queue prefix logic. Got "
-                f"n_action_steps={self.n_action_steps}, chunk_size={self.chunk_size}, "
-                f"max_delay={self.max_delay}."
-            )
+        self.validate_action_horizon()
 
         if not isinstance(self.spacetime_layer_stride, int) or self.spacetime_layer_stride < 1:
             raise ValueError(

--- a/src/opentau/policies/pi06/configuration_pi06.py
+++ b/src/opentau/policies/pi06/configuration_pi06.py
@@ -229,28 +229,10 @@ class PI06Config(PreTrainedConfig):
         validate_state_action_representation_only_config(
             self, policy_name=self.type, has_discrete_actions=True
         )
-        if self.n_action_steps > self.chunk_size:
-            raise ValueError(
-                f"The chunk size is the upper bound for the number of action steps per model invocation. Got "
-                f"{self.n_action_steps} for `n_action_steps` and {self.chunk_size} for `chunk_size`."
-            )
+        self.validate_action_horizon()
         if self.n_obs_steps != 1:
             raise ValueError(
                 f"Multiple observation steps not handled yet. Got `nobs_steps={self.n_obs_steps}`"
-            )
-
-        if self.max_delay > self.chunk_size:
-            raise ValueError(
-                f"The max delay must be less than or equal to the chunk size. Got {self.max_delay} for `max_delay` and {self.chunk_size} for `chunk_size`."
-            )
-
-        if self.n_action_steps < self.chunk_size and self.max_delay != 0:
-            raise ValueError(
-                "A shortened execution horizon (n_action_steps < chunk_size) is not yet "
-                "supported together with real-time inference delay (max_delay > 0); they "
-                "would entangle the action-queue prefix logic. Got "
-                f"n_action_steps={self.n_action_steps}, chunk_size={self.chunk_size}, "
-                f"max_delay={self.max_delay}."
             )
 
     def validate_features(self) -> None:

--- a/src/opentau/policies/pi07/low_level/configuration_pi07_low_level.py
+++ b/src/opentau/policies/pi07/low_level/configuration_pi07_low_level.py
@@ -384,25 +384,7 @@ class PI07LowLevelConfig(PreTrainedConfig):
         if not isinstance(self.history_interval, int) or self.history_interval < 1:
             raise ValueError(f"`history_interval` must be a positive integer, got {self.history_interval}.")
 
-        if self.n_action_steps > self.chunk_size:
-            raise ValueError(
-                f"The chunk size is the upper bound for the number of action steps per model invocation. Got "
-                f"{self.n_action_steps} for `n_action_steps` and {self.chunk_size} for `chunk_size`."
-            )
-
-        if self.max_delay > self.chunk_size:
-            raise ValueError(
-                f"The max delay must be less than or equal to the chunk size. Got {self.max_delay} for `max_delay` and {self.chunk_size} for `chunk_size`."
-            )
-
-        if self.n_action_steps < self.chunk_size and self.max_delay != 0:
-            raise ValueError(
-                "A shortened execution horizon (n_action_steps < chunk_size) is not yet "
-                "supported together with real-time inference delay (max_delay > 0); they "
-                "would entangle the action-queue prefix logic. Got "
-                f"n_action_steps={self.n_action_steps}, chunk_size={self.chunk_size}, "
-                f"max_delay={self.max_delay}."
-            )
+        self.validate_action_horizon()
 
     def validate_features(self) -> None:
         """Validates the features and adds empty cameras if configured."""

--- a/src/opentau/policies/pi07_paligemma/low_level/configuration_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/configuration_pi07_low_level.py
@@ -301,25 +301,7 @@ class PI07PaligemmaLowLevelConfig(PreTrainedConfig):
             raise ValueError(f"`n_obs_steps` must be a positive integer, got {self.n_obs_steps}.")
         if not isinstance(self.history_interval, int) or self.history_interval < 1:
             raise ValueError(f"`history_interval` must be a positive integer, got {self.history_interval}.")
-        if self.n_action_steps > self.chunk_size:
-            raise ValueError(
-                f"The chunk size is the upper bound for the number of action steps per model invocation. Got "
-                f"{self.n_action_steps} for `n_action_steps` and {self.chunk_size} for `chunk_size`."
-            )
-
-        if self.max_delay > self.chunk_size:
-            raise ValueError(
-                f"The max delay must be less than or equal to the chunk size. Got {self.max_delay} for `max_delay` and {self.chunk_size} for `chunk_size`."
-            )
-
-        if self.n_action_steps < self.chunk_size and self.max_delay != 0:
-            raise ValueError(
-                "A shortened execution horizon (n_action_steps < chunk_size) is not yet "
-                "supported together with real-time inference delay (max_delay > 0); they "
-                "would entangle the action-queue prefix logic. Got "
-                f"n_action_steps={self.n_action_steps}, chunk_size={self.chunk_size}, "
-                f"max_delay={self.max_delay}."
-            )
+        self.validate_action_horizon()
 
     def validate_features(self) -> None:
         """Validates the features and adds empty cameras if configured.

--- a/tests/configs/test_shape_field_propagation.py
+++ b/tests/configs/test_shape_field_propagation.py
@@ -36,6 +36,8 @@ import pytest
 from opentau.configs import parser
 from opentau.configs.policies import PreTrainedConfig
 from opentau.configs.train import PIPELINE_TO_POLICY_SHAPE_FIELDS, TrainPipelineConfig
+from opentau.policies.pi05.configuration_pi05 import PI05Config
+from opentau.policies.value.configuration_value import ValueConfig
 
 TRAIN_CONFIG_SOURCE = Path("src/opentau/configs/train.py")
 ARTIFACT_DIR = Path("tests/artifacts/configs")
@@ -71,6 +73,14 @@ def _make_cfg(dataset_mixture_config, policy_config, **overrides):
         **PIPELINE_WIDTHS,
         **overrides,
     }
+    # `action_chunk` lands on `policy.chunk_size`, and the policy rejects
+    # `n_action_steps > chunk_size` once it does (`validate_action_horizon`).
+    # PIPELINE_WIDTHS deliberately disagrees with every policy default -- including the
+    # default 50-step execution horizon -- so the horizon has to come along, which is
+    # exactly what a real config that sets `action_chunk` has to do. It is not itself a
+    # propagated width, so nothing in this module asserts on it.
+    if "n_action_steps" in _declared_fields(policy_config):
+        policy_config.n_action_steps = kwargs["action_chunk"]
     return TrainPipelineConfig(**kwargs)
 
 
@@ -295,3 +305,131 @@ def test_no_shape_width_is_assigned_to_the_policy_outside_the_helper():
         "assign policy widths only inside _propagate_shape_fields_to_policy(), which "
         f"skips fields the policy does not declare; found: {offenders}"
     )
+
+
+# --- the policy invariants keyed on the propagated widths --------------------------
+#
+# `chunk_size` is not just carried; the policy constrains it. `n_action_steps` (the
+# inference execution horizon) must be <= `chunk_size`, and a shortened horizon cannot
+# be combined with the delay knob. Those checks run in the policy config's
+# `__post_init__` -- which is over by the time the propagation loop above assigns -- so
+# they were only ever checked against the `chunk_size` the policy *declared*, never
+# against the propagated `action_chunk`. `_propagate_shape_fields_to_policy` now re-runs
+# them through `PreTrainedConfig.validate_action_horizon`.
+
+POLICIES_WITH_EXECUTION_HORIZON = [
+    (name, cls)
+    for name, cls in _all_policy_configs()
+    if {"chunk_size", "n_action_steps"} <= {f.name for f in dataclasses.fields(cls)}
+]
+
+
+def test_action_chunk_below_the_policy_execution_horizon_is_rejected(dataset_mixture_config, policy_config):
+    """The reported case: `action_chunk` set, `n_action_steps` left at its default.
+
+    `PI0Config(n_action_steps=50)` under `action_chunk=13` is exactly the pair the
+    policy config raises on when it appears in a JSON config, and it used to be
+    reachable silently through propagation.
+    """
+    with pytest.raises(ValueError, match="n_action_steps") as exc_info:
+        TrainPipelineConfig(
+            dataset_mixture=dataset_mixture_config,
+            policy=policy_config,  # n_action_steps defaults to 50
+            batch_size=8,
+            action_chunk=13,
+        )
+    # Blaming `policy.chunk_size` alone would send the reader to a field that reads as
+    # untouched in their config; the pipeline field that overwrote it has to be named.
+    assert "action_chunk" in str(exc_info.value)
+
+
+def test_action_chunk_matching_the_execution_horizon_propagates(dataset_mixture_config, policy_config):
+    """The legal case still propagates -- the guard rejects only the contradiction."""
+    policy_config.n_action_steps = 13
+
+    cfg = _make_cfg(dataset_mixture_config, policy_config)
+
+    assert (cfg.policy.chunk_size, cfg.policy.n_action_steps) == (13, 13)
+
+
+def test_the_delay_knob_is_rechecked_against_the_propagated_chunk_size(dataset_mixture_config):
+    """Re-validation covers every `chunk_size` invariant, not only `n_action_steps`.
+
+    This policy config is **valid standalone** -- its horizon is not shortened, since
+    `n_action_steps == chunk_size` -- and becomes illegal only once `action_chunk`
+    widens `chunk_size` underneath it.
+    """
+    policy = PI05Config(chunk_size=10, n_action_steps=10, max_delay=5)
+
+    with pytest.raises(ValueError, match="max_delay"):
+        TrainPipelineConfig(
+            dataset_mixture=dataset_mixture_config,
+            policy=policy,
+            batch_size=8,
+            action_chunk=50,
+        )
+
+
+def test_a_policy_without_an_execution_horizon_is_left_alone(dataset_mixture_config):
+    """`value` declares `chunk_size` but no `n_action_steps`, so there is nothing to
+    contradict -- it must still receive the width rather than trip a guard.
+    """
+    cfg = _make_cfg(dataset_mixture_config, ValueConfig())
+
+    assert cfg.policy.chunk_size == 13
+    assert not hasattr(cfg.policy, "n_action_steps")
+
+
+@pytest.mark.parametrize("policy_type,policy_cls", POLICIES_WITH_EXECUTION_HORIZON)
+def test_the_propagated_width_is_rechecked_for_every_policy(dataset_mixture_config, policy_type, policy_cls):
+    """Swept over the registry, like the presence check above.
+
+    Each of these configs carried its own copy of the horizon invariant, so a policy
+    that stops routing through `validate_action_horizon` -- or a new one that never
+    starts -- silently regains the dodge.
+    """
+    policy = policy_cls()  # defaults hold n_action_steps == chunk_size
+
+    with pytest.raises(ValueError, match="n_action_steps"):
+        TrainPipelineConfig(
+            dataset_mixture=dataset_mixture_config,
+            policy=policy,
+            batch_size=8,
+            action_chunk=policy.n_action_steps - 1,
+        )
+
+
+@pytest.mark.parametrize("policy_type,policy_cls", POLICIES_WITH_EXECUTION_HORIZON)
+def test_the_policy_config_still_enforces_the_horizon_itself(policy_type, policy_cls):
+    """The other half: deduplicating the check must not lose it from any config.
+
+    Policy configs are also built directly -- eval, inference, notebooks -- where no
+    pipeline propagation runs to catch it for them.
+    """
+    with pytest.raises(ValueError, match="n_action_steps"):
+        policy_cls(chunk_size=10, n_action_steps=50)
+
+
+def test_validate_rechecks_the_horizon_after_the_pretrained_reload(dataset_mixture_config, tmp_path):
+    """`validate()` replaces `self.policy` wholesale, so it needs the same guard.
+
+    Same route as the width test above: `--policy.path` loads a checkpoint's config
+    *after* `__post_init__` already propagated onto a different (here `None`) policy.
+    """
+    checkpoint_policy = json.loads((ARTIFACT_DIR / "train_config.json").read_text())["policy"]
+    assert checkpoint_policy["n_action_steps"] == 50, "artifact no longer exercises the conflict"
+    (tmp_path / "config.json").write_text(json.dumps(checkpoint_policy))
+
+    with patch.object(parser, "get_path_arg", return_value=tmp_path):
+        cfg = TrainPipelineConfig(
+            dataset_mixture=dataset_mixture_config,
+            policy=None,
+            output_dir=str(tmp_path / "run"),
+            job_name="test_run",
+            batch_size=8,
+            use_policy_training_preset=True,
+            **PIPELINE_WIDTHS,  # action_chunk=13 against the checkpoint's 50-step horizon
+        )
+
+        with pytest.raises(ValueError, match="n_action_steps"):
+            cfg.validate()

--- a/tests/policies/test_pi0.py
+++ b/tests/policies/test_pi0.py
@@ -446,6 +446,17 @@ class TestPI0ExecutionHorizon:
         cfg = self._config(chunk_size=10, n_action_steps=10, safety_buffer=2)
         assert cfg.safety_buffer == 2
 
+    def test_guard_rejects_safety_buffer_above_chunk_size(self):
+        # `select_action` refills whenever `len(queue) <= safety_buffer`, and the
+        # queue never holds more than `chunk_size` actions — so a safety_buffer
+        # past the chunk size silently re-queries the model every single step,
+        # decoding a full chunk to execute one action. pi0 names this knob
+        # `safety_buffer` where every other policy names it `max_delay`; the
+        # shared `validate_action_horizon` reads the name off
+        # `action_horizon_delay_field`, so this also pins pi0's override of it.
+        with pytest.raises(ValueError, match="safety_buffer"):
+            self._config(chunk_size=10, n_action_steps=10, safety_buffer=11)
+
     def test_select_action_executes_first_n_then_requeries(self):
         """Model decodes the full ``chunk_size`` chunk, but ``select_action``
         executes only the first ``n_action_steps`` before re-querying.

--- a/tests/policies/test_pi05_mem.py
+++ b/tests/policies/test_pi05_mem.py
@@ -74,7 +74,10 @@ class TestPI05MemConfig:
             PI05MemConfig(chunk_size=10, n_action_steps=20)
 
     def test_max_delay_exceeds_chunk_size(self):
-        with pytest.raises(ValueError, match="max delay"):
+        # Matches the field name, not the prose around it: the guard now lives in
+        # the shared `PreTrainedConfig.validate_action_horizon`, which names the
+        # knob it read (`max_delay` here, `safety_buffer` on pi0).
+        with pytest.raises(ValueError, match="max_delay"):
             PI05MemConfig(chunk_size=10, n_action_steps=10, max_delay=20)
 
     def test_validate_features_adds_empty_cameras(self):

--- a/tests/policies/test_pi06.py
+++ b/tests/policies/test_pi06.py
@@ -381,7 +381,10 @@ class TestPI06Config:
         assert not any("knowledge_insulation" in r.message for r in caplog.records)
 
     def test_max_delay_larger_than_chunk_size_raises(self):
-        with pytest.raises(ValueError, match="max delay"):
+        # Matches the field name, not the prose around it: the guard now lives in
+        # the shared `PreTrainedConfig.validate_action_horizon`, which names the
+        # knob it read (`max_delay` here, `safety_buffer` on pi0).
+        with pytest.raises(ValueError, match="max_delay"):
             PI06Config(chunk_size=4, n_action_steps=4, max_delay=8)
 
 


### PR DESCRIPTION
## What this does

(🐛 Bug) `TrainPipelineConfig` propagates the pipeline-level `action_chunk` onto `policy.chunk_size`. That `setattr` runs **after** the policy config's `__post_init__`, so the policy's own `n_action_steps <= chunk_size` invariant — enforced in every policy config that has an execution horizon — is only ever checked against the `chunk_size` the policy *declared*, never against the propagated one:

```python
from opentau.configs.train import TrainPipelineConfig
from opentau.configs.default import DatasetMixtureConfig, DatasetConfig
from opentau.policies.pi0.configuration_pi0 import PI0Config
dm = DatasetMixtureConfig(datasets=[DatasetConfig(repo_id="m", root="/tmp/m")])
c = TrainPipelineConfig(dataset_mixture=dm, policy=PI0Config(), batch_size=8, action_chunk=10)
print(c.policy.chunk_size, c.policy.n_action_steps)   # -> 10 50, silently
```

`n_action_steps=50 > chunk_size=10` is exactly what `PI0Config.__post_init__` raises on when it appears in a JSON config, but propagation reached it with nothing raising. Every in-repo config under `configs/` dodges this only by setting `policy.n_action_steps` equal to `action_chunk` by hand; a config that sets top-level `action_chunk` and leaves `n_action_steps` at its default hits it. The same dodge covered the two sibling invariants keyed on `chunk_size` (delay knob `<= chunk_size`, and shortened-horizon-vs-non-zero-delay).

This is independent of #510, which fixed *which* fields propagate (`max_action_state` → `max_action_dim`); `chunk_size` propagated correctly all along. It builds directly on #510's `_propagate_shape_fields_to_policy` — nothing in that helper's copy loop changes here, the re-validation is appended to it.

**Approach — re-validate after propagating, and fail loudly.** Not clamping: silently rewriting `n_action_steps` would change the execution horizon under the user and persist into the saved config.

* New `PreTrainedConfig.validate_action_horizon()` holds the three `chunk_size`-keyed checks, replacing the copy that lived in each of the seven policy configs (pi0, pi05, pi05_mem, pi06, pi07/low_level, pi07_paligemma/low_level, cosmos3 — and so cosmos3_nano / pi05_continuous_state by inheritance). It is a no-op for configs that declare no execution horizon (`value` has `chunk_size` but no `n_action_steps`; the high-level planners have neither).
* Each policy `__post_init__` now calls it, and so does `_propagate_shape_fields_to_policy` once its copy loop is done — which covers both call sites for free, including the `validate()` one that matters on its own (`--policy.path=...` replaces `self.policy` wholesale after `__post_init__` already ran).
* The propagation site re-raises with the pipeline field named, since `policy.chunk_size` reads as untouched in the user's JSON:

  > The chunk size is the upper bound for the number of action steps per model invocation. Got 50 for `n_action_steps` and 10 for `chunk_size`. `policy.chunk_size` was overwritten with the pipeline-level `action_chunk` (10), so the conflict is between `action_chunk` and the policy fields it does not propagate. Set `policy.n_action_steps` to `action_chunk` (or below it, for a deliberately shortened execution horizon), or change `action_chunk` — a policy-level `chunk_size` is ignored either way.

* pi0 names its knob `safety_buffer` where the others name it `max_delay`. The shared validator reads the name off an `action_horizon_delay_field` ClassVar that pi0 overrides — so pi0 also **gains** the `safety_buffer <= chunk_size` bound its siblings already had (its `select_action` refills whenever `len(queue) <= safety_buffer`, and the queue never holds more than `chunk_size`, so a larger value silently re-queries every step).

Three notes for reviewers:

1. **A config with `n_action_steps > action_chunk` now fails at config time.** No in-repo config trips it (checked all of `configs/**` and `tests/artifacts/configs/`), but an external checkpoint could: the model only ever decoded `chunk_size` actions and `select_action` sliced `min(n_action_steps, chunk_size)`, so such a run was *effectively* running at `action_chunk`. Setting `n_action_steps = action_chunk` reproduces what it was doing.
2. **#510's `_make_cfg` test helper needed a one-line change** — `PIPELINE_WIDTHS` sets `action_chunk=13` deliberately disagreeing with every policy default, which includes the default 50-step horizon, so the fixtures were themselves building the illegal pair. The helper now carries `n_action_steps` along when the policy declares it, which is exactly what a real config setting `action_chunk` has to do. Nothing in that module asserts on `n_action_steps`, so no existing pin is weakened.
3. The unified messages name the field (`` `max_delay` must be <= the chunk size ``) instead of prose ("The max delay must be..."). Two existing tests matched on the prose and were updated to match the field name, which is the more robust pin.

## How it was tested

`pre-commit run --all-files` (all hooks pass), then `pytest -m "not gpu and not network" -n auto`: **2637 passed, 13 skipped, 2 failed**, neither from this change. `tests/utils/test_libero_utils.py::test_libero2torch` fails on a missing local LIBERO `init_files` path and fails identically on this branch's base. `tests/utils/test_utils_benchmark.py::test_exception_handling` asserts a 0.05 s `sleep` lands within ±0.01 s of wall clock, which is a coin flip on a machine running the suite under `-n auto`; it passes in isolation, on a clean tree, and on re-run.

Added to `tests/configs/test_shape_field_propagation.py` (#510's module for this helper, reusing its registry sweep and fixtures):

- `test_action_chunk_below_the_policy_execution_horizon_is_rejected` — the reproduction above; asserts the message names both `n_action_steps` and `action_chunk`.
- `test_action_chunk_matching_the_execution_horizon_propagates` — the legal case still propagates.
- `test_the_delay_knob_is_rechecked_against_the_propagated_chunk_size` — re-validation is not just the one check: a `PI05Config(chunk_size=10, n_action_steps=10, max_delay=5)` that is **valid standalone** becomes illegal once `action_chunk=50` widens `chunk_size` underneath it.
- `test_a_policy_without_an_execution_horizon_is_left_alone` — `value` (has `chunk_size`, no `n_action_steps`) still receives the width instead of tripping a guard.
- `test_the_propagated_width_is_rechecked_for_every_policy` and `test_the_policy_config_still_enforces_the_horizon_itself` — both swept over the registry via the module's existing `_all_policy_configs()`, so a policy added later is covered automatically. Currently 9 types each: cosmos3, cosmos3_nano, pi0, pi05, pi05_continuous_state, pi05_mem, pi06, pi07_low_level, pi07_paligemma_low_level.
- `test_validate_rechecks_the_horizon_after_the_pretrained_reload` — pins the `validate()` path via the real `--policy.path` route, with an assertion on the artifact so the test can't quietly stop exercising the conflict.

Added to `tests/policies/test_pi0.py`: `test_guard_rejects_safety_buffer_above_chunk_size`, which also pins pi0's `action_horizon_delay_field` override — without it the validator would read a `max_delay` pi0 does not have and skip both delay checks.

Mutation-checked the new tests rather than trusting them: replacing the `validate_action_horizon()` call at the propagation site with `pass` fails 12 of them (and leaves the legal-case ones passing, as they should).

**GPU suite** (`pytest -m "gpu" -n 0` on an internal GPU dev box, single GPU, `dev` + `libero` extras): **25 passed, 144 skipped, 2 failed**. Both failures are missing sim assets on that box, not this change: a LIBERO `.bddl` file absent under the configured `LIBERO_CONFIG_PATH`, and `robocasa is not installed` (the `robocasa` extra was not synced). Both fail identically on this PR's base commit, checked by re-running the two files at the base in the same worktree. Nothing under `envs/` is touched here.

That run was on this branch's pre-rebase commit, before it was rebased onto #510. The rebase changed only `configs/train.py` (the propagation helper became #510's, with the re-validation appended) and the placement of the new CPU tests: **every file under `src/opentau/policies/` is byte-identical between the two commits**, and the only GPU-marked module that references `TrainPipelineConfig` at all is `tests/envs/test_robocasa.py`, whose GPU test is one of the two already failing for the missing extra.

**Regression tests were not run.** They are the nightly `regression_test.yml` job on an AWS g6.12xlarge; this change adds config-time validation only — no forward, normalization, or data-path code — so it cannot move a loss curve, and the run costs real money. Both checklist boxes below are therefore left unchecked rather than claiming a run that did not happen; say the word and I will dispatch `regression_test.yml` against this branch and check them.

## How to checkout & try?

```bash
pytest -sx tests/configs/test_shape_field_propagation.py
```

```bash
pytest -sx tests/policies/test_pi0.py -k safety_buffer
```

```bash
python -c "
from opentau.configs.train import TrainPipelineConfig
from opentau.configs.default import DatasetMixtureConfig, DatasetConfig
from opentau.policies.pi0.configuration_pi0 import PI0Config
dm = DatasetMixtureConfig(datasets=[DatasetConfig(repo_id='m', root='/tmp/m')])
TrainPipelineConfig(dataset_mixture=dm, policy=PI0Config(), batch_size=8, action_chunk=10)
"
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
