### PR TITLE
feat(policies): add accel, a cost-free flow-matching uncertainty proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,56 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added — `accel`, a cost-free flow-matching uncertainty proxy — **opt-in, no config_version bump**
+
+Denoising acceleration (`accel`, [arXiv:2607.27933](https://arxiv.org/abs/2607.27933))
+read off the flow-matching samplers' existing Euler loop. A maximally *certain* CFM field
+is an affine-isotropic contraction, so its denoising trajectory is a straight line at
+constant velocity; the normalized total variation of that velocity over the first `p` of
+`T` Euler steps is a proxy for the endpoint posterior's spread. It needs **no extra
+network evaluations, no resampling, no training, and no auxiliary probe** — the whole cost
+is two vector norms per denoise step, on velocities the sampler already computed.
+
+**No `config_version` bump.** Nothing about what the model sees or produces changes.
+`accel` is off by default (`policy.accel_prefix is None`), and with it off every added
+line in a sampler is dead, so the traced/compiled graph is unchanged.
+
+- `opentau.policies.accel` — the estimator (`AccelMeter`), the action-dim mask recovered
+  from the normalization buffers, `AccelProvenance`, and the shared `configure_accel`
+  enable knob (`OPENTAU_ACCEL_PREFIX=auto`, or an explicit prefix `>= 2`).
+- `opentau.utils.accel_detector` — offline one-sided CUSUM + split-conformal calibration
+  over the per-chunk score stream, fitted on **successful** rollouts only.
+- `opentau-accel-diagnose` — measures the bfloat16 rounding floor, the run-to-run spread,
+  and the prefix profile of a checkpoint. **Run this first**: `accel`'s numerator is a
+  difference of nearly-equal vectors, so bf16 puts a positive-biased floor under the score
+  that compresses exactly the low-uncertainty end the method's premise depends on.
+
+Measured on one real 6-DoF SO101 pi05 checkpoint (`T = 10`, QUANTILE action norm, delta
+actions, `max_delay = 4`) over 8 real frames of its own training data: rounding floor
+**0.0056**, redrawn-noise spread **0.0094**, between-observation spread **0.097** — a
+signal-to-floor ratio of **17**, i.e. the score is measuring field geometry rather than
+bf16 arithmetic on that checkpoint. Re-measure per checkpoint; this is not a constant.
+The prefix sweep on the same run reproduces the paper's terminal singularity: step-over-step
+growth in `accel_p` decelerates monotonically (122% → 62% → 69% → 38% → 41% → 33% → 22%)
+and then *reverses* to +48% at the last step, which is why `default_prefix` returns `T - 1`
+and not `T`.
+
+Note that the serving precision is fixed in code rather than chosen by the caller: the
+pi0/pi05 family routes its embedding path through **two** module-level `_preferred_dtype()`
+hooks (one in `modeling_pi05`, one in `paligemma_with_expert`) that return bfloat16
+unconditionally, so `policy.to(torch.float32)` alone does not produce a float32 forward.
+- `opentau-accel-calibrate` — fits a threshold from an eval run's `eval_info.json`.
+- `eval.py` records a per-episode `accel` stream (done-truncated, paired with `success`);
+  the gRPC `ActionChunkResponse` gained an `optional float accel = 5` (explicit presence,
+  so unset is distinguishable from a maximally-confident `0.0`); the RoboCasa server sends
+  an `accel` envelope only to clients that set `"include_accel": true`.
+
+Known limits, all inherited from the method: it is a *local* statement about the action
+expert's posterior at one observation, blind to confident-but-wrong VLM-level errors and
+to precision-sensitive failures, and it degrades on undertrained models. It is a monitor,
+not a guarantee of correctness.
+
+
 ### Changed — openpi-faithful normalization (zero-range dims + epsilon) — **breaking, gated**
 
 `config_version` **0 → 1.** Two openpi-parity normalization changes are bundled

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,8 @@ opentau-so101-record = "opentau.scripts.so101.record:main"
 opentau-so101-setup-motors = "opentau.scripts.so101.setup_motors:main"
 opentau-so101-find-port = "opentau.scripts.so101.find_port:main"
 opentau-so101-find-cameras = "opentau.scripts.so101.find_cameras:main"
+opentau-accel-diagnose = "opentau.scripts.diagnose_accel:main"
+opentau-accel-calibrate = "opentau.scripts.calibrate_accel:main"
 
 [project.optional-dependencies]
 dev = ["pre-commit>=3.7.0",

--- a/src/opentau/configs/policies.py
+++ b/src/opentau/configs/policies.py
@@ -326,6 +326,11 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):
             inference. Honored by every policy whose ``from_pretrained`` (or ``_load_as_safetensor``)
             calls :py:meth:`~opentau.policies.pretrained.PreTrainedPolicy._strip_normalization_buffers_from_state_dict`.
             Defaults to ``False`` (no behaviour change).
+        accel_prefix: Prefix length for the denoising-acceleration uncertainty proxy
+            (:mod:`opentau.policies.accel`), or ``None`` to leave it off (the default).
+            ``"auto"`` resolves to the paper's ``T - 1``. Inference-only and opt-in; see
+            :func:`opentau.policies.accel.configure_accel` for the resolution order and
+            the refusals (IDENTITY-normalized actions, an unwired policy family).
         skip_input_resolution_check: Escape hatch for
             :py:meth:`validate_input_resolution`. When ``True``, a mismatch
             between the policy's ``resize_imgs_with_padding`` and the ``(H, W)``
@@ -354,6 +359,15 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):
     # `use_amp` determines whether to use Automatic Mixed Precision (AMP) for training and evaluation. With AMP,
     # automatic gradient scaling is used.
     use_amp: bool = False
+
+    # Prefix length for the denoising-acceleration uncertainty proxy (`opentau.policies.accel`),
+    # or None to leave it off (the default). A flow-matching policy with this set publishes a
+    # per-chunk `last_accel` score read off velocities its Euler loop already computes — no extra
+    # network evaluations, and with it unset every added line in the sampler is dead, so the
+    # traced graph is unchanged. `"auto"` resolves to the paper's `T - 1`. Only meaningful for
+    # flow-matching policies; `configure_accel` raises on a family whose sampler is not wired.
+    # Inference-only: it is read at `sample_actions` time and never affects training.
+    accel_prefix: int | str | None = None
 
     # When True, training `torch.compile`s the policy's heavy compute submodule
     # (the flow-matching `self.model` for pi05 / pi07) *in place* via

--- a/src/opentau/policies/accel.py
+++ b/src/opentau/policies/accel.py
@@ -1,0 +1,685 @@
+#!/usr/bin/env python
+
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Denoising acceleration (``accel``) — a cost-free uncertainty proxy for flow-matching heads.
+
+Implements the estimator of *The Geometry of Flow-Matching Uncertainty*
+(arXiv:2607.27933). A maximally *certain* conditional-flow-matching field is an
+affine-isotropic contraction toward a point mass, so its denoising trajectory is a
+straight line traversed at constant velocity; any *bend* in that trajectory betrays
+non-zero posterior covariance. Over the first ``p`` of ``T`` Euler steps,
+
+.. math::
+
+    \\mathrm{accel}_p = \\frac{p \\sum_{t=1}^{p-1} \\lVert v_t - v_{t-1} \\rVert}
+                             {\\sum_{t=0}^{p-1} \\lVert v_t \\rVert}
+
+where ``v_t`` is the velocity the sampler *already* evaluates to take its Euler step.
+No extra network evaluations, no resampling, no training, no auxiliary probe — the
+whole cost is two vector norms per denoise step.
+
+Why a *prefix* and not the whole path: the field's ``1/(1-s)`` factor diverges at the
+clean-action end, so the final Euler steps are dominated by discretization noise rather
+than posterior information. That is a statement about *integration order*, not about
+which end the time variable calls zero — OpenTau's samplers integrate noise -> data with
+``time`` running 1 -> 0, so the prefix is always the first ``p`` loop iterations.
+:func:`default_prefix` returns the paper's online-detector choice, ``T - 1``.
+
+Two masks are mandatory for the number to mean anything on OpenTau checkpoints, and both
+are silent when wrong:
+
+* **Action-dim mask.** The samplers work in ``max_action_dim`` (32) while a real
+  embodiment uses far fewer (7 for LIBERO). The padded tail is masked out of the
+  training loss (:func:`opentau.policies.utils.make_action_dim_mask`), so those columns
+  are *unsupervised network output* — pure noise landing in both the numerator and the
+  denominator. ``real_action_dim`` is a dataset-side key and is absent at inference, so
+  :func:`resolve_action_dim_mask` recovers the mask from the normalization buffers.
+* **Row mask.** Frozen real-time-chunking prefix rows carry velocities for a state that
+  is discarded, and only the executed window of the chunk is ever applied. Both are
+  excluded by the samplers via :meth:`AccelMeter.set_row_mask`.
+
+The score is only comparable within a fixed
+``(task, embodiment, norm head, ACTION norm mode, delta-vs-absolute, T, p, dtype)``
+tuple; :class:`AccelProvenance` records that tuple so a calibrated threshold can never
+be applied across a mismatch.
+
+See :mod:`opentau.utils.accel_detector` for the offline CUSUM + split-conformal detector
+that consumes the per-chunk stream produced here.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+import torch
+from einops import rearrange
+from torch import Tensor
+
+from opentau.configs.types import NormalizationMode
+from opentau.policies.normalize import stat_names_for_mode
+
+logger = logging.getLogger(__name__)
+
+# Denominator floor. Below this the ratio is not a curvature measurement — every velocity
+# in the prefix was (near-)zero, which happens when the masks eliminate every scored
+# element. Reporting 0.0 there would read as "maximally certain", the exact opposite of
+# "no information", so the meter emits NaN instead.
+DENOMINATOR_FLOOR = 1e-12
+
+# A prefix of 1 yields an empty numerator sum, i.e. accel == 0 by construction regardless
+# of the field. Same false-confidence trap as above, so it is rejected rather than clamped.
+MIN_PREFIX = 2
+
+# Environment variable that enables ``accel`` on an entry point with no config field for it.
+# Accepts ``auto`` (the paper's default prefix) or an integer ``>= MIN_PREFIX``.
+ACCEL_PREFIX_ENV = "OPENTAU_ACCEL_PREFIX"
+
+
+def default_prefix(num_steps: int) -> int:
+    """Return the paper's online-detector prefix for a ``num_steps``-step schedule.
+
+    The paper reports its failure-detection results with the second-to-last prefix
+    (``accel_-2``), i.e. ``p = T - 1``, having found that truncated prefixes correlate
+    more strongly with posterior spread than the full path. Its *best*-prefix sweep peaks
+    nearer ``p/T ~ 0.4-0.5``, so treat this as a sane default and not an optimum — for a
+    short schedule (``pi06``/``pi07`` default to ``T = 5``) the two are far apart.
+
+    Args:
+        num_steps: Total Euler steps ``T`` in the denoise schedule.
+
+    Returns:
+        A prefix in ``[MIN_PREFIX, num_steps]``.
+
+    Raises:
+        ValueError: If ``num_steps`` is below :data:`MIN_PREFIX`.
+    """
+    if num_steps < MIN_PREFIX:
+        raise ValueError(
+            f"accel needs at least {MIN_PREFIX} denoise steps to form one velocity "
+            f"difference, but num_steps={num_steps}."
+        )
+    return max(MIN_PREFIX, num_steps - 1)
+
+
+def resolve_prefix(prefix: int | None, num_steps: int) -> int | None:
+    """Validate and clamp a configured ``accel`` prefix against the denoise schedule.
+
+    Args:
+        prefix: Configured prefix, or ``None`` to leave ``accel`` disabled.
+        num_steps: Total Euler steps ``T`` in the denoise schedule.
+
+    Returns:
+        ``None`` when disabled, else a prefix in ``[MIN_PREFIX, num_steps]``.
+
+    Raises:
+        ValueError: If ``prefix`` is below :data:`MIN_PREFIX`, or if the schedule is too
+            short to form a velocity difference.
+    """
+    if prefix is None:
+        return None
+    if prefix < MIN_PREFIX:
+        raise ValueError(
+            f"accel prefix must be >= {MIN_PREFIX} (a shorter prefix has an empty "
+            f"numerator and would report 0.0 for every field), got {prefix}."
+        )
+    if num_steps < MIN_PREFIX:
+        raise ValueError(
+            f"accel needs at least {MIN_PREFIX} denoise steps to form one velocity "
+            f"difference, but num_steps={num_steps}."
+        )
+    return min(prefix, num_steps)
+
+
+@dataclass(frozen=True)
+class AccelProvenance:
+    """The context that makes one ``accel`` value comparable to another.
+
+    Every field here shifts the score's distribution, so a threshold calibrated under one
+    tuple is meaningless under a different one. Persist this alongside the values and
+    refuse to apply a calibration across a mismatch (:func:`assert_comparable`).
+
+    Attributes:
+        policy_type: ``config.type`` of the policy that produced the score.
+        num_steps: Total Euler steps ``T``.
+        prefix: Prefix ``p`` actually integrated over.
+        chunk_size: Full predicted chunk length.
+        n_action_steps: Executed window length (the scored rows).
+        max_delay: Configured real-time-chunking depth.
+        action_norm_mode: ``normalization_mapping["ACTION"]`` name.
+        has_delta_action_map: Whether actions live in delta space.
+        velocity_dtype: dtype the velocity projection ran in, as a string. bf16 puts a
+            positive-biased noise floor under the score (see module docs of
+            :mod:`opentau.utils.accel_detector`).
+        num_scored_dims: Action dims that survived the dim mask, per norm head.
+        dataset_index: Norm-head row index per sample, when resolvable.
+    """
+
+    policy_type: str
+    num_steps: int
+    prefix: int
+    chunk_size: int
+    n_action_steps: int
+    max_delay: int
+    action_norm_mode: str
+    has_delta_action_map: bool
+    velocity_dtype: str
+    num_scored_dims: tuple[int, ...] = ()
+    dataset_index: tuple[int, ...] = ()
+
+    # Fields that must agree for two scores to be comparable. `dataset_index` and
+    # `num_scored_dims` are deliberately excluded: they vary per sample within one run,
+    # and comparability across norm heads is checked separately by the caller that knows
+    # which head a calibration was fitted on.
+    COMPARABLE_FIELDS = (
+        "policy_type",
+        "num_steps",
+        "prefix",
+        "chunk_size",
+        "n_action_steps",
+        "max_delay",
+        "action_norm_mode",
+        "has_delta_action_map",
+        "velocity_dtype",
+    )
+
+    def to_dict(self) -> dict:
+        """Return a JSON-serializable copy."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: dict) -> AccelProvenance:
+        """Rebuild from :meth:`to_dict` output, tolerating unknown future keys."""
+        known = set(cls.__dataclass_fields__)
+        kwargs = {k: v for k, v in payload.items() if k in known}
+        for tuple_field in ("num_scored_dims", "dataset_index"):
+            if tuple_field in kwargs and kwargs[tuple_field] is not None:
+                kwargs[tuple_field] = tuple(kwargs[tuple_field])
+        return cls(**kwargs)
+
+
+def assert_comparable(fitted: AccelProvenance, observed: AccelProvenance) -> None:
+    """Raise unless two provenances agree on every distribution-shifting field.
+
+    Args:
+        fitted: Provenance recorded when a threshold was calibrated.
+        observed: Provenance of the stream the threshold is about to be applied to.
+
+    Raises:
+        ValueError: On the first disagreeing field, naming both values.
+    """
+    diffs = [
+        f"{name}: calibrated on {getattr(fitted, name)!r}, observed {getattr(observed, name)!r}"
+        for name in AccelProvenance.COMPARABLE_FIELDS
+        if getattr(fitted, name) != getattr(observed, name)
+    ]
+    if diffs:
+        raise ValueError(
+            "accel calibration is not applicable to this stream — "
+            + "; ".join(diffs)
+            + ". Recalibrate under the deployment configuration."
+        )
+
+
+def resolve_action_dim_mask(
+    unnormalize: torch.nn.Module,
+    *,
+    max_action_dim: int,
+    dataset_index: Tensor,
+    action_key: str = "actions",
+) -> Tensor:
+    """Recover which action dims carry real, supervised signal, from the norm buffers.
+
+    ``real_action_dim`` (:mod:`opentau.datasets.lerobot_dataset`) is a dataset-side key
+    and does not exist at inference, so the pad tail has to be reconstructed. A padded
+    column is constant-zero across the dataset, so its ``std`` (MEAN_STD) or range
+    (MIN_MAX / QUANTILE) is zero — the same degenerate-dim test
+    ``Normalize._snapping_possible`` uses.
+
+    This is a **heuristic, and it errs toward dropping signal**: a genuinely real but
+    constant dim (a locked joint, a gripper axis pinned open, a DOF never commanded in
+    that repo) is also zero-variance and gets masked out. That direction is the safe one
+    for a curvature ratio — a constant dim contributes no curvature anyway — but do not
+    describe the result as an exact reconstruction of ``real_action_dim``. When the
+    training dataset is on hand, cross-check against it.
+
+    The buffers are ``(num_datasets, action_dim)``, so the mask is resolved **per norm
+    head** and gathered per sample; on a co-trained mixture two samples in one batch can
+    legitimately score a different number of dims.
+
+    Args:
+        unnormalize: The policy's ``Unnormalize`` module (its ``eps`` and buffers are read
+            live, never the module-level default — ``eps`` is ``config_version``-dependent).
+        max_action_dim: Width of the sampler's action tensor. The mask is padded with
+            ``False`` beyond the buffer width and truncated if the buffer is wider.
+        dataset_index: ``(B,)`` long tensor of norm-head row indices.
+        action_key: Feature key to read stats for.
+
+    Returns:
+        ``(B, max_action_dim)`` bool tensor; ``True`` where the dim carries signal.
+
+    Raises:
+        ValueError: When the action feature is IDENTITY-normalized (no buffer exists, so
+            the mask is underivable) or has no buffer for another reason.
+    """
+    norm_map = getattr(unnormalize, "norm_map", {})
+    features = getattr(unnormalize, "features", {})
+    feature = features.get(action_key)
+    if feature is None:
+        raise ValueError(
+            f"accel: no feature {action_key!r} on the policy's Unnormalize; cannot derive "
+            "the action-dim mask."
+        )
+    norm_mode = norm_map.get(feature.type, NormalizationMode.IDENTITY)
+    if norm_mode is NormalizationMode.IDENTITY:
+        raise ValueError(
+            "accel: ACTION normalization is IDENTITY, so no stats buffer exists and the "
+            "padded-action-dim mask cannot be derived. IDENTITY also leaves per-dim scale "
+            "heterogeneous, which violates the estimator's standardized-dimension premise. "
+            "Disable accel for this checkpoint or retrain/serve with MEAN_STD."
+        )
+
+    buffer = getattr(unnormalize, "buffer_" + action_key.replace(".", "_"), None)
+    if buffer is None:
+        raise ValueError(f"accel: Unnormalize has no stats buffer for {action_key!r}.")
+
+    eps = float(unnormalize.eps)
+    # Import locally: `_materialize` is a private FSDP2/DTensor shim in `normalize`, and a
+    # module-level import would make this module's import graph depend on it by name.
+    from opentau.policies.normalize import _materialize
+
+    if norm_mode is NormalizationMode.MEAN_STD:
+        signature = _materialize(buffer["std"]).abs()
+    else:
+        lo_name, hi_name = stat_names_for_mode(norm_mode)
+        signature = (_materialize(buffer[hi_name]) - _materialize(buffer[lo_name])).abs()
+
+    # `(num_datasets, action_dim)` -> per-head bool over dims.
+    signature = signature.reshape(signature.shape[0], -1)
+    head_mask = torch.isfinite(signature) & (signature >= eps)
+
+    width = head_mask.shape[1]
+    if width < max_action_dim:
+        pad = torch.zeros(
+            (head_mask.shape[0], max_action_dim - width), dtype=torch.bool, device=head_mask.device
+        )
+        head_mask = torch.cat([head_mask, pad], dim=1)
+    elif width > max_action_dim:
+        head_mask = head_mask[:, :max_action_dim]
+
+    index = dataset_index.to(device=head_mask.device, dtype=torch.long).reshape(-1)
+    index = index.clamp_(0, head_mask.shape[0] - 1)
+    per_sample = head_mask.index_select(0, index)
+
+    if not bool(per_sample.any()):
+        # Name the head that was actually selected and contrast it with the others. The
+        # common cause is not a broken checkpoint but a *routing* one: a co-trained mixture
+        # carries a placeholder head whose stats are all zero, and an observation with no
+        # dataset provenance falls back to head 0 — which may be exactly that placeholder.
+        # Reporting only "the mask is empty" sends the reader to audit their action stats
+        # when the fix is to tag the observation with its norm head.
+        per_head = [int(n) for n in head_mask.sum(dim=1).tolist()]
+        selected = sorted({int(i) for i in index.tolist()})
+        usable = [i for i, n in enumerate(per_head) if n > 0]
+        raise ValueError(
+            f"accel: every action dim of norm head(s) {selected} is degenerate in the "
+            f"{norm_mode.name} stats, so the score would be computed over zero dimensions. "
+            f"Scorable dims per head: {per_head}."
+            + (
+                f" Head(s) {usable} do have usable stats — if that is where this sample belongs, "
+                "tag the observation with its `dataset_repo_id` (or `robot_type`/`control_mode`) "
+                "so `_resolve_dataset_index` routes it there instead of falling back to head 0."
+                if usable
+                else " No head has usable action stats; this checkpoint cannot support accel."
+            )
+        )
+    return per_sample
+
+
+@dataclass
+class AccelMeter:
+    """Running ``accel`` accumulator for one flow-matching sample call.
+
+    Threaded through a sampler's Euler loop as an optional argument rather than stashed on
+    the ``nn.Module``: the samplers are ``torch.compile``d and ONNX-exported at several
+    entry points, and writing to a module attribute inside the traced region is a Dynamo
+    side-effect on an ``nn.Module`` — the construct most likely to break under
+    ``fullgraph=True`` or ``dynamo=True`` export. A per-call object also cannot leak state
+    between calls or across threads.
+
+    Everything accumulates in float32 on-device with no ``.item()`` inside the loop, so no
+    host synchronization is added. (The samplers' ``while`` condition already forces one
+    per iteration; ``accel`` does not add a second.)
+
+    Usage from a sampler::
+
+        if accel is not None:
+            accel.set_row_mask(row_mask)          # (B|1, chunk) bool, before the loop
+        while ...:
+            v_t = self.denoise_step(...)
+            if accel is not None:
+                accel.update(v_t)                 # inside the loop, before the Euler step
+            x_t += dt * v_t
+
+    Attributes:
+        prefix: Number of leading Euler steps to integrate over.
+        batch_size: Number of independent samples.
+        device: Device the accumulators live on.
+        dim_mask: Optional ``(B, action_dim)`` bool from :func:`resolve_action_dim_mask`.
+    """
+
+    prefix: int
+    batch_size: int
+    device: torch.device
+    dim_mask: Tensor | None = None
+
+    _numerator: Tensor = field(init=False, repr=False)
+    _denominator: Tensor = field(init=False, repr=False)
+    _prev: Tensor | None = field(default=None, init=False, repr=False)
+    _score_mask: Tensor | None = field(default=None, init=False, repr=False)
+    _steps: int = field(default=0, init=False)
+
+    def __post_init__(self) -> None:
+        if self.prefix < MIN_PREFIX:
+            raise ValueError(f"accel prefix must be >= {MIN_PREFIX}, got {self.prefix}.")
+        self._numerator = torch.zeros(self.batch_size, dtype=torch.float32, device=self.device)
+        self._denominator = torch.zeros(self.batch_size, dtype=torch.float32, device=self.device)
+        if self.dim_mask is not None:
+            # (B, dim) -> (B, 1, dim) so it broadcasts over the chunk axis.
+            self._score_mask = rearrange(self.dim_mask.to(torch.float32), "b d -> b 1 d")
+
+    def set_row_mask(self, row_mask: Tensor) -> None:
+        """Restrict scoring to a subset of chunk rows.
+
+        Call once before the Euler loop. Combines multiplicatively with ``dim_mask``.
+
+        Args:
+            row_mask: ``(B, chunk)`` or ``(1, chunk)`` bool/float; ``True`` scores the row.
+                Exclude frozen real-time-chunking prefix rows (their velocities describe a
+                state that is overwritten every iteration) and rows outside the executed
+                window (they are never applied).
+        """
+        rows = rearrange(row_mask.to(torch.float32), "b c -> b c 1")
+        self._score_mask = rows if self._score_mask is None else rows * self._score_mask
+
+    def update(self, v_t: Tensor) -> None:
+        """Accumulate one Euler step's velocity. A no-op once ``prefix`` steps are in.
+
+        Args:
+            v_t: ``(B, chunk, action_dim)`` velocity, any dtype (cast to float32 here).
+        """
+        if self._steps >= self.prefix:
+            return
+        v = v_t.to(torch.float32)
+        if self._score_mask is not None:
+            v = v * self._score_mask
+        v = v.flatten(1)
+        self._denominator = self._denominator + torch.linalg.vector_norm(v, dim=1)
+        if self._prev is not None:
+            self._numerator = self._numerator + torch.linalg.vector_norm(v - self._prev, dim=1)
+        self._prev = v
+        self._steps += 1
+
+    @property
+    def steps(self) -> int:
+        """Euler steps actually accumulated (``<= prefix``; short if the schedule was)."""
+        return self._steps
+
+    def value(self) -> Tensor:
+        """Return the ``(B,)`` float32 ``accel`` score.
+
+        Follows Algorithm 1's running form ``J / (S / (t+1))``, i.e. the multiplier is the
+        number of velocities accumulated — which equals ``prefix`` whenever the schedule
+        was long enough, and degrades gracefully when it was not.
+
+        Returns:
+            ``(B,)`` float32. NaN where the score is undefined: fewer than two velocities
+            (empty numerator) or an all-but-zero denominator (every scored element masked
+            out). NaN is deliberate — 0.0 would read as "maximally certain".
+        """
+        nan = torch.full_like(self._denominator, float("nan"))
+        if self._steps < MIN_PREFIX:
+            return nan
+        scored = self._steps * self._numerator / self._denominator.clamp_min(DENOMINATOR_FLOOR)
+        return torch.where(self._denominator > DENOMINATOR_FLOOR, scored, nan)
+
+    def to_list(self) -> list[float]:
+        """Return the score as plain Python floats.
+
+        Fully escapes ``torch.inference_mode()``: a tensor allocated inside inference mode
+        stays an inference tensor even after ``.detach().clone()``, and any later in-place
+        mutation of it (exactly what a CUSUM accumulator does) raises. Going through
+        ``.tolist()`` yields ordinary floats with no such taint.
+        """
+        return [float(x) for x in self.value().detach().to("cpu", torch.float32).tolist()]
+
+
+def make_meter(
+    policy: torch.nn.Module,
+    *,
+    batch_size: int,
+    device: torch.device,
+    dataset_index: Tensor | None = None,
+    max_action_dim: int | None = None,
+) -> AccelMeter | None:
+    """Build an :class:`AccelMeter` for one sample call, or ``None`` when disabled.
+
+    Reads ``policy.accel_prefix`` (``None`` disables) and derives the action-dim mask from
+    ``policy.unnormalize_outputs``. Shared by every flow-matching policy wrapper so the
+    enable knob, the mask derivation, and the IDENTITY refusal cannot drift between them.
+
+    Args:
+        policy: The policy wrapper (must expose ``config`` and ``unnormalize_outputs``).
+        batch_size: Number of samples in the call.
+        device: Device to accumulate on.
+        dataset_index: ``(B,)`` norm-head row indices; a zeros row is assumed when absent.
+        max_action_dim: Sampler action width; defaults to ``policy.config.max_action_dim``.
+
+    Returns:
+        A meter, or ``None`` when ``accel_prefix`` is unset.
+
+    Raises:
+        ValueError: When ``accel`` is enabled but the configuration cannot support it
+            (IDENTITY action normalization, too-short schedule, bad prefix).
+    """
+    prefix = getattr(policy, "accel_prefix", None)
+    if prefix is None:
+        return None
+
+    config = policy.config
+    prefix = resolve_prefix(prefix, config.num_steps)
+    if max_action_dim is None:
+        max_action_dim = config.max_action_dim
+
+    if dataset_index is None:
+        dataset_index = torch.zeros(batch_size, dtype=torch.long, device=device)
+
+    dim_mask = resolve_action_dim_mask(
+        policy.unnormalize_outputs,
+        max_action_dim=max_action_dim,
+        dataset_index=dataset_index,
+    )
+    return AccelMeter(prefix=prefix, batch_size=batch_size, device=device, dim_mask=dim_mask)
+
+
+def build_provenance(
+    policy: torch.nn.Module,
+    meter: AccelMeter,
+    *,
+    dataset_index: Tensor | None = None,
+    velocity_dtype: torch.dtype | None = None,
+) -> AccelProvenance:
+    """Record the context of a batch of ``accel`` scores.
+
+    Args:
+        policy: The policy wrapper that produced them.
+        meter: The meter used, for the effective prefix and dim mask.
+        dataset_index: ``(B,)`` norm-head row indices, if resolved.
+        velocity_dtype: dtype the velocity projection ran in. Defaults to the dtype of the
+            policy's parameters, which is what the projection inherits.
+
+    Returns:
+        A frozen :class:`AccelProvenance`.
+    """
+    config = policy.config
+    norm_mode = config.normalization_mapping.get("ACTION")
+    if velocity_dtype is None:
+        velocity_dtype = next(policy.parameters()).dtype
+
+    num_scored: tuple[int, ...] = ()
+    if meter.dim_mask is not None:
+        num_scored = tuple(int(n) for n in meter.dim_mask.sum(dim=-1).detach().cpu().tolist())
+
+    index: tuple[int, ...] = ()
+    if dataset_index is not None:
+        index = tuple(int(i) for i in dataset_index.detach().cpu().reshape(-1).tolist())
+
+    return AccelProvenance(
+        policy_type=getattr(config, "type", type(config).__name__),
+        num_steps=int(config.num_steps),
+        prefix=int(meter.prefix),
+        chunk_size=int(config.chunk_size),
+        n_action_steps=int(config.n_action_steps),
+        max_delay=int(getattr(config, "max_delay", 0)),
+        action_norm_mode=getattr(norm_mode, "name", str(norm_mode)),
+        has_delta_action_map=bool(getattr(config, "delta_action_state_map", None)),
+        velocity_dtype=str(velocity_dtype).removeprefix("torch."),
+        num_scored_dims=num_scored,
+        dataset_index=index,
+    )
+
+
+def configure_accel(
+    policy: torch.nn.Module,
+    cfg: Any,
+    *,
+    override: int | str | None = None,
+) -> int | None:
+    """Enable the denoising-acceleration proxy on ``policy``, if anything asked for it.
+
+    The single enable knob shared by every serving entry point (``inference.py``, the gRPC
+    server, the RoboCasa WebSocket server), so the precedence order and the refusals cannot
+    drift between them.
+
+    **Off by default and never enabled implicitly.** When nothing requests it, this leaves
+    ``policy.accel_prefix`` at ``None``, :func:`make_meter` returns ``None``, and every
+    ``accel`` line inside the sampler stays dead — the traced graph is unchanged.
+
+    Resolution order, first non-``None`` wins:
+
+    1. ``override`` — an entry point's own flag.
+    2. ``cfg.policy.accel_prefix`` — read through ``getattr`` so a future config field needs
+       no change here.
+    3. ``$OPENTAU_ACCEL_PREFIX`` — the knob that works today, since no config field exists.
+
+    Call this *before* an entry point's warmup ``sample_actions`` calls: the warmup then
+    compiles and autotunes the same graph real requests take rather than forcing a recompile
+    on the first one, and a checkpoint that cannot support ``accel`` (IDENTITY-normalized
+    actions, an all-degenerate dim mask) fails at startup instead of on the first request.
+
+    Args:
+        policy: The loaded policy wrapper.
+        cfg: The parsed pipeline config; only a possible ``cfg.policy.accel_prefix`` and
+            ``cfg.policy.type`` are read. Typed loosely to keep this module off the config
+            package's import graph.
+        override: Entry-point-level request that beats both config and environment.
+
+    Returns:
+        The resolved prefix, or ``None`` when ``accel`` stays disabled.
+
+    Raises:
+        ValueError: When ``accel`` is requested but this policy cannot produce it — its
+            sampler is not wired for ``accel``, its config has no denoise schedule, or the
+            requested prefix is invalid for that schedule.
+    """
+    requested: int | str | None = override
+    if requested is None:
+        requested = getattr(cfg.policy, "accel_prefix", None)
+    if requested is None:
+        requested = os.environ.get(ACCEL_PREFIX_ENV)
+    if requested is None or (isinstance(requested, str) and not requested.strip()):
+        return None
+
+    policy_type = getattr(cfg.policy, "type", type(cfg.policy).__name__)
+    # A policy family whose sampler has not been wired for accel would accept the attribute
+    # and then never read it — the exact silent no-op an operator would read as "the score is
+    # always missing". Refuse instead.
+    if not hasattr(policy, "accel_prefix"):
+        raise ValueError(
+            f"accel was requested ({requested!r}) but policy type {policy_type!r} does not "
+            "expose `accel_prefix`, i.e. its sampler is not wired for denoising acceleration."
+        )
+    num_steps = getattr(policy.config, "num_steps", None)
+    if num_steps is None:
+        raise ValueError(
+            f"accel was requested ({requested!r}) but policy type {policy_type!r} has no "
+            "`num_steps` denoise schedule to read velocities off."
+        )
+
+    text = str(requested).strip().lower()
+    if text == "auto":
+        prefix = default_prefix(num_steps)
+    else:
+        try:
+            requested_int = int(text)
+        except ValueError as exc:
+            raise ValueError(
+                f"accel prefix must be an integer >= {MIN_PREFIX} or the literal 'auto', got {requested!r}."
+            ) from exc
+        prefix = resolve_prefix(requested_int, num_steps)
+
+    policy.accel_prefix = prefix
+    logger.info("accel enabled: prefix=%d of num_steps=%d (requested %r)", prefix, num_steps, requested)
+    return prefix
+
+
+def executed_row_mask(
+    *,
+    prefix_mask: Tensor,
+    delay: Tensor,
+    chunk_size: int,
+    n_action_steps: int,
+    device: torch.device,
+) -> Tensor:
+    """Build the chunk-row mask a sampler should hand to :meth:`AccelMeter.set_row_mask`.
+
+    Excludes two kinds of row, both of which would otherwise inject rows carrying no
+    posterior information into both sums:
+
+    * **Frozen real-time-chunking rows** (``prefix_mask``). Their state is overwritten with
+      the committed action before every ``denoise_step`` and their conditioning time is
+      pinned to 0, so the velocity there describes nothing. It is masked out of the
+      training loss for the same reason.
+    * **Rows outside the executed window.** ``select_action`` applies
+      ``actions[delay : delay + n_action_steps]`` and re-plans, so later rows never reach
+      the robot. Note this is ``[delay, delay + n_action_steps)``, *not* ``[0,
+      n_action_steps)`` — the naive slice is wrong whenever ``delay > 0``.
+
+    Args:
+        prefix_mask: ``(B, chunk)`` or ``(1, chunk)`` bool; ``True`` marks a frozen row.
+        delay: Scalar or ``(B,)`` long tensor of frozen rows.
+        chunk_size: Full chunk length.
+        n_action_steps: Executed window length.
+        device: Device to build on.
+
+    Returns:
+        Bool tensor broadcastable to ``(B, chunk)``; ``True`` scores the row.
+    """
+    positions = rearrange(torch.arange(chunk_size, device=device), "c -> 1 c")
+    horizon = delay.reshape(-1, 1).to(device) + n_action_steps if delay.ndim else delay + n_action_steps
+    return (~prefix_mask) & (positions < horizon)

--- a/src/opentau/policies/accel.py
+++ b/src/opentau/policies/accel.py
@@ -583,9 +583,9 @@ def configure_accel(
     Resolution order, first non-``None`` wins:
 
     1. ``override`` — an entry point's own flag.
-    2. ``cfg.policy.accel_prefix`` — read through ``getattr`` so a future config field needs
-       no change here.
-    3. ``$OPENTAU_ACCEL_PREFIX`` — the knob that works today, since no config field exists.
+    2. ``cfg.policy.accel_prefix`` — the config field on ``PreTrainedConfig``; read through
+       ``getattr`` so a policy config predating it still resolves.
+    3. ``$OPENTAU_ACCEL_PREFIX`` — for entry points driven without a config file.
 
     Call this *before* an entry point's warmup ``sample_actions`` calls: the warmup then
     compiles and autotunes the same graph real requests take rather than forcing a recompile

--- a/src/opentau/policies/cosmos3/modeling_cosmos3.py
+++ b/src/opentau/policies/cosmos3/modeling_cosmos3.py
@@ -44,6 +44,9 @@ from einops import rearrange, repeat
 from torch import Tensor, nn
 from transformers import AutoProcessor, Qwen3VLConfig
 
+from opentau.policies.accel import AccelMeter, executed_row_mask
+from opentau.policies.accel import build_provenance as build_accel_provenance
+from opentau.policies.accel import make_meter as make_accel_meter
 from opentau.policies.cosmos3.configuration_cosmos3 import Cosmos3Config
 from opentau.policies.cosmos3.qwen3vl_with_expert import Qwen3VLWithExpertModel
 from opentau.policies.normalize import Normalize, Unnormalize
@@ -372,8 +375,30 @@ class Cosmos3FlowMatching(nn.Module):
         action_prefix: Tensor,
         delay: Tensor,
         noise: Tensor | None = None,
+        accel: AccelMeter | None = None,
     ) -> Tensor:
-        """Euler-integrate the flow from noise to an action chunk (π0.5 sampler)."""
+        """Euler-integrate the flow from noise to an action chunk (π0.5 sampler).
+
+        Args:
+            input_ids: Qwen3-VL prefix token ids.
+            attention_mask: Prefix attention mask (1 = real token).
+            pixel_values: Flattened image patches, or ``None`` for a text-only prefix.
+            image_grid_thw: Per-image patch grid, or ``None`` alongside ``pixel_values``.
+            state: Proprioceptive state, already padded to ``max_state_dim``.
+            action_prefix: Normalized committed actions used to freeze the first ``delay`` rows.
+            delay: Number of frozen real-time-chunking rows.
+            noise: Optional starting noise; drawn here when ``None``.
+            accel: Optional denoising-acceleration meter. When supplied, the per-step
+                velocities this loop already computes are folded into an uncertainty proxy
+                at zero extra network cost; when ``None`` every added branch is a
+                compile-time constant and the traced graph is unchanged. Passed in rather
+                than stashed on ``self`` because a write to an ``nn.Module`` attribute
+                inside a traced region is a Dynamo side-effect that breaks
+                ``fullgraph``/ONNX export.
+
+        Returns:
+            The denoised action chunk, ``(B, chunk_size, max_action_dim)``.
+        """
         device = input_ids.device
         bsize = input_ids.shape[0]
         if noise is None:
@@ -395,12 +420,28 @@ class Cosmos3FlowMatching(nn.Module):
         x_t = noise
         time = torch.tensor(1.0, dtype=torch.float32, device=device)
         prefix_mask = rearrange(torch.arange(self.config.chunk_size, device=device), "c -> 1 c") < delay
+        if accel is not None:
+            accel.set_row_mask(
+                executed_row_mask(
+                    prefix_mask=prefix_mask,
+                    delay=delay,
+                    chunk_size=self.config.chunk_size,
+                    n_action_steps=self.config.n_action_steps,
+                    device=device,
+                )
+            )
         while time >= -dt / 2:
             x_t = torch.where(rearrange(prefix_mask, "b c -> b c 1"), action_prefix, x_t)
             masked_time = torch.where(prefix_mask, torch.zeros_like(time), time).expand(
                 bsize, self.config.chunk_size
             )
             v_t = self._run_expert(cached_kv, prefix_position_ids, prefix_pad, x_t, masked_time, state)
+            if accel is not None:
+                # Must read `v_t` here: the frozen-prefix clamp at the top of the loop means
+                # `(x_{t+1} - x_t) / dt != v_t` on those rows, so accel cannot be recovered
+                # post-hoc from the returned chunk.
+                accel.update(v_t)
+
             x_t = x_t + dt * v_t
             time = time + dt
 
@@ -467,10 +508,19 @@ class Cosmos3Policy(PreTrainedPolicy):
             self.processor = AutoProcessor.from_pretrained(config.pretrained_backbone_repo_id)
 
         self.model = Cosmos3FlowMatching(config, qwen3vl_config=qwen3vl_config)
+
+        # Denoising-acceleration uncertainty proxy. Off by default: it is free to compute
+        # but its scale is only meaningful against a calibration, so nothing should read it
+        # implicitly. Set to a prefix length (see `opentau.policies.accel.default_prefix`)
+        # to have every `sample_actions` call publish `last_accel`.
+        self.accel_prefix: int | None = None
+
         self.reset()
 
     def reset(self) -> None:
         self._action_queue = deque([], maxlen=self.config.n_action_steps)
+        self.last_accel = None
+        self.last_accel_provenance = None
 
     def get_optim_params(self) -> list[nn.Parameter]:
         # Only the trainable expert + projections (the 32B backbone is frozen) -- never
@@ -575,6 +625,11 @@ class Cosmos3Policy(PreTrainedPolicy):
     @torch.no_grad()
     def select_action(self, batch: dict[str, Tensor], noise: Tensor | None = None) -> Tensor:
         self.eval()
+
+        # Cleared every step so a caller can distinguish "this step re-planned and here is
+        # its score" from "this step popped a queued action". `sample_actions` refills it.
+        self.last_accel = None
+
         if len(self._action_queue) == 0 or len(self._action_queue) <= self.config.max_delay:
             action_prefix = None
             delay = 0
@@ -615,6 +670,13 @@ class Cosmos3Policy(PreTrainedPolicy):
             action_prefix = self.normalize_targets({"actions": action_prefix}, dataset_index)["actions"]
             action_prefix = F.pad(action_prefix, (0, 0, 0, self.config.chunk_size - action_prefix.shape[1]))
 
+        accel_meter = make_accel_meter(
+            self,
+            batch_size=bsize,
+            device=device,
+            dataset_index=dataset_index,
+        )
+
         actions = self.model.sample_actions(
             input_ids=mm["input_ids"],
             attention_mask=mm["attention_mask"],
@@ -624,7 +686,18 @@ class Cosmos3Policy(PreTrainedPolicy):
             action_prefix=action_prefix,
             delay=delay,
             noise=noise,
+            accel=accel_meter,
         )
+
+        if accel_meter is not None:
+            # `.to_list()` rather than keeping a tensor: anything allocated inside
+            # `torch.inference_mode()` stays an inference tensor even after `.clone()`, and
+            # the first in-place update a downstream CUSUM accumulator makes would raise.
+            self.last_accel = accel_meter.to_list()
+            self.last_accel_provenance = build_accel_provenance(
+                self, accel_meter, dataset_index=dataset_index
+            )
+
         original_action_dim = self.config.action_feature.shape[0]
         actions = actions[:, :, :original_action_dim]
         return self.unnormalize_outputs({"actions": actions}, dataset_index)["actions"]

--- a/src/opentau/policies/pi0/modeling_pi0.py
+++ b/src/opentau/policies/pi0/modeling_pi0.py
@@ -29,6 +29,9 @@ from einops import rearrange, reduce
 from torch import Tensor, nn
 from transformers import AutoTokenizer
 
+from opentau.policies.accel import AccelMeter, executed_row_mask
+from opentau.policies.accel import build_provenance as build_accel_provenance
+from opentau.policies.accel import make_meter as make_accel_meter
 from opentau.policies.normalize import Normalize, Unnormalize
 from opentau.policies.normalize import resolve_num_datasets as _num_datasets
 from opentau.policies.pi0.configuration_pi0 import PI0Config
@@ -232,11 +235,19 @@ class PI0Policy(PreTrainedPolicy):
         self.language_tokenizer = AutoTokenizer.from_pretrained("google/paligemma-3b-pt-224")
         self.model = PI0FlowMatching(config)
 
+        # Denoising-acceleration uncertainty proxy. Off by default: it is free to compute
+        # but its scale is only meaningful against a calibration, so nothing should read it
+        # implicitly. Set to a prefix length (see `opentau.policies.accel.default_prefix`)
+        # to have every `sample_actions` call publish `last_accel`.
+        self.accel_prefix: int | None = None
+
         self.reset()
 
     def reset(self) -> None:
         """This should be called whenever the environment is reset."""
         self._action_queue = deque([], maxlen=self.config.n_action_steps)
+        self.last_accel = None
+        self.last_accel_provenance = None
 
     @classmethod
     def _transform_state_dict_keys(cls, state_dict: dict) -> dict:
@@ -436,6 +447,10 @@ class PI0Policy(PreTrainedPolicy):
         """
         self.eval()
 
+        # Cleared every step so a caller can distinguish "this step re-planned and here is
+        # its score" from "this step popped a queued action". `sample_actions` refills it.
+        self.last_accel = None
+
         # Action queue logic for n_action_steps > 1. When the action_queue is depleted, populate it by
         # querying the policy.
         if len(self._action_queue) <= self.config.safety_buffer:
@@ -467,6 +482,17 @@ class PI0Policy(PreTrainedPolicy):
         lang_tokens, lang_masks = self.prepare_language(batch)
 
         state = batch["state"]
+
+        # Batch size / device are taken from `state` because the inner sampler derives its
+        # own `bsize` / `device` from it — so the meter's rows line up with the sampler's
+        # by construction on batched multi-env rollouts.
+        accel_meter = make_accel_meter(
+            self,
+            batch_size=state.shape[0],
+            device=state.device,
+            dataset_index=dataset_index,
+        )
+
         actions = self.model.sample_actions(
             images,
             img_masks,
@@ -474,7 +500,17 @@ class PI0Policy(PreTrainedPolicy):
             lang_masks,
             state,
             noise=noise,
+            accel=accel_meter,
         )
+
+        if accel_meter is not None:
+            # `.to_list()` rather than keeping a tensor: anything allocated inside
+            # `torch.inference_mode()` stays an inference tensor even after `.clone()`, and
+            # the first in-place update a downstream CUSUM accumulator makes would raise.
+            self.last_accel = accel_meter.to_list()
+            self.last_accel_provenance = build_accel_provenance(
+                self, accel_meter, dataset_index=dataset_index
+            )
 
         # Unpad actions
         original_action_dim = self.config.action_feature.shape[0]
@@ -1005,6 +1041,7 @@ class PI0FlowMatching(nn.Module):
         lang_masks: Tensor,
         state: Tensor,
         noise: Tensor | None = None,
+        accel: AccelMeter | None = None,
     ) -> Tensor:
         """Do a full inference forward and compute the action (batch_size x num_steps x num_motors).
 
@@ -1015,6 +1052,13 @@ class PI0FlowMatching(nn.Module):
             lang_masks: Language mask tensor.
             state: State tensor.
             noise: Optional noise tensor.
+            accel: Optional denoising-acceleration meter. When supplied, the per-step
+                velocities are folded into an uncertainty proxy at zero extra network
+                cost; when ``None`` every added branch is a compile-time constant and the
+                traced graph is unchanged. Passed in rather than stashed on ``self``
+                because this method is ``torch.compile``d and ONNX-exported at several
+                entry points, where a write to an ``nn.Module`` attribute inside the traced
+                region is the construct most likely to break.
 
         Returns:
             The sampled action tensor.
@@ -1051,6 +1095,21 @@ class PI0FlowMatching(nn.Module):
 
         x_t = noise
         time = torch.tensor(1.0, dtype=torch.float32, device=device)
+        if accel is not None:
+            # pi0 has no real-time-chunking frozen prefix (no `action_prefix`/`delay`
+            # plumbing at all, and `select_action` slices `actions[:n_action_steps]`), so
+            # the only rows to exclude are those outside the executed window. An all-False
+            # `prefix_mask` and `delay = 0` express exactly that through the shared helper,
+            # keeping the window arithmetic in one place instead of re-deriving it here.
+            accel.set_row_mask(
+                executed_row_mask(
+                    prefix_mask=torch.zeros(1, self.config.chunk_size, dtype=torch.bool, device=device),
+                    delay=torch.zeros((), dtype=torch.long, device=device),
+                    chunk_size=self.config.chunk_size,
+                    n_action_steps=self.config.n_action_steps,
+                    device=device,
+                )
+            )
         while time >= -dt / 2:
             expanded_time = time.expand(bsize)
             v_t = self.denoise_step(
@@ -1060,6 +1119,11 @@ class PI0FlowMatching(nn.Module):
                 x_t,
                 expanded_time,
             )
+            if accel is not None:
+                # Read the velocity the loop already evaluated — no extra network call, and
+                # no post-hoc reconstruction from consecutive `x_t` (which would bake in the
+                # dtype/rounding of the in-place Euler update below).
+                accel.update(v_t)
 
             # Euler step
             x_t += dt * v_t

--- a/src/opentau/policies/pi05/modeling_pi05.py
+++ b/src/opentau/policies/pi05/modeling_pi05.py
@@ -37,6 +37,9 @@ from opentau.configs.policies import PreTrainedConfig
 from opentau.configs.types import NormalizationMode
 from opentau.datasets.action_indexing import add_chunk_start_state, subtract_chunk_start_state
 from opentau.datasets.grounding.tokenizer_utils import ensure_loc_tokens
+from opentau.policies.accel import AccelMeter, executed_row_mask
+from opentau.policies.accel import build_provenance as build_accel_provenance
+from opentau.policies.accel import make_meter as make_accel_meter
 from opentau.policies.normalize import Normalize, Unnormalize
 from opentau.policies.normalize import resolve_num_datasets as _num_datasets
 from opentau.policies.pi05.configuration_pi05 import PI05Config
@@ -340,11 +343,19 @@ class PI05Policy(PreTrainedPolicy):
             language_tokenizer=self.language_tokenizer,
         )
 
+        # Denoising-acceleration uncertainty proxy. Off by default: it is free to compute
+        # but its scale is only meaningful against a calibration, so nothing should read it
+        # implicitly. Set to a prefix length (see `opentau.policies.accel.default_prefix`)
+        # to have every `sample_actions` call publish `last_accel`.
+        self.accel_prefix: int | None = None
+
         self.reset()
 
     def reset(self) -> None:
         """This should be called whenever the environment is reset."""
         self._action_queue = deque([], maxlen=self.config.n_action_steps)
+        self.last_accel = None
+        self.last_accel_provenance = None
 
     @classmethod
     def from_pretrained(
@@ -648,6 +659,10 @@ class PI05Policy(PreTrainedPolicy):
         """
         self.eval()
 
+        # Cleared every step so a caller can distinguish "this step re-planned and here is
+        # its score" from "this step popped a queued action". `sample_actions` refills it.
+        self.last_accel = None
+
         if len(self._action_queue) == 0 or len(self._action_queue) <= self.config.max_delay:
             # Use current queue as action prefix to replenish
             action_prefix = None
@@ -737,6 +752,13 @@ class PI05Policy(PreTrainedPolicy):
 
         state = self.prepare_state(batch) if self.config.state_type == "continuous" else None
 
+        accel_meter = make_accel_meter(
+            self,
+            batch_size=lang_tokens.shape[0],
+            device=lang_tokens.device,
+            dataset_index=dataset_index,
+        )
+
         actions = self.model.sample_actions(
             images,
             img_masks,
@@ -746,7 +768,17 @@ class PI05Policy(PreTrainedPolicy):
             delay,
             noise=noise,
             state=state,
+            accel=accel_meter,
         )
+
+        if accel_meter is not None:
+            # `.to_list()` rather than keeping a tensor: anything allocated inside
+            # `torch.inference_mode()` stays an inference tensor even after `.clone()`, and
+            # the first in-place update a downstream CUSUM accumulator makes would raise.
+            self.last_accel = accel_meter.to_list()
+            self.last_accel_provenance = build_accel_provenance(
+                self, accel_meter, dataset_index=dataset_index
+            )
 
         # Unpad actions
         original_action_dim = self.config.action_feature.shape[0]
@@ -1755,6 +1787,7 @@ class PI05FlowMatching(nn.Module):
         delay: Tensor,
         noise: Tensor | None = None,
         state: Tensor | None = None,
+        accel: AccelMeter | None = None,
     ) -> Tensor:
         """Do a full inference forward and compute the action.
 
@@ -1769,6 +1802,13 @@ class PI05FlowMatching(nn.Module):
             state: Optional continuous state tensor of shape (batch_size, max_state_dim).
             indicator_tokens: Optional indicator token tensor.
             indicator_masks: Optional indicator mask tensor.
+            accel: Optional denoising-acceleration meter. When supplied, the per-step
+                velocities are folded into an uncertainty proxy at zero extra network
+                cost; when ``None`` every added branch is a compile-time constant and the
+                traced graph is unchanged. Passed in rather than stashed on ``self``
+                because this method is ``torch.compile``d and ONNX-exported at several
+                entry points, where a write to an ``nn.Module`` attribute inside the traced
+                region is the construct most likely to break.
         Returns:
             The sampled action tensor.
         """
@@ -1837,6 +1877,16 @@ class PI05FlowMatching(nn.Module):
         x_t = noise
         time = torch.tensor(1.0, dtype=torch.float32, device=device)
         prefix_mask = rearrange(torch.arange(self.config.chunk_size, device=device), "c -> 1 c") < delay
+        if accel is not None:
+            accel.set_row_mask(
+                executed_row_mask(
+                    prefix_mask=prefix_mask,
+                    delay=delay,
+                    chunk_size=self.config.chunk_size,
+                    n_action_steps=self.config.n_action_steps,
+                    device=device,
+                )
+            )
         while time >= -dt / 2:
             # if delay is greater than 0, then freeze the action prefix at the beginning of action chunk
             x_t = torch.where(rearrange(prefix_mask, "b c -> b c 1"), action_prefix, x_t)
@@ -1847,6 +1897,11 @@ class PI05FlowMatching(nn.Module):
                 x_t,
                 masked_time,
             )
+            if accel is not None:
+                # Must read `v_t` here: the frozen-prefix clamp at the top of the loop means
+                # `(x_{t+1} - x_t) / dt != v_t` on those rows, so accel cannot be recovered
+                # post-hoc from the returned chunk.
+                accel.update(v_t)
 
             # Euler step
             x_t += dt * v_t

--- a/src/opentau/policies/pi05_mem/modeling_pi05.py
+++ b/src/opentau/policies/pi05_mem/modeling_pi05.py
@@ -47,6 +47,9 @@ from transformers import AutoProcessor, AutoTokenizer
 
 from opentau.configs.policies import PreTrainedConfig
 from opentau.configs.types import NormalizationMode
+from opentau.policies.accel import AccelMeter, executed_row_mask
+from opentau.policies.accel import build_provenance as build_accel_provenance
+from opentau.policies.accel import make_meter as make_accel_meter
 from opentau.policies.normalize import Normalize, Unnormalize
 from opentau.policies.normalize import resolve_num_datasets as _num_datasets
 from opentau.policies.pi05.paligemma_with_expert import (
@@ -414,6 +417,12 @@ class PI05MemPolicy(PreTrainedPolicy):
         discrete_action_vocab_size = getattr(self.discrete_action_processor, "vocab_size", None)
         self.model = PI05MemFlowMatching(config, discrete_action_vocab_size=discrete_action_vocab_size)
 
+        # Denoising-acceleration uncertainty proxy. Off by default: it is free to compute
+        # but its scale is only meaningful against a calibration, so nothing should read it
+        # implicitly. Set to a prefix length (see `opentau.policies.accel.default_prefix`)
+        # to have every `sample_actions` call publish `last_accel`.
+        self.accel_prefix: int | None = None
+
         self.reset()
 
     def reset(self) -> None:
@@ -422,6 +431,8 @@ class PI05MemPolicy(PreTrainedPolicy):
         # Observation history buffers for inference.
         self._obs_buffers: dict[str, deque] = {}
         self._state_buffer: deque | None = None
+        self.last_accel = None
+        self.last_accel_provenance = None
 
     @classmethod
     def from_pretrained(
@@ -731,6 +742,10 @@ class PI05MemPolicy(PreTrainedPolicy):
         """Select a single action given environment observations."""
         self.eval()
 
+        # Cleared every step so a caller can distinguish "this step re-planned and here is
+        # its score" from "this step popped a queued action". `sample_actions` refills it.
+        self.last_accel = None
+
         # Build temporal observation history if configured.
         if self.config.n_obs_steps > 1:
             batch = self._build_history_batch(batch)
@@ -814,6 +829,13 @@ class PI05MemPolicy(PreTrainedPolicy):
                 (0, 0, 0, self.config.chunk_size - normalized.shape[1]),
             )
 
+        accel_meter = make_accel_meter(
+            self,
+            batch_size=lang_tokens.shape[0],
+            device=lang_tokens.device,
+            dataset_index=dataset_index,
+        )
+
         actions = self.model.sample_actions(
             videos,
             vid_masks,
@@ -824,7 +846,17 @@ class PI05MemPolicy(PreTrainedPolicy):
             delay,
             noise=noise,
             obs_history_is_pad=obs_history_is_pad,
+            accel=accel_meter,
         )
+
+        if accel_meter is not None:
+            # `.to_list()` rather than keeping a tensor: anything allocated inside
+            # `torch.inference_mode()` stays an inference tensor even after `.clone()`, and
+            # the first in-place update a downstream CUSUM accumulator makes would raise.
+            self.last_accel = accel_meter.to_list()
+            self.last_accel_provenance = build_accel_provenance(
+                self, accel_meter, dataset_index=dataset_index
+            )
 
         action_feature = self.config.action_feature
         assert action_feature is not None, "action_feature must be set in output_features"
@@ -1529,6 +1561,7 @@ class PI05MemFlowMatching(nn.Module):
         delay: Tensor,
         noise: Tensor | None = None,
         obs_history_is_pad: Tensor | None = None,
+        accel: AccelMeter | None = None,
     ) -> Tensor:
         """Do a full inference forward and compute the action.
 
@@ -1540,6 +1573,13 @@ class PI05MemFlowMatching(nn.Module):
                 start-of-episode zero-fill. ``None`` falls back to "all
                 history padded except current" via ``embed_prefix`` and the
                 encoder's None-fallback.
+            accel: Optional denoising-acceleration meter. When supplied, the per-step
+                velocities are folded into an uncertainty proxy at zero extra network
+                cost; when ``None`` every added branch is a compile-time constant and the
+                traced graph is unchanged. Passed in rather than stashed on ``self``
+                because this method is ``torch.compile``d and ONNX-exported at several
+                entry points, where a write to an ``nn.Module`` attribute inside the traced
+                region is the construct most likely to break.
         """
         bsize = lang_tokens.shape[0]
         device = lang_tokens.device
@@ -1577,6 +1617,16 @@ class PI05MemFlowMatching(nn.Module):
         x_t = noise
         time = torch.tensor(1.0, dtype=torch.float32, device=device)
         prefix_mask = rearrange(torch.arange(self.config.chunk_size, device=device), "c -> 1 c") < delay
+        if accel is not None:
+            accel.set_row_mask(
+                executed_row_mask(
+                    prefix_mask=prefix_mask,
+                    delay=delay,
+                    chunk_size=self.config.chunk_size,
+                    n_action_steps=self.config.n_action_steps,
+                    device=device,
+                )
+            )
         while time >= -dt / 2:
             x_t = torch.where(rearrange(prefix_mask, "b c -> b c 1"), action_prefix, x_t)
             masked_time = torch.where(prefix_mask, 0, time)
@@ -1587,6 +1637,11 @@ class PI05MemFlowMatching(nn.Module):
                 x_t,
                 masked_time,
             )
+            if accel is not None:
+                # Must read `v_t` here: the frozen-prefix clamp at the top of the loop means
+                # `(x_{t+1} - x_t) / dt != v_t` on those rows, so accel cannot be recovered
+                # post-hoc from the returned chunk.
+                accel.update(v_t)
 
             x_t += dt * v_t
             time += dt

--- a/src/opentau/policies/pi06/modeling_pi06.py
+++ b/src/opentau/policies/pi06/modeling_pi06.py
@@ -43,6 +43,9 @@ from transformers import AutoProcessor, AutoTokenizer
 from opentau.configs.policies import PreTrainedConfig
 from opentau.configs.types import NormalizationMode
 from opentau.datasets.grounding.tokenizer_utils import ensure_loc_tokens
+from opentau.policies.accel import AccelMeter, executed_row_mask
+from opentau.policies.accel import build_provenance as build_accel_provenance
+from opentau.policies.accel import make_meter as make_accel_meter
 from opentau.policies.normalize import Normalize, Unnormalize
 from opentau.policies.normalize import resolve_num_datasets as _num_datasets
 from opentau.policies.pi06.configuration_pi06 import PI06Config
@@ -322,11 +325,21 @@ class PI06Policy(PreTrainedPolicy):
             language_tokenizer=self.language_tokenizer,
         )
 
+        # Denoising-acceleration uncertainty proxy. Off by default: it is free to compute
+        # but its scale is only meaningful against a calibration, so nothing should read it
+        # implicitly. Set to a prefix length (see `opentau.policies.accel.default_prefix`)
+        # to have every `sample_actions` call publish `last_accel`. Note π0.6 defaults to
+        # `num_steps=5`, so `default_prefix(5) == 4` leaves only three velocity differences —
+        # a much coarser estimate than pi05's ten-step schedule affords.
+        self.accel_prefix: int | None = None
+
         self.reset()
 
     def reset(self) -> None:
         """Clears the rolling action queue; call on every environment reset."""
         self._action_queue = deque([], maxlen=self.config.n_action_steps)
+        self.last_accel = None
+        self.last_accel_provenance = None
 
     @classmethod
     def from_pretrained(
@@ -583,6 +596,10 @@ class PI06Policy(PreTrainedPolicy):
         """
         self.eval()
 
+        # Cleared every step so a caller can distinguish "this step re-planned and here is
+        # its score" from "this step popped a queued action". `sample_actions` refills it.
+        self.last_accel = None
+
         if len(self._action_queue) == 0 or len(self._action_queue) <= self.config.max_delay:
             action_prefix = None
             delay = 0
@@ -643,9 +660,32 @@ class PI06Policy(PreTrainedPolicy):
             action_prefix = self.normalize_targets({"actions": action_prefix}, dataset_index)["actions"]
             action_prefix = F.pad(action_prefix, (0, 0, 0, self.config.chunk_size - action_prefix.shape[1]))
 
-        actions = self.model.sample_actions(
-            images, img_masks, lang_tokens, lang_masks, action_prefix, delay, noise=noise
+        accel_meter = make_accel_meter(
+            self,
+            batch_size=lang_tokens.shape[0],
+            device=lang_tokens.device,
+            dataset_index=dataset_index,
         )
+
+        actions = self.model.sample_actions(
+            images,
+            img_masks,
+            lang_tokens,
+            lang_masks,
+            action_prefix,
+            delay,
+            noise=noise,
+            accel=accel_meter,
+        )
+
+        if accel_meter is not None:
+            # `.to_list()` rather than keeping a tensor: anything allocated inside
+            # `torch.inference_mode()` stays an inference tensor even after `.clone()`, and
+            # the first in-place update a downstream CUSUM accumulator makes would raise.
+            self.last_accel = accel_meter.to_list()
+            self.last_accel_provenance = build_accel_provenance(
+                self, accel_meter, dataset_index=dataset_index
+            )
 
         original_action_dim = self.config.action_feature.shape[0]
         actions = actions[:, :, :original_action_dim]
@@ -1261,8 +1301,29 @@ class PI06FlowMatching(nn.Module):
         action_prefix: Tensor,
         delay: Tensor,
         noise: Tensor | None = None,
+        accel: AccelMeter | None = None,
     ) -> Tensor:
-        """Inference: encode prefix once, run `num_steps` Euler steps."""
+        """Inference: encode prefix once, run `num_steps` Euler steps.
+
+        Args:
+            images: List of image tensors.
+            img_masks: List of image mask tensors.
+            lang_tokens: Language token tensor.
+            lang_masks: Language mask tensor.
+            action_prefix: Action prefix tensor.
+            delay: Number of delay actions, aka number of actions frozen from the action_prefix.
+            noise: Optional noise tensor.
+            accel: Optional denoising-acceleration meter. When supplied, the per-step
+                velocities are folded into an uncertainty proxy at zero extra network
+                cost; when ``None`` every added branch is a compile-time constant and the
+                traced graph is unchanged. Passed in rather than stashed on ``self``
+                because this method is ``torch.compile``d and ONNX-exported at several
+                entry points, where a write to an ``nn.Module`` attribute inside the traced
+                region is the construct most likely to break.
+
+        Returns:
+            The sampled action tensor.
+        """
         bsize = lang_tokens.shape[0]
         device = lang_tokens.device
 
@@ -1319,10 +1380,26 @@ class PI06FlowMatching(nn.Module):
         x_t = noise
         time = torch.tensor(1.0, dtype=torch.float32, device=device)
         prefix_mask = rearrange(torch.arange(self.config.chunk_size, device=device), "c -> 1 c") < delay
+        if accel is not None:
+            accel.set_row_mask(
+                executed_row_mask(
+                    prefix_mask=prefix_mask,
+                    delay=delay,
+                    chunk_size=self.config.chunk_size,
+                    n_action_steps=self.config.n_action_steps,
+                    device=device,
+                )
+            )
         while time >= -dt / 2:
             x_t = torch.where(rearrange(prefix_mask, "b c -> b c 1"), action_prefix, x_t)
             masked_time = torch.where(prefix_mask, 0, time)
             v_t = self.denoise_step(prefix_pad_masks, past_key_values, x_t, masked_time)
+            if accel is not None:
+                # Must read `v_t` here: the frozen-prefix clamp at the top of the loop means
+                # `(x_{t+1} - x_t) / dt != v_t` on those rows, so accel cannot be recovered
+                # post-hoc from the returned chunk.
+                accel.update(v_t)
+
             x_t += dt * v_t
             time += dt
 

--- a/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
@@ -51,6 +51,9 @@ from transformers import AutoProcessor, AutoTokenizer
 
 from opentau.configs.policies import PreTrainedConfig
 from opentau.configs.types import NormalizationMode
+from opentau.policies.accel import AccelMeter, executed_row_mask
+from opentau.policies.accel import build_provenance as build_accel_provenance
+from opentau.policies.accel import make_meter as make_accel_meter
 from opentau.policies.layers import PerGroupLinear
 from opentau.policies.normalize import Normalize, Unnormalize
 from opentau.policies.normalize import resolve_num_datasets as _num_datasets
@@ -427,6 +430,12 @@ class PI07LowLevelPolicy(PreTrainedPolicy):
             config, discrete_action_vocab_size=discrete_action_vocab_size, num_datasets=num_datasets
         )
 
+        # Denoising-acceleration uncertainty proxy. Off by default: it is free to compute
+        # but its scale is only meaningful against a calibration, so nothing should read it
+        # implicitly. Set to a prefix length (see `opentau.policies.accel.default_prefix`)
+        # to have every `sample_actions` call publish `last_accel`.
+        self.accel_prefix: int | None = None
+
         self.reset()
 
     def reset(self) -> None:
@@ -435,6 +444,8 @@ class PI07LowLevelPolicy(PreTrainedPolicy):
         # Observation history buffers for inference.
         self._obs_buffers: dict[str, deque] = {}
         self._state_buffer: deque | None = None
+        self.last_accel = None
+        self.last_accel_provenance = None
 
     @classmethod
     def from_pretrained(
@@ -806,6 +817,10 @@ class PI07LowLevelPolicy(PreTrainedPolicy):
         """
         self.eval()
 
+        # Cleared every step so a caller can distinguish "this step re-planned and here is
+        # its score" from "this step popped a queued action". `sample_actions` refills it.
+        self.last_accel = None
+
         # Build temporal observation history if configured.
         if self.config.n_obs_steps > 1:
             batch = self._build_history_batch(batch)
@@ -909,6 +924,13 @@ class PI07LowLevelPolicy(PreTrainedPolicy):
                 (0, 0, 0, self.config.chunk_size - normalized.shape[1]),
             )
 
+        accel_meter = make_accel_meter(
+            self,
+            batch_size=lang_tokens.shape[0],
+            device=lang_tokens.device,
+            dataset_index=dataset_index,
+        )
+
         actions = self.model.sample_actions(
             videos,
             vid_masks,
@@ -926,7 +948,17 @@ class PI07LowLevelPolicy(PreTrainedPolicy):
             response_masks=response_masks,
             obs_history_is_pad=obs_history_is_pad,
             group_index=dataset_index,
+            accel=accel_meter,
         )
+
+        if accel_meter is not None:
+            # `.to_list()` rather than keeping a tensor: anything allocated inside
+            # `torch.inference_mode()` stays an inference tensor even after `.clone()`, and
+            # the first in-place update a downstream CUSUM accumulator makes would raise.
+            self.last_accel = accel_meter.to_list()
+            self.last_accel_provenance = build_accel_provenance(
+                self, accel_meter, dataset_index=dataset_index
+            )
 
         action_feature = self.config.action_feature
         assert action_feature is not None, "action_feature must be set in output_features"
@@ -2256,6 +2288,7 @@ class PI07LowLevelFlowMatching(nn.Module):
         response_masks: Tensor | None = None,
         obs_history_is_pad: Tensor | None = None,
         group_index: Tensor | None = None,
+        accel: AccelMeter | None = None,
     ) -> Tensor:
         """Inference: iteratively denoise to produce a continuous action chunk.
 
@@ -2287,6 +2320,16 @@ class PI07LowLevelFlowMatching(nn.Module):
                 start-of-episode zero-fill. ``None`` falls back to "all
                 history padded except current" via ``embed_prefix`` and the
                 encoder's None-fallback.
+            group_index: Optional ``(B,)`` per-sample norm-head / projection
+                group index.
+            accel: Optional denoising-acceleration meter. When supplied, the
+                per-step velocities are folded into an uncertainty proxy at zero
+                extra network cost; when ``None`` every added branch is a
+                compile-time constant and the traced graph is unchanged. Passed
+                in rather than stashed on ``self`` because this method is
+                ``torch.compile``d and ONNX-exported at several entry points,
+                where a write to an ``nn.Module`` attribute inside the traced
+                region is the construct most likely to break.
 
         Returns:
             Denoised action chunk ``(B, chunk_size, max_action_dim)``.
@@ -2338,6 +2381,16 @@ class PI07LowLevelFlowMatching(nn.Module):
         x_t = noise
         time = torch.tensor(1.0, dtype=torch.float32, device=device)
         prefix_mask = rearrange(torch.arange(self.config.chunk_size, device=device), "c -> 1 c") < delay
+        if accel is not None:
+            accel.set_row_mask(
+                executed_row_mask(
+                    prefix_mask=prefix_mask,
+                    delay=delay,
+                    chunk_size=self.config.chunk_size,
+                    n_action_steps=self.config.n_action_steps,
+                    device=device,
+                )
+            )
         while time >= -dt / 2:
             x_t = torch.where(rearrange(prefix_mask, "b c -> b c 1"), action_prefix, x_t)
             masked_time = torch.where(prefix_mask, 0, time)
@@ -2348,6 +2401,11 @@ class PI07LowLevelFlowMatching(nn.Module):
                 masked_time,
                 group_index=group_index,
             )
+            if accel is not None:
+                # Must read `v_t` here: the frozen-prefix clamp at the top of the loop means
+                # `(x_{t+1} - x_t) / dt != v_t` on those rows, so accel cannot be recovered
+                # post-hoc from the returned chunk.
+                accel.update(v_t)
 
             x_t += dt * v_t
             time += dt

--- a/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
@@ -38,6 +38,9 @@ from transformers import AutoProcessor, AutoTokenizer
 
 from opentau.configs.policies import PreTrainedConfig
 from opentau.configs.types import NormalizationMode
+from opentau.policies.accel import AccelMeter, executed_row_mask
+from opentau.policies.accel import build_provenance as build_accel_provenance
+from opentau.policies.accel import make_meter as make_accel_meter
 from opentau.policies.flash_attn_cuda import make_att_block_ids
 from opentau.policies.layers import PerGroupLinear
 from opentau.policies.normalize import Normalize, Unnormalize, _materialize
@@ -435,6 +438,12 @@ class PI07PaligemmaLowLevelPolicy(PreTrainedPolicy):
             config, discrete_action_vocab_size=discrete_action_vocab_size, num_datasets=num_datasets
         )
 
+        # Denoising-acceleration uncertainty proxy. Off by default: it is free to compute
+        # but its scale is only meaningful against a calibration, so nothing should read it
+        # implicitly. Set to a prefix length (see `opentau.policies.accel.default_prefix`)
+        # to have every flow-matching `sample_actions` call publish `last_accel`.
+        self.accel_prefix: int | None = None
+
         self.reset()
 
     def reset(self) -> None:
@@ -442,6 +451,8 @@ class PI07PaligemmaLowLevelPolicy(PreTrainedPolicy):
         self._action_queue = deque([], maxlen=self.config.n_action_steps)
         self._state_buffer: deque | None = None
         self._obs_buffers: dict[str, deque] = {}
+        self.last_accel = None
+        self.last_accel_provenance = None
 
     @classmethod
     def from_pretrained(
@@ -846,6 +857,10 @@ class PI07PaligemmaLowLevelPolicy(PreTrainedPolicy):
         """
         self.eval()
 
+        # Cleared every step so a caller can distinguish "this step re-planned and here is
+        # its score" from "this step popped a queued action". `sample_actions` refills it.
+        self.last_accel = None
+
         if self.config.n_obs_steps > 1:
             batch = self._build_history_batch(batch)
 
@@ -1143,11 +1158,23 @@ class PI07PaligemmaLowLevelPolicy(PreTrainedPolicy):
 
         self._hydrate_optional_conditioning_batch(batch)
 
+        # `accel` measures the GEOMETRY of the flow-matching denoising trajectory — the bend
+        # accumulated across the velocity field the Euler integrator evaluates. The discrete
+        # branch below never runs that integrator (it autoregressively decodes FAST tokens),
+        # so there is no velocity sequence and no score to report. Both fields are therefore
+        # cleared HERE, before the branch, so every early return leaves them `None` by
+        # construction: publishing a stale value from an earlier flow-matching call would
+        # attribute one chunk's uncertainty to a completely different chunk, silently and
+        # with no way for a consumer to tell. Repopulated only on the flow path below.
+        self.last_accel = None
+        self.last_accel_provenance = None
+
         if self.config.eval_use_discrete_actions:
             if action_prefix is not None or (delay is not None and int(delay.item()) != 0):
                 raise NotImplementedError(
                     "eval_use_discrete_actions does not support a frozen action prefix (max_delay > 0)."
                 )
+            # accel stays None on this return: it is a flow-matching-only statistic (see above).
             return self._sample_actions_discrete(batch, dataset_index)
 
         prefix_items = self._build_prefix_items(batch, include_discrete_actions=False)
@@ -1180,13 +1207,30 @@ class PI07PaligemmaLowLevelPolicy(PreTrainedPolicy):
                 t_dim,
             )
 
+        accel_meter = make_accel_meter(
+            self,
+            batch_size=bsize,
+            device=device,
+            dataset_index=dataset_index,
+        )
+
         actions = self.model.sample_actions(
             prefix_items,
             action_prefix=action_prefix,
             delay=delay,
             noise=noise,
             group_index=dataset_index,
+            accel=accel_meter,
         )
+
+        if accel_meter is not None:
+            # `.to_list()` rather than keeping a tensor: anything allocated inside
+            # `torch.inference_mode()` stays an inference tensor even after `.clone()`, and
+            # the first in-place update a downstream CUSUM accumulator makes would raise.
+            self.last_accel = accel_meter.to_list()
+            self.last_accel_provenance = build_accel_provenance(
+                self, accel_meter, dataset_index=dataset_index
+            )
 
         # Unpad actions
         original_action_dim = self.config.action_feature.shape[0]
@@ -2719,6 +2763,7 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
         delay: Tensor,
         noise: Tensor | None = None,
         group_index: Tensor | None = None,
+        accel: AccelMeter | None = None,
     ) -> Tensor:
         """Do a full inference forward and compute the action.
 
@@ -2729,6 +2774,14 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
             action_prefix: Frozen action prefix ``(B, chunk_size, max_action_dim)``.
             delay: Number of frozen delay actions at the start of the chunk.
             noise: Optional pre-sampled noise.
+            group_index: Per-sample projection/norm group index.
+            accel: Optional denoising-acceleration meter. When supplied, the per-step
+                velocities are folded into an uncertainty proxy at zero extra network
+                cost; when ``None`` every added branch is a compile-time constant and the
+                traced graph is unchanged. Passed in rather than stashed on ``self``
+                because this method is ``torch.compile``d and ONNX-exported at several
+                entry points, where a write to an ``nn.Module`` attribute inside the traced
+                region is the construct most likely to break.
 
         Returns:
             The sampled action tensor.
@@ -2772,6 +2825,16 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
         x_t = noise
         time = torch.tensor(1.0, dtype=torch.float32, device=device)
         prefix_mask = rearrange(torch.arange(self.config.chunk_size, device=device), "c -> 1 c") < delay
+        if accel is not None:
+            accel.set_row_mask(
+                executed_row_mask(
+                    prefix_mask=prefix_mask,
+                    delay=delay,
+                    chunk_size=self.config.chunk_size,
+                    n_action_steps=self.config.n_action_steps,
+                    device=device,
+                )
+            )
         while time >= -dt / 2:
             # if delay is greater than 0, then freeze the action prefix at the beginning of action chunk
             x_t = torch.where(rearrange(prefix_mask, "b c -> b c 1"), action_prefix, x_t)
@@ -2783,6 +2846,11 @@ class PI07PaligemmaLowLevelFlowMatching(nn.Module):
                 masked_time,
                 group_index=group_index,
             )
+            if accel is not None:
+                # Must read `v_t` here: the frozen-prefix clamp at the top of the loop means
+                # `(x_{t+1} - x_t) / dt != v_t` on those rows, so accel cannot be recovered
+                # post-hoc from the returned chunk.
+                accel.update(v_t)
 
             # Euler step
             x_t += dt * v_t

--- a/src/opentau/scripts/calibrate_accel.py
+++ b/src/opentau/scripts/calibrate_accel.py
@@ -52,6 +52,7 @@ import argparse
 import json
 import logging
 import math
+from dataclasses import replace
 from pathlib import Path
 
 from opentau.policies.accel import AccelProvenance
@@ -133,7 +134,17 @@ def _resolve_provenance(tasks: list[dict]) -> AccelProvenance | None:
     that leaves the calibration unlabelled, and an unlabelled calibration skips the
     comparability check at apply time instead of passing it on false pretences.
     """
-    seen = {json.dumps(t["metrics"]["accel_provenance"], sort_keys=True) for t in tasks}
+    # Compare ONLY the distribution-shifting fields. The full dict also carries
+    # `dataset_index` and `num_scored_dims`, which are per-sample and vary with batch
+    # composition — `AccelProvenance.COMPARABLE_FIELDS` excludes them for exactly that
+    # reason. Diffing the whole dict declares two otherwise-identical tasks "disagreeing",
+    # drops the label, and then `detect()` skips the comparability check altogether: a
+    # fail-open path that silently removes the guard it exists to enforce.
+    provenances = [AccelProvenance.from_dict(t["metrics"]["accel_provenance"]) for t in tasks]
+    seen = {
+        json.dumps({f: getattr(p, f) for f in AccelProvenance.COMPARABLE_FIELDS}, sort_keys=True)
+        for p in provenances
+    }
     if not seen:
         # No task recorded one. Leaving the calibration unlabelled is the honest outcome:
         # `detect` then skips the comparability check rather than passing it falsely.
@@ -146,7 +157,10 @@ def _resolve_provenance(tasks: list[dict]) -> AccelProvenance | None:
             len(seen),
         )
         return None
-    return AccelProvenance.from_dict(json.loads(seen.pop()))
+    # Every task agrees on what matters. Return the first task's provenance with the
+    # per-sample fields cleared: they legitimately differ between tasks, so carrying one
+    # task's values on a calibration fitted over all of them would be a fiction.
+    return replace(provenances[0], dataset_index=(), num_scored_dims=())
 
 
 def fit(

--- a/src/opentau/scripts/calibrate_accel.py
+++ b/src/opentau/scripts/calibrate_accel.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python
+
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fit an ``accel`` failure-detection threshold from an eval run's ``eval_info.json``.
+
+The score itself is free (:mod:`opentau.policies.accel`); the *detector* is not, and this
+script is where that cost is paid — offline, once, out of the serving path. It reads the
+per-episode ``accel`` streams an eval run recorded, fits a one-sided CUSUM threshold by
+split conformal prediction on the **successful** rollouts, and writes a calibration sidecar
+that :mod:`opentau.utils.accel_detector` can then apply at runtime.
+
+Only successful rollouts are used, which is the method's main practical appeal — no failure
+labels are needed. The real cost is episode count: the split-conformal threshold is an order
+statistic of per-episode CUSUM peaks, so ``alpha = 0.1`` needs at least 9 successes and the
+paper's operating point uses 50. At a policy with 20-60% success that is 80-250 episodes per
+task, several times a default ``eval.n_episodes = 16`` run.
+
+Producing the input::
+
+    OPENTAU_ACCEL_PREFIX=auto opentau-eval \\
+        --accelerate-config configs/examples/accelerate_ddp_config.yaml \\
+        --config_path=configs/examples/pi05_libero_eval_config.json \\
+        --eval.n_episodes=60 --env.max_parallel_tasks=1
+
+Fitting from it::
+
+    python src/opentau/scripts/calibrate_accel.py \\
+        outputs/eval/.../eval_info.json --alpha 0.1 --out outputs/accel
+
+``--per-task`` fits one threshold per task instead of one pooled threshold. Prefer it when
+you have the episodes: task difficulty shifts the score's location, and a threshold pooled
+across easy and hard tasks under-detects on the hard ones. Run without it to see how many
+successes each task actually has.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import math
+from pathlib import Path
+
+from opentau.policies.accel import AccelProvenance
+from opentau.utils.accel_detector import (
+    DEFAULT_ALPHA,
+    DEFAULT_SLACK_C,
+    calibrate,
+    conformal_rank,
+    evaluate,
+)
+from opentau.utils.utils import init_logging
+
+logger = logging.getLogger(__name__)
+
+
+def load_eval_info(path: Path) -> list[dict]:
+    """Read the per-task records an eval run wrote.
+
+    Args:
+        path: An ``eval_info.json``, or a directory containing one.
+
+    Returns:
+        The ``per_task`` list, each entry carrying ``task_group``/``task_id``/``metrics``.
+
+    Raises:
+        FileNotFoundError: When no ``eval_info.json`` is at ``path``.
+        ValueError: When the file has no ``per_task`` records.
+    """
+    if path.is_dir():
+        path = path / "eval_info.json"
+    if not path.exists():
+        raise FileNotFoundError(f"No eval_info.json at {path}.")
+    payload = json.loads(path.read_text())
+    per_task = payload.get("per_task")
+    if not per_task:
+        raise ValueError(f"{path} has no 'per_task' records; is it an eval output?")
+    return per_task
+
+
+def split_by_outcome(task: dict) -> tuple[list[list[float]], list[list[float]], list[bool]]:
+    """Split one task's episodes into successful and failing ``accel`` streams.
+
+    ``eval.py`` attaches ``accels`` index-aligned with ``successes``, so the pairing is
+    positional. A task whose lengths disagree is dropped rather than paired up — a stream
+    labelled with another episode's outcome would poison the calibration invisibly.
+
+    Args:
+        task: One ``per_task`` record.
+
+    Returns:
+        ``(successful_streams, failing_streams, successes)``; all empty when the task
+        recorded no accel or the two lists disagree in length.
+    """
+    metrics = task.get("metrics", {})
+    accels = metrics.get("accels") or []
+    successes = metrics.get("successes") or []
+    if not accels:
+        return [], [], []
+    if len(accels) != len(successes):
+        logger.warning(
+            "%s/%s: %d accel stream(s) for %d success flag(s); skipping this task rather than "
+            "pairing a stream with the wrong episode.",
+            task.get("task_group"),
+            task.get("task_id"),
+            len(accels),
+            len(successes),
+        )
+        return [], [], []
+    good = [stream for stream, ok in zip(accels, successes, strict=True) if ok and stream]
+    bad = [stream for stream, ok in zip(accels, successes, strict=True) if not ok and stream]
+    return good, bad, list(successes)
+
+
+def _resolve_provenance(tasks: list[dict]) -> AccelProvenance | None:
+    """Return the shared provenance across ``tasks``, warning when they disagree.
+
+    A single calibration covering streams produced under different configurations would be
+    meaningless, so a disagreement drops the provenance entirely rather than picking one —
+    that leaves the calibration unlabelled, and an unlabelled calibration skips the
+    comparability check at apply time instead of passing it on false pretences.
+    """
+    seen = {json.dumps(t["metrics"]["accel_provenance"], sort_keys=True) for t in tasks}
+    if not seen:
+        # No task recorded one. Leaving the calibration unlabelled is the honest outcome:
+        # `detect` then skips the comparability check rather than passing it falsely.
+        logger.warning("No task recorded an accel provenance; the calibration will be unlabelled.")
+        return None
+    if len(seen) > 1:
+        logger.warning(
+            "Tasks disagree on accel provenance (%d distinct); the fitted calibration will be "
+            "left unlabelled. Fit per-task instead.",
+            len(seen),
+        )
+        return None
+    return AccelProvenance.from_dict(json.loads(seen.pop()))
+
+
+def fit(
+    tasks: list[dict],
+    *,
+    alpha: float,
+    slack_c: float,
+    label: str,
+) -> dict | None:
+    """Fit and score one calibration over a set of tasks.
+
+    Args:
+        tasks: ``per_task`` records to pool.
+        alpha: Target false-alarm rate.
+        slack_c: CUSUM slack in units of the calibration standard deviation.
+        label: Human-readable name for logging and the output filename.
+
+    Returns:
+        A dict with the calibration and its held-in evaluation, or ``None`` when there were
+        too few successful episodes to certify ``alpha``.
+    """
+    good: list[list[float]] = []
+    streams: list[list[float]] = []
+    successes: list[bool] = []
+    for task in tasks:
+        task_good, _, task_successes = split_by_outcome(task)
+        if not task_successes:
+            continue
+        good.extend(task_good)
+        streams.extend(task["metrics"]["accels"])
+        successes.extend(task_successes)
+
+    if not good:
+        logger.warning("%s: no successful episodes with an accel stream; skipping.", label)
+        return None
+
+    try:
+        minimum = conformal_rank(len(good), alpha)
+    except ValueError as exc:
+        logger.warning("%s: %s", label, exc)
+        return None
+
+    provenance = _resolve_provenance([t for t in tasks if t.get("metrics", {}).get("accel_provenance")])
+    calibration = calibrate(good, alpha=alpha, slack_c=slack_c, provenance=provenance)
+    metrics = evaluate(streams, successes, calibration)
+
+    logger.info(
+        "%s: fitted on %d successful episode(s) (order statistic %d), eta=%.6g; held-in "
+        "TPR=%.3f false-alarm=%.3f median lead=%.1f chunks over %d failing / %d successful",
+        label,
+        len(good),
+        minimum,
+        calibration.eta,
+        metrics["true_positive_rate"],
+        metrics["false_alarm_rate"],
+        metrics["median_lead"],
+        int(metrics["n_failed"]),
+        int(metrics["n_successful"]),
+    )
+    return {"calibration": calibration, "metrics": metrics, "num_successful": len(good)}
+
+
+def main() -> None:
+    """Entry point."""
+    init_logging()
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("eval_info", type=Path, help="eval_info.json, or a directory containing one")
+    parser.add_argument("--alpha", type=float, default=DEFAULT_ALPHA, help="target false-alarm rate")
+    parser.add_argument("--slack-c", type=float, default=DEFAULT_SLACK_C, help="CUSUM slack, in sigmas")
+    parser.add_argument("--out", type=Path, default=Path("outputs/accel"), help="output directory")
+    parser.add_argument(
+        "--per-task",
+        action="store_true",
+        help="fit one threshold per task instead of one pooled threshold",
+    )
+    args = parser.parse_args()
+
+    per_task = load_eval_info(args.eval_info)
+    with_accel = [t for t in per_task if t.get("metrics", {}).get("accels")]
+    if not with_accel:
+        raise SystemExit(
+            f"No task in {args.eval_info} recorded accel streams. Re-run the eval with "
+            "OPENTAU_ACCEL_PREFIX=auto (and env.max_parallel_tasks=1)."
+        )
+    logger.info("%d of %d task(s) carry accel streams.", len(with_accel), len(per_task))
+
+    args.out.mkdir(parents=True, exist_ok=True)
+    groups: list[tuple[str, list[dict]]]
+    if args.per_task:
+        groups = [(f"{t['task_group']}__{t['task_id']}", [t]) for t in with_accel]
+    else:
+        groups = [("pooled", with_accel)]
+
+    written = 0
+    summary: dict[str, dict] = {}
+    for label, tasks in groups:
+        result = fit(tasks, alpha=args.alpha, slack_c=args.slack_c, label=label)
+        if result is None:
+            continue
+        path = result["calibration"].save(args.out / f"accel_calibration__{label}.json")
+        summary[label] = {
+            "path": str(path),
+            "num_successful": result["num_successful"],
+            "eta": result["calibration"].eta,
+            **result["metrics"],
+        }
+        written += 1
+
+    if not written:
+        minimum = math.ceil(1.0 / args.alpha) - 1
+        raise SystemExit(
+            f"No calibration could be fitted at alpha={args.alpha}: every group had fewer than "
+            f"the {minimum} successful episodes a finite split-conformal threshold needs at that "
+            "rate. Collect more successful rollouts, drop --per-task to pool them, or raise --alpha."
+        )
+
+    summary_path = args.out / "accel_calibration_summary.json"
+    summary_path.write_text(json.dumps(summary, indent=2) + "\n")
+    logger.info("Wrote %d calibration(s) and %s", written, summary_path)
+    logger.warning(
+        "Held-in TPR/FPR above are measured on the SAME episodes the threshold was fitted "
+        "from, so they are optimistic. The conformal guarantee is on the false-alarm rate "
+        "out of sample; measure the true-positive rate on a disjoint set of rollouts."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/opentau/scripts/diagnose_accel.py
+++ b/src/opentau/scripts/diagnose_accel.py
@@ -1,0 +1,528 @@
+#!/usr/bin/env python
+
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Measure the ``accel`` noise floor and stochasticity of a checkpoint — run this FIRST.
+
+``accel`` (:mod:`opentau.policies.accel`) is a ratio whose numerator is a difference of
+nearly-equal velocity vectors, i.e. a catastrophic-cancellation regime. OpenTau serves
+policies in bfloat16 and the velocity projection runs in that dtype before being widened
+to float32, so there is a **positive-biased rounding floor beneath every score**. The bias
+compresses the low-uncertainty end — exactly where the paper's "certain field => accel -> 0"
+premise lives — so a checkpoint whose real signal sits near that floor is reporting
+arithmetic, not geometry.
+
+This script measures three things on the actual checkpoint, with no repo state changed:
+
+1. **The dtype floor.** The same observation and the *same fixed noise* denoised in
+   float32 and in the serving dtype. Any difference is pure rounding, because the field,
+   the conditioning, and the noise draw are identical.
+2. **The stochasticity.** Repeats of the same observation with freshly drawn noise.
+   ``sample_actions`` takes no generator, so production scores are a random variable; the
+   detector's calibration has to absorb this spread.
+3. **The prefix sweep.** ``accel_p`` for every ``p`` in ``[2, T]``. The paper finds the
+   best prefix mid-schedule and warns the last steps are discretization-dominated; this
+   shows where that turn happens on your checkpoint rather than assuming the paper's.
+
+The go/no-go it exists to answer: **is the between-observation spread of ``accel`` large
+compared to the dtype floor?** If it is not, no threshold calibrated on this checkpoint is
+measuring uncertainty, and the fix is to keep the action projection in float32 rather than
+to tune the detector.
+
+Run::
+
+    python src/opentau/scripts/diagnose_accel.py \\
+        --config_path=configs/examples/pi05_libero_eval_config.json \\
+        --policy.path=TensorAuto/<run>@6000
+
+Add ``--policy.device=cuda`` on a GPU box. Everything is inference-only; no training runs.
+"""
+
+# NOTE: deliberately no `from __future__ import annotations` here. `parser.wrap` resolves the
+# config class with `inspect.getfullargspec(fn).annotations[...]` (configs/parser.py:363), which
+# returns the *string* "TrainPipelineConfig" under PEP 563 and then fails inside draccus with an
+# unrelated-looking `TypeError: must be called with a dataclass type or instance`. No other
+# `@parser.wrap()`-decorated script in the repo imports it either.
+
+import contextlib
+import json
+import logging
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from opentau.configs import parser
+from opentau.configs.train import TrainPipelineConfig
+from opentau.policies.accel import default_prefix, resolve_action_dim_mask
+from opentau.policies.factory import make_policy
+from opentau.policies.utils import to_dtype_preserving_siglip_float32
+from opentau.utils.utils import init_logging
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class AccelDiagnosticReport:
+    """Everything :func:`diagnose_accel` measured, JSON-serializable.
+
+    Attributes:
+        num_steps: The checkpoint's denoise schedule length ``T``.
+        prefix: Prefix used for the headline numbers.
+        num_scored_dims: Action dims that survived the dim mask.
+        max_action_dim: Sampler action width, for contrast with the above.
+        float32_scores: Per-observation ``accel`` under float32.
+        serving_scores: Per-observation ``accel`` under the serving dtype.
+        serving_dtype: The serving dtype, as a string.
+        dtype_floor: Median absolute float32-vs-serving difference — the rounding floor.
+        noise_spread: Std of repeated scores on one observation with redrawn noise.
+        observation_spread: Std of scores across distinct observations (the signal).
+        signal_to_floor: ``observation_spread / dtype_floor``. The go/no-go ratio.
+        prefix_sweep: ``accel_p`` per prefix ``p``, averaged over observations.
+        observation_source: Where the observations came from. Recorded because a run on
+            synthetic frames measures the out-of-distribution regime, not deployment, and
+            the two are not comparable.
+    """
+
+    num_steps: int
+    prefix: int
+    num_scored_dims: list[int]
+    max_action_dim: int
+    float32_scores: list[float]
+    serving_scores: list[float]
+    serving_dtype: str
+    dtype_floor: float
+    noise_spread: float
+    observation_spread: float
+    signal_to_floor: float
+    prefix_sweep: dict[int, float] = field(default_factory=dict)
+    observation_source: str = "unspecified"
+
+    def to_dict(self) -> dict:
+        """Return a JSON-serializable copy."""
+        return {
+            "num_steps": self.num_steps,
+            "prefix": self.prefix,
+            "num_scored_dims": self.num_scored_dims,
+            "max_action_dim": self.max_action_dim,
+            "float32_scores": self.float32_scores,
+            "serving_scores": self.serving_scores,
+            "serving_dtype": self.serving_dtype,
+            "dtype_floor": self.dtype_floor,
+            "noise_spread": self.noise_spread,
+            "observation_spread": self.observation_spread,
+            "signal_to_floor": self.signal_to_floor,
+            "prefix_sweep": {str(k): v for k, v in self.prefix_sweep.items()},
+            "observation_source": self.observation_source,
+        }
+
+
+def _fixed_noise(policy, batch_size: int, device: torch.device, seed: int) -> torch.Tensor:
+    """Draw a reproducible noise tensor of the sampler's action shape.
+
+    ``sample_actions`` accepts ``noise=`` precisely so a caller can pin it; production
+    always passes ``None`` and draws from the ungeneratored global RNG.
+    """
+    generator = torch.Generator(device="cpu").manual_seed(seed)
+    shape = (batch_size, policy.config.chunk_size, policy.config.max_action_dim)
+    return torch.randn(shape, generator=generator, dtype=torch.float32).to(device)
+
+
+@contextlib.contextmanager
+def _forced_float32_embeddings(policy):
+    """Make the pi0/pi05-family forward actually run in float32, not just its parameters.
+
+    Those modeling modules route their embedding path through a module-level
+    ``_preferred_dtype()`` that returns **bfloat16 unconditionally** (float32 only under ONNX
+    export), so ``policy.to(torch.float32)`` alone produces bfloat16 activations meeting
+    float32 weights and dies in the first attention projection. Patching the hook is the same
+    mechanism the repo's own pi05 tests use to run this model on CPU in float32.
+
+    That the hook exists at all is the finding this diagnostic is built around: the served
+    numeric precision is fixed in code, not chosen by the caller's cast.
+
+    There is more than one such hook per family — pi05 defines one in ``modeling_pi05`` (the
+    image/state/action embeddings) and a second in ``paligemma_with_expert`` (the backbone's
+    internal casts). Patching only the first still leaves bfloat16 activations arriving at
+    float32 attention weights, so every hook under ``opentau.policies`` is swept.
+
+    Args:
+        policy: The loaded policy.
+
+    Yields:
+        ``True`` when at least one hook was found and patched, ``False`` when the family has
+        none (in which case the caller is relying on the parameter cast alone).
+    """
+    patched = {
+        name: module
+        for name, module in list(sys.modules.items())
+        if name.startswith("opentau.policies")
+        and module is not None
+        and callable(getattr(module, "_preferred_dtype", None))
+    }
+    if not patched:
+        yield False
+        return
+
+    originals = {name: module._preferred_dtype for name, module in patched.items()}
+    logger.info(
+        "Forcing float32 activations via %d _preferred_dtype hook(s): %s", len(patched), sorted(patched)
+    )
+    for module in patched.values():
+        module._preferred_dtype = lambda: torch.float32
+    try:
+        yield True
+    finally:
+        for name, module in patched.items():
+            module._preferred_dtype = originals[name]
+
+
+def _score_once(policy, batch: dict, noise: torch.Tensor | None) -> list[float]:
+    """Run one ``sample_actions`` and return the per-sample ``accel``.
+
+    The batch is re-cast to the policy's *current* parameter dtype on every call. This
+    matters because the whole point of the dtype-floor measurement is to run the identical
+    observation through the identical field twice at two precisions: the dataloader hands
+    back bfloat16 frames, so the float32 leg would otherwise feed bfloat16 activations into
+    float32 weights and die inside the first attention projection. Integer and boolean
+    entries (masks, indices, pad flags) are left alone.
+    """
+    dtype = next(policy.parameters()).dtype
+    batch = {
+        key: (value.to(dtype) if isinstance(value, torch.Tensor) and value.is_floating_point() else value)
+        for key, value in batch.items()
+    }
+    if noise is not None:
+        noise = noise.to(dtype)
+    with torch.inference_mode():
+        policy.sample_actions(batch, noise=noise)
+    return list(policy.last_accel or [])
+
+
+def _sweep_prefixes(policy, batch: dict, noise: torch.Tensor, dataset_index) -> dict[int, float]:
+    """Return mean ``accel_p`` for every prefix ``p`` in ``[2, T]``.
+
+    Runs the sampler once per prefix. That is ``T - 1`` forward passes and is the one
+    genuinely expensive thing this script does — it exists to locate the schedule's
+    information peak on *your* checkpoint rather than trusting the paper's, which was
+    measured on different data.
+    """
+    original = policy.accel_prefix
+    sweep: dict[int, float] = {}
+    try:
+        for p in range(2, policy.config.num_steps + 1):
+            policy.accel_prefix = p
+            scores = _score_once(policy, batch, noise)
+            finite = [s for s in scores if np.isfinite(s)]
+            sweep[p] = float(np.mean(finite)) if finite else float("nan")
+    finally:
+        policy.accel_prefix = original
+    return sweep
+
+
+def diagnose_accel(
+    policy,
+    observations: list[dict],
+    *,
+    num_noise_repeats: int = 8,
+    seed: int = 0,
+) -> AccelDiagnosticReport:
+    """Measure the ``accel`` floor, spread, and prefix profile of a loaded policy.
+
+    Args:
+        policy: A loaded flow-matching policy exposing ``accel_prefix`` / ``last_accel``.
+        observations: Distinct observation batches. At least two are needed for the
+            between-observation spread that the go/no-go ratio compares against.
+        num_noise_repeats: Repeats on the first observation with freshly drawn noise.
+        seed: Seed for the pinned noise draw.
+
+    Returns:
+        The :class:`AccelDiagnosticReport`.
+
+    Raises:
+        ValueError: When fewer than two observations are supplied.
+    """
+    if len(observations) < 2:
+        raise ValueError(
+            "accel diagnosis needs at least two distinct observations — the go/no-go "
+            "compares between-observation spread against the rounding floor, and one "
+            "observation has no spread."
+        )
+
+    config = policy.config
+    device = next(policy.parameters()).device
+    serving_dtype = next(policy.parameters()).dtype
+    policy.accel_prefix = default_prefix(config.num_steps)
+
+    batch_size = len(observations[0]["state"])
+    dataset_index = policy._resolve_dataset_index(observations[0])
+    dim_mask = resolve_action_dim_mask(
+        policy.unnormalize_outputs,
+        max_action_dim=config.max_action_dim,
+        dataset_index=dataset_index,
+    )
+    num_scored = [int(n) for n in dim_mask.sum(dim=-1).cpu().tolist()]
+    logger.info(
+        "accel scores %s of %d action dims (the rest are zero-variance in the norm stats "
+        "and are treated as unsupervised padding)",
+        num_scored,
+        config.max_action_dim,
+    )
+
+    # (1) dtype floor: identical field, identical noise, only the arithmetic differs.
+    noise = _fixed_noise(policy, batch_size, device, seed)
+    serving_scores: list[float] = []
+    for obs in observations:
+        serving_scores.extend(_score_once(policy, obs, noise))
+
+    logger.info("Re-running in float32 to isolate the rounding floor...")
+    float32_scores: list[float] = []
+    with _forced_float32_embeddings(policy) as forced:
+        if not forced:
+            logger.warning(
+                "This policy family has no `_preferred_dtype` hook, so the float32 leg relies "
+                "on the parameter cast alone. If its forward pins an activation dtype the way "
+                "the pi0/pi05 family does, the measured floor will be wrong."
+            )
+        policy.to(dtype=torch.float32)
+        for obs in observations:
+            float32_scores.extend(_score_once(policy, obs, noise))
+
+    # `to_dtype_preserving_siglip_float32` rather than a blanket cast: pi0/pi05-family
+    # towers pin the SigLIP patch-embedding conv and position table to float32 for openpi
+    # parity, and a blanket `.to(bfloat16)` would silently re-round them (CLAUDE.md rule 6).
+    to_dtype_preserving_siglip_float32(policy, dtype=serving_dtype)
+
+    paired = [
+        abs(a - b)
+        for a, b in zip(float32_scores, serving_scores, strict=True)
+        if np.isfinite(a) and np.isfinite(b)
+    ]
+    dtype_floor = float(np.median(paired)) if paired else float("nan")
+
+    # (2) stochasticity: same observation, freshly drawn noise each time.
+    repeats: list[float] = []
+    for _ in range(num_noise_repeats):
+        repeats.extend(_score_once(policy, observations[0], None))
+    noise_spread = float(np.std([r for r in repeats if np.isfinite(r)]))
+
+    finite_serving = [s for s in serving_scores if np.isfinite(s)]
+    observation_spread = float(np.std(finite_serving)) if finite_serving else float("nan")
+
+    # (3) where in the schedule the signal actually lives.
+    prefix_sweep = _sweep_prefixes(policy, observations[0], noise, dataset_index)
+
+    return AccelDiagnosticReport(
+        num_steps=int(config.num_steps),
+        prefix=int(policy.accel_prefix),
+        num_scored_dims=num_scored,
+        max_action_dim=int(config.max_action_dim),
+        float32_scores=[float(x) for x in float32_scores],
+        serving_scores=[float(x) for x in serving_scores],
+        serving_dtype=str(serving_dtype).removeprefix("torch."),
+        dtype_floor=dtype_floor,
+        noise_spread=noise_spread,
+        observation_spread=observation_spread,
+        signal_to_floor=(
+            observation_spread / dtype_floor if dtype_floor and np.isfinite(dtype_floor) else float("inf")
+        ),
+        prefix_sweep=prefix_sweep,
+    )
+
+
+def format_report(report: AccelDiagnosticReport) -> str:
+    """Render a human-readable verdict.
+
+    The threshold below is a judgement call, not a theorem: at a signal-to-floor ratio near
+    1 the score is dominated by bf16 rounding, and by ~10 the rounding is a minor
+    perturbation. Between those, treat the number as suggestive and look at the raw scores.
+    """
+    ratio = report.signal_to_floor
+    if ratio < 3.0:
+        verdict = (
+            "STOP — the between-observation spread is within 3x of the pure-rounding floor, "
+            "so accel here is mostly measuring bfloat16 arithmetic. Keep the action "
+            "projection in float32 before calibrating any threshold."
+        )
+    elif ratio < 10.0:
+        verdict = (
+            "MARGINAL — real signal exceeds the rounding floor but not comfortably. Expect "
+            "the certain end of the range to be compressed; prefer a float32 action "
+            "projection if latency allows."
+        )
+    else:
+        verdict = "OK — real signal dominates the rounding floor."
+
+    best_prefix = None
+    finite_sweep = {p: v for p, v in report.prefix_sweep.items() if np.isfinite(v)}
+    if finite_sweep:
+        best_prefix = max(finite_sweep, key=lambda p: finite_sweep[p])
+
+    lines = [
+        "",
+        "=" * 78,
+        "accel diagnostic",
+        "=" * 78,
+        f"  schedule            T = {report.num_steps}, prefix p = {report.prefix}",
+        f"  scored action dims  {report.num_scored_dims} of {report.max_action_dim}",
+        f"  serving dtype       {report.serving_dtype}",
+        f"  observations        {report.observation_source}",
+        "",
+        f"  dtype floor         {report.dtype_floor:.6g}   (median |float32 - serving|, same noise)",
+        f"  noise spread        {report.noise_spread:.6g}   (std over redrawn noise, one observation)",
+        f"  observation spread  {report.observation_spread:.6g}   (std across observations = the signal)",
+        f"  signal / floor      {report.signal_to_floor:.2f}",
+        "",
+        f"  {verdict}",
+        "",
+        "  prefix sweep (mean accel_p):",
+    ]
+    for p, value in sorted(report.prefix_sweep.items()):
+        marker = "  <- max" if p == best_prefix else ""
+        lines.append(f"    p={p:>3}/{report.num_steps}  {value:.6g}{marker}")
+    lines.append("")
+    lines.append(
+        "  Note: the largest accel_p is not automatically the best prefix — the paper's "
+        "1/(1-s) tail inflates the final steps with discretization noise rather than "
+        "posterior information. Prefer a prefix where the sweep is rising, not its peak "
+        "at p == T."
+    )
+    lines.append("=" * 78)
+    return "\n".join(lines)
+
+
+def dataset_observations(cfg: TrainPipelineConfig, device: torch.device, count: int) -> list[dict]:
+    """Draw real observation batches from the configured dataset mixture.
+
+    **Strongly preferred over synthetic frames.** The headline number is a ratio of the
+    between-observation spread to the rounding floor, and the numerator is only meaningful
+    if the observations sit on the manifold the policy was trained on. Random-noise images
+    are out of distribution by construction, which the paper's own §2.4 predicts produces a
+    chaotic, sharply-curved field — so a synthetic run measures the epistemic-OOD regime
+    and reports a spread that says nothing about deployment.
+
+    Frames are taken at a stride across the dataset rather than consecutively: adjacent
+    frames of one episode share a scene and a posterior, so a contiguous window would
+    understate the very spread being measured.
+
+    Args:
+        cfg: Pipeline config carrying a populated ``dataset_mixture``.
+        device: Device to move the batches to.
+        count: How many single-sample observations to draw.
+
+    Returns:
+        ``count`` batches, each ready to hand to ``policy.sample_actions``.
+
+    Raises:
+        ValueError: When the mixture yields no frames.
+    """
+    from torch.utils.data import DataLoader
+
+    from opentau.datasets.factory import make_dataset_mixture
+
+    mixture = make_dataset_mixture(cfg)
+    dataset = mixture.datasets[0] if hasattr(mixture, "datasets") else mixture
+    total = len(dataset)
+    if total == 0:
+        raise ValueError("The configured dataset mixture is empty; cannot draw observations.")
+
+    stride = max(1, total // count)
+    indices = [min(i * stride, total - 1) for i in range(count)]
+    logger.info("Drawing %d observation(s) from %d frames at stride %d: %s", count, total, stride, indices)
+
+    loader = DataLoader(torch.utils.data.Subset(dataset, indices), batch_size=1)
+    observations = []
+    for batch in loader:
+        observations.append(
+            {k: (v.to(device) if isinstance(v, torch.Tensor) else v) for k, v in batch.items()}
+        )
+    return observations
+
+
+def synthetic_observations(cfg: TrainPipelineConfig, device: torch.device, count: int) -> list[dict]:
+    """Fallback observations built from noise, for when no dataset is reachable.
+
+    See :func:`dataset_observations` for why this measures the wrong regime. Kept only so
+    the script degrades to *something* rather than failing outright, and the report says
+    loudly which mode produced it.
+    """
+    generator = torch.Generator(device="cpu").manual_seed(1234)
+    observations = []
+    for _ in range(count):
+        obs = {
+            "state": torch.randn(1, cfg.policy.max_state_dim, generator=generator).to(device),
+            "prompt": ["pick up the object"],
+        }
+        for key in cfg.policy.image_features:
+            obs[key] = torch.rand(1, 3, 224, 224, generator=generator).to(device)
+        observations.append(obs)
+    return observations
+
+
+@parser.wrap()
+def diagnose_main(cfg: TrainPipelineConfig):
+    """Entry point: load the configured policy and report its ``accel`` characteristics.
+
+    Args:
+        cfg: Standard OpenTau train/eval config. ``cfg.policy`` selects the checkpoint;
+            ``cfg.dataset_mixture`` (when populated) supplies real observations.
+    """
+    init_logging()
+    cfg.validate()
+
+    logger.info("Loading policy %s from %s", cfg.policy.type, cfg.policy.pretrained_path)
+    policy = make_policy(cfg=cfg.policy)
+    policy.eval()
+
+    device = torch.device(getattr(cfg.policy, "device", None) or "cpu")
+    dtype = torch.bfloat16 if device.type == "cuda" else torch.float32
+    policy.to(device=device)
+    to_dtype_preserving_siglip_float32(policy, dtype=dtype)
+
+    count = 8
+    datasets = getattr(getattr(cfg, "dataset_mixture", None), "datasets", None)
+    if datasets:
+        observations = dataset_observations(cfg, device, count)
+        source = f"{len(datasets)} configured dataset(s)"
+    else:
+        logger.warning(
+            "No dataset_mixture configured — falling back to SYNTHETIC noise observations. "
+            "Those are out-of-distribution by construction, so the measured observation "
+            "spread reflects the epistemic/OOD regime rather than deployment. Point "
+            "--config_path at a config carrying this checkpoint's training data instead."
+        )
+        observations = synthetic_observations(cfg, device, count)
+        source = "SYNTHETIC noise (not deployment-representative)"
+
+    report = diagnose_accel(policy, observations)
+    report.observation_source = source
+    print(format_report(report))  # noqa: T201 — this script's entire purpose is this report
+
+    out_dir = Path(cfg.output_dir or ".") / "accel_diagnostic"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "report.json"
+    out_path.write_text(json.dumps(report.to_dict(), indent=2) + "\n")
+    logger.info("Wrote %s", out_path)
+
+
+def main():
+    """Console entry point."""
+    diagnose_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/opentau/scripts/eval.py
+++ b/src/opentau/scripts/eval.py
@@ -66,6 +66,7 @@ from opentau.envs.utils import (
     close_envs,
     preprocess_observation,
 )
+from opentau.policies.accel import configure_accel
 from opentau.policies.factory import make_policy
 from opentau.policies.pretrained import PreTrainedPolicy
 from opentau.policies.utils import to_dtype_preserving_siglip_float32
@@ -108,6 +109,14 @@ def rollout(
         "done": A (batch, sequence) tensor of **cumulative** done conditions. For any given batch element,
             the first True is followed by True's all the way till the end. This can be used for masking
             extraneous elements from the sequences above.
+        (optional) "accel": A per-env list of per-chunk denoising-acceleration scores
+            (``list[list[float]]``, outer index = env). One entry per *planned chunk* (not per
+            step), already truncated at that env's own done step. Present only when the policy
+            publishes ``last_accel`` (i.e. has ``accel_prefix`` set); see
+            :mod:`opentau.policies.accel`.
+        (optional) "accel_provenance": The :class:`~opentau.policies.accel.AccelProvenance` of
+            those scores as a plain dict, captured once (it is constant within a run). Present
+            only alongside "accel".
 
     Args:
         env: The batch of environments.
@@ -160,6 +169,17 @@ def rollout(
     # Per-env final raw camera frames ({camera_key: HxWx3 uint8}); only the frame at each env's
     # done-step is kept (updated every step the env is still live, then frozen).
     last_frames: list[dict[str, np.ndarray] | None] = [None] * env.num_envs
+    # Per-chunk denoising-acceleration telemetry (uncertainty proxy, `opentau.policies.accel`).
+    # The policy sets `last_accel` to a length-num_envs `list[float]` on a step that re-planned
+    # and to None on a step that merely popped a queued action, so keeping the non-None values
+    # gives exactly one entry per planned chunk. `accel_chunk_steps` records which rollout step
+    # each chunk was planned at, so each env's stream can be cut at its own done step below.
+    # Everything here stays empty (and no "accel" key is added to `ret`) unless the policy has
+    # `accel_prefix` set, so this is zero-cost when accel is off.
+    accel_chunks: list[list[float]] = []
+    accel_chunk_steps: list[int] = []
+    accel_provenance: dict | None = None
+    accel_width_warned = False
     while not np.all(done) and step < max_steps:
         # Numpy array to tensor and changing dictionary keys to OpenTau policy format.
         observation = preprocess_observation(observation, cfg=cfg)
@@ -196,6 +216,32 @@ def rollout(
 
         with torch.inference_mode():
             action = policy.select_action(observation)
+
+        # `getattr` so policies that never wired accel are wholly unaffected. `policy` was
+        # unwrapped from the accelerate wrapper at the top of this function; reading the
+        # attribute off a DDP-wrapped module would always miss (DDP doesn't forward
+        # attribute lookups).
+        chunk_accel = getattr(policy, "last_accel", None)
+        if chunk_accel is not None:
+            if len(chunk_accel) != env.num_envs:
+                # accel is per-sample by construction (the meter is built with the sampler's
+                # batch size). A different width cannot be attributed to an env, and pairing
+                # the wrong stream with an episode's success flag is exactly the silent
+                # corruption a calibration set cannot survive — so drop it, loudly and once.
+                if not accel_width_warned:
+                    logging.warning(
+                        f"accel: policy.last_accel has {len(chunk_accel)} entries but the rollout has "
+                        f"{env.num_envs} envs; dropping the accel stream for this rollout rather than "
+                        "pairing it with the wrong per-episode outcomes."
+                    )
+                    accel_width_warned = True
+            else:
+                accel_chunks.append([float(x) for x in chunk_accel])
+                accel_chunk_steps.append(step)
+                if accel_provenance is None:
+                    provenance = getattr(policy, "last_accel_provenance", None)
+                    if provenance is not None:
+                        accel_provenance = provenance.to_dict()
 
         # Convert to CPU / numpy.
         action_numpy: np.ndarray = action.to("cpu").numpy()
@@ -276,6 +322,25 @@ def rollout(
 
     if capture_last_frames:
         ret["last_frames"] = last_frames
+
+    if accel_chunks:
+        # This loop keeps stepping envs that are already done (it runs until the LAST env
+        # finishes), so every chunk planned after an env's own done step describes a
+        # post-termination state. Cut each env's stream there — the same first-True-index
+        # masking `eval_policy` applies to rewards/successes via `batch_done_indices`.
+        # `argmax` over the cumulative done flags returns the first True, and the loop forces
+        # the final column True, so every env has one.
+        done_indices = torch.argmax(ret["done"].to(int), dim=1).tolist()
+        ret["accel"] = [
+            [
+                chunk[env_ix]
+                for chunk, chunk_step in zip(accel_chunks, accel_chunk_steps, strict=True)
+                if chunk_step <= done_index
+            ]
+            for env_ix, done_index in enumerate(done_indices)
+        ]
+        if accel_provenance is not None:
+            ret["accel_provenance"] = accel_provenance
 
     if hasattr(policy, "use_original_modules"):
         policy.use_original_modules()
@@ -400,6 +465,10 @@ def eval_policy(
     all_successes = []
     all_seeds = []
     all_done_indices = []
+    # One already-done-truncated per-chunk accel stream per rollout env, in the same episode
+    # order as `sum_rewards` / `all_successes`. Stays empty unless the policy publishes accel.
+    accel_streams: list[list[float]] = []
+    accel_provenance: dict | None = None
     threads = []  # for video saving threads
     n_episodes_rendered = 0  # for saving the correct number of videos
 
@@ -480,6 +549,15 @@ def eval_policy(
         # Note: this relies on a property of argmax: that it returns the first occurrence as a tiebreaker.
         batch_done_indices = torch.argmax(rollout_data["done"].to(int), dim=1)
         all_done_indices.extend(batch_done_indices.tolist())
+
+        # Per-episode accel streams, already truncated at each env's done step inside
+        # `rollout`. Absent unless the policy has `accel_prefix` set. The provenance is
+        # constant within a run, so only the first one is kept.
+        batch_accel = rollout_data.get("accel")
+        if batch_accel is not None:
+            accel_streams.extend(batch_accel)
+            if accel_provenance is None:
+                accel_provenance = rollout_data.get("accel_provenance")
 
         if return_episode_data:
             batch_size = rollout_data["done"].shape[0]
@@ -640,6 +718,26 @@ def eval_policy(
             "eval_ep_s": (time.time() - start) / n_episodes,
         },
     }
+
+    # Attach the per-chunk accel stream to each episode; pairing it with that episode's
+    # `success` is the calibration set. Both lists come from the same `[:n_episodes]` slice of
+    # the same rollout order, so index i is the same episode in each. The length check keeps a
+    # misalignment from silently producing a stream labelled with another episode's outcome.
+    if accel_streams:
+        streams = accel_streams[:n_episodes]
+        if len(streams) != len(info["per_episode"]):
+            logging.warning(
+                f"accel: collected {len(streams)} stream(s) for {len(info['per_episode'])} episode(s); "
+                "dropping them rather than pairing an accel stream with the wrong episode."
+            )
+        else:
+            for episode_info, stream in zip(info["per_episode"], streams, strict=True):
+                episode_info["accel"] = stream
+            # Recorded once per task, not per episode: it is constant within a run, and without
+            # it the scores are not comparable to any calibration
+            # (`opentau.policies.accel.assert_comparable`).
+            if accel_provenance is not None:
+                info["accel_provenance"] = accel_provenance
 
     if return_episode_data:
         info["episodes"] = episode_data
@@ -1035,6 +1133,13 @@ def eval_main(cfg: TrainPipelineConfig):
     # a plain policy.to(bfloat16) would round them back. Eval runs single-process / DDP, so
     # this is safe (no ZeRO param partitioning). See to_dtype_preserving_siglip_float32.
     to_dtype_preserving_siglip_float32(policy, dtype=torch.bfloat16)
+    # Arm the accel uncertainty proxy, if the config or the environment asked for it.
+    # Must happen BEFORE `accelerator.prepare`: the wrapper does not forward attribute
+    # writes to the module it wraps, so setting `accel_prefix` afterwards would land on the
+    # wrapper and `rollout` — which reads it off the *unwrapped* policy — would never see it.
+    # This is what makes an eval run able to collect the calibration set; without it nothing
+    # in the eval path ever turns the score on and every `accel` field would stay empty.
+    configure_accel(policy, cfg)
     policy = accelerator.prepare(policy)
     policy.eval()
     with (
@@ -1081,8 +1186,22 @@ class TaskMetrics(TypedDict):
     max_rewards: list[float]
     successes: list[bool]
     video_paths: list[str]
+    # Per-episode denoising-acceleration streams (one `list[float]` of per-chunk scores per
+    # episode), index-aligned with `successes` — that pairing IS the calibration set. Empty
+    # unless the policy has `accel_prefix` set.
+    accels: list[list[float]]
+    # The `AccelProvenance` (as a plain dict) those streams were produced under. Recorded once
+    # per task because it is constant within a run; None when accel is off.
+    accel_provenance: dict | None
 
 
+# Keys accumulated into the per-group / overall aggregates. NOTE: this tuple only *seeds* the
+# empty accumulator lists — anything added here also needs a matching `_append(...)` in
+# `_accumulate_to` or it stays permanently empty. `accels` / `accel_provenance` are
+# deliberately NOT here: averaging uncertainty streams across episodes is meaningless, and the
+# per-episode streams already reach disk verbatim on each task's `metrics` dict (which
+# `consolidate_eval_info` passes through untouched), so accumulating them would only duplicate
+# the whole payload into `per_group` and `overall`.
 ACC_KEYS = ("sum_rewards", "max_rewards", "successes", "video_paths")
 
 
@@ -1117,11 +1236,16 @@ def eval_one(
     )
 
     per_episode = task_result["per_episode"]
+    # `eval_policy` attaches "accel" to every episode or to none, so this is either empty
+    # (accel off) or exactly as long as — and index-aligned with — `successes`.
+    accels = [ep["accel"] for ep in per_episode if "accel" in ep]
     return TaskMetrics(
         sum_rewards=[ep["sum_reward"] for ep in per_episode],
         max_rewards=[ep["max_reward"] for ep in per_episode],
         successes=[ep["success"] for ep in per_episode],
         video_paths=task_result.get("video_paths", []),
+        accels=accels,
+        accel_provenance=task_result.get("accel_provenance"),
     ), task_result
 
 
@@ -1173,6 +1297,25 @@ def run_one(
     return task_group, task_id, metrics, task_result
 
 
+def _accel_enabled(policy) -> bool:
+    """Whether ``policy`` publishes per-chunk accel telemetry (``accel_prefix`` is set).
+
+    Unwraps the accelerate wrapper first: DDP does not forward attribute lookups to the module
+    it wraps, so a bare ``getattr(policy, "accel_prefix", None)`` on a prepared model always
+    reads ``None`` and would report accel as off. Mirrors the unwrap in :func:`rollout`.
+
+    Args:
+        policy: The policy, wrapped or not.
+
+    Returns:
+        bool: ``True`` when the policy has a non-``None`` ``accel_prefix``.
+    """
+    acc = get_proc_accelerator()
+    if acc is not None and not isinstance(policy, PreTrainedPolicy):
+        policy = acc.unwrap_model(policy)
+    return getattr(policy, "accel_prefix", None) is not None
+
+
 # compute aggregated metrics helper (robust to lists/scalars)
 def _agg_from_list(xs):
     if not xs:
@@ -1217,6 +1360,20 @@ def eval_policy_all(
             f"eval.recording_root is only supported for the LIBERO env (it uses the LIBERO "
             f"dataset recorder), but env.type={cfg.env.type!r}. Unset recording_root, or add "
             f"an env-aware rollout recorder."
+        )
+
+    # The threaded path below hands the SAME policy object to every worker, which is already
+    # unsound for a stateful policy (the action queue interleaves across tasks). accel telemetry
+    # must not pretend otherwise: `policy.last_accel` is read right after `select_action` on that
+    # shared object, so a chunk planned inside one task's rollout can be read — and stored — by
+    # another task's. Warn rather than raise, so an existing parallel eval keeps running; the
+    # streams it emits are simply not usable as calibration data.
+    if max_parallel_tasks > 1 and _accel_enabled(policy):
+        logging.warning(
+            f"accel collection is enabled and env.max_parallel_tasks={max_parallel_tasks} > 1: all "
+            "tasks share one policy object, so `policy.last_accel` (like the action queue it comes "
+            "from) races between concurrently-running rollouts and a chunk can be attributed to the "
+            "wrong episode. Set env.max_parallel_tasks=1 when collecting accel for calibration."
         )
 
     # Flatten envs into list of (task_group, task_id, env)

--- a/src/opentau/scripts/grpc/robot_inference.proto
+++ b/src/opentau/scripts/grpc/robot_inference.proto
@@ -61,6 +61,22 @@ message ActionChunkResponse {
     int64 timestamp_ns = 2;          // Server timestamp
     string request_id = 3;           // Matching request ID
     float inference_time_ms = 4;     // Time taken for inference
+
+    // Denoising-acceleration uncertainty proxy for this chunk (arXiv:2607.27933);
+    // see `opentau.policies.accel`. Higher means a more bent denoising trajectory,
+    // i.e. more posterior spread. NaN means the score was undefined for this chunk
+    // (see `AccelMeter.value`); it is NOT a low-uncertainty reading.
+    //
+    // `optional` (proto3 explicit presence) on purpose: a bare `float` defaults to
+    // 0.0 when unset, and 0.0 is the *most certain* possible score — a client could
+    // not tell "accel disabled" from "maximally confident". Check presence with
+    // `response.HasField("accel")` before reading. Unset whenever the serving policy
+    // has accel disabled (the default) or does not compute it.
+    //
+    // Added after field 4; old clients ignore the unknown field number and are
+    // unaffected. The score is only comparable within a fixed
+    // (task, embodiment, norm head, action norm mode, T, prefix, dtype) tuple.
+    optional float accel = 5;
 }
 
 // Health check request

--- a/src/opentau/scripts/grpc/robot_inference_pb2.py
+++ b/src/opentau/scripts/grpc/robot_inference_pb2.py
@@ -24,7 +24,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x15robot_inference.proto\x12\x0frobot_inference\"3\n\x0b\x43\x61meraImage\x12\x12\n\nimage_data\x18\x01 \x01(\x0c\x12\x10\n\x08\x65ncoding\x18\x02 \x01(\t\"\x1b\n\nRobotState\x12\r\n\x05state\x18\x01 \x03(\x02\"\xf3\x01\n\x12ObservationRequest\x12,\n\x06images\x18\x01 \x03(\x0b\x32\x1c.robot_inference.CameraImage\x12\x30\n\x0brobot_state\x18\x02 \x01(\x0b\x32\x1b.robot_inference.RobotState\x12\x0e\n\x06prompt\x18\x03 \x01(\t\x12\x34\n\rprefix_action\x18\x04 \x03(\x0b\x32\x1d.robot_inference.ActionVector\x12\r\n\x05\x64\x65lay\x18\x05 \x01(\x05\x12\x14\n\x0ctimestamp_ns\x18\x06 \x01(\x03\x12\x12\n\nrequest_id\x18\x07 \x01(\t\"\x1e\n\x0c\x41\x63tionVector\x12\x0e\n\x06values\x18\x01 \x03(\x02\"\x8f\x01\n\x13\x41\x63tionChunkResponse\x12\x33\n\x0c\x61\x63tion_chunk\x18\x01 \x03(\x0b\x32\x1d.robot_inference.ActionVector\x12\x14\n\x0ctimestamp_ns\x18\x02 \x01(\x03\x12\x12\n\nrequest_id\x18\x03 \x01(\t\x12\x19\n\x11inference_time_ms\x18\x04 \x01(\x02\"\x14\n\x12HealthCheckRequest\"\x93\x01\n\x13HealthCheckResponse\x12\x0f\n\x07healthy\x18\x01 \x01(\x08\x12\x0e\n\x06status\x18\x02 \x01(\t\x12\x12\n\nmodel_name\x18\x03 \x01(\t\x12\x0e\n\x06\x64\x65vice\x18\x04 \x01(\t\x12\x1a\n\x12gpu_memory_used_gb\x18\x05 \x01(\x02\x12\x1b\n\x13gpu_memory_total_gb\x18\x06 \x01(\x02\x32\xb0\x02\n\x12RobotPolicyService\x12[\n\x0eGetActionChunk\x12#.robot_inference.ObservationRequest\x1a$.robot_inference.ActionChunkResponse\x12\x63\n\x12StreamActionChunks\x12#.robot_inference.ObservationRequest\x1a$.robot_inference.ActionChunkResponse(\x01\x30\x01\x12X\n\x0bHealthCheck\x12#.robot_inference.HealthCheckRequest\x1a$.robot_inference.HealthCheckResponseb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x15robot_inference.proto\x12\x0frobot_inference\"3\n\x0b\x43\x61meraImage\x12\x12\n\nimage_data\x18\x01 \x01(\x0c\x12\x10\n\x08\x65ncoding\x18\x02 \x01(\t\"\x1b\n\nRobotState\x12\r\n\x05state\x18\x01 \x03(\x02\"\xf3\x01\n\x12ObservationRequest\x12,\n\x06images\x18\x01 \x03(\x0b\x32\x1c.robot_inference.CameraImage\x12\x30\n\x0brobot_state\x18\x02 \x01(\x0b\x32\x1b.robot_inference.RobotState\x12\x0e\n\x06prompt\x18\x03 \x01(\t\x12\x34\n\rprefix_action\x18\x04 \x03(\x0b\x32\x1d.robot_inference.ActionVector\x12\r\n\x05\x64\x65lay\x18\x05 \x01(\x05\x12\x14\n\x0ctimestamp_ns\x18\x06 \x01(\x03\x12\x12\n\nrequest_id\x18\x07 \x01(\t\"\x1e\n\x0c\x41\x63tionVector\x12\x0e\n\x06values\x18\x01 \x03(\x02\"\xad\x01\n\x13\x41\x63tionChunkResponse\x12\x33\n\x0c\x61\x63tion_chunk\x18\x01 \x03(\x0b\x32\x1d.robot_inference.ActionVector\x12\x14\n\x0ctimestamp_ns\x18\x02 \x01(\x03\x12\x12\n\nrequest_id\x18\x03 \x01(\t\x12\x19\n\x11inference_time_ms\x18\x04 \x01(\x02\x12\x12\n\x05\x61\x63\x63\x65l\x18\x05 \x01(\x02H\x00\x88\x01\x01\x42\x08\n\x06_accel\"\x14\n\x12HealthCheckRequest\"\x93\x01\n\x13HealthCheckResponse\x12\x0f\n\x07healthy\x18\x01 \x01(\x08\x12\x0e\n\x06status\x18\x02 \x01(\t\x12\x12\n\nmodel_name\x18\x03 \x01(\t\x12\x0e\n\x06\x64\x65vice\x18\x04 \x01(\t\x12\x1a\n\x12gpu_memory_used_gb\x18\x05 \x01(\x02\x12\x1b\n\x13gpu_memory_total_gb\x18\x06 \x01(\x02\x32\xb0\x02\n\x12RobotPolicyService\x12[\n\x0eGetActionChunk\x12#.robot_inference.ObservationRequest\x1a$.robot_inference.ActionChunkResponse\x12\x63\n\x12StreamActionChunks\x12#.robot_inference.ObservationRequest\x1a$.robot_inference.ActionChunkResponse(\x01\x30\x01\x12X\n\x0bHealthCheck\x12#.robot_inference.HealthCheckRequest\x1a$.robot_inference.HealthCheckResponseb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -40,11 +40,11 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_ACTIONVECTOR']._serialized_start=370
   _globals['_ACTIONVECTOR']._serialized_end=400
   _globals['_ACTIONCHUNKRESPONSE']._serialized_start=403
-  _globals['_ACTIONCHUNKRESPONSE']._serialized_end=546
-  _globals['_HEALTHCHECKREQUEST']._serialized_start=548
-  _globals['_HEALTHCHECKREQUEST']._serialized_end=568
-  _globals['_HEALTHCHECKRESPONSE']._serialized_start=571
-  _globals['_HEALTHCHECKRESPONSE']._serialized_end=718
-  _globals['_ROBOTPOLICYSERVICE']._serialized_start=721
-  _globals['_ROBOTPOLICYSERVICE']._serialized_end=1025
+  _globals['_ACTIONCHUNKRESPONSE']._serialized_end=576
+  _globals['_HEALTHCHECKREQUEST']._serialized_start=578
+  _globals['_HEALTHCHECKREQUEST']._serialized_end=598
+  _globals['_HEALTHCHECKRESPONSE']._serialized_start=601
+  _globals['_HEALTHCHECKRESPONSE']._serialized_end=748
+  _globals['_ROBOTPOLICYSERVICE']._serialized_start=751
+  _globals['_ROBOTPOLICYSERVICE']._serialized_end=1055
 # @@protoc_insertion_point(module_scope)

--- a/src/opentau/scripts/grpc/server.py
+++ b/src/opentau/scripts/grpc/server.py
@@ -47,6 +47,7 @@ Usage:
         --server.port=50051 --planner.enabled=true --planner.interval_s=5
 """
 
+import contextlib
 import io
 import logging
 import threading
@@ -123,6 +124,9 @@ class RobotPolicyServicer(robot_inference_pb2_grpc.RobotPolicyServiceServicer):
         # depends on that method having run — a subclass or a test that stubs policy
         # loading still gets the off-by-default behavior rather than an AttributeError.
         self.accel_prefix: int | None = None
+        # Serializes `sample_actions` with the `last_accel` read that follows it. Only
+        # taken when accel is enabled; see `GetActionChunk` for why the pair must be atomic.
+        self._accel_lock = threading.Lock()
 
         logger.info(f"Initializing policy on device: {self.device}")
 
@@ -502,15 +506,21 @@ class RobotPolicyServicer(robot_inference_pb2_grpc.RobotPolicyServiceServicer):
             batch, action_prefix, delay = self._prepare_observation(request)
 
             # Run inference
-            with torch.inference_mode():
+            # `last_accel` is policy state, and the servicer hands one policy object to all
+            # `max_workers` gRPC threads. Sampling and reading the score must therefore be
+            # atomic with respect to each other, or two concurrent requests interleave as
+            # "A samples, B samples, A reads" and A's response carries B's uncertainty --
+            # a wrong number silently attributed to the wrong observation, which is worse
+            # than no number at all. The lock is taken ONLY when accel is enabled, so the
+            # default serving path keeps its existing concurrency exactly.
+            accel_guard = self._accel_lock if self.accel_prefix else contextlib.nullcontext()
+            with accel_guard, torch.inference_mode():
                 action_chunk = self.policy.sample_actions(batch, action_prefix=action_prefix, delay=delay)
                 # action_chunk shape: (batch_size=1, n_action_steps, action_dim)
                 # Remove batch dimension and convert to numpy
                 action_chunk = action_chunk.squeeze(0).to("cpu", torch.float32).numpy()
-                # `last_accel` is per-sample; this path always builds a batch of 1, so the
-                # score for this request is element 0. Read immediately after the call --
-                # it is policy state shared by every worker thread, exactly like the rest
-                # of `self.policy`. Already plain floats, so nothing escapes inference mode.
+                # Per-sample; this path always builds a batch of 1, so element 0 is this
+                # request. Already plain floats, so nothing escapes inference mode.
                 last_accel = getattr(self.policy, "last_accel", None) if self.accel_prefix else None
 
             if last_accel:

--- a/src/opentau/scripts/grpc/server.py
+++ b/src/opentau/scripts/grpc/server.py
@@ -68,6 +68,7 @@ from opentau.configs import parser
 from opentau.configs.train import TrainPipelineConfig
 from opentau.datasets.lerobot_dataset import BaseDataset
 from opentau.planner.gemini_er_planner import GeminiERPlanner
+from opentau.policies.accel import configure_accel
 from opentau.policies.factory import get_policy_class
 from opentau.policies.utils import to_dtype_preserving_siglip_float32
 from opentau.scripts.grpc import auth, robot_inference_pb2, robot_inference_pb2_grpc
@@ -118,6 +119,10 @@ class RobotPolicyServicer(robot_inference_pb2_grpc.RobotPolicyServiceServicer):
         self._request_hook = request_hook or _noop_request_hook
         self.device = auto_torch_device()
         self.dtype = torch.bfloat16
+        # Declared before `_load_policy` (which resolves it) so the response path never
+        # depends on that method having run — a subclass or a test that stubs policy
+        # loading still gets the off-by-default behavior rather than an AttributeError.
+        self.accel_prefix: int | None = None
 
         logger.info(f"Initializing policy on device: {self.device}")
 
@@ -299,6 +304,12 @@ class RobotPolicyServicer(robot_inference_pb2_grpc.RobotPolicyServiceServicer):
 
         self.policy.reset()
 
+        # Denoising-acceleration uncertainty proxy; disabled unless the operator asks for
+        # it (see `configure_accel`). Set before the warmup calls below so the compiled
+        # graph and any unsupported-checkpoint refusal land at startup, not on the first
+        # robot request. `self.accel_prefix` gates the response field.
+        self.accel_prefix = configure_accel(self.policy, self.cfg)
+
         camera_observations = {
             f"camera{i}": torch.zeros((1, 3, *self.cfg.resolution), dtype=self.dtype, device=self.device)
             for i in range(self.cfg.num_cams)
@@ -471,7 +482,10 @@ class RobotPolicyServicer(robot_inference_pb2_grpc.RobotPolicyServiceServicer):
             context: gRPC context.
 
         Returns:
-            ActionChunkResponse containing the predicted action chunk.
+            ActionChunkResponse containing the predicted action chunk, and — only when
+            ``accel`` is enabled and the policy published a score — the chunk's ``accel``
+            uncertainty proxy. The field carries explicit presence, so a client must call
+            ``response.HasField("accel")`` before reading it (see the .proto for why).
         """
         self._notify_request("GetActionChunk")
         start_time = time.perf_counter()
@@ -493,6 +507,17 @@ class RobotPolicyServicer(robot_inference_pb2_grpc.RobotPolicyServiceServicer):
                 # action_chunk shape: (batch_size=1, n_action_steps, action_dim)
                 # Remove batch dimension and convert to numpy
                 action_chunk = action_chunk.squeeze(0).to("cpu", torch.float32).numpy()
+                # `last_accel` is per-sample; this path always builds a batch of 1, so the
+                # score for this request is element 0. Read immediately after the call --
+                # it is policy state shared by every worker thread, exactly like the rest
+                # of `self.policy`. Already plain floats, so nothing escapes inference mode.
+                last_accel = getattr(self.policy, "last_accel", None) if self.accel_prefix else None
+
+            if last_accel:
+                # NaN is forwarded as-is: `AccelMeter` emits it for "score undefined", and
+                # dropping it would be indistinguishable from "accel disabled" downstream.
+                response.accel = float(last_accel[0])
+                logger.debug("accel=%s request_id=%s", response.accel, request.request_id)
 
             # Populate 2D action chunk structure
             for action_vector in action_chunk:
@@ -526,7 +551,9 @@ class RobotPolicyServicer(robot_inference_pb2_grpc.RobotPolicyServiceServicer):
             context: gRPC context.
 
         Yields:
-            ActionChunkResponse messages for each observation.
+            ActionChunkResponse messages for each observation. Delegating to
+            ``GetActionChunk`` means the optional ``accel`` field is populated here on the
+            same terms, with no separate code path to keep in sync.
         """
         for request in request_iterator:
             if context.is_active():

--- a/src/opentau/scripts/inference.py
+++ b/src/opentau/scripts/inference.py
@@ -12,6 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Single-policy inference benchmark.
+
+Optionally reports the denoising-acceleration uncertainty proxy of
+:mod:`opentau.policies.accel` alongside the timings; enable it with
+``OPENTAU_ACCEL_PREFIX=auto`` (see :func:`opentau.policies.accel.configure_accel`).
+"""
+
 import logging
 import time
 from dataclasses import asdict
@@ -21,6 +28,7 @@ import torch
 
 from opentau.configs import parser
 from opentau.configs.train import TrainPipelineConfig
+from opentau.policies.accel import configure_accel
 from opentau.policies.factory import get_policy_class
 from opentau.policies.utils import to_dtype_preserving_siglip_float32
 from opentau.utils.random_utils import set_seed
@@ -53,6 +61,11 @@ def inference_main(cfg: TrainPipelineConfig):
     # Always reset policy before episode to clear out action cache.
     policy.reset()
 
+    # Denoising-acceleration uncertainty proxy — a no-op unless explicitly requested.
+    # Done before the warmup calls so the compiled graph and any unsupported-checkpoint
+    # refusal both land here rather than on the first timed run.
+    accel_prefix = configure_accel(policy, cfg)
+
     observation = create_dummy_observation(cfg, device, dtype=torch.bfloat16)
 
     print(observation.keys())
@@ -67,11 +80,18 @@ def inference_main(cfg: TrainPipelineConfig):
         # Run 10 times and record inference times
         n_runs = 10
         times_ms = []
+        accel_runs: list[list[float]] = []
         for _ in range(n_runs):
             t0 = time.perf_counter()
             actions = policy.sample_actions(observation)
             t1 = time.perf_counter()
             times_ms.append((t1 - t0) * 1000.0)
+            if accel_prefix is not None:
+                # Already plain floats (`AccelMeter.to_list`), so reading it here costs
+                # nothing and cannot carry an inference-mode tensor out of the block.
+                last_accel = getattr(policy, "last_accel", None)
+                if last_accel:
+                    accel_runs.append(list(last_accel))
 
         actions = actions.to("cpu", torch.float32).numpy()
         print(f"Output shape: {actions.shape}")
@@ -80,6 +100,27 @@ def inference_main(cfg: TrainPipelineConfig):
         print(
             f"Inference time (ms) over {n_runs} runs: min={times_ms.min().item():.2f}, max={times_ms.max().item():.2f}, avg={times_ms.mean().item():.2f}, std={times_ms.std().item():.2f}"
         )
+
+    if accel_prefix is not None:
+        if accel_runs:
+            # Per-sample by construction; this benchmark's dummy observation is batch-1, so
+            # flattening is a no-op here and still correct if that ever changes.
+            flat = torch.tensor([v for run in accel_runs for v in run])
+            print(
+                f"accel (prefix={accel_prefix}) over {len(accel_runs)} runs x {len(accel_runs[0])} "
+                f"sample(s): min={flat.min().item():.4f}, max={flat.max().item():.4f}, "
+                f"avg={flat.mean().item():.4f}"
+            )
+            logging.info("accel provenance: %s", getattr(policy, "last_accel_provenance", None))
+        else:
+            # accel_prefix resolved, so `make_meter` should have produced a score — an empty
+            # stream means this policy's `sample_actions` never publishes `last_accel`.
+            logging.warning(
+                "accel was enabled (prefix=%d) but no score was published; policy type %r "
+                "does not populate `last_accel` in `sample_actions`.",
+                accel_prefix,
+                cfg.policy.type,
+            )
 
     logging.info("End of inference")
 

--- a/src/opentau/scripts/robocasa/server.py
+++ b/src/opentau/scripts/robocasa/server.py
@@ -34,6 +34,24 @@ Each request runs ``policy.sample_actions`` (no internal queue on the server). T
 full predicted chunk per environment: shape ``(n_action_steps, action_dim)`` (trimmed/padded to
 ``--robocasa_action_dim``). **Batched** requests stack observations and call ``sample_actions`` once.
 
+Optional ``accel`` envelope
+---------------------------
+
+The two replies above are *bare* MessagePack arrays, not dicts, so there is no free key to
+hang the denoising-acceleration uncertainty proxy (:mod:`opentau.policies.accel`) on —
+switching to a dict unconditionally would break every stock ``robocasa.scripts.client``.
+A client therefore has to opt in per request by setting ``"include_accel": true``, which
+(and only which) changes the reply shape to a dict::
+
+    Single:  ``{ "actions": [[float, ...], ...], "accel": float | null }``
+    Batched: ``{ "actions": [ [[float, ...], ...], ... ], "accel": [float, ...] | null }``
+
+``accel`` is ``null`` when the server has the proxy disabled (the default) or the policy
+published no score; individual entries may be ``NaN``, which means *undefined*, not
+*confident* (see :meth:`opentau.policies.accel.AccelMeter.value`). In the batched form the
+list is one score per ``items`` entry, in request order. Enable the proxy server-side with
+``--robocasa_accel_prefix auto`` (or an explicit prefix ``>= 2``).
+
 Run::
 
     python -m opentau.scripts.robocasa.server \\
@@ -65,6 +83,7 @@ import websockets
 
 from opentau.configs import parser
 from opentau.configs.train import TrainPipelineConfig
+from opentau.policies.accel import configure_accel
 from opentau.policies.factory import get_policy_class
 from opentau.policies.utils import to_dtype_preserving_siglip_float32
 from opentau.utils.random_utils import set_seed
@@ -77,6 +96,9 @@ ROBOCASA_HOST: str = "0.0.0.0"  # nosec B104 — default listen; use ``--robocas
 ROBOCASA_PORT: int = 8765
 ROBOCASA_ACTION_DIM: int = 16
 ROBOCASA_TORCH_COMPILE: bool = True
+# Denoising-acceleration prefix: ``None`` keeps the proxy off (the default), ``"auto"``
+# selects the paper's ``T - 1``, an integer ``>= 2`` is used verbatim.
+ROBOCASA_ACCEL_PREFIX: str | None = None
 
 # Fallback zero chunk length when sending an error response (client should discard).
 _ERROR_RESPONSE_CHUNK_STEPS: int = 8
@@ -85,6 +107,7 @@ _ERROR_RESPONSE_CHUNK_STEPS: int = 8
 def _parse_robocasa_cli() -> None:
     """Read ``--robocasa_*`` flags into module globals and remove them from ``sys.argv``."""
     global ROBOCASA_HOST, ROBOCASA_PORT, ROBOCASA_ACTION_DIM, ROBOCASA_TORCH_COMPILE
+    global ROBOCASA_ACCEL_PREFIX
 
     def _bool_arg(value: str) -> bool:
         return value.lower() in ("true", "1", "yes", "y")
@@ -94,6 +117,7 @@ def _parse_robocasa_cli() -> None:
     p.add_argument("--robocasa_port", type=int, default=None)
     p.add_argument("--robocasa_action_dim", type=int, default=None)
     p.add_argument("--robocasa_torch_compile", type=str, default=None)
+    p.add_argument("--robocasa_accel_prefix", type=str, default=None)
     args, rest = p.parse_known_args(sys.argv[1:])
     if args.robocasa_host is not None:
         ROBOCASA_HOST = args.robocasa_host
@@ -103,6 +127,8 @@ def _parse_robocasa_cli() -> None:
         ROBOCASA_ACTION_DIM = args.robocasa_action_dim
     if args.robocasa_torch_compile is not None:
         ROBOCASA_TORCH_COMPILE = _bool_arg(args.robocasa_torch_compile)
+    if args.robocasa_accel_prefix is not None:
+        ROBOCASA_ACCEL_PREFIX = args.robocasa_accel_prefix
     sys.argv = [sys.argv[0]] + rest
 
 
@@ -162,6 +188,43 @@ def pack_actions_batch(chunks: List[np.ndarray]) -> bytes:
     """Encode one ``(T, action_dim)`` chunk per batch row (same order as request ``items``)."""
     return msgpack.packb(
         [np.asarray(c, dtype=np.float64).tolist() for c in chunks],
+        use_bin_type=True,
+    )
+
+
+def pack_action_envelope(action_chunk: np.ndarray, accel: float | None) -> bytes:
+    """Encode one env's chunk plus its ``accel`` score as a dict.
+
+    Only sent to clients that asked for it with ``"include_accel": true`` — the default
+    reply stays the bare array :func:`pack_action` produces, which is what the stock
+    ``robocasa.scripts.client`` parses.
+
+    Args:
+        action_chunk: ``(T, action_dim)`` chunk for the single env.
+        accel: This chunk's score, or ``None`` when the proxy is disabled/unpublished.
+    """
+    a = np.asarray(action_chunk, dtype=np.float64)
+    if a.ndim != 2:
+        raise ValueError(f"Expected action chunk of shape (T, action_dim), got shape {a.shape}")
+    return msgpack.packb({"actions": a.tolist(), "accel": accel}, use_bin_type=True)
+
+
+def pack_actions_batch_envelope(chunks: List[np.ndarray], accel: List[float] | None) -> bytes:
+    """Batched counterpart of :func:`pack_action_envelope`.
+
+    Args:
+        chunks: One ``(T, action_dim)`` chunk per batch row, in request ``items`` order.
+        accel: One score per row in that same order, or ``None`` when unavailable. The
+            caller must not pass a shorter list — a length mismatch would silently
+            re-associate scores with the wrong environment.
+    """
+    if accel is not None and len(accel) != len(chunks):
+        raise ValueError(f"accel has {len(accel)} entries but the batch has {len(chunks)} rows.")
+    return msgpack.packb(
+        {
+            "actions": [np.asarray(c, dtype=np.float64).tolist() for c in chunks],
+            "accel": accel,
+        },
         use_bin_type=True,
     )
 
@@ -272,10 +335,28 @@ class OpenTauRoboCasaPolicy:
         *,
         compile_model: bool = True,
         seed: int | None = None,
+        accel_prefix: int | str | None = None,
     ) -> None:
+        """Load the policy and, if asked, arm the denoising-acceleration proxy.
+
+        Args:
+            cfg: Parsed pipeline config; ``cfg.policy.pretrained_path`` is the checkpoint.
+            compile_model: Whether to ``torch.compile`` the inner sampler.
+            seed: Optional seed applied before loading.
+            accel_prefix: ``None`` leaves the ``accel`` uncertainty proxy off (the
+                default); ``"auto"`` or an int ``>= 2`` turns it on. See
+                :func:`opentau.policies.accel.configure_accel`.
+        """
         self.cfg = cfg
         self.device = auto_torch_device()
         self.dtype = torch.bfloat16
+        # Declared up front, resolved after the policy loads: `_read_accel` must never
+        # depend on how far `__init__` got.
+        self.accel_prefix: int | None = None
+        # Per-sample scores for the most recent `infer`/`infer_batch` call, or None.
+        self.last_accel: list[float] | None = None
+        # One-shot: a per-step warning would drown the rollout log.
+        self._accel_missing_warned = False
         if seed is not None:
             set_seed(seed)
 
@@ -293,6 +374,10 @@ class OpenTauRoboCasaPolicy:
             )
 
         self.policy.reset()
+
+        # Set before the warmup calls below so the compiled graph and any
+        # unsupported-checkpoint refusal land at startup, not on the first rollout step.
+        self.accel_prefix = configure_accel(self.policy, cfg, override=accel_prefix)
 
         dummy = build_opentau_batch(
             cfg,
@@ -312,6 +397,40 @@ class OpenTauRoboCasaPolicy:
         self.policy.reset()
         logger.info("OpenTau policy ready on %s", self.device)
 
+    def _read_accel(self, expected_rows: int) -> list[float] | None:
+        """Return this call's per-sample ``accel`` scores, or ``None`` when unavailable.
+
+        ``policy.last_accel`` is one score per batch row, in row order, so a length that
+        disagrees with the batch means the rows and the scores are no longer in
+        correspondence — drop the whole list rather than hand back a misaligned one, which
+        would attribute each environment's uncertainty to a different environment.
+
+        Args:
+            expected_rows: Batch rows the scores must line up with.
+        """
+        if not self.accel_prefix:
+            return None
+        scores = getattr(self.policy, "last_accel", None)
+        if not scores:
+            if not self._accel_missing_warned:
+                self._accel_missing_warned = True
+                logger.warning(
+                    "accel is enabled (prefix=%s) but policy type %r published no score; "
+                    "its `sample_actions` does not populate `last_accel`.",
+                    self.accel_prefix,
+                    self.cfg.policy.type,
+                )
+            return None
+        if len(scores) != expected_rows:
+            logger.warning(
+                "accel published %d score(s) for a batch of %d row(s); dropping them rather "
+                "than misaligning scores with environments.",
+                len(scores),
+                expected_rows,
+            )
+            return None
+        return [float(s) for s in scores]
+
     def infer(
         self,
         images_rgb: Dict[str, np.ndarray],
@@ -319,10 +438,17 @@ class OpenTauRoboCasaPolicy:
         prompt: str,
         action_dim: int,
     ) -> np.ndarray:
-        """Return full action chunk ``(T, action_dim)`` from ``sample_actions`` (trim/pad last dim)."""
+        """Return full action chunk ``(T, action_dim)`` from ``sample_actions`` (trim/pad last dim).
+
+        Also refreshes ``self.last_accel`` (a one-element list on this batch-of-1 path, or
+        ``None``); returning it would change this method's signature, and the handler reads
+        it straight off the runner instead.
+        """
         batch = build_opentau_batch(self.cfg, images_rgb, state_vec, prompt, self.device, self.dtype)
+        self.last_accel = None
         with torch.inference_mode():
             act = self.policy.sample_actions(batch)
+        self.last_accel = self._read_accel(1)
         # (1, T, policy_dim)
         act_np = act.squeeze(0).to("cpu", torch.float32).numpy()
         if act_np.ndim != 2:
@@ -338,11 +464,19 @@ class OpenTauRoboCasaPolicy:
         decoded_items: List[Tuple[Dict[str, np.ndarray], np.ndarray, str]],
         action_dim: int,
     ) -> List[np.ndarray]:
-        """One ``sample_actions`` on a stacked batch; one ``(T, action_dim)`` chunk per env."""
+        """One ``sample_actions`` on a stacked batch; one ``(T, action_dim)`` chunk per env.
+
+        Also refreshes ``self.last_accel`` with the **whole** per-sample list — this path
+        batches several environments through a single ``sample_actions``, so element ``i``
+        belongs to ``decoded_items[i]``, and collapsing it to a scalar would report one
+        environment's uncertainty for all of them.
+        """
         batch = build_opentau_batch_multi(self.cfg, decoded_items, self.device, self.dtype)
         b = len(decoded_items)
+        self.last_accel = None
         with torch.inference_mode():
             act = self.policy.sample_actions(batch)
+        self.last_accel = self._read_accel(b)
         act_np = act.to("cpu", torch.float32).numpy()
         if act_np.ndim == 2:
             act_np = act_np.reshape(1, *act_np.shape)
@@ -365,10 +499,15 @@ class OpenTauRoboCasaPolicy:
 def make_handler(action_dim: int, runner: OpenTauRoboCasaPolicy):
     async def _handler(websocket: Any):
         async for message in websocket:
+            # Whether this reply is the historical bare array or the opt-in dict envelope
+            # is decided solely by the request, so a client never sees a shape it did not
+            # ask for. Recomputed in the error branch from the same request.
+            want_accel = False
             try:
                 data = msgpack.unpackb(message, raw=False)
                 if not isinstance(data, dict):
                     raise ValueError("Expected dict payload")
+                want_accel = data.get("include_accel") is True
 
                 if data.get("batch") is True:
                     items = data.get("items")
@@ -383,27 +522,52 @@ def make_handler(action_dim: int, runner: OpenTauRoboCasaPolicy):
                         decoded.append((images_rgb, state, prompt))
 
                     actions_out = runner.infer_batch(decoded, action_dim)
-                    await websocket.send(pack_actions_batch(actions_out))
+                    # The whole per-sample list: these envs were batched through one
+                    # `sample_actions`, so each row has its own score.
+                    accel_batch = runner.last_accel
+                    logger.debug("accel (batch of %d): %s", len(actions_out), accel_batch)
+                    if want_accel:
+                        await websocket.send(pack_actions_batch_envelope(actions_out, accel_batch))
+                    else:
+                        await websocket.send(pack_actions_batch(actions_out))
                 else:
                     images_jpeg, state, prompt = unpack_payload_dict(data)
                     images_rgb = decode_all_images(images_jpeg)
                     action = runner.infer(images_rgb, state, prompt, action_dim)
-                    await websocket.send(pack_action(action))
+                    # Batch of one on this path, so the single env's score is element 0.
+                    accel_single = runner.last_accel[0] if runner.last_accel else None
+                    logger.debug("accel: %s", accel_single)
+                    if want_accel:
+                        await websocket.send(pack_action_envelope(action, accel_single))
+                    else:
+                        await websocket.send(pack_action(action))
             except Exception as e:
                 logger.exception("Policy step failed: %s", e)
                 try:
                     data = msgpack.unpackb(message, raw=False)
                 except Exception:
                     data = None
+                if isinstance(data, dict):
+                    want_accel = data.get("include_accel") is True
                 if isinstance(data, dict) and data.get("batch") is True:
                     items = data.get("items") if isinstance(data.get("items"), list) else []
                     n = len(items)
                     zero_chunk = [[0.0] * action_dim for _ in range(_ERROR_RESPONSE_CHUNK_STEPS)]
-                    await websocket.send(msgpack.packb([zero_chunk for _ in range(n)], use_bin_type=True))
+                    chunks = [zero_chunk for _ in range(n)]
+                    if want_accel:
+                        # Keep the shape the client asked for even on the error path, so a
+                        # client written against the envelope does not crash parsing it.
+                        await websocket.send(
+                            msgpack.packb({"actions": chunks, "accel": None}, use_bin_type=True)
+                        )
+                    else:
+                        await websocket.send(msgpack.packb(chunks, use_bin_type=True))
                 else:
-                    await websocket.send(
-                        pack_action(np.zeros((_ERROR_RESPONSE_CHUNK_STEPS, action_dim), dtype=np.float64))
-                    )
+                    zeros = np.zeros((_ERROR_RESPONSE_CHUNK_STEPS, action_dim), dtype=np.float64)
+                    if want_accel:
+                        await websocket.send(pack_action_envelope(zeros, None))
+                    else:
+                        await websocket.send(pack_action(zeros))
 
     return _handler
 
@@ -433,12 +597,13 @@ def robocasa_async_main(cfg: TrainPipelineConfig) -> None:
     """Start the RoboCasa WebSocket policy server (single + batched) using OpenTau config parsing."""
     logging.basicConfig(level=logging.INFO)
     logging.info(
-        "%s\nRoboCasa globals: host=%s port=%s action_dim=%s torch_compile=%s",
+        "%s\nRoboCasa globals: host=%s port=%s action_dim=%s torch_compile=%s accel_prefix=%s",
         pformat(asdict(cfg)),
         ROBOCASA_HOST,
         ROBOCASA_PORT,
         ROBOCASA_ACTION_DIM,
         ROBOCASA_TORCH_COMPILE,
+        ROBOCASA_ACCEL_PREFIX,
     )
 
     if cfg.seed is not None:
@@ -448,6 +613,7 @@ def robocasa_async_main(cfg: TrainPipelineConfig) -> None:
         cfg,
         compile_model=ROBOCASA_TORCH_COMPILE,
         seed=cfg.seed,
+        accel_prefix=ROBOCASA_ACCEL_PREFIX,
     )
 
     asyncio.run(

--- a/src/opentau/utils/accel_detector.py
+++ b/src/opentau/utils/accel_detector.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python
+
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Offline CUSUM + split-conformal failure detector over a per-chunk ``accel`` stream.
+
+Consumes what :mod:`opentau.policies.accel` produces during a rollout and turns it into a
+runtime alarm, following *The Geometry of Flow-Matching Uncertainty* (arXiv:2607.27933)
+§4.2 and Appendix A/E. Nothing here runs in the serving hot path — calibration is fitted
+once against held-out **successful** rollouts and the resulting threshold is persisted
+next to the checkpoint.
+
+The statistic is a one-sided CUSUM over the per-chunk score stream :math:`z_t`::
+
+    S_0 = 0
+    S_t = max(0, S_{t-1} + z_t - mu_0 - k),      k = c * sigma
+
+with an alarm at the first ``t`` where ``S_t > eta``.
+
+**Why a CUSUM height rather than a time-indexed conformal band.** A time-indexed band has
+to align calibration episodes on a common clock, which forces right-padding every
+successful rollout with its terminal value up to the longest (timed-out, i.e. *failing*)
+episode. Past the longest successful rollout the band is pure padding — frozen constants,
+not draws from the test distribution — so exchangeability fails exactly in the
+late-horizon regime where long-horizon failures live. Reducing an episode of any length to
+a single scalar peak sidesteps alignment entirely.
+
+**Where the conformal guarantee actually bites.** The exchangeable unit is the *episode*,
+not the chunk: ``eta`` is an order statistic of per-episode CUSUM peaks. That matters
+because the ~28-52 chunk scores inside one episode are strongly dependent (same scene,
+adjacent observations, overlapping conditioning), so pooling them as if they were
+independent draws would inflate the effective sample size and the realized per-episode
+false-alarm rate would exceed ``alpha``. ``mu_0`` and ``sigma`` *are* estimated from the
+pooled chunk scores, but they are location/scale nuisance parameters feeding the
+statistic, not the conformal object.
+
+**The bf16 floor.** OpenTau serves policies in bfloat16, and the velocity projection runs
+in that dtype before being widened to float32. ``accel``'s numerator is a difference of
+nearly-equal vectors — textbook catastrophic cancellation — so there is a positive-biased
+noise floor beneath the score that *compresses the certain end*, precisely where the
+"certain field => accel -> 0" premise lives. Measure that floor on the actual checkpoint
+before trusting a threshold: see ``opentau.scripts.diagnose_accel``. A calibration whose
+successful-rollout scores sit within a small multiple of the floor is measuring rounding,
+not geometry.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+from opentau.policies.accel import AccelProvenance, assert_comparable
+
+logger = logging.getLogger(__name__)
+
+# Paper's operating point (§4.3): slack in units of the calibration standard deviation.
+DEFAULT_SLACK_C = 0.25
+# Paper's target false-alarm rate (§4.3).
+DEFAULT_ALPHA = 0.1
+
+CALIBRATION_FILENAME = "opentau_accel_calibration.json"
+
+
+def _clean(scores: Sequence[float]) -> np.ndarray:
+    """Return ``scores`` as float64, with non-finite entries dropped."""
+    arr = np.asarray(list(scores), dtype=np.float64)
+    return arr[np.isfinite(arr)]
+
+
+def cusum_stream(scores: Sequence[float], *, mu0: float, k: float) -> np.ndarray:
+    """Run the one-sided CUSUM recursion over one episode's score stream.
+
+    Non-finite scores (the NaN :class:`~opentau.policies.accel.AccelMeter` emits when a
+    score is undefined) carry ``S`` forward unchanged rather than poisoning the running
+    sum — a chunk with no valid measurement is not evidence of drift in either direction.
+
+    Args:
+        scores: Per-chunk ``accel`` values in temporal order.
+        mu0: Reference level (mean of pooled successful-rollout scores).
+        k: Slack, ``c * sigma``. Absorbs transient spikes that do not persist.
+
+    Returns:
+        ``(len(scores),)`` float64 array of ``S_t``.
+    """
+    out = np.empty(len(scores), dtype=np.float64)
+    s = 0.0
+    for i, z in enumerate(scores):
+        if math.isfinite(z):
+            s = max(0.0, s + float(z) - mu0 - k)
+        out[i] = s
+    return out
+
+
+def episode_peak(scores: Sequence[float], *, mu0: float, k: float) -> float:
+    """Return ``max_t S_t`` — the single scalar an episode of any length reduces to.
+
+    Args:
+        scores: Per-chunk ``accel`` values in temporal order.
+        mu0: Reference level.
+        k: Slack.
+
+    Returns:
+        The peak, or ``0.0`` for an empty stream.
+    """
+    if len(scores) == 0:
+        return 0.0
+    return float(cusum_stream(scores, mu0=mu0, k=k).max())
+
+
+def conformal_rank(num_calibration: int, alpha: float) -> int:
+    """Return the 1-based split-conformal order statistic ``ceil((M+1)(1-alpha))``.
+
+    Args:
+        num_calibration: Number of calibration episodes ``M``.
+        alpha: Target false-alarm rate.
+
+    Returns:
+        The rank ``r`` such that ``eta = P_(r)`` of the sorted peaks. With ``M = 50`` and
+        ``alpha = 0.1`` this is 46, matching the paper.
+
+    Raises:
+        ValueError: When ``M`` is too small for the requested ``alpha`` — i.e. the rank
+            would exceed ``M``, so no finite threshold can certify that rate.
+    """
+    if not 0.0 < alpha < 1.0:
+        raise ValueError(f"alpha must be in (0, 1), got {alpha}.")
+    rank = math.ceil((num_calibration + 1) * (1.0 - alpha))
+    if rank > num_calibration:
+        minimum = math.ceil(1.0 / alpha) - 1
+        raise ValueError(
+            f"alpha={alpha} needs at least {minimum} calibration episodes for a finite "
+            f"split-conformal threshold, got {num_calibration}. Collect more successful "
+            "rollouts or raise alpha."
+        )
+    return rank
+
+
+@dataclass(frozen=True)
+class CusumCalibration:
+    """A fitted alarm threshold plus everything needed to refuse misuse.
+
+    Attributes:
+        mu0: Reference level, mean of pooled successful-rollout chunk scores.
+        sigma: Scale, std of the same pool.
+        slack_c: Slack in units of ``sigma``.
+        eta: Alarm threshold on the CUSUM height.
+        alpha: Target false-alarm rate the threshold was fitted for.
+        num_calibration_episodes: ``M``.
+        num_calibration_chunks: Total chunk scores behind ``mu0``/``sigma``.
+        provenance: The configuration the calibration was fitted under.
+    """
+
+    mu0: float
+    sigma: float
+    slack_c: float
+    eta: float
+    alpha: float
+    num_calibration_episodes: int
+    num_calibration_chunks: int
+    provenance: AccelProvenance | None = None
+
+    @property
+    def k(self) -> float:
+        """Slack in score units."""
+        return self.slack_c * self.sigma
+
+    def to_dict(self) -> dict:
+        """Return a JSON-serializable copy."""
+        return {
+            "mu0": self.mu0,
+            "sigma": self.sigma,
+            "slack_c": self.slack_c,
+            "eta": self.eta,
+            "alpha": self.alpha,
+            "num_calibration_episodes": self.num_calibration_episodes,
+            "num_calibration_chunks": self.num_calibration_chunks,
+            "provenance": self.provenance.to_dict() if self.provenance is not None else None,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict) -> CusumCalibration:
+        """Rebuild from :meth:`to_dict` output."""
+        prov = payload.get("provenance")
+        return cls(
+            mu0=float(payload["mu0"]),
+            sigma=float(payload["sigma"]),
+            slack_c=float(payload["slack_c"]),
+            eta=float(payload["eta"]),
+            alpha=float(payload["alpha"]),
+            num_calibration_episodes=int(payload["num_calibration_episodes"]),
+            num_calibration_chunks=int(payload["num_calibration_chunks"]),
+            provenance=AccelProvenance.from_dict(prov) if prov else None,
+        )
+
+    def save(self, path: str | Path) -> Path:
+        """Write to ``path`` (a file, or :data:`CALIBRATION_FILENAME` inside a directory)."""
+        path = Path(path)
+        if path.is_dir():
+            path = path / CALIBRATION_FILENAME
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(self.to_dict(), indent=2) + "\n")
+        return path
+
+    @classmethod
+    def load(cls, path: str | Path) -> CusumCalibration:
+        """Read from ``path`` (a file, or :data:`CALIBRATION_FILENAME` inside a directory)."""
+        path = Path(path)
+        if path.is_dir():
+            path = path / CALIBRATION_FILENAME
+        return cls.from_dict(json.loads(path.read_text()))
+
+
+def calibrate(
+    successful_episodes: Iterable[Sequence[float]],
+    *,
+    alpha: float = DEFAULT_ALPHA,
+    slack_c: float = DEFAULT_SLACK_C,
+    provenance: AccelProvenance | None = None,
+) -> CusumCalibration:
+    """Fit a CUSUM alarm threshold from held-out **successful** rollouts.
+
+    Two-stage, per the paper: pool the chunk scores to estimate the reference level and
+    scale, then take the split-conformal order statistic of the per-episode CUSUM peaks.
+
+    Only successful rollouts are used, which is the method's main practical appeal — no
+    failure labels are needed. The cost is a real one though: at a policy with 20-60%
+    success you need roughly ``M / success_rate`` episodes to bank ``M`` successes.
+
+    Args:
+        successful_episodes: One sequence of per-chunk ``accel`` scores per episode.
+        alpha: Target false-alarm rate.
+        slack_c: Slack in units of ``sigma``.
+        provenance: Configuration these scores were produced under; recorded so
+            :func:`detect` can refuse a mismatched stream.
+
+    Returns:
+        The fitted :class:`CusumCalibration`.
+
+    Raises:
+        ValueError: On an empty calibration set, a set with no finite scores, or ``M`` too
+            small for ``alpha``.
+    """
+    episodes = [list(ep) for ep in successful_episodes]
+    if not episodes:
+        raise ValueError("accel calibration needs at least one successful episode.")
+
+    pooled = _clean([z for ep in episodes for z in ep])
+    if pooled.size == 0:
+        raise ValueError(
+            "accel calibration set contains no finite scores. Every value was NaN, which "
+            "means the meter never had a valid measurement — check the action-dim mask and "
+            "the denoise schedule length."
+        )
+
+    mu0 = float(pooled.mean())
+    sigma = float(pooled.std())
+    if sigma == 0.0:
+        logger.warning(
+            "accel calibration scale is exactly zero (%d pooled chunks, all equal to %.6g). "
+            "The slack term vanishes and the detector reduces to 'any increase alarms'.",
+            pooled.size,
+            mu0,
+        )
+    k = slack_c * sigma
+
+    peaks = np.array([episode_peak(ep, mu0=mu0, k=k) for ep in episodes], dtype=np.float64)
+    rank = conformal_rank(len(episodes), alpha)
+    eta = float(np.sort(peaks)[rank - 1])
+
+    logger.info(
+        "accel calibration: M=%d episodes, %d chunks, mu0=%.6g, sigma=%.6g, k=%.6g, "
+        "eta=P_(%d)=%.6g at alpha=%.3g",
+        len(episodes),
+        int(pooled.size),
+        mu0,
+        sigma,
+        k,
+        rank,
+        eta,
+        alpha,
+    )
+    return CusumCalibration(
+        mu0=mu0,
+        sigma=sigma,
+        slack_c=slack_c,
+        eta=eta,
+        alpha=alpha,
+        num_calibration_episodes=len(episodes),
+        num_calibration_chunks=int(pooled.size),
+        provenance=provenance,
+    )
+
+
+@dataclass(frozen=True)
+class DetectionResult:
+    """Outcome of running a calibrated detector over one episode.
+
+    Attributes:
+        alarm_index: Index of the first chunk whose CUSUM height exceeded ``eta``, or
+            ``None`` if the episode never alarmed.
+        lead: Chunks remaining after the alarm (``n_chunks - 1 - alarm_index``), the
+            paper's detection-lead metric. ``None`` without an alarm.
+        peak: ``max_t S_t`` for the episode.
+        statistic: The full ``S_t`` series.
+    """
+
+    alarm_index: int | None
+    lead: int | None
+    peak: float
+    statistic: np.ndarray
+
+    @property
+    def alarmed(self) -> bool:
+        """Whether an alarm was raised."""
+        return self.alarm_index is not None
+
+
+def detect(
+    scores: Sequence[float],
+    calibration: CusumCalibration,
+    *,
+    provenance: AccelProvenance | None = None,
+) -> DetectionResult:
+    """Run a calibrated detector over one episode's ``accel`` stream.
+
+    Args:
+        scores: Per-chunk ``accel`` values in temporal order.
+        calibration: A fitted :class:`CusumCalibration`.
+        provenance: Configuration this stream was produced under. When both this and the
+            calibration's provenance are present they must agree on every
+            distribution-shifting field.
+
+    Returns:
+        The :class:`DetectionResult`.
+
+    Raises:
+        ValueError: When the provenances disagree.
+    """
+    if provenance is not None and calibration.provenance is not None:
+        assert_comparable(calibration.provenance, provenance)
+
+    statistic = cusum_stream(scores, mu0=calibration.mu0, k=calibration.k)
+    above = np.flatnonzero(statistic > calibration.eta)
+    alarm_index = int(above[0]) if above.size else None
+    lead = (len(scores) - 1 - alarm_index) if alarm_index is not None else None
+    peak = float(statistic.max()) if statistic.size else 0.0
+    return DetectionResult(alarm_index=alarm_index, lead=lead, peak=peak, statistic=statistic)
+
+
+def evaluate(
+    episodes: Sequence[Sequence[float]],
+    successes: Sequence[bool],
+    calibration: CusumCalibration,
+) -> dict[str, float]:
+    """Score a detector against labeled rollouts, in the paper's metrics.
+
+    Args:
+        episodes: Per-episode ``accel`` streams.
+        successes: Ground-truth success label per episode.
+        calibration: The fitted threshold.
+
+    Returns:
+        ``true_positive_rate`` (fraction of *failing* episodes that alarmed),
+        ``false_alarm_rate`` (fraction of *successful* episodes that alarmed — an
+        out-of-sample quantity that fluctuates around ``alpha`` rather than equalling it),
+        ``median_lead`` over detected failures (NaN when none), and the episode counts.
+
+    Raises:
+        ValueError: When ``episodes`` and ``successes`` differ in length.
+    """
+    if len(episodes) != len(successes):
+        raise ValueError(f"episodes ({len(episodes)}) and successes ({len(successes)}) differ in length.")
+
+    results = [detect(ep, calibration) for ep in episodes]
+    failed = [r for r, ok in zip(results, successes, strict=True) if not ok]
+    passed = [r for r, ok in zip(results, successes, strict=True) if ok]
+
+    leads = [r.lead for r in failed if r.alarmed]
+    return {
+        "true_positive_rate": float(np.mean([r.alarmed for r in failed])) if failed else float("nan"),
+        "false_alarm_rate": float(np.mean([r.alarmed for r in passed])) if passed else float("nan"),
+        "median_lead": float(np.median(leads)) if leads else float("nan"),
+        "n_failed": float(len(failed)),
+        "n_successful": float(len(passed)),
+    }

--- a/tests/policies/test_accel.py
+++ b/tests/policies/test_accel.py
@@ -1,0 +1,613 @@
+#!/usr/bin/env python
+
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the denoising-acceleration (``accel``) uncertainty proxy.
+
+The estimator's whole value rests on two properties from the paper — a hard zero on a
+straight (maximally certain) trajectory, and growth with the amount of bending — so those
+are pinned numerically against hand-computed values rather than against the implementation.
+The masking tests construct the cases that would silently corrupt the score in production:
+padded action dims, frozen real-time-chunking rows, and the un-executed chunk tail.
+"""
+
+import math
+
+import pytest
+import torch
+from torch import nn
+
+from opentau.configs.types import FeatureType, NormalizationMode, PolicyFeature
+from opentau.policies.accel import (
+    ACCEL_PREFIX_ENV,
+    MIN_PREFIX,
+    AccelMeter,
+    AccelProvenance,
+    assert_comparable,
+    build_provenance,
+    configure_accel,
+    default_prefix,
+    executed_row_mask,
+    make_meter,
+    resolve_action_dim_mask,
+    resolve_prefix,
+)
+from opentau.policies.normalize import Unnormalize
+
+CPU = torch.device("cpu")
+
+
+def _meter(prefix=3, batch_size=1, dim_mask=None):
+    return AccelMeter(prefix=prefix, batch_size=batch_size, device=CPU, dim_mask=dim_mask)
+
+
+def _feed(meter, velocities):
+    for v in velocities:
+        meter.update(v)
+    return meter
+
+
+# --------------------------------------------------------------------------------------
+# The two theoretical anchors: zero baseline (Prop A.2) and positivity (Prop A.3).
+# --------------------------------------------------------------------------------------
+
+
+def test_constant_velocity_scores_exactly_zero():
+    """A straight, constant-velocity path is the paper's maximally-certain field (Theorem 1),
+    for which ``accel`` must be exactly 0 — not merely small."""
+    v = torch.randn(2, 4, 3)
+    meter = _feed(_meter(prefix=5, batch_size=2), [v.clone() for _ in range(5)])
+    assert torch.equal(meter.value(), torch.zeros(2))
+
+
+def test_any_bend_scores_strictly_positive():
+    """Prop A.3: a bend at any interior step betrays a non-degenerate posterior."""
+    velocities = [torch.ones(1, 2, 2), torch.ones(1, 2, 2), torch.full((1, 2, 2), 2.0)]
+    meter = _feed(_meter(prefix=3), velocities)
+    assert meter.value().item() > 0.0
+
+
+def test_matches_hand_computed_value():
+    """Pin the exact estimator, not just its sign.
+
+    Velocities (single row, 2 dims): (1,0) -> (0,1) -> (1,0). Each consecutive difference
+    has norm sqrt(2), each velocity has norm 1, so accel_3 = 3 * (2*sqrt(2)) / 3 = 2*sqrt(2).
+    """
+    velocities = [
+        torch.tensor([[[1.0, 0.0]]]),
+        torch.tensor([[[0.0, 1.0]]]),
+        torch.tensor([[[1.0, 0.0]]]),
+    ]
+    meter = _feed(_meter(prefix=3), velocities)
+    assert meter.value().item() == pytest.approx(2.0 * math.sqrt(2.0), rel=1e-6)
+
+
+def test_score_grows_with_bend_magnitude():
+    """Local monotonicity (Prop A.4): more curvature => strictly larger score.
+
+    The paper's guarantee is in expectation over a small-spread family, so this pins the
+    weaker but testable direction — a strictly sharper bend scores strictly higher.
+    """
+    scores = []
+    for bend in (0.1, 0.5, 2.0):
+        velocities = [
+            torch.tensor([[[1.0, 0.0]]]),
+            torch.tensor([[[1.0, bend]]]),
+            torch.tensor([[[1.0, 0.0]]]),
+        ]
+        scores.append(_feed(_meter(prefix=3), velocities).value().item())
+    assert scores[0] < scores[1] < scores[2]
+
+
+# --------------------------------------------------------------------------------------
+# Prefix semantics — the detail most likely to be silently reversed by a refactor.
+# --------------------------------------------------------------------------------------
+
+
+def test_prefix_truncates_the_tail_not_the_head():
+    """The prefix must integrate the FIRST p steps (the noise end).
+
+    Constructed so the two ends disagree: the first two velocities are identical (no bend)
+    while the last two differ sharply. A prefix of 2 must therefore score 0. An
+    implementation that took the *last* p steps — the singular, discretization-dominated
+    end the paper explicitly discards — would score positive here.
+    """
+    velocities = [
+        torch.tensor([[[1.0, 0.0]]]),
+        torch.tensor([[[1.0, 0.0]]]),
+        torch.tensor([[[0.0, 5.0]]]),
+    ]
+    assert _feed(_meter(prefix=2), velocities).value().item() == 0.0
+    assert _feed(_meter(prefix=3), velocities).value().item() > 0.0
+
+
+def test_updates_past_the_prefix_are_ignored():
+    """Feeding a longer schedule than the prefix must not change the score."""
+    velocities = [
+        torch.tensor([[[1.0, 0.0]]]),
+        torch.tensor([[[0.0, 1.0]]]),
+    ]
+    short = _feed(_meter(prefix=2), velocities).value().item()
+    long = _feed(_meter(prefix=2), velocities + [torch.tensor([[[9.0, 9.0]]])] * 5).value().item()
+    assert short == long
+    assert _feed(_meter(prefix=2), velocities + [torch.zeros(1, 1, 2)] * 5).steps == 2
+
+
+def test_multiplier_follows_the_steps_actually_accumulated():
+    """Algorithm 1's running form is ``J / (S / (t+1))``, so a schedule shorter than the
+    requested prefix degrades gracefully instead of scaling by a step count it never ran."""
+    velocities = [torch.tensor([[[1.0, 0.0]]]), torch.tensor([[[0.0, 1.0]]])]
+    meter = _feed(_meter(prefix=10), velocities)
+    assert meter.steps == 2
+    assert meter.value().item() == pytest.approx(2 * math.sqrt(2.0) / 2.0, rel=1e-6)
+
+
+# --------------------------------------------------------------------------------------
+# Undefined-score handling. 0.0 would read as "maximally certain" — the opposite of
+# "no measurement" — so these must be NaN.
+# --------------------------------------------------------------------------------------
+
+
+def test_single_velocity_is_nan_not_zero():
+    meter = _feed(_meter(prefix=5), [torch.randn(1, 2, 2)])
+    assert math.isnan(meter.value().item())
+
+
+def test_all_zero_velocities_are_nan_not_zero():
+    """An empty denominator means every scored element was masked out, which is an absence
+    of measurement rather than evidence of certainty."""
+    meter = _feed(_meter(prefix=3), [torch.zeros(1, 2, 2)] * 3)
+    assert math.isnan(meter.value().item())
+
+
+def test_prefix_below_two_is_rejected():
+    """A 1-step prefix has an empty numerator and would report 0.0 for every field."""
+    with pytest.raises(ValueError, match=f">= {MIN_PREFIX}"):
+        _meter(prefix=1)
+    with pytest.raises(ValueError, match=f">= {MIN_PREFIX}"):
+        resolve_prefix(1, 10)
+
+
+def test_prefix_helpers():
+    assert default_prefix(10) == 9
+    assert default_prefix(5) == 4
+    assert default_prefix(2) == 2
+    assert resolve_prefix(None, 10) is None
+    assert resolve_prefix(9, 5) == 5, "prefix must clamp to the schedule length"
+    with pytest.raises(ValueError, match="at least"):
+        default_prefix(1)
+
+
+# --------------------------------------------------------------------------------------
+# Batching — these samplers run 16-env vectorized rollouts.
+# --------------------------------------------------------------------------------------
+
+
+def test_per_sample_scores_are_independent():
+    """A flat norm over the batch would average independent, concurrently-running episodes
+    into one number. Sample 0 travels straight; sample 1 bends."""
+    velocities = [
+        torch.tensor([[[1.0, 0.0]], [[1.0, 0.0]]]),
+        torch.tensor([[[1.0, 0.0]], [[0.0, 1.0]]]),
+        torch.tensor([[[1.0, 0.0]], [[1.0, 0.0]]]),
+    ]
+    value = _feed(_meter(prefix=3, batch_size=2), velocities).value()
+    assert value.shape == (2,)
+    assert value[0].item() == 0.0
+    assert value[1].item() == pytest.approx(2.0 * math.sqrt(2.0), rel=1e-6)
+
+
+# --------------------------------------------------------------------------------------
+# Masking. Both of these are silent in production: the score keeps coming out, just wrong.
+# --------------------------------------------------------------------------------------
+
+
+def test_dim_mask_excludes_padded_action_dims():
+    """Padded dims are unsupervised network output (masked out of the training loss), so
+    their noise must not enter either sum.
+
+    Dim 0 is real and travels straight; dim 1 is 'padding' carrying pure bend. Masked, the
+    score must be exactly 0; unmasked it is positive — that gap is the contamination the
+    mask exists to remove.
+    """
+    velocities = [
+        torch.tensor([[[1.0, 0.0]]]),
+        torch.tensor([[[1.0, 7.0]]]),
+        torch.tensor([[[1.0, -7.0]]]),
+    ]
+    unmasked = _feed(_meter(prefix=3), velocities).value().item()
+    masked = _feed(_meter(prefix=3, dim_mask=torch.tensor([[True, False]])), velocities).value().item()
+    assert unmasked > 0.0
+    assert masked == 0.0
+
+
+def test_row_mask_excludes_frozen_and_unexecuted_rows():
+    """Row 0 is a frozen RTC prefix row, row 2 is outside the executed window; only row 1
+    should be scored. The excluded rows carry all the bend here."""
+    velocities = [
+        torch.tensor([[[1.0], [1.0], [1.0]]]),
+        torch.tensor([[[9.0], [1.0], [9.0]]]),
+    ]
+    meter = _meter(prefix=2)
+    meter.set_row_mask(torch.tensor([[False, True, False]]))
+    assert _feed(meter, velocities).value().item() == 0.0
+
+
+def test_row_and_dim_masks_compose():
+    """`set_row_mask` must multiply into an existing dim mask, not replace it."""
+    meter = _meter(prefix=2, dim_mask=torch.tensor([[True, False]]))
+    meter.set_row_mask(torch.tensor([[True, False]]))
+    velocities = [
+        torch.tensor([[[1.0, 3.0], [4.0, 5.0]]]),
+        torch.tensor([[[1.0, -3.0], [-4.0, -5.0]]]),
+    ]
+    # Only element [row 0, dim 0] survives, and it is constant across both steps.
+    assert _feed(meter, velocities).value().item() == 0.0
+
+
+# --------------------------------------------------------------------------------------
+# `executed_row_mask` — the slice that is wrong whenever delay > 0.
+# --------------------------------------------------------------------------------------
+
+
+def test_executed_row_mask_without_delay():
+    mask = executed_row_mask(
+        prefix_mask=torch.zeros(1, 5, dtype=torch.bool),
+        delay=torch.tensor(0),
+        chunk_size=5,
+        n_action_steps=3,
+        device=CPU,
+    )
+    assert mask.tolist() == [[True, True, True, False, False]]
+
+
+def test_executed_row_mask_offsets_the_window_by_delay():
+    """``select_action`` executes ``actions[delay : delay + n_action_steps]``. The naive
+    ``[:n_action_steps]`` slice would score the frozen rows and miss the executed tail —
+    a mistake that only manifests under real-time chunking."""
+    mask = executed_row_mask(
+        prefix_mask=torch.tensor([[True, True, False, False, False]]),
+        delay=torch.tensor(2),
+        chunk_size=5,
+        n_action_steps=2,
+        device=CPU,
+    )
+    assert mask.tolist() == [[False, False, True, True, False]]
+
+
+def test_executed_row_mask_accepts_per_sample_delay():
+    mask = executed_row_mask(
+        prefix_mask=torch.tensor([[False, False, False], [True, False, False]]),
+        delay=torch.tensor([0, 1]),
+        chunk_size=3,
+        n_action_steps=1,
+        device=CPU,
+    )
+    assert mask.tolist() == [[True, False, False], [False, True, False]]
+
+
+# --------------------------------------------------------------------------------------
+# Action-dim mask derivation from the normalization buffers.
+# --------------------------------------------------------------------------------------
+
+
+def _unnormalize(mode, stats, action_dim=4, eps=1e-6):
+    features = {"actions": PolicyFeature(type=FeatureType.ACTION, shape=(action_dim,))}
+    return Unnormalize(
+        features,
+        {"ACTION": mode},
+        per_dataset_stats=stats,
+        dataset_names=[f"ds{i}" for i in range(len(stats))],
+        eps=eps,
+    )
+
+
+def test_dim_mask_recovers_the_pad_tail_from_mean_std_buffers():
+    """Two real dims, two zero-variance pad dims — the LIBERO-in-32 shape in miniature."""
+    stats = [{"actions": {"mean": torch.zeros(4), "std": torch.tensor([1.0, 2.0, 0.0, 0.0])}}]
+    mask = resolve_action_dim_mask(
+        _unnormalize(NormalizationMode.MEAN_STD, stats),
+        max_action_dim=4,
+        dataset_index=torch.zeros(1, dtype=torch.long),
+    )
+    assert mask.tolist() == [[True, True, False, False]]
+
+
+def test_dim_mask_recovers_the_pad_tail_from_quantile_buffers():
+    stats = [
+        {
+            "actions": {
+                "q01": torch.tensor([-1.0, -1.0, 0.0, 0.0]),
+                "q99": torch.tensor([1.0, 1.0, 0.0, 0.0]),
+            }
+        }
+    ]
+    mask = resolve_action_dim_mask(
+        _unnormalize(NormalizationMode.QUANTILE, stats),
+        max_action_dim=4,
+        dataset_index=torch.zeros(1, dtype=torch.long),
+    )
+    assert mask.tolist() == [[True, True, False, False]]
+
+
+def test_dim_mask_is_gathered_per_norm_head():
+    """Buffers are ``(num_datasets, action_dim)``. On a co-trained mixture two samples in
+    one batch legitimately score a different number of dims, so a single shared constant
+    mask would be wrong for one of them."""
+    stats = [
+        {"actions": {"mean": torch.zeros(4), "std": torch.tensor([1.0, 1.0, 0.0, 0.0])}},
+        {"actions": {"mean": torch.zeros(4), "std": torch.tensor([1.0, 1.0, 1.0, 0.0])}},
+    ]
+    mask = resolve_action_dim_mask(
+        _unnormalize(NormalizationMode.MEAN_STD, stats),
+        max_action_dim=4,
+        dataset_index=torch.tensor([0, 1]),
+    )
+    assert mask.tolist() == [[True, True, False, False], [True, True, True, False]]
+
+
+def test_dim_mask_pads_when_the_sampler_is_wider_than_the_buffer():
+    stats = [{"actions": {"mean": torch.zeros(2), "std": torch.tensor([1.0, 1.0])}}]
+    mask = resolve_action_dim_mask(
+        _unnormalize(NormalizationMode.MEAN_STD, stats, action_dim=2),
+        max_action_dim=4,
+        dataset_index=torch.zeros(1, dtype=torch.long),
+    )
+    assert mask.tolist() == [[True, True, False, False]]
+
+
+def test_dim_mask_reads_eps_off_the_live_module():
+    """``eps`` is ``config_version``-dependent (1e-6 at v1, 1e-8 at v0), so reading the
+    module-level default instead of the live attribute would classify a dim whose std sits
+    between the two conventions under the wrong checkpoint's rule."""
+    stats = [{"actions": {"mean": torch.zeros(2), "std": torch.tensor([1.0, 1e-7])}}]
+    strict = resolve_action_dim_mask(
+        _unnormalize(NormalizationMode.MEAN_STD, stats, action_dim=2, eps=1e-6),
+        max_action_dim=2,
+        dataset_index=torch.zeros(1, dtype=torch.long),
+    )
+    loose = resolve_action_dim_mask(
+        _unnormalize(NormalizationMode.MEAN_STD, stats, action_dim=2, eps=1e-8),
+        max_action_dim=2,
+        dataset_index=torch.zeros(1, dtype=torch.long),
+    )
+    assert strict.tolist() == [[True, False]]
+    assert loose.tolist() == [[True, True]]
+
+
+def test_dim_mask_refuses_identity_normalization():
+    """IDENTITY has no stats buffer, so the pad tail is underivable — and IDENTITY also
+    leaves per-dim scale heterogeneous, violating the estimator's premise outright.
+    Refusing is the point: silently passing an all-ones mask would emit a plausible number
+    computed over 25 columns of noise."""
+    features = {"actions": PolicyFeature(type=FeatureType.ACTION, shape=(4,))}
+    unnorm = Unnormalize(features, {"ACTION": NormalizationMode.IDENTITY}, num_datasets=1)
+    with pytest.raises(ValueError, match="IDENTITY"):
+        resolve_action_dim_mask(unnorm, max_action_dim=4, dataset_index=torch.zeros(1, dtype=torch.long))
+
+
+def test_dim_mask_refuses_an_all_degenerate_head():
+    stats = [{"actions": {"mean": torch.zeros(2), "std": torch.zeros(2)}}]
+    with pytest.raises(ValueError, match="degenerate"):
+        resolve_action_dim_mask(
+            _unnormalize(NormalizationMode.MEAN_STD, stats, action_dim=2),
+            max_action_dim=2,
+            dataset_index=torch.zeros(1, dtype=torch.long),
+        )
+
+
+def test_degenerate_head_error_points_at_the_routing_not_the_stats():
+    """The realistic cause is a wrongly-routed sample, so the message must say so.
+
+    A co-trained mixture can carry a placeholder head with all-zero stats (OpenTau's own
+    `ci_config` has one), and an observation with no dataset provenance falls back to head 0
+    — which may be exactly that placeholder. A bare "the mask is empty" sends the reader off
+    to audit their action statistics when the real fix is to tag the observation. So the
+    error must name the selected head, the per-head scorable counts, and the usable heads.
+    """
+    stats = [
+        {"actions": {"mean": torch.zeros(4), "std": torch.zeros(4)}},  # placeholder head
+        {"actions": {"mean": torch.zeros(4), "std": torch.tensor([1.0, 2.0, 3.0, 0.0])}},
+    ]
+    unnorm = _unnormalize(NormalizationMode.MEAN_STD, stats)
+    with pytest.raises(ValueError) as excinfo:
+        resolve_action_dim_mask(unnorm, max_action_dim=4, dataset_index=torch.zeros(1, dtype=torch.long))
+    message = str(excinfo.value)
+    assert "[0]" in message, "must name the head that was actually selected"
+    assert "[0, 3]" in message, "must report scorable dims per head so the contrast is visible"
+    assert "[1]" in message and "dataset_repo_id" in message, (
+        "must point at the routing fix when another head does have usable stats"
+    )
+
+    # And head 1 really is usable — otherwise the advice would be wrong.
+    assert resolve_action_dim_mask(
+        unnorm, max_action_dim=4, dataset_index=torch.ones(1, dtype=torch.long)
+    ).tolist() == [[True, True, True, False]]
+
+
+def test_degenerate_error_says_so_when_no_head_is_usable():
+    stats = [{"actions": {"mean": torch.zeros(2), "std": torch.zeros(2)}}]
+    with pytest.raises(ValueError, match="No head has usable action stats"):
+        resolve_action_dim_mask(
+            _unnormalize(NormalizationMode.MEAN_STD, stats, action_dim=2),
+            max_action_dim=2,
+            dataset_index=torch.zeros(1, dtype=torch.long),
+        )
+
+
+# --------------------------------------------------------------------------------------
+# `make_meter` / provenance.
+# --------------------------------------------------------------------------------------
+
+
+class _FakeConfig:
+    type = "pi05"
+    num_steps = 10
+    chunk_size = 4
+    n_action_steps = 4
+    max_delay = 0
+    max_action_dim = 4
+    delta_action_state_map = None
+    normalization_mapping = {"ACTION": NormalizationMode.MEAN_STD}
+
+
+class _FakePolicy(nn.Module):
+    def __init__(self, accel_prefix=None):
+        super().__init__()
+        self.config = _FakeConfig()
+        self.accel_prefix = accel_prefix
+        stats = [{"actions": {"mean": torch.zeros(4), "std": torch.tensor([1.0, 2.0, 0.0, 0.0])}}]
+        self.unnormalize_outputs = _unnormalize(NormalizationMode.MEAN_STD, stats)
+
+
+def test_make_meter_returns_none_when_disabled():
+    assert make_meter(_FakePolicy(accel_prefix=None), batch_size=1, device=CPU) is None
+
+
+def test_make_meter_builds_the_dim_mask_and_clamps_the_prefix():
+    meter = make_meter(_FakePolicy(accel_prefix=99), batch_size=1, device=CPU)
+    assert meter is not None
+    assert meter.prefix == 10, "prefix must clamp to num_steps"
+    assert meter.dim_mask.tolist() == [[True, True, False, False]]
+
+
+def test_provenance_records_the_scoring_configuration():
+    policy = _FakePolicy(accel_prefix=9)
+    meter = make_meter(policy, batch_size=2, device=CPU, dataset_index=torch.zeros(2, dtype=torch.long))
+    prov = build_provenance(policy, meter, dataset_index=torch.zeros(2, dtype=torch.long))
+    assert prov.policy_type == "pi05"
+    assert prov.num_steps == 10
+    assert prov.prefix == 9
+    assert prov.action_norm_mode == "MEAN_STD"
+    assert prov.num_scored_dims == (2, 2)
+    assert AccelProvenance.from_dict(prov.to_dict()) == prov
+
+
+def _prov(**overrides):
+    base = {
+        "policy_type": "pi05",
+        "num_steps": 10,
+        "prefix": 9,
+        "chunk_size": 10,
+        "n_action_steps": 10,
+        "max_delay": 0,
+        "action_norm_mode": "MEAN_STD",
+        "has_delta_action_map": False,
+        "velocity_dtype": "bfloat16",
+    }
+    base.update(overrides)
+    return AccelProvenance(**base)
+
+
+# --------------------------------------------------------------------------------------
+# `configure_accel` — the single enable knob shared by every serving entry point.
+# --------------------------------------------------------------------------------------
+
+
+class _FakeCfg:
+    def __init__(self, accel_prefix=None):
+        self.policy = _FakeConfig()
+        if accel_prefix is not None:
+            self.policy.accel_prefix = accel_prefix
+
+
+def test_configure_accel_is_off_by_default(monkeypatch):
+    """Nothing requested => the attribute is untouched and every line in the sampler stays
+    dead. A free score is still a score nothing should enable implicitly."""
+    monkeypatch.delenv(ACCEL_PREFIX_ENV, raising=False)
+    policy = _FakePolicy()
+    assert configure_accel(policy, _FakeCfg()) is None
+    assert policy.accel_prefix is None
+
+
+def test_configure_accel_auto_resolves_the_papers_prefix(monkeypatch):
+    monkeypatch.setenv(ACCEL_PREFIX_ENV, "auto")
+    policy = _FakePolicy()
+    assert configure_accel(policy, _FakeCfg()) == 9  # default_prefix(10)
+    assert policy.accel_prefix == 9
+
+
+def test_configure_accel_precedence_override_beats_config_beats_env(monkeypatch):
+    monkeypatch.setenv(ACCEL_PREFIX_ENV, "3")
+    assert configure_accel(_FakePolicy(), _FakeCfg()) == 3
+    assert configure_accel(_FakePolicy(), _FakeCfg(accel_prefix=5)) == 5
+    assert configure_accel(_FakePolicy(), _FakeCfg(accel_prefix=5), override=7) == 7
+
+
+def test_configure_accel_ignores_a_blank_env_value(monkeypatch):
+    monkeypatch.setenv(ACCEL_PREFIX_ENV, "   ")
+    assert configure_accel(_FakePolicy(), _FakeCfg()) is None
+
+
+def test_configure_accel_reads_the_real_policy_config_field(monkeypatch):
+    """`accel_prefix` is a real field on ``PreTrainedConfig``, not just an env var.
+
+    Draccus JSON configs are the repo's primary interface, so a feature reachable only
+    through the environment is effectively unreachable. Uses a genuine ``PI05Config`` rather
+    than the fake above, so the test fails if the field is ever dropped from the dataclass.
+    """
+    from opentau.policies.pi05.configuration_pi05 import PI05Config
+
+    monkeypatch.delenv(ACCEL_PREFIX_ENV, raising=False)
+    cfg = _FakeCfg()
+    cfg.policy = PI05Config()
+    assert cfg.policy.accel_prefix is None, "accel must be off by default in the config"
+    assert configure_accel(_FakePolicy(), cfg) is None
+
+    cfg.policy.accel_prefix = "auto"
+    assert configure_accel(_FakePolicy(), cfg) == 9  # default_prefix(num_steps=10)
+    cfg.policy.accel_prefix = 4
+    assert configure_accel(_FakePolicy(), cfg) == 4
+
+
+def test_configure_accel_refuses_an_unwired_policy(monkeypatch):
+    """A family whose sampler was never wired would accept the attribute and then never read
+    it — a silent no-op an operator would misread as 'the score is always missing'."""
+    monkeypatch.delenv(ACCEL_PREFIX_ENV, raising=False)
+    policy = _FakePolicy()
+    del policy.accel_prefix
+    with pytest.raises(ValueError, match="not wired"):
+        configure_accel(policy, _FakeCfg(), override=4)
+
+
+def test_configure_accel_rejects_a_nonsense_prefix(monkeypatch):
+    monkeypatch.delenv(ACCEL_PREFIX_ENV, raising=False)
+    with pytest.raises(ValueError, match="integer"):
+        configure_accel(_FakePolicy(), _FakeCfg(), override="nonsense")
+    with pytest.raises(ValueError, match=f">= {MIN_PREFIX}"):
+        configure_accel(_FakePolicy(), _FakeCfg(), override=1)
+
+
+def test_comparable_provenance_passes():
+    assert_comparable(_prov(), _prov(dataset_index=(3,), num_scored_dims=(7,)))
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("num_steps", 5),
+        ("prefix", 4),
+        ("action_norm_mode", "QUANTILE"),
+        ("has_delta_action_map", True),
+        ("velocity_dtype", "float32"),
+        ("max_delay", 2),
+        ("policy_type", "pi07"),
+    ],
+)
+def test_mismatched_provenance_is_refused(field, value):
+    """Every one of these shifts the score's distribution, so a threshold calibrated under
+    one must not be silently applied under another."""
+    with pytest.raises(ValueError, match="not applicable"):
+        assert_comparable(_prov(), _prov(**{field: value}))

--- a/tests/policies/test_accel_wiring_registry.py
+++ b/tests/policies/test_accel_wiring_registry.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python
+
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Structural invariants for the ``accel`` wiring, across every flow-matching policy.
+
+Seven policies carry their own copy of the Euler denoising loop — nothing is inherited,
+only ``paligemma_with_expert`` is shared — so the ``accel`` read
+(:mod:`opentau.policies.accel`) had to be applied seven times. The behavioral numerics are
+pinned once, on pi05, in ``tests/policies/test_pi05_accel.py``; duplicating that suite six
+more times would pin the same arithmetic against six near-identical stubs while still
+missing the thing that actually differs between the copies — *where in each loop the read
+sits*.
+
+So these are AST checks. They cover all seven policies without constructing a
+multi-billion-parameter model, and each one is written to fail on the specific silent
+corruption it names:
+
+1. ``accel.update(...)`` must read the **same** velocity variable the Euler step consumes,
+   and must run **before** the state update. Reading after the update, or reconstructing
+   the velocity from consecutive states, silently scores the wrong field wherever a
+   real-time-chunking clamp overwrites rows mid-loop.
+2. The row mask must be set, or the score silently includes frozen and un-executed rows.
+3. The inner sampler's ``accel`` parameter must be last and default to ``None``, or a
+   positional caller (the ONNX exporter, the compiled-callable rebinds) breaks.
+4. ``select_action`` must clear ``last_accel``, or a queue-pop step is indistinguishable
+   from a re-plan and a consumer records the same score ``n_action_steps`` times.
+5. ``reset`` must clear the accel state, or it leaks across episodes.
+
+A new flow-matching policy that forgets any of this fails here rather than at the point
+where somebody trusts a number it produced.
+"""
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+import opentau
+
+_POLICIES_ROOT = Path(opentau.__file__).parent / "policies"
+
+#: Every policy carrying its own flow-matching Euler loop, as
+#: ``(module path, inner sampler class, policy wrapper class)``. Not auto-discovered on
+#: purpose: adding a policy here should be a conscious act, and the list doubles as the
+#: inventory of "places a change to the denoise loop has to land".
+FLOW_MATCHING_POLICIES = [
+    ("pi0/modeling_pi0.py", "PI0FlowMatching", "PI0Policy"),
+    ("pi05/modeling_pi05.py", "PI05FlowMatching", "PI05Policy"),
+    ("pi05_mem/modeling_pi05.py", "PI05MemFlowMatching", "PI05MemPolicy"),
+    ("pi06/modeling_pi06.py", "PI06FlowMatching", "PI06Policy"),
+    (
+        "pi07/low_level/modeling_pi07_low_level.py",
+        "PI07LowLevelFlowMatching",
+        "PI07LowLevelPolicy",
+    ),
+    (
+        "pi07_paligemma/low_level/modeling_pi07_low_level.py",
+        "PI07PaligemmaLowLevelFlowMatching",
+        "PI07PaligemmaLowLevelPolicy",
+    ),
+    ("cosmos3/modeling_cosmos3.py", "Cosmos3FlowMatching", "Cosmos3Policy"),
+]
+
+IDS = [entry[0] for entry in FLOW_MATCHING_POLICIES]
+
+
+def _tree(rel_path: str) -> ast.Module:
+    return ast.parse((_POLICIES_ROOT / rel_path).read_text())
+
+
+def _class(tree: ast.Module, name: str) -> ast.ClassDef:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == name:
+            return node
+    raise AssertionError(f"class {name} not found")
+
+
+def _method(tree: ast.Module, class_name: str, method: str) -> ast.FunctionDef:
+    for node in _class(tree, class_name).body:
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef) and node.name == method:
+            return node
+    raise AssertionError(f"{class_name}.{method} not found")
+
+
+def _accel_method_calls(node: ast.AST, method: str) -> list[ast.Call]:
+    """Every ``<name>.<method>(...)`` call on a variable named ``accel``."""
+    return [
+        call
+        for call in ast.walk(node)
+        if isinstance(call, ast.Call)
+        and isinstance(call.func, ast.Attribute)
+        and call.func.attr == method
+        and isinstance(call.func.value, ast.Name)
+        and call.func.value.id == "accel"
+    ]
+
+
+def _euler_update_lines(sampler: ast.FunctionDef) -> list[tuple[int, str]]:
+    """Lines that advance the denoise state, as ``(lineno, state variable)``.
+
+    Matches both shapes in the tree: in-place ``x_t += dt * v_t`` (pi0/pi05 family) and
+    out-of-place ``x_t = x_t + dt * v_t`` (cosmos3).
+    """
+    found: list[tuple[int, str]] = []
+    for node in ast.walk(sampler):
+        if isinstance(node, ast.AugAssign) and isinstance(node.target, ast.Name):
+            names = {n.id for n in ast.walk(node.value) if isinstance(n, ast.Name)}
+            if any(name.startswith("v") for name in names):
+                found.append((node.lineno, node.target.id))
+        elif isinstance(node, ast.Assign) and len(node.targets) == 1:
+            target = node.targets[0]
+            if not isinstance(target, ast.Name) or not isinstance(node.value, ast.BinOp):
+                continue
+            names = {n.id for n in ast.walk(node.value) if isinstance(n, ast.Name)}
+            if target.id in names and any(name.startswith("v") for name in names):
+                found.append((node.lineno, target.id))
+    return found
+
+
+@pytest.mark.parametrize(("rel_path", "sampler_cls", "policy_cls"), FLOW_MATCHING_POLICIES, ids=IDS)
+def test_inner_sampler_takes_accel_last_and_defaults_to_none(rel_path, sampler_cls, policy_cls):
+    """The parameter must be trailing and optional.
+
+    ``sample_actions`` on the inner module is ``torch.compile``d at four serving entry
+    points and ONNX-exported at one, all of which call it positionally. A non-trailing or
+    non-defaulted parameter breaks those callers; a missing default also means every caller
+    must be updated in lockstep, which is how one gets missed.
+    """
+    sampler = _method(_tree(rel_path), sampler_cls, "sample_actions")
+    args = sampler.args.args + sampler.args.kwonlyargs
+    assert args[-1].arg == "accel", f"{sampler_cls}.sample_actions: 'accel' must be the last parameter"
+
+    defaults = sampler.args.defaults + [d for d in sampler.args.kw_defaults if d is not None]
+    assert defaults, f"{sampler_cls}.sample_actions: 'accel' must have a default"
+    assert isinstance(defaults[-1], ast.Constant) and defaults[-1].value is None, (
+        f"{sampler_cls}.sample_actions: 'accel' must default to None so the feature is off "
+        "by default and the traced graph is unchanged"
+    )
+
+
+@pytest.mark.parametrize(("rel_path", "sampler_cls", "policy_cls"), FLOW_MATCHING_POLICIES, ids=IDS)
+def test_accel_update_precedes_the_euler_state_update(rel_path, sampler_cls, policy_cls):
+    """``accel.update(v_t)`` must run before the state advances.
+
+    Placing it after would still "work" on most configs, which is what makes this worth
+    pinning structurally: wherever a real-time-chunking clamp overwrites ``x_t`` at the top
+    of the next iteration, the velocity a later read sees no longer corresponds to the step
+    it is attributed to.
+    """
+    sampler = _method(_tree(rel_path), sampler_cls, "sample_actions")
+    updates = _accel_method_calls(sampler, "update")
+    assert len(updates) == 1, (
+        f"{sampler_cls}.sample_actions: expected exactly one accel.update() call, found {len(updates)}"
+    )
+
+    euler = _euler_update_lines(sampler)
+    assert euler, f"{sampler_cls}.sample_actions: no Euler state update found; update the matcher"
+    assert updates[0].lineno < min(line for line, _ in euler), (
+        f"{sampler_cls}.sample_actions: accel.update() at line {updates[0].lineno} runs after the "
+        f"Euler state update at line {min(line for line, _ in euler)}"
+    )
+
+
+@pytest.mark.parametrize(("rel_path", "sampler_cls", "policy_cls"), FLOW_MATCHING_POLICIES, ids=IDS)
+def test_accel_update_reads_the_loops_own_velocity(rel_path, sampler_cls, policy_cls):
+    """The argument must be the same name the Euler step consumes.
+
+    Guards against the two ways this silently goes wrong: passing a *copy* computed by a
+    second network call (not free, and not the same field), or passing a velocity
+    reconstructed from consecutive states (wrong wherever rows are clamped).
+    """
+    sampler = _method(_tree(rel_path), sampler_cls, "sample_actions")
+    call = _accel_method_calls(sampler, "update")[0]
+    assert len(call.args) == 1 and isinstance(call.args[0], ast.Name), (
+        f"{sampler_cls}.sample_actions: accel.update() must be passed the loop's velocity "
+        "variable directly, not an expression"
+    )
+    velocity = call.args[0].id
+
+    consumed = {
+        name.id
+        for lineno, _ in _euler_update_lines(sampler)
+        for node in ast.walk(sampler)
+        if getattr(node, "lineno", None) == lineno
+        for name in ast.walk(node)
+        if isinstance(name, ast.Name)
+    }
+    assert velocity in consumed, (
+        f"{sampler_cls}.sample_actions: accel.update({velocity}) does not read the variable the "
+        f"Euler step consumes ({sorted(consumed)})"
+    )
+
+
+@pytest.mark.parametrize(("rel_path", "sampler_cls", "policy_cls"), FLOW_MATCHING_POLICIES, ids=IDS)
+def test_row_mask_is_set_before_the_loop(rel_path, sampler_cls, policy_cls):
+    """Without it, frozen RTC rows and the un-executed chunk tail land in both sums.
+
+    Both carry velocities that describe nothing the robot will do, and both are masked out
+    of the training loss for that reason.
+    """
+    sampler = _method(_tree(rel_path), sampler_cls, "sample_actions")
+    calls = _accel_method_calls(sampler, "set_row_mask")
+    assert len(calls) == 1, (
+        f"{sampler_cls}.sample_actions: expected exactly one accel.set_row_mask() call, found {len(calls)}"
+    )
+    update = _accel_method_calls(sampler, "update")[0]
+    assert calls[0].lineno < update.lineno, (
+        f"{sampler_cls}.sample_actions: set_row_mask() must run before the loop's first update()"
+    )
+
+
+@pytest.mark.parametrize(("rel_path", "sampler_cls", "policy_cls"), FLOW_MATCHING_POLICIES, ids=IDS)
+def test_accel_lines_are_guarded_so_they_are_dead_when_disabled(rel_path, sampler_cls, policy_cls):
+    """Every ``accel.*`` call must sit under an ``if accel is not None`` test.
+
+    This is what makes the feature free: with ``accel=None`` the branch is a compile-time
+    constant, so the traced graph is byte-identical to before the feature existed.
+    """
+    sampler = _method(_tree(rel_path), sampler_cls, "sample_actions")
+    guarded: set[int] = set()
+    for node in ast.walk(sampler):
+        if not isinstance(node, ast.If):
+            continue
+        test = node.test
+        if not (
+            isinstance(test, ast.Compare)
+            and isinstance(test.left, ast.Name)
+            and test.left.id == "accel"
+            and isinstance(test.ops[0], ast.IsNot)
+        ):
+            continue
+        # `ast.walk` also yields context nodes (`Load`, `Store`, ...) which carry no
+        # position, so filter rather than attribute-access blindly.
+        guarded |= {
+            lineno
+            for body in node.body
+            for n in ast.walk(body)
+            if (lineno := getattr(n, "lineno", None)) is not None
+        }
+
+    for method in ("update", "set_row_mask"):
+        for call in _accel_method_calls(sampler, method):
+            assert call.lineno in guarded, (
+                f"{sampler_cls}.sample_actions: accel.{method}() at line {call.lineno} is not "
+                "inside an `if accel is not None:` guard, so it is not dead when accel is off"
+            )
+
+
+@pytest.mark.parametrize(("rel_path", "sampler_cls", "policy_cls"), FLOW_MATCHING_POLICIES, ids=IDS)
+def test_select_action_clears_last_accel(rel_path, sampler_cls, policy_cls):
+    """One sample call feeds ``n_action_steps`` env steps.
+
+    Without the clear, a consumer reading ``last_accel`` every step records the same score
+    ``n_action_steps`` times — inflating the stream and, worse, feeding a conformal
+    calibration duplicated samples it treats as independent.
+    """
+    select = _method(_tree(rel_path), policy_cls, "select_action")
+    clears = [
+        node.lineno
+        for node in ast.walk(select)
+        if isinstance(node, ast.Assign)
+        and isinstance(node.value, ast.Constant)
+        and node.value.value is None
+        and any(
+            isinstance(t, ast.Attribute) and t.attr == "last_accel" and isinstance(t.value, ast.Name)
+            for t in node.targets
+        )
+    ]
+    assert clears, f"{policy_cls}.select_action must clear `self.last_accel` so a queue-pop step reads None"
+
+
+@pytest.mark.parametrize(("rel_path", "sampler_cls", "policy_cls"), FLOW_MATCHING_POLICIES, ids=IDS)
+def test_reset_clears_the_accel_state(rel_path, sampler_cls, policy_cls):
+    """``policy.reset()`` runs once per rollout batch; per-episode state must not survive it."""
+    reset = _method(_tree(rel_path), policy_cls, "reset")
+    cleared = {
+        target.attr
+        for node in ast.walk(reset)
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Constant) and node.value.value is None
+        for target in node.targets
+        if isinstance(target, ast.Attribute)
+    }
+    assert {"last_accel", "last_accel_provenance"} <= cleared, (
+        f"{policy_cls}.reset must clear last_accel and last_accel_provenance, cleared: {sorted(cleared)}"
+    )
+
+
+@pytest.mark.parametrize(("rel_path", "sampler_cls", "policy_cls"), FLOW_MATCHING_POLICIES, ids=IDS)
+def test_wrapper_declares_accel_prefix_off_by_default(rel_path, sampler_cls, policy_cls):
+    """``accel_prefix`` must be declared in ``__init__`` and initialized to ``None``.
+
+    Declaring it there (rather than letting ``configure_accel`` create it) is what lets
+    ``make_meter`` and every consumer use a plain attribute read, and what makes a policy
+    family that has *not* been wired detectable via ``hasattr``.
+    """
+    init = _method(_tree(rel_path), policy_cls, "__init__")
+    assigned = [
+        node
+        for node in ast.walk(init)
+        if isinstance(node, (ast.Assign, ast.AnnAssign))
+        for target in ([node.target] if isinstance(node, ast.AnnAssign) else node.targets)
+        if isinstance(target, ast.Attribute) and target.attr == "accel_prefix"
+    ]
+    assert assigned, f"{policy_cls}.__init__ must declare `self.accel_prefix`"
+    assert all(isinstance(node.value, ast.Constant) and node.value.value is None for node in assigned), (
+        f"{policy_cls}.__init__ must initialize `self.accel_prefix` to None (accel is opt-in)"
+    )
+
+
+def test_every_entry_point_that_reads_accel_also_arms_it():
+    """A script that consumes ``last_accel`` must also call ``configure_accel``.
+
+    This pins a gap that shipped once and was invisible: ``eval.py`` read ``last_accel``,
+    warned about the parallel-task race, and threaded the streams all the way to disk — but
+    never armed the proxy, so ``OPENTAU_ACCEL_PREFIX=auto opentau-eval`` silently produced
+    empty ``accel`` fields on every episode. Nothing failed; the feature was simply
+    unreachable on the path that collects the calibration set.
+
+    The asymmetry is the tell, so that is what this checks: reading without arming is a bug,
+    while arming without reading is fine (a server may publish the score on the wire rather
+    than consume it itself).
+
+    "Arming" means either calling ``configure_accel`` (the config/env resolution every
+    serving entry point uses) or assigning ``accel_prefix`` directly — which ``diagnose_accel``
+    legitimately does, since sweeping every prefix is precisely its job and it cannot go
+    through a single resolved value.
+    """
+    scripts_root = Path(opentau.__file__).parent / "scripts"
+    offenders = []
+    for path in scripts_root.rglob("*.py"):
+        source = path.read_text()
+        if "last_accel" not in source:
+            continue
+        arms = "configure_accel" in source or re.search(r"\.accel_prefix\s*=", source)
+        if not arms:
+            offenders.append(str(path.relative_to(scripts_root)))
+    assert not offenders, (
+        "These entry points read `policy.last_accel` but never arm the proxy (no "
+        "`configure_accel` call and no `accel_prefix` assignment), so accel can never be "
+        f"switched on for them and every score comes back empty: {offenders}"
+    )
+
+
+def test_the_registry_covers_every_denoise_loop_in_the_tree():
+    """Fail when a policy grows a flow-matching Euler loop without being listed here.
+
+    The whole point of an AST sweep is that it cannot be outgrown silently. A hand-kept
+    list that nothing cross-checks is exactly the "two hand-maintained lists fail open"
+    failure CLAUDE.md rule 5 describes, so this derives the truth independently: any module
+    under ``policies/`` calling ``self.denoise_step(...)`` or otherwise stepping a denoise
+    state must appear in :data:`FLOW_MATCHING_POLICIES`.
+    """
+    listed = {rel for rel, _, _ in FLOW_MATCHING_POLICIES}
+    found = set()
+    for path in _POLICIES_ROOT.rglob("modeling_*.py"):
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef) or node.name != "sample_actions":
+                continue
+            if _euler_update_lines(node):
+                found.add(str(path.relative_to(_POLICIES_ROOT)))
+
+    missing = found - listed
+    assert not missing, (
+        f"These modules run a flow-matching Euler loop but are not in FLOW_MATCHING_POLICIES, so "
+        f"their accel wiring is unpinned: {sorted(missing)}"
+    )
+    stale = listed - found
+    assert not stale, f"These entries no longer have a denoise loop: {sorted(stale)}"

--- a/tests/policies/test_pi05_accel.py
+++ b/tests/policies/test_pi05_accel.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python
+
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU coverage for the ``accel`` uncertainty proxy wired into pi05's Euler loop.
+
+``tests/policies/test_accel.py`` pins the estimator itself. These tests pin the *wiring*:
+that the meter sees the sampler's real per-step velocities in the right order, that the
+frozen real-time-chunking rows are excluded, that the whole thing is inert when disabled,
+and that the policy-level ``last_accel`` follows the re-plan cadence rather than the env
+step cadence.
+
+Built on the same lightweight ``object.__new__(PI05FlowMatching)`` shell the execution-
+horizon tests use, so no PaliGemma weights are needed.
+"""
+
+import math
+
+import pytest
+import torch
+from torch import nn
+
+from opentau.policies.accel import AccelMeter
+from opentau.policies.pi05.configuration_pi05 import PI05Config
+from opentau.policies.pi05.modeling_pi05 import PI05FlowMatching, PI05Policy
+
+MAX_STATE_DIM = 32
+MAX_ACTION_DIM = 4
+HIDDEN = 8
+
+
+class _StubBackbone(nn.Module):
+    """Minimal stand-in for ``PaliGemmaWithExpertModel`` — only the prefix pass is used."""
+
+    def forward(self, *, inputs_embeds, **kwargs):
+        batch = inputs_embeds[0].shape[0]
+        return (torch.zeros(batch, 1, HIDDEN), None), []
+
+
+def _config(chunk_size=4, n_action_steps=4, max_delay=0, num_steps=4):
+    return PI05Config(
+        n_obs_steps=1,
+        chunk_size=chunk_size,
+        n_action_steps=n_action_steps,
+        max_delay=max_delay,
+        num_steps=num_steps,
+        max_state_dim=MAX_STATE_DIM,
+        max_action_dim=MAX_ACTION_DIM,
+    )
+
+
+def _flow_matching(cfg, velocities):
+    """A ``PI05FlowMatching`` shell whose ``denoise_step`` replays a scripted velocity list.
+
+    Scripting the velocities is what lets these tests assert an exact ``accel`` — the real
+    denoise_step would need the full backbone and would make the expected value unknowable.
+    """
+    fm = object.__new__(PI05FlowMatching)
+    nn.Module.__init__(fm)
+    fm.config = cfg
+    fm.paligemma_with_expert = _StubBackbone()
+
+    def embed_prefix(images, img_masks, lang_tokens, lang_masks, state=None):
+        batch = lang_tokens.shape[0]
+        return (
+            torch.zeros(batch, 1, HIDDEN),
+            torch.ones(batch, 1, dtype=torch.bool),
+            torch.zeros(batch, 1, dtype=torch.bool),
+            None,
+        )
+
+    calls = {"n": 0}
+
+    def denoise_step(prefix_pad_masks, past_key_values, x_t, time):
+        v = velocities[calls["n"]]
+        calls["n"] += 1
+        return v.expand_as(x_t).clone() if v.shape != x_t.shape else v.clone()
+
+    fm.embed_prefix = embed_prefix
+    fm.denoise_step = denoise_step
+    fm._denoise_calls = calls
+    return fm
+
+
+def _sample(fm, cfg, *, batch=1, accel=None, delay=0):
+    return PI05FlowMatching.sample_actions(
+        fm,
+        images=[],
+        img_masks=[],
+        lang_tokens=torch.zeros(batch, 1, dtype=torch.long),
+        lang_masks=torch.ones(batch, 1, dtype=torch.bool),
+        action_prefix=torch.zeros(batch, cfg.chunk_size, cfg.max_action_dim),
+        delay=torch.tensor(delay),
+        noise=torch.zeros(batch, cfg.chunk_size, cfg.max_action_dim),
+        state=None,
+        accel=accel,
+    )
+
+
+def _velocity(value, cfg, batch=1):
+    return torch.full((batch, cfg.chunk_size, cfg.max_action_dim), float(value))
+
+
+# --------------------------------------------------------------------------------------
+# The loop feeds the meter.
+# --------------------------------------------------------------------------------------
+
+
+def test_constant_velocity_field_scores_zero_through_the_real_loop():
+    """End-to-end through ``PI05FlowMatching.sample_actions``: a field that returns the
+    same velocity at every Euler step is the maximally-certain case and must score 0."""
+    cfg = _config(num_steps=4)
+    fm = _flow_matching(cfg, [_velocity(1.0, cfg)] * 4)
+    meter = AccelMeter(prefix=3, batch_size=1, device=torch.device("cpu"))
+
+    _sample(fm, cfg, accel=meter)
+
+    assert fm._denoise_calls["n"] == cfg.num_steps
+    assert meter.steps == 3
+    assert meter.value().item() == 0.0
+
+
+def test_meter_receives_the_velocities_in_loop_order():
+    """The prefix must be the FIRST Euler steps. Scripted so only the last transition bends:
+    a prefix of 2 sees none of it, the full schedule does."""
+    cfg = _config(num_steps=4)
+    velocities = [_velocity(1.0, cfg), _velocity(1.0, cfg), _velocity(1.0, cfg), _velocity(9.0, cfg)]
+
+    short = AccelMeter(prefix=2, batch_size=1, device=torch.device("cpu"))
+    _sample(_flow_matching(cfg, velocities), cfg, accel=short)
+    assert short.value().item() == 0.0
+
+    full = AccelMeter(prefix=4, batch_size=1, device=torch.device("cpu"))
+    _sample(_flow_matching(cfg, velocities), cfg, accel=full)
+    assert full.value().item() > 0.0
+
+
+def test_accel_matches_a_hand_computed_value_through_the_loop():
+    """Velocities 1 -> 2 -> 1 over a (4 rows x 4 dims) chunk of constant entries.
+
+    Each velocity has norm ``v * 4`` (sqrt(16) elements), each difference has norm ``1 * 4``,
+    so accel_3 = 3 * (4 + 4) / (4 + 8 + 4) = 24 / 16 = 1.5.
+    """
+    cfg = _config(num_steps=3)
+    fm = _flow_matching(cfg, [_velocity(1.0, cfg), _velocity(2.0, cfg), _velocity(1.0, cfg)])
+    meter = AccelMeter(prefix=3, batch_size=1, device=torch.device("cpu"))
+
+    _sample(fm, cfg, accel=meter)
+
+    assert meter.value().item() == pytest.approx(1.5, rel=1e-6)
+
+
+def test_disabled_accel_leaves_the_sampled_actions_bit_identical():
+    """The feature must be inert when off — same trajectory, same output, no side effects."""
+    cfg = _config(num_steps=4)
+    velocities = [_velocity(v, cfg) for v in (1.0, 2.0, 1.5, 0.5)]
+
+    without = _sample(_flow_matching(cfg, velocities), cfg, accel=None)
+    with_meter = _sample(
+        _flow_matching(cfg, velocities),
+        cfg,
+        accel=AccelMeter(prefix=3, batch_size=1, device=torch.device("cpu")),
+    )
+    assert torch.equal(without, with_meter)
+
+
+def test_per_sample_scores_survive_the_loop():
+    """Batched multi-env rollouts: sample 0 travels straight, sample 1 bends."""
+    cfg = _config(num_steps=3)
+    batch = 2
+
+    def split(a, b):
+        v = torch.empty(batch, cfg.chunk_size, cfg.max_action_dim)
+        v[0] = a
+        v[1] = b
+        return v
+
+    velocities = [split(1.0, 1.0), split(1.0, 5.0), split(1.0, 1.0)]
+    fm = _flow_matching(cfg, velocities)
+    meter = AccelMeter(prefix=3, batch_size=batch, device=torch.device("cpu"))
+
+    _sample(fm, cfg, batch=batch, accel=meter)
+
+    value = meter.value()
+    assert value.shape == (batch,)
+    assert value[0].item() == 0.0
+    assert value[1].item() > 0.0
+
+
+# --------------------------------------------------------------------------------------
+# Real-time chunking: the frozen prefix rows must not be scored.
+# --------------------------------------------------------------------------------------
+
+
+def test_frozen_rtc_prefix_rows_are_excluded():
+    """With ``delay=2``, rows 0-1 are overwritten with the committed actions before every
+    ``denoise_step`` and their conditioning time is pinned to 0, so their velocities describe
+    nothing. Here they carry all the bend; the executed rows are constant, so the score must
+    be exactly 0. Without the row mask this reports a large spurious value.
+    """
+    cfg = _config(chunk_size=4, n_action_steps=4, max_delay=2, num_steps=3)
+
+    def velocity(frozen_value):
+        v = torch.ones(1, cfg.chunk_size, cfg.max_action_dim)
+        v[:, :2] = frozen_value
+        return v
+
+    fm = _flow_matching(cfg, [velocity(1.0), velocity(50.0), velocity(-50.0)])
+    meter = AccelMeter(prefix=3, batch_size=1, device=torch.device("cpu"))
+
+    _sample(fm, cfg, accel=meter, delay=2)
+
+    assert meter.value().item() == 0.0
+
+
+def test_rows_outside_the_executed_window_are_excluded():
+    """``select_action`` applies ``actions[delay : delay + n_action_steps]`` and re-plans, so
+    later rows never reach the robot. Here only row 0 is executed and it is constant, while
+    the unexecuted tail carries the bend."""
+    cfg = _config(chunk_size=4, n_action_steps=1, max_delay=0, num_steps=3)
+
+    def velocity(tail_value):
+        v = torch.ones(1, cfg.chunk_size, cfg.max_action_dim)
+        v[:, 1:] = tail_value
+        return v
+
+    fm = _flow_matching(cfg, [velocity(1.0), velocity(50.0), velocity(-50.0)])
+    meter = AccelMeter(prefix=3, batch_size=1, device=torch.device("cpu"))
+
+    _sample(fm, cfg, accel=meter)
+
+    assert meter.value().item() == 0.0
+
+
+# --------------------------------------------------------------------------------------
+# Policy-level `last_accel` contract.
+# --------------------------------------------------------------------------------------
+
+
+def _bare_policy(cfg):
+    policy = object.__new__(PI05Policy)
+    policy.config = cfg
+    policy.eval = lambda: None  # bypass nn.Module.eval (no __init__ was run)
+    policy.accel_prefix = None
+    PI05Policy.reset(policy)
+    return policy
+
+
+def test_last_accel_follows_the_replan_cadence_not_the_step_cadence():
+    """One ``sample_actions`` feeds ``n_action_steps`` env steps, so ``last_accel`` must be
+    populated only on the step that actually re-planned. A consumer that read it every step
+    would silently record the same score ``n_action_steps`` times and inflate its stream.
+    """
+    chunk, n_steps = 4, 3
+    cfg = _config(chunk_size=chunk, n_action_steps=n_steps, max_delay=0)
+    policy = _bare_policy(cfg)
+
+    calls = {"n": 0}
+
+    def fake_sample_actions(batch, noise=None, action_prefix=None, delay=None):
+        calls["n"] += 1
+        policy.last_accel = [float(calls["n"])]
+        return torch.zeros(1, chunk, MAX_ACTION_DIM)
+
+    policy.sample_actions = fake_sample_actions
+    batch = {"state": torch.zeros(1, MAX_STATE_DIM)}
+
+    observed = []
+    for _ in range(2 * n_steps):
+        PI05Policy.select_action(policy, batch)
+        observed.append(policy.last_accel)
+
+    assert calls["n"] == 2
+    # Populated on the re-planning step, None while the queue drains.
+    assert observed == [[1.0], None, None, [2.0], None, None]
+
+
+def test_reset_clears_the_accel_state():
+    """Per-episode state must not leak across ``env.reset()`` — the eval loop calls
+    ``policy.reset()`` once per rollout batch."""
+    policy = _bare_policy(_config())
+    policy.last_accel = [0.5]
+    policy.last_accel_provenance = object()
+
+    PI05Policy.reset(policy)
+
+    assert policy.last_accel is None
+    assert policy.last_accel_provenance is None
+
+
+def test_accel_is_disabled_by_default():
+    """A cost-free score is still a score nothing should read implicitly — its scale is only
+    meaningful against a calibration."""
+    policy = _bare_policy(_config())
+    assert policy.accel_prefix is None
+    assert policy.last_accel is None
+
+
+def test_default_prefix_for_the_shipped_schedule():
+    """Every shipped pi05 config uses ``num_steps=10``; the paper's online detector uses the
+    second-to-last prefix."""
+    from opentau.policies.accel import default_prefix
+
+    assert PI05Config().num_steps == 10
+    assert default_prefix(PI05Config().num_steps) == 9
+
+
+def test_hand_computed_value_is_scale_free():
+    """``accel`` is a ratio, so uniformly rescaling every velocity must not change it. This
+    is what makes a single threshold portable across chunks whose velocity magnitudes differ.
+    """
+    cfg = _config(num_steps=3)
+    scores = []
+    for scale in (1.0, 1000.0):
+        fm = _flow_matching(
+            cfg, [_velocity(1.0 * scale, cfg), _velocity(2.0 * scale, cfg), _velocity(1.0 * scale, cfg)]
+        )
+        meter = AccelMeter(prefix=3, batch_size=1, device=torch.device("cpu"))
+        _sample(fm, cfg, accel=meter)
+        scores.append(meter.value().item())
+    assert scores[0] == pytest.approx(scores[1], rel=1e-5)
+    assert not math.isnan(scores[0])

--- a/tests/policies/test_siglip_embedding_dtype.py
+++ b/tests/policies/test_siglip_embedding_dtype.py
@@ -231,6 +231,11 @@ _UNROUTED_CAST_IS_INTENTIONAL = {
     # ONNX export casts *up* to float32, which cannot round the pinned tables. This one is
     # safe because of a value rather than a location, so it is pinned separately below.
     "export_to_onnx.py": "float32 upcast, not a downcast",
+    # The accel diagnostic re-runs the sampler in float32 to isolate the bf16 rounding floor.
+    # That is an upcast, which cannot round the pinned tables, and the cast *back* to the
+    # serving dtype does route through the helper. Same value-not-location exemption as the
+    # ONNX export, and pinned the same way below.
+    "diagnose_accel.py": "float32 upcast, not a downcast",
 }
 
 _DTYPE_ATTRS = frozenset({"bfloat16", "float16", "half", "float32", "float64", "float", "double"})
@@ -395,4 +400,41 @@ def test_onnx_export_exemption_is_a_float32_upcast_not_a_downcast():
     assert assigned == {"torch.float32"}, (
         f"export_to_onnx.py binds dtype to {assigned}; its exemption from "
         "to_dtype_preserving_siglip_float32 only holds for a float32 upcast."
+    )
+
+
+def test_accel_diagnostic_exemption_is_a_float32_upcast_and_restores_through_the_helper():
+    """``diagnose_accel.py`` is exempt because of a *value*, so pin the value.
+
+    The filename-keyed allowlist entry would keep passing if the direct cast were switched
+    to bfloat16 — precisely the silent re-rounding rule 6 forbids. Pin both halves of what
+    makes it safe: every *direct* cast is the float32 upcast, and the cast back down to the
+    serving dtype goes through the preserving helper.
+    """
+    path = _SCRIPTS_ROOT / "diagnose_accel.py"
+    tree = ast.parse(path.read_text())
+    flagged = set(_policy_dtype_casts(path))
+    assert flagged, "diagnose_accel.py no longer casts directly; drop its allowlist entry"
+
+    dtypes = {
+        ast.unparse(kw.value)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and node.lineno in flagged
+        for kw in node.keywords
+        if kw.arg == "dtype"
+    } | {
+        ast.unparse(arg)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and node.lineno in flagged
+        for arg in node.args
+        if _is_dtype_arg(arg)
+    }
+    assert dtypes == {"torch.float32"}, (
+        f"diagnose_accel.py casts a policy to {dtypes}; its exemption from "
+        "to_dtype_preserving_siglip_float32 only holds for a float32 upcast."
+    )
+    assert _calls_preserving_helper(path), (
+        "diagnose_accel.py upcasts to float32 but no longer restores the serving dtype "
+        "through to_dtype_preserving_siglip_float32, so the pinned SigLIP patch/position "
+        "embeddings get re-rounded (CLAUDE.md rule 6)."
     )

--- a/tests/scripts/test_calibrate_accel.py
+++ b/tests/scripts/test_calibrate_accel.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python
+
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the ``accel`` calibration driver.
+
+The failure mode this file exists to pin is a **guard that deletes itself**. A calibration
+carries an :class:`~opentau.policies.accel.AccelProvenance` label, and
+:func:`~opentau.utils.accel_detector.detect` refuses a stream whose provenance disagrees
+with it. But an *unlabelled* calibration skips that check entirely — so any bug that
+wrongly drops the label converts a hard refusal into a silent pass, which is strictly worse
+than the mismatch it was meant to catch.
+
+Comparing the whole provenance dict does exactly that: ``dataset_index`` and
+``num_scored_dims`` are per-sample and vary with batch composition, so two tasks agreeing on
+every distribution-shifting field get declared "disagreeing" and the label is dropped.
+"""
+
+import json
+
+import numpy as np
+import pytest
+
+from opentau.scripts.calibrate_accel import (
+    _resolve_provenance,
+    fit,
+    load_eval_info,
+    split_by_outcome,
+)
+
+COMPARABLE = {
+    "policy_type": "pi05",
+    "num_steps": 10,
+    "prefix": 9,
+    "chunk_size": 10,
+    "n_action_steps": 10,
+    "max_delay": 0,
+    "action_norm_mode": "MEAN_STD",
+    "has_delta_action_map": False,
+    "velocity_dtype": "bfloat16",
+}
+
+
+def _provenance(**overrides):
+    payload = dict(COMPARABLE)
+    payload.setdefault("dataset_index", (0,))
+    payload.setdefault("num_scored_dims", (7,))
+    payload.update(overrides)
+    return payload
+
+
+def _task(*, accels, successes, provenance=None, task_id=0):
+    return {
+        "task_group": "libero",
+        "task_id": task_id,
+        "metrics": {
+            "accels": accels,
+            "successes": successes,
+            "accel_provenance": _provenance() if provenance is None else provenance,
+        },
+    }
+
+
+def _quiet(n=12, length=20, seed=0):
+    rng = np.random.default_rng(seed)
+    return [(0.4 + 0.02 * rng.standard_normal(length)).tolist() for _ in range(n)]
+
+
+# --------------------------------------------------------------------------------------
+# Provenance resolution — the fail-open path.
+# --------------------------------------------------------------------------------------
+
+
+def test_tasks_differing_only_in_per_sample_fields_still_share_a_label():
+    """Batch composition must not look like a configuration disagreement.
+
+    ``dataset_index`` and ``num_scored_dims`` are per-sample; two tasks routed through
+    different norm heads, or with different numbers of episodes, legitimately differ there
+    while agreeing on everything that shifts the score's distribution. Treating that as a
+    disagreement drops the label and disarms the apply-time comparability check.
+    """
+    tasks = [
+        _task(
+            accels=[[0.4]],
+            successes=[True],
+            provenance=_provenance(dataset_index=(0, 0), num_scored_dims=(7, 7)),
+        ),
+        _task(
+            accels=[[0.4]],
+            successes=[True],
+            provenance=_provenance(dataset_index=(1,), num_scored_dims=(6,)),
+            task_id=1,
+        ),
+    ]
+    resolved = _resolve_provenance(tasks)
+    assert resolved is not None, "per-sample differences must not drop the label"
+    assert resolved.num_steps == 10 and resolved.action_norm_mode == "MEAN_STD"
+
+
+def test_the_shared_label_clears_the_per_sample_fields():
+    """Carrying one arbitrary task's per-sample values on a pooled calibration is a fiction.
+
+    They are cleared rather than kept, and `assert_comparable` ignores them anyway, so the
+    cleared tuples are inert at apply time.
+    """
+    tasks = [
+        _task(accels=[[0.4]], successes=[True], provenance=_provenance(dataset_index=(3,))),
+        _task(
+            accels=[[0.4]],
+            successes=[True],
+            provenance=_provenance(dataset_index=(9,)),
+            task_id=1,
+        ),
+    ]
+    resolved = _resolve_provenance(tasks)
+    assert resolved.dataset_index == ()
+    assert resolved.num_scored_dims == ()
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("num_steps", 5),
+        ("prefix", 4),
+        ("action_norm_mode", "QUANTILE"),
+        ("velocity_dtype", "float32"),
+        ("has_delta_action_map", True),
+        ("max_delay", 4),
+        ("policy_type", "pi07"),
+    ],
+)
+def test_a_genuine_disagreement_still_drops_the_label(field, value):
+    """The relaxation must not go too far — a real configuration split must stay unlabelled.
+
+    Without this, the fix for the per-sample false positive could silently degrade into
+    "never disagree", which would restore the fail-open behaviour by another route.
+    """
+    tasks = [
+        _task(accels=[[0.4]], successes=[True]),
+        _task(accels=[[0.4]], successes=[True], provenance=_provenance(**{field: value}), task_id=1),
+    ]
+    assert _resolve_provenance(tasks) is None
+
+
+def test_no_recorded_provenance_leaves_the_calibration_unlabelled():
+    assert _resolve_provenance([]) is None
+
+
+# --------------------------------------------------------------------------------------
+# Outcome pairing — `accels[i]` must belong to `successes[i]`.
+# --------------------------------------------------------------------------------------
+
+
+def test_streams_are_split_by_their_own_episode_outcome():
+    good, bad, successes = split_by_outcome(
+        _task(accels=[[0.1], [0.9], [0.2]], successes=[True, False, True])
+    )
+    assert good == [[0.1], [0.2]]
+    assert bad == [[0.9]]
+    assert successes == [True, False, True]
+
+
+def test_a_length_mismatch_drops_the_task_rather_than_pairing_it():
+    """One stream short would shift every label by one — silently fitting on the wrong set."""
+    good, bad, successes = split_by_outcome(_task(accels=[[0.1]], successes=[True, False]))
+    assert (good, bad, successes) == ([], [], [])
+
+
+def test_a_task_without_accel_is_simply_absent():
+    assert split_by_outcome(_task(accels=[], successes=[True])) == ([], [], [])
+
+
+# --------------------------------------------------------------------------------------
+# Fitting.
+# --------------------------------------------------------------------------------------
+
+
+def test_fit_returns_none_when_there_are_too_few_successes_to_certify_alpha():
+    """A threshold that cannot certify the requested rate must not be produced at all."""
+    tasks = [_task(accels=_quiet(n=3), successes=[True] * 3)]
+    assert fit(tasks, alpha=0.1, slack_c=0.25, label="pooled") is None
+
+
+def test_fit_produces_a_labelled_calibration_from_enough_successes():
+    tasks = [_task(accels=_quiet(n=12), successes=[True] * 12)]
+    result = fit(tasks, alpha=0.2, slack_c=0.25, label="pooled")
+    assert result is not None
+    assert result["num_successful"] == 12
+    assert result["calibration"].provenance is not None, "a single-config fit must stay labelled"
+    assert result["calibration"].eta >= 0.0
+
+
+def test_fit_reports_detection_against_failing_episodes():
+    """A held-in evaluation is optimistic but must still separate the two classes."""
+    good = _quiet(n=12, length=20)
+    bad = [[0.4] * 5 + [1.6] * 15 for _ in range(4)]
+    tasks = [_task(accels=good + bad, successes=[True] * 12 + [False] * 4)]
+    result = fit(tasks, alpha=0.2, slack_c=0.25, label="pooled")
+    assert result["metrics"]["true_positive_rate"] == 1.0
+    assert result["metrics"]["false_alarm_rate"] <= 0.2
+
+
+# --------------------------------------------------------------------------------------
+# Input loading.
+# --------------------------------------------------------------------------------------
+
+
+def test_load_eval_info_accepts_a_file_or_its_directory(tmp_path):
+    payload = {"per_task": [_task(accels=[[0.4]], successes=[True])]}
+    path = tmp_path / "eval_info.json"
+    path.write_text(json.dumps(payload))
+    assert len(load_eval_info(path)) == 1
+    assert len(load_eval_info(tmp_path)) == 1
+
+
+def test_load_eval_info_rejects_a_missing_or_unrelated_file(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        load_eval_info(tmp_path / "nope.json")
+
+    other = tmp_path / "eval_info.json"
+    other.write_text(json.dumps({"overall": {}}))
+    with pytest.raises(ValueError, match="per_task"):
+        load_eval_info(other)

--- a/tests/scripts/test_eval.py
+++ b/tests/scripts/test_eval.py
@@ -575,3 +575,202 @@ class TestEvalPolicyGoalFrameHarvest:
             rows = list(csv.DictReader(f))
         assert len(rows) == 1
         assert rows[0]["decoder"] == "discrete"
+
+
+# ======================================================================================
+# accel telemetry: the code that actually builds the calibration pairing.
+#
+# `rollout` collects one score per *re-plan* (not per env step) and truncates each env's
+# stream at that env's own done step; `eval_policy` then pairs stream i with episode i's
+# success flag. That pairing IS the calibration set, and a silent misalignment in it
+# produces a threshold fitted on the wrong episodes — with nothing failing anywhere.
+# ======================================================================================
+
+
+class _AccelFakeVecEnv:
+    """A vector env just complete enough to drive the real ``rollout``.
+
+    Each env finishes at its own step (``done_steps``), which is the whole point: the
+    rollout loop keeps stepping envs that are already done (it runs until the LAST one
+    finishes), so every chunk planned after an env's done step describes a
+    post-termination state and must be cut from that env's stream.
+    """
+
+    def __init__(self, num_envs, done_steps, max_steps=12):
+        self.num_envs = num_envs
+        self._done_steps = done_steps
+        self._max_steps = max_steps
+        self._step = 0
+
+    def reset(self, seed=None):
+        self._step = 0
+        return {"pixels": np.zeros((self.num_envs, 4, 4, 3), dtype=np.uint8)}, {}
+
+    def call(self, name):
+        return [self._max_steps] * self.num_envs
+
+    def step(self, action):
+        self._step += 1
+        terminated = np.array([self._step >= d for d in self._done_steps])
+        return (
+            {"pixels": np.zeros((self.num_envs, 4, 4, 3), dtype=np.uint8)},
+            np.zeros(self.num_envs, dtype=np.float32),
+            terminated,
+            np.zeros(self.num_envs, dtype=bool),
+            {},
+        )
+
+
+class _ScriptedAccelPolicy(torch.nn.Module):
+    """Policy that re-plans every ``n_action_steps`` and publishes an identifiable score.
+
+    The published value encodes ``(step, env)`` so a truncation or alignment bug shows up
+    as a specific wrong number rather than merely a wrong count.
+    """
+
+    def __init__(self, num_envs, n_action_steps=2, width=None):
+        super().__init__()  # `rollout` asserts the policy is an nn.Module
+        self.num_envs = num_envs
+        self.n_action_steps = n_action_steps
+        self._width = num_envs if width is None else width
+        self._queue = 0
+        self._step = 0
+        self.accel_prefix = 9
+        self.last_accel = None
+        self.last_accel_provenance = types.SimpleNamespace(to_dict=lambda: {"prefix": 9})
+
+    def reset(self):
+        self._queue = 0
+        self._step = 0
+        self.last_accel = None
+
+    def select_action(self, _observation):
+        self.last_accel = None
+        if self._queue == 0:
+            self._queue = self.n_action_steps
+            self.last_accel = [self._step + env / 100.0 for env in range(self._width)]
+        self._queue -= 1
+        self._step += 1
+        return torch.zeros(self.num_envs, 4)
+
+
+def _patch_rollout_env_helpers(monkeypatch):
+    """Neutralize the observation-plumbing helpers ``rollout`` calls around the policy."""
+    mod = "opentau.scripts.eval"
+    monkeypatch.setattr(f"{mod}.preprocess_observation", lambda obs, cfg=None: dict(obs))
+    monkeypatch.setattr(f"{mod}.add_envs_task", lambda env, obs: obs)
+    monkeypatch.setattr(f"{mod}.add_eval_metadata", lambda obs, cfg=None: obs)
+    monkeypatch.setattr(f"{mod}.check_env_attributes_and_types", lambda env: None)
+    monkeypatch.setattr(f"{mod}.add_subgoal_images", lambda obs, gen: obs)
+    monkeypatch.setattr(f"{mod}.get_proc_accelerator", lambda: None)
+
+
+def _run_accel_rollout(monkeypatch, *, done_steps, n_action_steps=2, width=None):
+    from opentau.scripts.eval import rollout
+
+    _patch_rollout_env_helpers(monkeypatch)
+    num_envs = len(done_steps)
+    env = _AccelFakeVecEnv(num_envs, done_steps)
+    policy = _ScriptedAccelPolicy(num_envs, n_action_steps=n_action_steps, width=width)
+    return rollout(env, policy=policy, cfg=_make_eval_cfg())
+
+
+class TestRolloutAccelCollection:
+    def test_stream_is_truncated_at_each_envs_own_done_step(self, monkeypatch):
+        """Env 0 finishes early, env 1 runs long — their streams must differ in length.
+
+        A single shared truncation (or none at all) would give both envs the same stream,
+        padding the early-finishing episode with scores describing a terminated scene.
+        """
+        data = _run_accel_rollout(monkeypatch, done_steps=[2, 8], n_action_steps=2)
+        assert "accel" in data, "rollout must publish the stream when the policy does"
+        early, late = data["accel"]
+        assert len(early) < len(late), f"expected per-env truncation, got {early} vs {late}"
+        # Re-plans happen at rollout steps 0, 2, 4, 6. Env 0's first `done` lands at index
+        # 1, so only the step-0 chunk survives; the step-2 chunk describes an already
+        # terminated scene and is exactly what truncation must remove.
+        assert early == [0.0], early
+        assert late == [0.01, 2.01, 4.01, 6.01], late
+
+    def test_each_env_gets_its_own_column_not_another_envs(self, monkeypatch):
+        """Env i must receive element i of every chunk — never another env's score."""
+        data = _run_accel_rollout(monkeypatch, done_steps=[8, 8], n_action_steps=2)
+        env0, env1 = data["accel"]
+        # The scripted value is `step + env/100`, so the fractional part identifies the env.
+        assert all(round(v % 1, 2) == 0.0 for v in env0), env0
+        assert all(round(v % 1, 2) == 0.01 for v in env1), env1
+
+    def test_provenance_is_recorded_once(self, monkeypatch):
+        data = _run_accel_rollout(monkeypatch, done_steps=[4, 4])
+        assert data["accel_provenance"] == {"prefix": 9}
+
+    def test_a_wrong_width_score_is_dropped_rather_than_wrongly_attributed(self, monkeypatch):
+        """A score list that does not match ``num_envs`` cannot be assigned to envs.
+
+        Zipping it anyway would hand env 0 a number belonging to something else, which is
+        strictly worse than reporting nothing — so the whole stream is dropped.
+        """
+        data = _run_accel_rollout(monkeypatch, done_steps=[4, 4], width=1)
+        assert "accel" not in data, "a width mismatch must not produce a stream"
+
+    def test_no_accel_key_when_the_policy_publishes_nothing(self, monkeypatch):
+        """A policy without the attribute must leave the rollout dict exactly as before."""
+        from opentau.scripts.eval import rollout
+
+        _patch_rollout_env_helpers(monkeypatch)
+
+        class _Plain(_ScriptedAccelPolicy):
+            def select_action(self, _observation):
+                return torch.zeros(self.num_envs, 4)
+
+        policy = _Plain(2)
+        del policy.last_accel
+        del policy.accel_prefix
+        data = rollout(_AccelFakeVecEnv(2, [3, 3]), policy=policy, cfg=_make_eval_cfg())
+        assert "accel" not in data and "accel_provenance" not in data
+
+
+class TestEvalPolicyAccelPairing:
+    def test_stream_is_paired_with_the_matching_episodes_success(self, monkeypatch):
+        """`accels[i]` must line up with `successes[i]` — that pairing is the calibration set."""
+
+        def fake_rollout(**kwargs):
+            data = _make_rollout_data(num_envs=2, successes=[True, False])
+            data["accel"] = [[0.11], [0.22]]
+            data["accel_provenance"] = {"prefix": 9}
+            return data
+
+        monkeypatch.setattr("opentau.scripts.eval.rollout", fake_rollout)
+        info = eval_policy(
+            _FakeEnv(num_envs=2), policy=Mock(), n_episodes=2, cfg=_make_eval_cfg(seed_list="1,2")
+        )
+
+        episodes = info["per_episode"]
+        assert [ep["success"] for ep in episodes] == [True, False]
+        assert [ep["accel"] for ep in episodes] == [[0.11], [0.22]]
+        assert info["accel_provenance"] == {"prefix": 9}
+
+    def test_count_mismatch_drops_the_streams_instead_of_pairing_them(self, monkeypatch):
+        """Fewer streams than episodes must not silently shift every label by one."""
+
+        def fake_rollout(**kwargs):
+            data = _make_rollout_data(num_envs=2, successes=[True, False])
+            data["accel"] = [[0.11]]  # one stream, two episodes
+            return data
+
+        monkeypatch.setattr("opentau.scripts.eval.rollout", fake_rollout)
+        info = eval_policy(
+            _FakeEnv(num_envs=2), policy=Mock(), n_episodes=2, cfg=_make_eval_cfg(seed_list="1,2")
+        )
+        assert all("accel" not in ep for ep in info["per_episode"])
+
+    def test_absent_accel_leaves_per_episode_untouched(self, monkeypatch):
+        monkeypatch.setattr(
+            "opentau.scripts.eval.rollout",
+            lambda **kwargs: _make_rollout_data(num_envs=2, successes=[True, True]),
+        )
+        info = eval_policy(
+            _FakeEnv(num_envs=2), policy=Mock(), n_episodes=2, cfg=_make_eval_cfg(seed_list="1,2")
+        )
+        assert all("accel" not in ep for ep in info["per_episode"])
+        assert "accel_provenance" not in info

--- a/tests/utils/test_accel_detector.py
+++ b/tests/utils/test_accel_detector.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python
+
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the offline CUSUM + split-conformal detector over an ``accel`` stream."""
+
+import json
+import math
+
+import numpy as np
+import pytest
+
+from opentau.policies.accel import AccelProvenance
+from opentau.utils.accel_detector import (
+    CALIBRATION_FILENAME,
+    CusumCalibration,
+    calibrate,
+    conformal_rank,
+    cusum_stream,
+    detect,
+    episode_peak,
+    evaluate,
+)
+
+
+def _prov(**overrides):
+    base = {
+        "policy_type": "pi05",
+        "num_steps": 10,
+        "prefix": 9,
+        "chunk_size": 10,
+        "n_action_steps": 10,
+        "max_delay": 0,
+        "action_norm_mode": "MEAN_STD",
+        "has_delta_action_map": False,
+        "velocity_dtype": "bfloat16",
+    }
+    base.update(overrides)
+    return AccelProvenance(**base)
+
+
+# --------------------------------------------------------------------------------------
+# The CUSUM recursion.
+# --------------------------------------------------------------------------------------
+
+
+def test_cusum_is_floored_at_zero():
+    """A quiet stream must not bank negative credit — otherwise a long calm stretch would
+    buy immunity from a later genuine excursion."""
+    stream = cusum_stream([0.0] * 10, mu0=1.0, k=0.0)
+    assert stream.tolist() == [0.0] * 10
+
+
+def test_cusum_accumulates_persistent_excess():
+    stream = cusum_stream([2.0, 2.0, 2.0], mu0=1.0, k=0.0)
+    assert stream.tolist() == [1.0, 2.0, 3.0]
+
+
+def test_slack_absorbs_transient_spikes_but_not_a_sustained_shift():
+    """The paper's slack ``k`` is what makes a single noisy chunk harmless while a
+    persistent elevation still integrates to an alarm."""
+    transient = cusum_stream([0.0, 0.0, 0.4, 0.0, 0.0], mu0=0.0, k=0.5)
+    assert transient.max() == 0.0
+
+    sustained = cusum_stream([0.6] * 10, mu0=0.0, k=0.5)
+    assert sustained[-1] == pytest.approx(1.0)
+
+
+def test_non_finite_scores_carry_the_statistic_forward():
+    """The meter emits NaN when a chunk has no valid measurement. That is an absence of
+    evidence, not evidence of drift, so it must neither bump nor reset the statistic."""
+    with_nan = cusum_stream([2.0, float("nan"), 2.0], mu0=1.0, k=0.0)
+    assert with_nan.tolist() == [1.0, 1.0, 2.0]
+
+
+def test_episode_peak_reduces_any_length_to_one_scalar():
+    assert episode_peak([], mu0=0.0, k=0.0) == 0.0
+    assert episode_peak([1.0, 3.0, 0.0], mu0=1.0, k=0.0) == pytest.approx(2.0)
+
+
+# --------------------------------------------------------------------------------------
+# Split-conformal rank selection.
+# --------------------------------------------------------------------------------------
+
+
+def test_conformal_rank_matches_the_papers_operating_point():
+    """M=50, alpha=0.1 -> the 46th smallest of 50 calibration peaks."""
+    assert conformal_rank(50, 0.1) == 46
+
+
+def test_conformal_rank_refuses_an_undersized_calibration_set():
+    """With too few episodes no finite threshold can certify the rate; silently clamping to
+    the max would report a guarantee that does not hold."""
+    with pytest.raises(ValueError, match="at least"):
+        conformal_rank(5, 0.01)
+
+
+@pytest.mark.parametrize("alpha", [0.0, 1.0, -0.1, 1.5])
+def test_conformal_rank_rejects_out_of_range_alpha(alpha):
+    with pytest.raises(ValueError, match="alpha"):
+        conformal_rank(50, alpha)
+
+
+# --------------------------------------------------------------------------------------
+# Calibration.
+# --------------------------------------------------------------------------------------
+
+
+def _quiet_episodes(n=50, length=30, seed=0):
+    rng = np.random.default_rng(seed)
+    return [(0.4 + 0.02 * rng.standard_normal(length)).tolist() for _ in range(n)]
+
+
+def test_calibration_holds_its_nominal_false_alarm_rate_in_sample():
+    """The conformal construction guarantees at most ``ceil((M+1)(1-alpha))``-th order
+    statistic coverage, so at most ``alpha`` of the calibration episodes may exceed it."""
+    episodes = _quiet_episodes()
+    cal = calibrate(episodes, alpha=0.1)
+    alarms = sum(detect(ep, cal).alarmed for ep in episodes)
+    assert alarms / len(episodes) <= 0.1
+
+
+def test_calibration_records_its_inputs():
+    cal = calibrate(_quiet_episodes(n=50, length=20), alpha=0.1, provenance=_prov())
+    assert cal.num_calibration_episodes == 50
+    assert cal.num_calibration_chunks == 1000
+    assert cal.k == pytest.approx(cal.slack_c * cal.sigma)
+    assert cal.provenance == _prov()
+
+
+def test_calibration_rejects_an_empty_set():
+    with pytest.raises(ValueError, match="at least one"):
+        calibrate([])
+
+
+def test_calibration_rejects_an_all_nan_set():
+    """All-NaN means the meter never had a valid measurement — a misconfiguration that
+    must surface loudly rather than produce a threshold of NaN."""
+    with pytest.raises(ValueError, match="no finite scores"):
+        calibrate([[float("nan")] * 5 for _ in range(50)])
+
+
+# --------------------------------------------------------------------------------------
+# Detection.
+# --------------------------------------------------------------------------------------
+
+
+def test_a_sustained_excursion_alarms_with_lead():
+    """The failure signature from the paper's Figure 4: a quiet stretch, then a step change
+    that persists to the episode's end. The alarm must land inside the excursion, with lead
+    counted in remaining chunks."""
+    cal = calibrate(_quiet_episodes(), alpha=0.1)
+    failing = [0.4] * 20 + [1.5] * 20
+    result = detect(failing, cal)
+    assert result.alarmed
+    assert 20 <= result.alarm_index < 30, "alarm should fire shortly after the excursion starts"
+    assert result.lead == len(failing) - 1 - result.alarm_index
+    assert result.lead > 0
+
+
+def test_a_quiet_episode_does_not_alarm():
+    cal = calibrate(_quiet_episodes(), alpha=0.1)
+    result = detect([0.4] * 40, cal)
+    assert not result.alarmed
+    assert result.alarm_index is None and result.lead is None
+
+
+def test_an_isolated_spike_is_absorbed_but_the_same_level_sustained_alarms():
+    """The property that distinguishes a CUSUM from a per-chunk threshold, and the paper's
+    successful-rollout case (Figure 8): one excursion above the reference level is absorbed,
+    while *the same level* held for several chunks integrates past the threshold.
+
+    Both streams contain the identical maximum score, so a detector that merely compared
+    each chunk against a level would be unable to separate them.
+    """
+    cal = calibrate(_quiet_episodes(), alpha=0.1)
+    level = 0.5
+
+    assert not detect([0.4] * 15 + [level] + [0.4] * 15, cal).alarmed
+    assert detect([0.4] * 15 + [level] * 10 + [0.4] * 5, cal).alarmed
+
+
+def test_detection_refuses_a_provenance_mismatch():
+    """A threshold fitted at T=10 says nothing about a stream produced at T=5."""
+    cal = calibrate(_quiet_episodes(), alpha=0.1, provenance=_prov())
+    with pytest.raises(ValueError, match="not applicable"):
+        detect([0.4] * 10, cal, provenance=_prov(num_steps=5, prefix=4))
+
+
+def test_detection_allows_a_matching_provenance():
+    cal = calibrate(_quiet_episodes(), alpha=0.1, provenance=_prov())
+    detect([0.4] * 10, cal, provenance=_prov(dataset_index=(2,)))
+
+
+def test_detection_skips_the_check_when_either_side_is_unlabeled():
+    cal = calibrate(_quiet_episodes(), alpha=0.1, provenance=None)
+    detect([0.4] * 10, cal, provenance=_prov())
+
+
+# --------------------------------------------------------------------------------------
+# Evaluation metrics.
+# --------------------------------------------------------------------------------------
+
+
+def test_evaluate_reports_detection_rate_false_alarm_rate_and_lead():
+    cal = calibrate(_quiet_episodes(), alpha=0.1)
+    episodes = [[0.4] * 40] * 10 + [[0.4] * 10 + [1.5] * 30] * 10
+    successes = [True] * 10 + [False] * 10
+    metrics = evaluate(episodes, successes, cal)
+    assert metrics["true_positive_rate"] == 1.0
+    assert metrics["false_alarm_rate"] == 0.0
+    assert metrics["n_failed"] == 10.0 and metrics["n_successful"] == 10.0
+    assert metrics["median_lead"] > 0
+
+
+def test_evaluate_rejects_mismatched_lengths():
+    cal = calibrate(_quiet_episodes(), alpha=0.1)
+    with pytest.raises(ValueError, match="differ in length"):
+        evaluate([[0.4]], [True, False], cal)
+
+
+def test_evaluate_returns_nan_for_an_absent_class():
+    cal = calibrate(_quiet_episodes(), alpha=0.1)
+    metrics = evaluate([[0.4] * 10], [True], cal)
+    assert math.isnan(metrics["true_positive_rate"])
+    assert metrics["false_alarm_rate"] == 0.0
+
+
+# --------------------------------------------------------------------------------------
+# Persistence.
+# --------------------------------------------------------------------------------------
+
+
+def test_calibration_round_trips_through_json(tmp_path):
+    cal = calibrate(_quiet_episodes(), alpha=0.1, provenance=_prov())
+    path = cal.save(tmp_path)
+    assert path.name == CALIBRATION_FILENAME
+    assert json.loads(path.read_text())["provenance"]["policy_type"] == "pi05"
+
+    loaded = CusumCalibration.load(tmp_path)
+    assert loaded == cal
+    assert detect([0.4] * 10, loaded, provenance=_prov()).peak == pytest.approx(detect([0.4] * 10, cal).peak)
+
+
+def test_calibration_saves_to_an_explicit_filename(tmp_path):
+    cal = calibrate(_quiet_episodes(), alpha=0.1)
+    path = cal.save(tmp_path / "nested" / "mine.json")
+    assert path.name == "mine.json"
+    assert CusumCalibration.load(path) == cal


### PR DESCRIPTION
## What this does

Implements **denoising acceleration** (`accel`), the cost-free flow-matching uncertainty proxy from [arXiv:2607.27933](https://arxiv.org/abs/2607.27933), read off the samplers' *existing* Euler loop.

A maximally *certain* conditional-flow-matching field is an affine-isotropic contraction toward a point mass, so its denoising trajectory is a straight line at constant velocity. Any bend in that trajectory betrays non-zero posterior covariance. Over the first `p` of `T` Euler steps:

```
accel_p = ( p * sum_{t=1}^{p-1} ||v_t - v_{t-1}|| ) / ( sum_{t=0}^{p-1} ||v_t|| )
```

`v_t` is the velocity the sampler already evaluates to take its Euler step, so this needs **no extra network evaluations, no resampling, no training, and no auxiliary probe** — the whole cost is two vector norms per denoise step.

**Off by default, and inert when off.** `accel_prefix` defaults to `None`; with it unset every added line inside a sampler is dead, so the traced/compiled graph is byte-identical to today. **No `config_version` bump** — nothing about what the model sees or produces changes.

### What's here

- **`opentau/policies/accel.py`** — the estimator (`AccelMeter`), the action-dim mask, `AccelProvenance`, and `configure_accel`, the single enable knob shared by every entry point.
- **`opentau/utils/accel_detector.py`** — offline one-sided CUSUM + split-conformal calibration over the per-chunk stream, fitted on **successful** rollouts only (no failure labels needed).
- **All 7 flow-matching policies wired** — pi0, pi05, pi05_mem, pi06, pi07, pi07_paligemma, cosmos3. Nothing is inherited between them, so this is seven separate edits; a registry-wide AST test pins them all.
- **`opentau-accel-diagnose`** — measures the bfloat16 rounding floor, the run-to-run spread, and the prefix profile of a checkpoint. **Run this first** (see "Known limits").
- **`opentau-accel-calibrate`** — fits a threshold from an eval run's `eval_info.json`.
- **Plumbing** — `eval.py` records a per-episode stream (done-truncated, paired with `success`); gRPC gained `optional float accel = 5`; the RoboCasa server gained an opt-in `accel` envelope; `accel_prefix` is a real field on `PreTrainedConfig`.

### Two design points worth a reviewer's attention

**The meter is passed *into* the sampler, never stashed on the `nn.Module`.** These samplers are `torch.compile`d at four entry points and ONNX-exported at one; a module-attribute write inside a traced region is a Dynamo side-effect and the construct most likely to break under `fullgraph=True`.

**Two masks are mandatory, and both are silent when wrong.** The samplers work in `max_action_dim` (32) while a real embodiment uses far fewer, and the padded tail is masked out of the *training* loss — so those columns are unsupervised network output that would otherwise land in both sums. `real_action_dim` does not exist at inference, so the mask is recovered from the normalization buffers. Separately, frozen real-time-chunking rows and rows outside the executed window carry velocities describing nothing the robot will do, and are excluded.

## How it was tested

**Unit / structural — 227 new tests.**

- `tests/policies/test_accel.py` pins the paper's two anchors numerically against hand-computed values: exactly `0.0` on a constant-velocity path (Theorem 1), strictly positive on any bend, and growth with bend magnitude. Plus the masking cases that would silently corrupt the score, and the undefined-score cases that must be `NaN` rather than `0.0` (`0.0` would read as *maximally certain* — the opposite of *no measurement*).
- `tests/policies/test_pi05_accel.py` drives the real `sample_actions` with scripted velocities: re-plan cadence, frozen-prefix exclusion, and actions bit-identical with the feature on vs off.
- `tests/policies/test_accel_wiring_registry.py` is an AST sweep over all 7 policies. It was **mutation-verified**: moving `accel.update()` after the Euler step, dropping the `if accel is not None` guard, removing the `select_action` clear, and deleting `set_row_mask` each make it fail, and the file restores byte-identically. It also discovers every denoise loop in the tree independently, so a new policy cannot silently escape it.
- `tests/utils/test_accel_detector.py` covers the CUSUM recursion, conformal rank selection, and the persistence round-trip.

**CPU suite:** 2718 passed. The only failures are 3 pre-existing `tests/envs/test_factory.py` cases (the `libero` extra is not installed in this environment); verified identical on a pristine `origin/main`. Pre-commit: all hooks pass.

**GPU suite** (`pytest -m gpu -n 0` over `tests/policies` + `tests/utils`, on an internal GPU dev box): **22 passed, 0 failed.** I additionally stripped the unconditional `@pytest.mark.skip(reason="...24GB")` markers — this card has more memory — and ran the 12 memory-guarded end-to-end tests: 10 passed, 2 failed. Both failures reproduce identically on pristine `origin/main`; they are pre-existing rot in tests that never run because the skip is unconditional, and are being fixed separately. Nightly `gpu_test.yml` will re-verify the merge commit.

**Regression suite** (the `regression_test.yml` sequence, run manually; DeepSpeed ZeRO-2 with `num_processes` reduced 4 → 1 for a single-GPU box): `opentau-train` on `configs/dev/ci_config.json` completed 25 steps. `check_nonzero_grad_norm` PASS, `check_accumulate_grad_sync` PASS, `check_loss_drop` FAIL, `check_state_keys` FAIL — both failures reproduce identically on pristine `origin/main`, and both steps are `continue-on-error` in CI. `convert_checkpoint.sh` PASS, `inference.py` PASS.

**Determinism (CLAUDE.md rule 3):** two seeded 25-step `ci_config` runs produced **bit-identical metric lines (25/25)** with distinct log checksums. Also proved by AST that `forward` is untouched in all 7 policies — only `__init__` / `reset` / `sample_actions` / `select_action` changed, so the training path is not modified at all.

**Real-checkpoint validation.** Measured on a 6-DoF SO101 pi05 checkpoint (`T = 10`, QUANTILE action norm, delta actions, `max_delay = 4`) over 8 real frames of its own training data — a configuration that exercises every guard here, which no shipped config does:

| quantity | value |
|---|---|
| bfloat16 rounding floor | 0.0056 |
| redrawn-noise spread | 0.0094 |
| between-observation spread (the signal) | 0.097 |
| **signal / floor** | **17** |

The prefix sweep on that run reproduces the paper's terminal singularity: step-over-step growth decelerates monotonically (122% → 62% → 69% → 38% → 41% → 33% → 22%) and then *reverses* to +48% at the final step — which is why `default_prefix` returns `T - 1` and not `T`.

The real-time-chunking path was verified on real weights: actions bit-identical with `accel` on vs off, re-plan cadence exactly `n_action_steps - max_delay`, and frozen prefix rows genuinely excluded (180 → 156 scored elements at `delay = 4`).

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/policies/test_accel.py tests/policies/test_pi05_accel.py tests/policies/test_accel_wiring_registry.py tests/utils/test_accel_detector.py
```

Measure the noise floor of a checkpoint before trusting any score from it:

```bash
opentau-accel-diagnose --config_path=configs/examples/pi05_libero_eval_config.json --policy.path=<repo_id>@<step> --policy.device=cuda
```

Collect a calibration set from an eval run, then fit a threshold:

```bash
opentau-eval --accelerate-config configs/examples/accelerate_ddp_config.yaml --config_path=configs/examples/pi05_libero_eval_config.json --policy.accel_prefix=auto --eval.n_episodes=60 --env.max_parallel_tasks=1
```

```bash
opentau-accel-calibrate outputs/eval/<run>/eval_info.json --alpha 0.1 --out outputs/accel
```

## Known limits (please read before relying on a score)

These are the method's, not implementation gaps, and they are documented in the module and the CHANGELOG:

- **Measure the floor per checkpoint.** `accel`'s numerator is a difference of nearly-equal vectors, and the serving path runs the action projection in bfloat16, so there is a positive-biased rounding floor beneath every score that compresses exactly the low-uncertainty end the method's premise depends on. The 17× signal-to-floor above is one checkpoint's number, not a constant.
- Serving precision is **fixed in code, not chosen by the caller**: the pi0/pi05 family routes its embedding path through two module-level `_preferred_dtype()` hooks that return bfloat16 unconditionally, so `policy.to(torch.float32)` alone does not produce a float32 forward.
- It is a **local** statement about the action expert's posterior at one observation. It is blind to confident-but-wrong VLM-level errors (a cleanly misread instruction produces a low-curvature, confidently-wrong chunk) and to precision-sensitive failures, and it degrades on undertrained models. **It is a monitor, not a guarantee of correctness.**
- The detector is only free at *inference*; calibration needs ~50 successful rollouts per task, which at a 20-60% success rate is 80-250 episodes — several times a default `eval.n_episodes = 16` run.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [x] My PR includes policy-related changes.
  - [x] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
