### PR TITLE
test(policies): replace unconditional GPU skips with VRAM-gated ones

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,9 +15,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import gc
 import os
 
 import pytest
+import torch
 from huggingface_hub import HfApi
 
 from opentau.datasets.standard_data_format_mapping import DATA_FEATURES_NAME_MAPPING
@@ -75,6 +77,30 @@ def patch_builtins_input(monkeypatch):
             print(text)
 
     monkeypatch.setattr("builtins.input", print_text)
+
+
+@pytest.fixture(autouse=True)
+def release_cuda_memory_after_gpu_test(request):
+    """Drop a finished GPU test's CUDA memory before the next one allocates.
+
+    `pytest -m gpu -n 0` runs every GPU test in one process. PyTorch frees its
+    own cached blocks when an allocation fails, but it never runs a Python GC,
+    so the reference cycles inside a just-finished test's `nn.Module` graph keep
+    whole models resident. Peaks that should overlap add up instead. Measured:
+    the four pi06/pi07 policy files OOM on a 24 GiB budget without this sweep
+    and pass with it, though no single test in them exceeds 19.6 GiB.
+
+    The marker check keeps this off the ~2600 CPU tests, where it would be pure
+    overhead. On a failing test pytest still holds the frame for the traceback,
+    so the sweep only reliably reclaims after a pass — which is the case that
+    matters for the tests that follow.
+    """
+    yield
+    if request.node.get_closest_marker("gpu") is None:
+        return
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
 
 
 @pytest.fixture(scope="session")

--- a/tests/policies/test_pi06.py
+++ b/tests/policies/test_pi06.py
@@ -44,6 +44,17 @@ from opentau.policies.pi06.modeling_pi06 import (
     resize_with_pad,
 )
 from opentau.policies.utils import PerSampleLoss, ce_per_sample
+from tests.utils import require_vram_gib
+
+# VRAM floor for the end-to-end tests below, which build the full Gemma 3 4B
+# backbone on CUDA. Measured peak in a fresh process on an RTX 5090: 19.6 GiB
+# reserved — by far the heaviest tests in the GPU suite (everything else tops
+# out at 11.6 GiB). The floor is deliberately set above a 24 GB card rather
+# than just above the peak: these run late in `pytest -m gpu -n 0`, and whether
+# 19.6 GiB plus the suite's residue clears a 24 GB card could not be verified
+# (the only >24 GB card available was under contention from other workloads).
+# Lower it to ~21 once someone can confirm on a quiet 24 GB card.
+MIN_VRAM_GIB = 24.0
 
 # Block-causal attention mask (pi05 / π0.6 prefix-LM pattern)
 
@@ -956,7 +967,7 @@ class TestPi06GradCkptEquivalence:
 # End-to-end integration — guarded because Gemma 3 4B is huge.
 
 
-@pytest.mark.skip(reason="Requires too much memory, does not fit on RTX 3090 24GB")
+@require_vram_gib(MIN_VRAM_GIB)
 @pytest.mark.gpu
 @pytest.mark.slow
 def test_complete_pi06_pipeline_integration_smoke(lerobot_dataset_metadata):
@@ -1028,7 +1039,7 @@ def test_complete_pi06_pipeline_integration_smoke(lerobot_dataset_metadata):
     assert all(v.isfinite() for v in loss.values())
 
 
-@pytest.mark.skip(reason="Requires too much memory, does not fit on RTX 3090 24GB")
+@require_vram_gib(MIN_VRAM_GIB)
 @pytest.mark.gpu
 @pytest.mark.slow
 def test_pi06_loc_tokens_extend_vocab_and_resize_embeddings(lerobot_dataset_metadata):

--- a/tests/policies/test_pi07_high_level_planner.py
+++ b/tests/policies/test_pi07_high_level_planner.py
@@ -23,6 +23,17 @@ from opentau.policies.pi07.high_level_planner.modeling_pi07_high_level import (
     PI07HighLevelPlannerPolicy,
     make_att_2d_masks,
 )
+from tests.utils import require_vram_gib
+
+# VRAM floor for the end-to-end test below, which builds the Gemma 3 backbone
+# on CUDA and runs a full forward at 448x448. Measured peak in a fresh process
+# on an RTX 5090: 17.3 GiB reserved, against 11.6 GiB for the heaviest
+# pre-existing GPU test. The floor is deliberately set above a 24 GB card
+# rather than just above the peak: this runs late in `pytest -m gpu -n 0`, and
+# whether 17.3 GiB plus the suite's residue clears a 24 GB card could not be
+# verified (the only >24 GB card available was under contention from other
+# workloads). Lower it to ~20 once someone can confirm on a quiet 24 GB card.
+MIN_VRAM_GIB = 24.0
 
 # Config defaults used across the test.
 NUM_CAMERAS = 2
@@ -149,7 +160,7 @@ class TestPI07HighLevelPlannerIntegration:
     # Main integration test
     # ------------------------------------------------------------------
 
-    @pytest.mark.skip(reason="Requires too much memory, does not fit on RTX 3090 24GB")
+    @require_vram_gib(MIN_VRAM_GIB)
     @pytest.mark.gpu
     @pytest.mark.slow
     def test_complete_pi07_high_level_planner_pipeline(self, lerobot_dataset_metadata):

--- a/tests/policies/test_pi07_low_level.py
+++ b/tests/policies/test_pi07_low_level.py
@@ -26,6 +26,13 @@ from opentau.policies.pi07.low_level.modeling_pi07_low_level import (
     _global_or_branch_decisions,
     make_att_2d_masks,
 )
+from tests.utils import require_vram_gib, to_cuda_bf16
+
+# VRAM floor for the end-to-end tests below, which build the tiny VLM on CUDA
+# and run a full forward at 448x448 with T=2. Measured peak on an RTX 5090:
+# 0.71 GiB reserved. The floor is the card size we require, so it carries
+# generous headroom over that for the CUDA context and fragmentation.
+MIN_VRAM_GIB = 4.0
 
 # Tiny VLM config so that the full forward pass fits within 24 GB GPU memory.
 # Backbone: 2 text layers × 512 hidden, 2 KV heads × 128 head_dim (=256 total).
@@ -353,7 +360,7 @@ class TestPI07LowLevelIntegration:
     # Main integration test
     # ------------------------------------------------------------------
 
-    @pytest.mark.skip(reason="Requires too much memory, does not fit on RTX 3090 24GB")
+    @require_vram_gib(MIN_VRAM_GIB)
     @pytest.mark.gpu
     @pytest.mark.slow
     def test_complete_pi07_low_level_pipeline(self, lerobot_dataset_metadata):
@@ -386,16 +393,14 @@ class TestPI07LowLevelIntegration:
                 ],
                 dim=1,
             ),
+            # The dataloader always emits this alongside the T-dimensioned
+            # camera/state tensors; `forward` only warns when it is absent, so
+            # omitting it would leave the masking path untested.
+            "obs_history_is_pad": torch.zeros(batch_size, N_OBS_STEPS, dtype=torch.bool),
         }
 
         policy.to(dtype=torch.bfloat16, device="cuda")
-        batch_cuda = {
-            key: value.to("cuda", non_blocking=True, dtype=torch.bfloat16)
-            if isinstance(value, torch.Tensor)
-            else value
-            for key, value in batch.items()
-        }
-        batch_cuda["action_is_pad"] = batch_cuda["action_is_pad"].to(dtype=torch.bool)
+        batch_cuda = to_cuda_bf16(batch)
 
         # ── Monkey-patch to capture intermediate tensors ──────────────
         captured = {}
@@ -547,13 +552,16 @@ class TestPI07LowLevelIntegration:
         policy.model.embed_prefix = capture_embed_prefix_infer
         policy.model.embed_suffix = capture_embed_suffix_infer
 
-        # Inference batch: SpaceTimeSiglip requires T == n_obs_steps frames, so
-        # videos stay 5-D (B, T, C, H, W) and state stays 3-D (B, T, D).
+        # Inference batch: `select_action` takes ONE observation per step and
+        # builds the temporal window itself (`_build_history_batch` buffers the
+        # frames and emits `obs_history_is_pad`), so cameras are 4-D
+        # (B, C, H, W) and state is 2-D (B, D). Handing it the already-stacked
+        # training tensors makes it stack a second time, yielding 6-D videos.
         infer_batch = {
-            "camera0": batch_cuda["camera0"],  # (B, T, C, H, W)
-            "camera1": batch_cuda["camera1"],
+            "camera0": batch_cuda["camera0"][:, -1],  # current frame, (B, C, H, W)
+            "camera1": batch_cuda["camera1"][:, -1],
             "subgoal0": batch_cuda["subgoal0"],  # already (B, C, H, W)
-            "state": batch_cuda["state"],  # (B, T, D)
+            "state": batch_cuda["state"][:, -1],  # current step, (B, D)
             "prompt": ["Pick up the red block"],
             "response": ["Grasp the red block"],
             "speed": torch.tensor([50], device="cuda"),
@@ -619,7 +627,7 @@ class TestPI07LowLevelIntegration:
 
         assert action.shape == (1, MAX_ACTION_DIM)
 
-    @pytest.mark.skip(reason="Requires too much memory, does not fit on RTX 3090 24GB")
+    @require_vram_gib(MIN_VRAM_GIB)
     @pytest.mark.gpu
     @pytest.mark.slow
     def test_no_optionals_path_on_real_gemma3(self, lerobot_dataset_metadata):
@@ -670,17 +678,7 @@ class TestPI07LowLevelIntegration:
         }
 
         policy.to(dtype=torch.bfloat16, device="cuda")
-        batch_cuda = {
-            key: value.to("cuda", non_blocking=True, dtype=torch.bfloat16)
-            if isinstance(value, torch.Tensor)
-            else value
-            for key, value in batch.items()
-        }
-        batch_cuda["action_is_pad"] = batch_cuda["action_is_pad"].to(dtype=torch.bool)
-        batch_cuda["speed_is_pad"] = batch_cuda["speed_is_pad"].to(dtype=torch.bool)
-        batch_cuda["quality_is_pad"] = batch_cuda["quality_is_pad"].to(dtype=torch.bool)
-        batch_cuda["mistake_is_pad"] = batch_cuda["mistake_is_pad"].to(dtype=torch.bool)
-        batch_cuda["subgoal_is_pad"] = batch_cuda["subgoal_is_pad"].to(dtype=torch.bool)
+        batch_cuda = to_cuda_bf16(batch)
 
         captured = {}
         original_embed_prefix = policy.model.embed_prefix
@@ -767,7 +765,7 @@ class TestPI07LowLevelRegression:
             "mistake_is_pad": torch.tensor([False] * batch_size, device="cuda"),
         }
 
-    @pytest.mark.skip(reason="Requires too much memory, does not fit on RTX 3090 24GB")
+    @require_vram_gib(MIN_VRAM_GIB)
     @pytest.mark.gpu
     @pytest.mark.slow
     def test_prepare_metadata_always_returns_tensors(self, lerobot_dataset_metadata):

--- a/tests/policies/test_pi07_paligemma_low_level.py
+++ b/tests/policies/test_pi07_paligemma_low_level.py
@@ -27,6 +27,14 @@ from opentau.policies.pi07_paligemma.low_level.modeling_pi07_low_level import (
     PI07PaligemmaLowLevelPolicy,
     make_att_2d_masks,
 )
+from tests.utils import require_vram_gib, to_cuda_bf16
+
+# VRAM floor for the end-to-end test below, which builds the PaliGemma VLM on
+# CUDA and runs a full forward at 224x224 with T=8. Measured peak in a fresh
+# process on an RTX 5090: 13.9 GiB reserved. That is the new ceiling of the GPU
+# suite on a 24 GB card (the heaviest pre-existing test peaks at 11.6 GiB), so
+# enabling it raises the suite's requirement by ~2 GiB, well inside budget.
+MIN_VRAM_GIB = 18.0
 
 
 def _legacy_embed_prefix(
@@ -124,7 +132,11 @@ def _legacy_embed_prefix(
 # Config defaults used across the test.
 NUM_CAMERAS = 2
 SIGLIP_TOKENS_PER_CAMERA = 256
-NUM_SUBGOAL_CAMERAS = 1
+# `prepare_subgoal_images` always emits one slot per `image_features` entry —
+# it pads the missing `subgoal{k}` keys with masked placeholders so the prefix
+# length cannot depend on which subgoal keys a batch happens to carry. So the
+# subgoal block is always NUM_CAMERAS images wide, not one.
+NUM_SUBGOAL_CAMERAS = NUM_CAMERAS
 SIGLIP_TOKENS_PER_SUBGOAL = 256
 PROMPT_MAX_LENGTH = 256
 RESPONSE_MAX_LENGTH = 52
@@ -139,10 +151,12 @@ N_OBS_STEPS = 8
 
 VIDEO_TOKENS = NUM_CAMERAS * SIGLIP_TOKENS_PER_CAMERA  # 512
 LANG_START = VIDEO_TOKENS  # 512
-SUBGOAL_TOKENS = NUM_SUBGOAL_CAMERAS * SIGLIP_TOKENS_PER_SUBGOAL  # 256
+SUBGOAL_TOKENS = NUM_SUBGOAL_CAMERAS * SIGLIP_TOKENS_PER_SUBGOAL  # 512
 
-# For inference: no discrete actions; state is 1 timestep for embed_prefix.
-INFER_STATE_TOKENS = 1
+# For inference: no discrete actions. `select_action` -> `_build_history_batch`
+# expands the single-step observation back to the full T = n_obs_steps window,
+# so the state block is the same width as in training.
+INFER_STATE_TOKENS = N_OBS_STEPS
 
 
 class TestPI07PaligemmaLowLevelIntegration:
@@ -277,6 +291,13 @@ class TestPI07PaligemmaLowLevelIntegration:
 
             self._check_ones_before_zeros(suffix_pad_masks[i])
 
+    @classmethod
+    def _num_cross_att_tokens(cls, prefix_pad_masks, tokenizer) -> int:
+        """Training-mode ``num_cross_att_tokens``: prefix minus the trailing
+        ``"Action: "`` indicator and the discrete-action span."""
+        action_lead_len = cls._indicator_lens(tokenizer)["action_lead"]
+        return prefix_pad_masks.shape[1] - action_lead_len - DISCRETE_ACTION_MAX_LENGTH
+
     def _verify_position_ids(
         self,
         prefix_position_ids,
@@ -292,7 +313,11 @@ class TestPI07PaligemmaLowLevelIntegration:
         if inference_mode:
             prefix_offsets = torch.sum(prefix_pad_masks, dim=-1)[:, None]
         else:
-            prefix_offsets = torch.sum(prefix_pad_masks[:, :-DISCRETE_ACTION_MAX_LENGTH], dim=-1)[:, None]
+            # `embed_prefix` drops every `exclude_from_cross_attention` item
+            # from `num_cross_att_tokens`, which is the trailing "Action: "
+            # indicator *and* the discrete-action span — not the span alone.
+            num_cross = self._num_cross_att_tokens(prefix_pad_masks, tokenizer)
+            prefix_offsets = torch.sum(prefix_pad_masks[:, :num_cross], dim=-1)[:, None]
 
         expected_suffix = prefix_offsets + torch.cumsum(suffix_pad_masks, dim=1) - 1
         assert torch.equal(suffix_position_ids, expected_suffix)
@@ -313,12 +338,13 @@ class TestPI07PaligemmaLowLevelIntegration:
         prefix_pad_masks,
         suffix_pad_masks,
         suffix_att_masks,
+        tokenizer,
         inference_mode=False,
     ):
         if inference_mode:
             num_cross = prefix_pad_masks.shape[1]
         else:
-            num_cross = prefix_pad_masks.shape[1] - DISCRETE_ACTION_MAX_LENGTH
+            num_cross = self._num_cross_att_tokens(prefix_pad_masks, tokenizer)
 
         expected = make_att_2d_masks(
             suffix_pad_masks,
@@ -335,7 +361,7 @@ class TestPI07PaligemmaLowLevelIntegration:
     # Main integration test
     # ------------------------------------------------------------------
 
-    @pytest.mark.skip(reason="Requires too much memory, does not fit on RTX 3090 24GB")
+    @require_vram_gib(MIN_VRAM_GIB)
     @pytest.mark.gpu
     @pytest.mark.slow
     def test_complete_pi07_low_level_pipeline(self, lerobot_dataset_metadata):
@@ -349,7 +375,11 @@ class TestPI07PaligemmaLowLevelIntegration:
         batch = {
             "camera0": torch.randn(batch_size, N_OBS_STEPS, 3, 224, 224),
             "camera1": torch.randn(batch_size, N_OBS_STEPS, 3, 224, 224),
+            # One subgoal per camera, as the dataloader emits (see the
+            # NUM_SUBGOAL_CAMERAS note): with only `subgoal0` the second slot
+            # is a masked placeholder and the sg block is not fully attended.
             "subgoal0": torch.randn(batch_size, 3, 224, 224),
+            "subgoal1": torch.randn(batch_size, 3, 224, 224),
             "state": torch.randn(batch_size, N_OBS_STEPS, MAX_STATE_DIM),
             "actions": torch.randn(batch_size, CHUNK_SIZE, MAX_ACTION_DIM),
             "prompt": ["Pick up the red block"],
@@ -373,13 +403,7 @@ class TestPI07PaligemmaLowLevelIntegration:
         }
 
         policy.to(dtype=torch.bfloat16, device="cuda")
-        batch_cuda = {
-            key: value.to("cuda", non_blocking=True, dtype=torch.bfloat16)
-            if isinstance(value, torch.Tensor)
-            else value
-            for key, value in batch.items()
-        }
-        batch_cuda["action_is_pad"] = batch_cuda["action_is_pad"].to(dtype=torch.bool)
+        batch_cuda = to_cuda_bf16(batch)
 
         # ── Monkey-patch to capture intermediate tensors ──────────────
         captured = {}
@@ -488,6 +512,7 @@ class TestPI07PaligemmaLowLevelIntegration:
             captured["prefix_pad_masks"],
             captured["suffix_pad_masks"],
             captured["suffix_att_masks"],
+            tokenizer,
         )
 
         assert isinstance(loss, dict)
@@ -535,6 +560,7 @@ class TestPI07PaligemmaLowLevelIntegration:
             "camera0": batch_cuda["camera0"][:, 0],  # (B, C, H, W)
             "camera1": batch_cuda["camera1"][:, 0],
             "subgoal0": batch_cuda["subgoal0"],  # already (B, C, H, W)
+            "subgoal1": batch_cuda["subgoal1"],
             "state": batch_cuda["state"][:, 0],  # (B, D)
             "prompt": ["Pick up the red block"],
             "response": ["Grasp the red block"],
@@ -595,6 +621,7 @@ class TestPI07PaligemmaLowLevelIntegration:
             captured_infer["prefix_pad_masks"],
             captured_infer["suffix_pad_masks"],
             captured_infer["suffix_att_masks"],
+            tokenizer,
             inference_mode=True,
         )
 
@@ -1929,8 +1956,14 @@ class TestPI07PaligemmaLowLevelSubgoalEmbedding:
         include_tensors: bool,
         subgoal_is_pad: torch.Tensor | bool,
         fill: float = 0.42,
+        present_keys: tuple[str, ...] = ("subgoal0", "subgoal1"),
     ) -> dict:
-        """Build a batch dict for ``prepare_subgoal_images``."""
+        """Build a batch dict for ``prepare_subgoal_images``.
+
+        ``present_keys`` selects which ``subgoal{k}`` tensors the batch carries
+        (only meaningful when ``include_tensors``); pass a subset to exercise
+        the mixed present/missing path.
+        """
         device = torch.device("cpu")
         batch: dict = {"state": torch.zeros(bsz, 1, MAX_STATE_DIM, device=device)}
         pad = torch.as_tensor(subgoal_is_pad, dtype=torch.bool, device=device).reshape(-1)
@@ -1939,8 +1972,9 @@ class TestPI07PaligemmaLowLevelSubgoalEmbedding:
         batch["subgoal_is_pad"] = pad
         if include_tensors:
             img = torch.full((bsz, 3, 224, 224), fill, device=device)
-            batch["subgoal0"] = img
-            batch["subgoal1"] = img * 0.9
+            per_key = {"subgoal0": img, "subgoal1": img * 0.9}
+            for key in present_keys:
+                batch[key] = per_key[key]
         return batch
 
     @classmethod
@@ -2107,6 +2141,68 @@ class TestPI07PaligemmaLowLevelSubgoalEmbedding:
             subgoal_vid_masks=m_pad,
         )
         assert torch.equal(pm_a, pm_b)
+
+    # ------------------------------------------------------------------ #
+    # Only SOME subgoal keys present — slots padded, prefix width unchanged
+    # ------------------------------------------------------------------ #
+    def test_partial_subgoal_keys_pad_out_to_one_slot_per_camera(self):
+        """A batch carrying ``subgoal0`` but not ``subgoal1`` must still produce
+        one slot per camera, with the fabricated slot masked off.
+
+        This is the case `prepare_subgoal_images`'s padding loop exists for:
+        with ``empty_cameras=0`` that loop is the only thing keeping the prefix
+        length independent of which ``subgoal{k}`` keys a batch happens to
+        carry. The all-present and no-key cases (covered above) both stay
+        correct if the loop is deleted — they have nothing missing to pad — so
+        without this test a regression that dropped it would pass the suite.
+
+        The comparison is against the all-present batch, not the no-key one:
+        a batch with no subgoal at all also carries no response and no
+        metadata, so it takes the no-optional-content branch and its trailing
+        block legitimately differs. `test_subgoal_tensors_all_is_pad_matches_
+        missing_keys` is what pins that path.
+        """
+        bsz = 1
+        v_part, m_part = self._prepare_subgoal(
+            self._subgoal_batch(
+                bsz,
+                include_tensors=True,
+                subgoal_is_pad=False,
+                present_keys=("subgoal0",),
+            )
+        )
+        assert len(v_part) == 2, f"missing subgoal key must still occupy a slot, got {len(v_part)}"
+        assert m_part[0].all(), "the supplied subgoal must stay attended"
+        assert not m_part[1].any(), "the fabricated slot must be masked off"
+
+        rt, rm, mt, mm = self._empty_response_metadata(bsz)
+
+        def embed(videos, masks):
+            return self._call_embed_prefix_with_subgoals(
+                bsize=bsz,
+                response_tokens=rt,
+                response_masks=rm,
+                metadata_tokens=mt,
+                metadata_masks=mm,
+                subgoal_videos=videos,
+                subgoal_vid_masks=masks,
+            )
+
+        v_all, m_all = self._prepare_subgoal(
+            self._subgoal_batch(bsz, include_tensors=True, subgoal_is_pad=False)
+        )
+        pm_part, sl = embed(v_part, m_part)
+        pm_all, sl_all = embed(v_all, m_all)
+
+        assert pm_part.shape[1] == pm_all.shape[1], "partial-key prefix width differs from all-present"
+        assert (sl["sg_vid_lo"], sl["sg_vid_hi"]) == (sl_all["sg_vid_lo"], sl_all["sg_vid_hi"])
+
+        # The placeholder occupies real prefix positions but is masked out of
+        # attention, so the supplied subgoal keeps its own slot's tokens.
+        real = pm_part[:, sl["sg_vid_lo"] : sl["sg_vid_lo"] + self._N_SG_TOKENS]
+        placeholder = pm_part[:, sl["sg_vid_lo"] + self._N_SG_TOKENS : sl["sg_vid_hi"]]
+        assert real.all(), "the supplied subgoal's tokens must be attended"
+        assert not placeholder.any(), "the fabricated slot's tokens must be masked out"
 
     # ------------------------------------------------------------------ #
     # Mixed batch — per-sample subgoal_is_pad

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -77,6 +77,75 @@ def require_cuda(func):
     return wrapper
 
 
+def cuda_total_vram_gib() -> float:
+    """Report the total VRAM of the current CUDA device.
+
+    Returns:
+        Total device memory in GiB, or ``0.0`` when CUDA is unavailable.
+    """
+    if not torch.cuda.is_available():
+        return 0.0
+    return torch.cuda.get_device_properties(torch.cuda.current_device()).total_memory / 1024**3
+
+
+def require_vram_gib(min_gib: float):
+    """Build a decorator that skips a test unless the CUDA device is big enough.
+
+    Deliberately a call-time decorator rather than a `pytest.mark.skipif`
+    whose condition is evaluated at import: reading device properties
+    initializes a CUDA context, and the gating CPU run (`-n auto`) imports
+    every test module in every xdist worker. On a GPU box that would spawn one
+    context per worker for tests that are deselected anyway.
+
+    Args:
+        min_gib: Total VRAM the card must have, in GiB. This is the card size
+            required, not the test's peak allocation: the conftest
+            `release_cuda_memory_after_gpu_test` fixture keeps peaks from
+            accumulating across tests, but the floor still has to cover the
+            CUDA context and allocator fragmentation on top of that peak.
+
+    Returns:
+        A decorator that skips the wrapped test when the device is smaller.
+    """
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            available = cuda_total_vram_gib()
+            if available < min_gib:
+                pytest.skip(f"requires >= {min_gib} GiB VRAM (device has {available:.1f} GiB)")
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def to_cuda_bf16(batch: dict, device: str = "cuda") -> dict:
+    """Move a test batch to ``device``, casting tensors to bfloat16 but keeping bool masks bool.
+
+    A blanket ``.to(dtype=torch.bfloat16)`` over the whole batch silently turns
+    ``*_is_pad`` masks into floats, which real dataloaders never do — the model
+    then fails on `~mask` (bitwise-not is integer/bool only) or, worse, on paths
+    where a float mask happens to broadcast and quietly changes semantics.
+
+    Args:
+        batch: Batch dict; tensor values are moved and cast, everything else
+            (prompt strings, metadata lists) passes through untouched.
+        device: Target device for the tensor values.
+
+    Returns:
+        A new dict with float tensors cast to bfloat16 on ``device`` and bool
+        tensors moved but left bool.
+    """
+    return {
+        key: value.to(device, non_blocking=True, dtype=None if value.dtype == torch.bool else torch.bfloat16)
+        if isinstance(value, torch.Tensor)
+        else value
+        for key, value in batch.items()
+    }
+
+
 def require_env(func):
     """
     Decorator that skips the test if the required environment package is not installed.

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -122,12 +122,17 @@ def require_vram_gib(min_gib: float):
 
 
 def to_cuda_bf16(batch: dict, device: str = "cuda") -> dict:
-    """Move a test batch to ``device``, casting tensors to bfloat16 but keeping bool masks bool.
+    """Move a test batch to ``device``, casting only its float tensors to bfloat16.
 
-    A blanket ``.to(dtype=torch.bfloat16)`` over the whole batch silently turns
-    ``*_is_pad`` masks into floats, which real dataloaders never do — the model
-    then fails on `~mask` (bitwise-not is integer/bool only) or, worse, on paths
-    where a float mask happens to broadcast and quietly changes semantics.
+    A blanket ``.to(dtype=torch.bfloat16)`` over the whole batch silently
+    rewrites the dtype of everything a real dataloader emits as bool or int:
+    ``*_is_pad`` masks become floats and the model fails on `~mask` (bitwise-not
+    is integer/bool only), while integer fields get rounded — the dataloader
+    emits ``speed``/``quality`` as ``torch.long`` and ``mistake`` as
+    ``torch.bool``, so casting them changes what ``prepare_metadata``
+    stringifies. Preserving every non-floating dtype keeps the batch shaped like
+    the real thing and keeps a future token-id tensor safe from the same
+    rounding.
 
     Args:
         batch: Batch dict; tensor values are moved and cast, everything else
@@ -135,11 +140,11 @@ def to_cuda_bf16(batch: dict, device: str = "cuda") -> dict:
         device: Target device for the tensor values.
 
     Returns:
-        A new dict with float tensors cast to bfloat16 on ``device`` and bool
-        tensors moved but left bool.
+        A new dict with floating-point tensors cast to bfloat16 on ``device``
+        and every other tensor moved with its dtype intact.
     """
     return {
-        key: value.to(device, non_blocking=True, dtype=None if value.dtype == torch.bool else torch.bfloat16)
+        key: value.to(device, non_blocking=True, dtype=torch.bfloat16 if value.is_floating_point() else None)
         if isinstance(value, torch.Tensor)
         else value
         for key, value in batch.items()


### PR DESCRIPTION
## What this does

Seven pi06 / pi07 integration tests carried
`@pytest.mark.skip(reason="Requires too much memory, does not fit on RTX 3090 24GB")`.
Because the skip was unconditional they ran **nowhere** — not on CI, not on a dev
box, not on a 80 GB A100 — and two of them had quietly rotted. This makes the
skip conditional on available VRAM and repairs the rot.

**Tests-only change.** `git diff --stat -- src/` is empty; no production
behaviour changes.

### The two rotted tests

Both failed identically on a pristine `main` once the marker was stripped, so
this is decay, not a regression.

1. **`test_pi07_low_level.py::...::test_complete_pi07_low_level_pipeline`** —
   `einops.EinopsError` in `prepare_videos`, 6-D video `[1, 2, 2, 3, 448, 448]`.
   `select_action` takes **one** observation per step and builds the temporal
   window itself (`_build_history_batch` buffers frames and emits
   `obs_history_is_pad`). The test handed it the already-stacked *training*
   tensors, so they got stacked a second time. The sibling pi07_paligemma test
   already does this correctly. Fixed the fixture to pass 4-D cameras / 2-D
   state.

2. **`test_pi07_paligemma_low_level.py::...::test_complete_pi07_low_level_pipeline`** —
   `TypeError: ~ (operator.invert) is only implemented on integer and
   Boolean-type tensors` on `frame_keep = ~obs_history_is_pad`. The test cast
   the whole batch to bfloat16, turning the bool mask into a float; only
   `action_is_pad` was restored by hand.

   **This is not a latent production bug.** I traced every source of
   `obs_history_is_pad`: `datasets/lerobot_dataset.py` builds it bool, both
   `_build_history_batch` implementations build it bool, and
   `scripts/benchmark_inference.py` builds it bool. No entry point casts batch
   tensors wholesale — `policy.to(bfloat16)` never touches the batch. So no real
   caller can reach the `~` with a non-bool, and the fix belongs in the fixture.
   The hand-maintained "restore this one key to bool" list is replaced with a
   `to_cuda_bf16` helper that preserves bool dtype by construction.

Fixing (2) revealed three further stale expectations in the same test, all
fixture-side and all confirmed against deliberate production behaviour:

- `NUM_SUBGOAL_CAMERAS = 1` → `NUM_CAMERAS`. `prepare_subgoal_images`
  deliberately pads to one slot per camera so prefix length cannot depend on
  which `subgoal{k}` keys a batch carries; the test now supplies `subgoal1` too,
  matching the file's own `_subgoal_batch` helper.
- `_verify_position_ids` / `_verify_action_expert_attention_mask` subtracted only
  the discrete-action span. `num_cross_att_tokens` drops every
  `exclude_from_cross_attention` item, which is the trailing `"Action: "`
  indicator **and** the span. The pi07 sibling test already had this right.
- `INFER_STATE_TOKENS = 1` → `N_OBS_STEPS`. It predates `_build_history_batch`,
  which restores the full `T` window at inference.

### Conditional skips

All seven sites now use `require_vram_gib(...)` from `tests/utils.py`, following
that file's existing `require_cuda` decorator convention. Floors are per-file and
set from measured peaks rather than one blanket number — the pi07_low_level tests
peak at 0.71 GiB, so a single high floor would have left them nearly as dead as
before:

| file | measured peak (fresh process) | floor |
|---|---|---|
| `test_pi07_low_level.py` | 0.71 GiB | 4 GiB |
| `test_pi07_paligemma_low_level.py` | 13.9 GiB | 18 GiB |
| `test_pi07_high_level_planner.py` | 17.3 GiB | 24 GiB |
| `test_pi06.py` | 19.6 GiB | 24 GiB |

A call-time decorator rather than `pytest.mark.skipif`: the condition needs
`get_device_properties`, which initializes a CUDA context, and the gating CPU run
imports every test module in all `-n auto` workers — on a GPU host that would
spawn one context per worker for tests that get deselected anyway.

The heaviest two files are floored above a 24 GB card. Their peaks (19.6 / 17.3
GiB) would probably fit, but I could not verify that they clear a 24 GB budget
*after* the rest of the suite has run, because no uncontended >24 GB card was
available. The floors are deliberately conservative, and each comment records the
measured peak and the value to lower it to once someone can confirm on a quiet
24 GB card.

### Cross-test memory accumulation

Running the four files in one process OOM'd even though no single test exceeds
19.6 GiB. PyTorch drops its cached blocks on OOM but never runs a Python GC, so
the reference cycles in each finished test's `nn.Module` graph stay resident and
peaks sum instead of overlapping. Added a `release_cuda_memory_after_gpu_test`
autouse fixture in `tests/conftest.py` (marker-gated, so it is a no-op for the
~2600 CPU tests). With it, all 12 pass in one process. This is most likely what
the original "does not fit on 24GB" note was actually about.

Effect on the GPU suite's ceiling on a 24 GB card: the heaviest **pre-existing**
GPU test peaks at 11.6 GiB; the heaviest test this PR newly enables there peaks
at 13.9 GiB. So the suite's requirement rises by roughly 2 GiB, well inside
budget. The two files floored at 24 GiB do not run there at all, leaving CI's
memory profile for them unchanged.

### Coverage gap closed

`prepare_subgoal_images`' padding loop exists for the *mixed* present/missing
subgoal-key case, but only the all-present and no-key cases were tested — both
stay correct if the loop is deleted. Added
`test_partial_subgoal_keys_pad_out_to_one_slot_per_camera`. Verified it is a real
pin: deleting the padding loop fails this test and no other in the class.

## How it was tested

- **GPU, targeted** — `pytest -m gpu -n 0` over the four touched files on a 32 GB
  dev GPU: **12 passed**, including all seven previously-dead tests. Also
  confirmed they pass together in a single process on a ~24 GiB budget, which is
  what exposed the accumulation issue above.
- **Skip machinery** — with the device reporting 22 GiB, the three tests floored
  at 24 GiB skip with `requires >= 24.0 GiB VRAM (device has 22.0 GiB)` and the
  rest still run.
- **Per-test VRAM peaks** measured with a temporary plugin (not committed) to set
  the floors from data rather than guesswork; the pre-existing GPU suite's own
  ceiling (11.6 GiB) was measured the same way.
- **Mutation check** on the new subgoal test: with the padding loop removed it
  fails and the other 15 tests in the class pass; restored via `git checkout`.
- **CPU** — `pytest -m "not gpu and not network" -n auto`: 2593 passed. Two
  failures are pre-existing and unrelated — `test_libero2torch` fails identically
  on a pristine `main` (local LIBERO asset paths), and `test_exception_handling`
  is a timing test that passes in isolation.
- **Pre-commit** — clean over all files.

Regression tests were not run; this PR changes no policy code.

## How to checkout & try? (for the reviewer)

```bash
git fetch origin claude/confident-allen-c1fdb8 && git checkout claude/confident-allen-c1fdb8
```

On a CUDA box, the tests that used to be dead everywhere:

```bash
pytest -m gpu -n 0 tests/policies/test_pi07_low_level.py tests/policies/test_pi07_paligemma_low_level.py tests/policies/test_pi07_high_level_planner.py tests/policies/test_pi06.py
```

The new CPU-only subgoal test:

```bash
pytest -sx tests/policies/test_pi07_paligemma_low_level.py::TestPI07PaligemmaLowLevelSubgoalEmbedding
```

To see the skip reason on a card below the floor, or to confirm nothing is
silently dead any more:

```bash
pytest -m gpu -n 0 -rs tests/policies/test_pi06.py
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
