### PR TITLE
chore: bump version to v0.13.0

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,8 +30,8 @@ project = "OpenTau"
 copyright = "2026, Tensor Auto Inc"
 author = "Tensor Auto Inc"
 
-version = "0.12.0"
-release = "0.12.0"
+version = "0.13.0"
+release = "0.13.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ huggingface = "https://huggingface.co/TensorAuto"
 
 [project]
 name = "opentau"
-version = "0.12.0"
+version = "0.13.0"
 description = "OpenTau: Tensor's VLA Training Infrastructure for Real-World Robotics in Pytorch"
 authors = [
     { name = "Shuheng Liu", email = "wish1104@icloud.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -2166,7 +2166,7 @@ wheels = [
 
 [[package]]
 name = "opentau"
-version = "0.12.0"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate" },


### PR DESCRIPTION
## What this does

Bumps the package version `0.12.0` → `0.13.0` for the v0.13.0 release. (📝 Documentation / chore)

Updates the version string in the three places every prior bump (#486, #472, #463) touched:

- `pyproject.toml` (`[project].version`)
- `docs/source/conf.py` (`version` and `release`)
- `uv.lock` (the `opentau` editable package entry)

No behavioral, policy, or dependency changes — only the version identifier. The diff is byte-for-byte the same shape as the prior bump: 3 files, 4 insertions, 4 deletions.

### What v0.13.0 ships

20 commits since `v0.12.0` (2026-07-24). The release notes will enumerate them; the ones a reader upgrading should know about:

**Features**
- `accel`, a cost-free flow-matching uncertainty proxy read off the existing Euler loop — opt-in, no `config_version` bump (#512)
- `repo_id@revision` checkpoint specs (`--policy.path=<repo>@6000`) plus a batch of `from_pretrained` loader fixes (#492)
- `train_state_action_representation_only` finetuning mode across nine policy types (#497)
- `delta_stats_max_rows`, a row cap for on-the-fly delta-action stats (#491)
- Injectable gRPC request hooks for inference tracking (#480)

**Fixes worth reading before upgrading**
- The train/val split is now identical on every rank (#498). It previously diverged per rank, so reported `Validation/*` metrics were measured on frames other ranks had trained on.
- The training sampler is seeded from `cfg.seed` (#503). **For any run with `cfg.seed` set, the training data order changes** — a different draw from the same distribution, but two runs across this commit are not step-for-step comparable.
- `action_chunk` is re-checked against the policy's execution horizon after propagation (#511). **A config with `n_action_steps > action_chunk` now fails at config time**; set `n_action_steps` to `action_chunk` to keep such a run's existing behavior.
- `max_action_dim` actually reaches the policy config (#510) — the assignment had been misspelled since the initial commit.
- Partial quantile coverage across an aggregated norm head warns instead of raising (#505).
- The RoboCasa server's policy cast no longer re-rounds the pinned float32 SigLIP embeddings (#507), and the sweep is now machine-checked.
- The delta-action horizon is read under the raw action column (#496), unbreaking every `use_delta_joint_actions` run.

`CHANGELOG.md` is left as-is, matching every prior release: its `[Unreleased]` section has never been stamped with a version, and its contents currently span both v0.12.0 and v0.13.0 work, so stamping the block wholesale would misattribute the v0.12.0 normalization entries. Untangling it is an editorial change that belongs in its own PR rather than riding along with a version bump.

## How it was tested

- `uv lock --check` → `Resolved 275 packages`, lockfile consistent with `pyproject.toml` (no re-resolution needed).
- `pre-commit run --files pyproject.toml docs/source/conf.py uv.lock` → all hooks passed (check toml, ruff, ruff-format, pyupgrade, typos, license header, secrets, bandit).
- Version resolves after sync: `python -c "import importlib.metadata as m; print(m.version('opentau'))"` → `0.13.0`.
- No source files changed, so no CPU/GPU test run applies to this diff.

## How to checkout & try? (for the reviewer)

```bash
git fetch origin claude/release-v0-13-0-54e717 && git checkout claude/release-v0-13-0-54e717
```

```bash
uv lock --check
```

```bash
uv sync --extra dev && uv run python -c "import opentau; print(opentau.__version__)"
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
