### PR TITLE
docs(changelog): split [Unreleased] into 0.13.0 and 0.12.0 sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,68 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+_Nothing yet._
+
+## [0.13.0] - 2026-08-17
+
+### Added
+
+* **`repo_id@revision` checkpoint specs.** `--policy.path`, `--config_path` and
+  `policy.pretrained_path` accept a revision suffix, so a published checkpoint can
+  be pinned to one training step:
+
+  ```bash
+  --policy.path=TensorAuto/<runid>-<runname>@6000   # the "6000" tag
+  --policy.path=TensorAuto/<runid>-<runname>        # main = the latest step
+  ```
+
+  Published checkpoints are now one repo per run with each saved step as a git
+  tag, rather than one repo per step. Bare repo ids are unaffected (no `@`, no
+  split, `main` as before), so previously published `<run>-<step>` repos keep
+  working. **A local path is never split**, even one containing `@` — an existing
+  path short-circuits, and a path-shaped string (leading `/`, `.`, `~`, a
+  backslash, or more than one `/`) is left alone so it still fails as a path
+  rather than as a bogus repo id. Parsed by `split_repo_revision` in
+  `opentau/utils/hub.py`; passing both an `@` suffix and a conflicting
+  `revision=` raises rather than silently picking one.
+* **`--policy.path=<repo>` works against a published checkpoint.** Uploaded repos
+  carried only `hf_config.json`, so `--policy.path=<repo>` failed on the missing
+  `config.json` and `--config_path=<repo>` on the missing `train_config.json`; you
+  had to fetch `hf_config.json` by hand. `PreTrainedConfig.from_pretrained` and
+  `TrainPipelineConfig.from_pretrained` now fall back to `hf_config.json` (reading
+  its `.policy` sub-object for the former), so the file is always found.
+
+  **Scope:** finding the file is not the same as decoding it. `--policy.path` reads
+  only the `.policy` sub-object and works on checkpoints going back as far as we
+  have tested. `--config_path` decodes the *whole* pipeline config, so it still
+  fails on a checkpoint whose train config predates an unrelated schema change —
+  verified against a real 2-step consolidated repo, where
+  `dataset_mixture.datasets[].grounding` (renamed to `vqa` in #124) raises a
+  `DecodingError`. That is deliberate: `grounding` was renamed, not deleted, so
+  stripping it would silently load the config with `vqa` at its default and lose a
+  setting the run was actually trained with. Failing loudly is the correct
+  behavior; use `--policy.path` for old checkpoints, or hand-edit the fetched
+  config.
+* **`policy.train_state_action_representation_only`** — an opt-in finetuning mode
+  for adapting a generic VLA checkpoint to a new dataset by training only the
+  parameters that are actually dataset-specific: the discrete-action
+  representation (`discrete_action_embedding` and `da_head`) and the state/action
+  projections (`state_proj`, `action_in_proj`, `action_out_proj`), which are the
+  only outer projections whose shape is a function of the robot rather than of the
+  architecture. Everything else freezes — the VLM backbone and its tied `lm_head`,
+  the vision/video encoder *and* the multimodal projector, the action expert, the
+  time MLPs, and the optional modality embeddings. Declared on the nine policy
+  types that have such a representation; the two high-level planners and `value`
+  deliberately do not carry the field, since it would train nothing there.
+  `config.dropout` is a no-op under the flag, because the frozen trunk is pinned to
+  `eval()`. Default `False`.
+* **Injectable request hooks on the gRPC inference server.** An embedding
+  application can observe accepted inference requests without coupling OpenTau to
+  platform-specific activity tracking. The default hook is a no-op, every
+  `GetActionChunk` request invokes it (including messages processed through
+  `StreamActionChunks`), and hook failures are isolated so they can never fail an
+  inference RPC.
+
 ### Added — `accel`, a cost-free flow-matching uncertainty proxy — **opt-in, no config_version bump**
 
 Denoising acceleration (`accel`, [arXiv:2607.27933](https://arxiv.org/abs/2607.27933))
@@ -59,118 +121,47 @@ expert's posterior at one observation, blind to confident-but-wrong VLM-level er
 to precision-sensitive failures, and it degrades on undertrained models. It is a monitor,
 not a guarantee of correctness.
 
+### Added — row cap for on-the-fly delta-action stats — *opt-in, no default change*
 
-### Changed — openpi-faithful normalization (zero-range dims + epsilon) — **breaking, gated**
+`DatasetMixtureConfig.delta_stats_max_rows: int | None` (default `None`) caps how
+many anchor frames each `use_delta_joint_actions` dataset contributes to the
+delta-action normalization stats computed on the fly at dataset load
+(`opentau/datasets/delta_action_stats.py`). That pass is `O(frames x chunk_size)`
+— an `H`-fold blow-up over a per-frame stats pass — so on a very large source the
+first run (before the disk cache is warm) can cost hours.
 
-`config_version` **0 → 1.** Two openpi-parity normalization changes are bundled
-into this one version (no checkpoint has been saved at `config_version` 1 yet, so
-they are all-or-nothing rather than split across versions).
+Set a positive int to bound it. Rows are subsampled with a **uniform stride over
+the whole dataset**, never a prefix, and the stride's phase carries across episode
+boundaries so episodes aren't all anchored at frame 0; a dataset's cap is split
+across its parquet files in proportion to the rows each actually contributes
+(counting only what an `episodes` / `excluded_episodes` filter selects), so a
+capped dataset pools in the same file ratio an uncapped one would. Cross-dataset
+pooling into a shared normalization head is unaffected either way — that path
+weights members by `info["total_frames"]`, not by the sampled `count`, so capping
+changes a dataset's estimator *precision*, never its share of the head. The cap
+applies **per dataset**, so
+one value bounds the worst case across a heterogeneous mixture while leaving
+datasets smaller than the cap byte-identical to before.
 
-**(1) Zero-range dims map to `0.0`.** Under MIN_MAX and QUANTILE normalization, a
-zero-range band (`max == min`: a zero-padded action/state tail dim, or a
-genuinely-constant real dim) now maps to **`0.0`** instead of the legacy
-**`-1.0`**. This matches the output of the reference implementation
-[openpi](https://github.com/Physical-Intelligence/openpi), which normalizes only
-the real dims (its `Normalize` slices `stats.q01[..., : x.shape[-1]]`) and
-zero-pads *after* normalization — so its padded columns are a `0.0` pad constant.
-OpenTau keeps padding in the dataset and reproduces that output arithmetically: a
-`0.5 * (denom - (max - min))` numerator offset that is a float-exact no-op on
-healthy dims and cancels the `* 2 - 1` re-centering exactly where the zero-range
-guard fires. Healthy dims are bit-identical to before; `Unnormalize` round-trips
-exactly; MEAN_STD is unchanged (it already emitted `0.0` on a zero-std dim).
+The cap is folded into the stats cache key, so changing it recomputes instead of
+serving numbers from a different sampling budget. It is folded in **only when
+set**, so uncapped configs keep the digest — and therefore the already-computed
+cache files — they had before this change.
 
-**(2) Normalization epsilon is openpi's `1e-6`.** The epsilon added to every
-normalization denominator (and used as the zero-range / zero-variance snap
-threshold) changes from `1e-8` to openpi's `1e-6`
-(`openpi.transforms.Normalize`). At `config_version` 1 a policy trained here and
-one trained in openpi agree to well under float32 resolution on the same inputs.
-Threaded per-policy via `config.normalization_epsilon()` → `Normalize(eps=...)`,
-gated exactly like (1): legacy checkpoints (`config_version` 0) keep `1e-8`, so
-their weights normalize as trained.
+Cost and fidelity, measured on a 100k-frame / 50-step-horizon source: the capped
+run drops the accumulation from `O(frames x chunk_size)` to `O(cap x chunk_size)`
+(2.10s → 0.23s of compute at a 20x subsample; 7.36s → 0.44s at a 200-step
+horizon), leaving only the parquet column read, which the cap does not shrink.
+`mean`/`std` and `q01`/`q99` stay within 0.02 / 0.05 standard deviations of the
+uncapped values at that subsample; `min`/`max` degrade first (~0.9 sd), since a
+subsample doesn't see the extremes — so MIN_MAX normalization is the mode most
+sensitive to a tight cap, and MEAN_STD / QUANTILE the least.
 
-Where OpenTau still, deliberately, differs from openpi: on a genuinely-constant
-*real* dim whose value deviates from the constant, openpi divides by `~1e-6` and
-emits `~1e6` (the "Outlier normalized state" blow-up); OpenTau's zero-range guard
-keeps it bounded and invertible at `2 * deviation`. We are openpi-faithful where
-openpi is correct and deliberately divergent only where it is numerically broken.
-
-**Why this is gated.** Every checkpoint trained before this change learned a
-constant `-1.0` across its padded dims (e.g. 24 of 32 dims for an openpi DROID
-norm-stats file padded to 32). Flipping the behavior unconditionally would
-invalidate those weights. The `config_version` field on the policy config gates
-it, and resolves automatically — **users do not set it manually**:
-
-* **Fresh training run** (`config_version` absent from your JSON): resolves to the
-  current version (1) → new `0.0` behavior.
-* **Loading pre-fix weights** whose config carries no tag: resolves to `0`
-  (legacy `-1.0`), so existing checkpoints, and serving / ONNX export of them,
-  keep their trained behavior. Resolution happens in
-  `PreTrainedPolicy.from_pretrained` — the single chokepoint every weight load
-  (factory fine-tune, resume, gRPC serve, export) crosses — keyed off the
-  weights, not the config file ("disk is truth").
-* **Fine-tuning from a pre-fix checkpoint stays on `config_version` 0**, including
-  the *new* checkpoints the fine-tune writes — the version tracks the
-  normalization convention the weights were trained under, not the code that
-  produced them. This is intentional: silently changing normalization under a
-  pretrained backbone would corrupt it. To deliberately migrate a fine-tune to
-  the new convention, pass `--policy.config_version=1`.
-* **Resume across this code change**: a run started before the change and resumed
-  after keeps `config_version` 0 mid-training (no discontinuity).
-
-Every saved checkpoint self-describes: `config.json` / `train_config.json` now
-carry a concrete `config_version` (and an informational `opentau_version`).
-
-### Added
-
-* **`repo_id@revision` checkpoint specs.** `--policy.path`, `--config_path` and
-  `policy.pretrained_path` accept a revision suffix, so a published checkpoint can
-  be pinned to one training step:
-
-  ```bash
-  --policy.path=TensorAuto/<runid>-<runname>@6000   # the "6000" tag
-  --policy.path=TensorAuto/<runid>-<runname>        # main = the latest step
-  ```
-
-  Published checkpoints are now one repo per run with each saved step as a git
-  tag, rather than one repo per step. Bare repo ids are unaffected (no `@`, no
-  split, `main` as before), so previously published `<run>-<step>` repos keep
-  working. **A local path is never split**, even one containing `@` — an existing
-  path short-circuits, and a path-shaped string (leading `/`, `.`, `~`, a
-  backslash, or more than one `/`) is left alone so it still fails as a path
-  rather than as a bogus repo id. Parsed by `split_repo_revision` in
-  `opentau/utils/hub.py`; passing both an `@` suffix and a conflicting
-  `revision=` raises rather than silently picking one.
-* **`--policy.path=<repo>` works against a published checkpoint.** Uploaded repos
-  carried only `hf_config.json`, so `--policy.path=<repo>` failed on the missing
-  `config.json` and `--config_path=<repo>` on the missing `train_config.json`; you
-  had to fetch `hf_config.json` by hand. `PreTrainedConfig.from_pretrained` and
-  `TrainPipelineConfig.from_pretrained` now fall back to `hf_config.json` (reading
-  its `.policy` sub-object for the former), so the file is always found.
-
-  **Scope:** finding the file is not the same as decoding it. `--policy.path` reads
-  only the `.policy` sub-object and works on checkpoints going back as far as we
-  have tested. `--config_path` decodes the *whole* pipeline config, so it still
-  fails on a checkpoint whose train config predates an unrelated schema change —
-  verified against a real 2-step consolidated repo, where
-  `dataset_mixture.datasets[].grounding` (renamed to `vqa` in #124) raises a
-  `DecodingError`. That is deliberate: `grounding` was renamed, not deleted, so
-  stripping it would silently load the config with `vqa` at its default and lose a
-  setting the run was actually trained with. Failing loudly is the correct
-  behavior; use `--policy.path` for old checkpoints, or hand-edit the fetched
-  config.
-* `config_version: int | None` and `opentau_version: str | None` on
-  `PreTrainedConfig`. `config_version` is a monotonic schema version for
-  behavioral conventions; `opentau_version` is an informational package-version
-  stamp, never read by any branch.
-* `fit_fast_tokenizer.py --config-version` (default: current). The FAST
-  discrete-action tokenizer bakes the normalization convention into its BPE
-  corpus, so it is versioned alongside the policy: the fit writes an
-  `opentau_action_norm.json` sidecar, and every policy that loads a
-  discrete-action tokenizer raises at construction if the tokenizer's convention
-  disagrees with its `config_version`. Upstream / pre-versioning tokenizers
-  (e.g. `physical-intelligence/fast`) carry no sidecar and are a no-op.
+Default `None` reads every row, exactly as before; nothing changes unless you set
+the field.
 
 ### Fixed
+
 
 * **The `config_version` normalization gate now actually runs for every policy.**
   It is documented above as the convention a checkpoint's weights were trained
@@ -246,6 +237,93 @@ carry a concrete `config_version` (and an informational `opentau_version`).
   `action_chunk` (what such a run was effectively doing) to keep its behavior.
   As a side effect of sharing the check, pi0 gains the `safety_buffer <=
   chunk_size` bound its `max_delay` siblings already enforced.
+* **The train/val split is identical on every rank.** `make_dataset` drew its
+  `random_split` from the global RNG, which `set_seed(seed, accelerator=...)`
+  deliberately offsets per process (`seed += process_index * 12345`) so that
+  per-sample draws are decorrelated across ranks. Every rank therefore partitioned
+  the data differently, and because each builds its own `Subset` views, each rank's
+  validation frames landed in some other rank's training set. Simulating 8 ranks
+  over a 353,222-frame dataset at a 2% val ratio, the intersection of the per-rank
+  validation sets is **empty** — 100% of the frames behind the reported
+  `Validation/*` metrics were in at least one rank's training set. Validation loss
+  was optimistically biased, `running_best` checkpoint selection was driven by that
+  contaminated metric, and val numbers were not comparable across runs with
+  different world sizes. The split now uses a dedicated, rank-independent
+  `torch.Generator` seeded from `cfg.seed` alone (with a fixed
+  `DEFAULT_VAL_SPLIT_SEED` for `cfg.seed = None`, which `train.py` otherwise leaves
+  on each process's own entropy — the same bug by another route). It is now a pure
+  function of `cfg.seed`, `len(dataset)` and the effective `val_split_ratio`,
+  independent of `process_index`, world size, mixture composition, and how much
+  global RNG ran beforehand. `warn_if_resumed_split_differs` warns when a resume
+  changes any of those inputs. The per-rank offset in `set_seed` is load-bearing
+  elsewhere and was left alone.
+* **The training sampler is seeded from `cfg.seed`.**
+  `WeightedDatasetMixture.get_dataloader` constructed `HierarchicalSampler` with
+  neither `seed` nor `generator`, so it fell back to a bare `torch.Generator()`.
+  That fallback is *not* unseeded — PyTorch default-constructs generators with a
+  fixed constant — so the stream was deterministic and identical on every rank,
+  and unlike the split above there was no cross-rank divergence and no leak. Two
+  things were wrong anyway: `cfg.seed` never reached the sampler, so a seed sweep
+  varied only model initialization and augmentation draws while feeding all its
+  runs identical data in identical order; and the data order rested on an
+  undocumented PyTorch implementation detail. The seed is now passed through as the
+  raw config value, so it stays rank-independent — which matters because
+  `accelerate.prepare` shards with `dispatch_batches=False`, where every rank
+  iterates the whole sampler stream and keeps the batches at its own offset. See
+  Migration notes: **this changes the data order of any run with `cfg.seed` set.**
+* **`max_action_dim` reaches the policy config.** `TrainPipelineConfig` assigned it
+  to `self.policy.max_action_state` — a field no `PreTrainedConfig` subclass
+  declares. Policy configs are plain unslotted dataclasses, so the assignment
+  silently created an attribute nothing reads and the width never propagated, while
+  its two siblings (`max_state_dim`, `chunk_size`) did. Loading a 6-DoF checkpoint
+  under a pipeline with the default `max_action_dim = 32` therefore forced the state
+  side to 32 while the action side stayed at 6, with no error. The typo dates to the
+  initial commit and was never spelled correctly. Both call sites now delegate to
+  one guarded `_propagate_shape_fields_to_policy`, driven by a single
+  `PIPELINE_TO_POLICY_SHAPE_FIELDS` mapping, which skips a field the policy
+  dataclass does not declare rather than inventing it — three registry policies
+  declare no `max_action_dim`, and the `chunk_size` line had been inventing one on
+  both high-level planners — and logs at WARNING when an override actually changes
+  a value. Every config under `configs/` already set both sides to the same value,
+  so no shipped config changes behavior.
+* **Partial quantile coverage across an aggregated norm head no longer raises.**
+  `aggregate_feature_stats` raised when the contributors sharing one normalization
+  head disagreed about carrying `q01`/`q99`, so the first mixture pairing a
+  quantile-migrated dataset with an unmigrated one died at startup — before the
+  checkpoint was even loaded, and regardless of whether the job used QUANTILE
+  normalization at all. The failure was symmetric in which dataset was the migrated
+  one. Partial coverage now behaves like the "nobody has it" case — the quantile is
+  simply absent from the aggregate — plus a warning naming how many contributors
+  were missing it and which. **The no-backfill principle is unchanged:** a quantile
+  is still never synthesized from a min/max. Two related fixes ride along:
+  `q10`/`q50`/`q90` are aggregated too (the loop covered only `q01`/`q99`, so the
+  inner quantiles that fleet stats now carry were silently dropped from every
+  aggregated head), and `aggregate_stats` keeps `weights` and `contributor_names`
+  aligned with its per-feature contributor filter — an unfiltered `weights` was
+  broadcast against a shorter stats stack, inflating `count` and skewing every
+  weighted stat against that denominator. Stats-resolution errors now name the
+  offending row rather than a bare index.
+* **The delta-action horizon is read under the raw action column.**
+  `_compute_or_load_delta_stats` read it as `dt_mean["actions"]`, but
+  `delta_timestamps_params` is keyed by **raw on-disk column names** — a standard
+  LeRobot repo names the column `action` — so **every** `use_delta_joint_actions`
+  run died at dataset build with `KeyError: 'actions'`. 13 of the 20 mappings in
+  `standard_data_format_mapping.py` use `"actions": "action"` and were affected;
+  the other 7 worked. It failed loudly and immediately, so the cost was a wasted
+  allocation rather than silent corruption. Introduced by the delta-joint-actions
+  feature in 0.12.0 and fixed here.
+* **The RoboCasa policy server preserves the float32 SigLIP embeddings.** It
+  blanket-cast the loaded policy to bfloat16, re-rounding the patch-embedding conv
+  and position-embedding table that `to_bfloat16_like_physical_intelligence` pins to
+  float32 for openpi parity. Nothing crashed; the precision was simply gone, and a
+  later `.to(float32)` cannot recover it — so a pi0/pi05-family checkpoint served
+  through this path did not have a bit-identical vision tower to the same checkpoint
+  under `eval.py` or the gRPC server, making success rates measured through the two
+  paths not strictly comparable. The cast now routes through
+  `to_dtype_preserving_siglip_float32`, as the other entry points already did. The
+  file predated that helper rather than being skipped by it. An AST guard now fails
+  when any script in `scripts/` grows an unlisted `policy.to(dtype=...)`, so the
+  next miss-by-omission is loud rather than silent.
 
 ### Migration notes
 
@@ -257,6 +335,105 @@ carry a concrete `config_version` (and an informational `opentau_version`).
   (pi0, value, cosmos3) already did. Expect small output differences on such a
   checkpoint; they are the *correction*. To deliberately keep the previous
   behavior, set `--policy.config_version=1` explicitly, which is honored untouched.
+* **Training data order changes for any run with `cfg.seed` set.** The sampler now
+  draws from `cfg.seed` instead of PyTorch's default-constructed generator.
+  Sampling is i.i.d. with replacement from the same weighted distribution, so this
+  is a different draw from the same distribution rather than a distributional
+  change — but two runs of the same config across this release are **not**
+  step-for-step comparable, and a run resumed across it does not continue its
+  previous stream. `cfg.seed = None` is bit-unchanged. Separately, and unchanged by
+  this release: the sampler's position is never checkpointed, so a resumed run
+  restarts its stream from the beginning rather than continuing it.
+* **Validation metrics change, and the new numbers are the correction.** With the
+  split now identical on every rank, `Validation/*` is measured on genuinely
+  held-out frames for the first time — previously every reported validation frame
+  was in some rank's training set. Expect validation loss to read **worse** than it
+  did on the same data before this release, and `running_best` checkpoint selection
+  to pick differently. Validation numbers are now also comparable across runs with
+  different world sizes, and across a resume that changes world size.
+* **A config with `n_action_steps > action_chunk` now fails at config time.** The
+  model always decoded only `chunk_size` actions, so set `n_action_steps` to
+  `action_chunk` — what such a run was effectively doing — to keep its behavior.
+  See Fixed.
+
+## [0.12.0] - 2026-07-24
+
+### Changed — openpi-faithful normalization (zero-range dims + epsilon) — **breaking, gated**
+
+`config_version` **0 → 1.** Two openpi-parity normalization changes are bundled
+into this one version (no checkpoint has been saved at `config_version` 1 yet, so
+they are all-or-nothing rather than split across versions).
+
+**(1) Zero-range dims map to `0.0`.** Under MIN_MAX and QUANTILE normalization, a
+zero-range band (`max == min`: a zero-padded action/state tail dim, or a
+genuinely-constant real dim) now maps to **`0.0`** instead of the legacy
+**`-1.0`**. This matches the output of the reference implementation
+[openpi](https://github.com/Physical-Intelligence/openpi), which normalizes only
+the real dims (its `Normalize` slices `stats.q01[..., : x.shape[-1]]`) and
+zero-pads *after* normalization — so its padded columns are a `0.0` pad constant.
+OpenTau keeps padding in the dataset and reproduces that output arithmetically: a
+`0.5 * (denom - (max - min))` numerator offset that is a float-exact no-op on
+healthy dims and cancels the `* 2 - 1` re-centering exactly where the zero-range
+guard fires. Healthy dims are bit-identical to before; `Unnormalize` round-trips
+exactly; MEAN_STD is unchanged (it already emitted `0.0` on a zero-std dim).
+
+**(2) Normalization epsilon is openpi's `1e-6`.** The epsilon added to every
+normalization denominator (and used as the zero-range / zero-variance snap
+threshold) changes from `1e-8` to openpi's `1e-6`
+(`openpi.transforms.Normalize`). At `config_version` 1 a policy trained here and
+one trained in openpi agree to well under float32 resolution on the same inputs.
+Threaded per-policy via `config.normalization_epsilon()` → `Normalize(eps=...)`,
+gated exactly like (1): legacy checkpoints (`config_version` 0) keep `1e-8`, so
+their weights normalize as trained.
+
+Where OpenTau still, deliberately, differs from openpi: on a genuinely-constant
+*real* dim whose value deviates from the constant, openpi divides by `~1e-6` and
+emits `~1e6` (the "Outlier normalized state" blow-up); OpenTau's zero-range guard
+keeps it bounded and invertible at `2 * deviation`. We are openpi-faithful where
+openpi is correct and deliberately divergent only where it is numerically broken.
+
+**Why this is gated.** Every checkpoint trained before this change learned a
+constant `-1.0` across its padded dims (e.g. 24 of 32 dims for an openpi DROID
+norm-stats file padded to 32). Flipping the behavior unconditionally would
+invalidate those weights. The `config_version` field on the policy config gates
+it, and resolves automatically — **users do not set it manually**:
+
+* **Fresh training run** (`config_version` absent from your JSON): resolves to the
+  current version (1) → new `0.0` behavior.
+* **Loading pre-fix weights** whose config carries no tag: resolves to `0`
+  (legacy `-1.0`), so existing checkpoints, and serving / ONNX export of them,
+  keep their trained behavior. Resolution happens in
+  `PreTrainedPolicy.from_pretrained` — the single chokepoint every weight load
+  (factory fine-tune, resume, gRPC serve, export) crosses — keyed off the
+  weights, not the config file ("disk is truth").
+* **Fine-tuning from a pre-fix checkpoint stays on `config_version` 0**, including
+  the *new* checkpoints the fine-tune writes — the version tracks the
+  normalization convention the weights were trained under, not the code that
+  produced them. This is intentional: silently changing normalization under a
+  pretrained backbone would corrupt it. To deliberately migrate a fine-tune to
+  the new convention, pass `--policy.config_version=1`.
+* **Resume across this code change**: a run started before the change and resumed
+  after keeps `config_version` 0 mid-training (no discontinuity).
+
+Every saved checkpoint self-describes: `config.json` / `train_config.json` now
+carry a concrete `config_version` (and an informational `opentau_version`).
+
+### Added
+
+* `config_version: int | None` and `opentau_version: str | None` on
+  `PreTrainedConfig`. `config_version` is a monotonic schema version for
+  behavioral conventions; `opentau_version` is an informational package-version
+  stamp, never read by any branch.
+* `fit_fast_tokenizer.py --config-version` (default: current). The FAST
+  discrete-action tokenizer bakes the normalization convention into its BPE
+  corpus, so it is versioned alongside the policy: the fit writes an
+  `opentau_action_norm.json` sidecar, and every policy that loads a
+  discrete-action tokenizer raises at construction if the tokenizer's convention
+  disagrees with its `config_version`. Upstream / pre-versioning tokenizers
+  (e.g. `physical-intelligence/fast`) carry no sidecar and are a no-op.
+
+### Migration notes
+
 * **Discrete-action (FAST) runs at `config_version` 1 need a tokenizer re-fit.**
   A `config_version` 1 policy pointed at a tokenizer fit under the old convention
   raises a clear error. Re-fit with `fit_fast_tokenizer.py --config-version 1`,
@@ -274,41 +451,6 @@ carry a concrete `config_version` (and an informational `opentau_version`).
   hand-built dict must re-emit it from the loaded config, or the tag is absent and
   the checkpoint is read as legacy.
 
-### Added — row cap for on-the-fly delta-action stats — *opt-in, no default change*
-
-`DatasetMixtureConfig.delta_stats_max_rows: int | None` (default `None`) caps how
-many anchor frames each `use_delta_joint_actions` dataset contributes to the
-delta-action normalization stats computed on the fly at dataset load
-(`opentau/datasets/delta_action_stats.py`). That pass is `O(frames x chunk_size)`
-— an `H`-fold blow-up over a per-frame stats pass — so on a very large source the
-first run (before the disk cache is warm) can cost hours.
-
-Set a positive int to bound it. Rows are subsampled with a **uniform stride over
-the whole dataset**, never a prefix, and the stride's phase carries across episode
-boundaries so episodes aren't all anchored at frame 0; a dataset's cap is split
-across its parquet files in proportion to the rows each actually contributes
-(counting only what an `episodes` / `excluded_episodes` filter selects), so a
-capped dataset pools in the same file ratio an uncapped one would. Cross-dataset
-pooling into a shared normalization head is unaffected either way — that path
-weights members by `info["total_frames"]`, not by the sampled `count`, so capping
-changes a dataset's estimator *precision*, never its share of the head. The cap
-applies **per dataset**, so
-one value bounds the worst case across a heterogeneous mixture while leaving
-datasets smaller than the cap byte-identical to before.
-
-The cap is folded into the stats cache key, so changing it recomputes instead of
-serving numbers from a different sampling budget. It is folded in **only when
-set**, so uncapped configs keep the digest — and therefore the already-computed
-cache files — they had before this change.
-
-Cost and fidelity, measured on a 100k-frame / 50-step-horizon source: the capped
-run drops the accumulation from `O(frames x chunk_size)` to `O(cap x chunk_size)`
-(2.10s → 0.23s of compute at a 20x subsample; 7.36s → 0.44s at a 200-step
-horizon), leaving only the parquet column read, which the cap does not shrink.
-`mean`/`std` and `q01`/`q99` stay within 0.02 / 0.05 standard deviations of the
-uncapped values at that subsample; `min`/`max` degrade first (~0.9 sd), since a
-subsample doesn't see the extremes — so MIN_MAX normalization is the mode most
-sensitive to a tight cap, and MEAN_STD / QUANTILE the least.
-
-Default `None` reads every row, exactly as before; nothing changes unless you set
-the field.
+[Unreleased]: https://github.com/TensorAuto/OpenTau/compare/v0.13.0...HEAD
+[0.13.0]: https://github.com/TensorAuto/OpenTau/compare/v0.12.0...v0.13.0
+[0.12.0]: https://github.com/TensorAuto/OpenTau/compare/v0.11.0...v0.12.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,7 +162,6 @@ the field.
 
 ### Fixed
 
-
 * **The `config_version` normalization gate now actually runs for every policy.**
   It is documented above as the convention a checkpoint's weights were trained
   under, resolved at load time by `PreTrainedPolicy.from_pretrained` — described


### PR DESCRIPTION
## What this does

Splits `CHANGELOG.md`'s single `[Unreleased]` block into proper `[0.13.0]` and `[0.12.0]` sections, and fills in the 0.13.0 changes that never got an entry. (📝 Documentation)

### The problem

`[Unreleased]` has never been stamped with a version since the file was created in #481. By the time v0.13.0 was cut it held **both releases' work at once**, so stamping the block wholesale would have misattributed the openpi normalization change to 0.13.0 when it actually shipped in 0.12.0. Verified by `git blame` — every line traces to exactly one PR, and every PR to exactly one release:

| Origin | Release | Content |
|---|---|---|
| #481, #485 | **0.12.0** | openpi-faithful normalization (`config_version` 0 → 1), the `config_version`/`opentau_version` fields, `fit_fast_tokenizer --config-version`, three migration notes |
| #491, #492, #494, #511, #512 | **0.13.0** | `accel`, `repo_id@revision` specs, the loader fixes, the delta-stats row cap, the `action_chunk` re-check, one migration note |

Note #492 inserted its `### Added` bullets at the *top* of the section #481 had created, so the two releases' entries were interleaved within a single list — which is why this needed blame rather than a scissor cut.

### What changed

**Existing prose is moved, not rewritten.** Every paragraph was extracted by exact line range and re-filed under the release that shipped it. Verified mechanically: every non-blank line of the committed file is still present afterwards (see below). Git renders the normalization block as delete+add because it *relocated* into the 0.12.0 section, not because it was edited.

**Structural changes:**
- `[Unreleased]` is now empty (`_Nothing yet._`), ready for the next cycle.
- The row-cap section moved from after "Migration notes" into the Added group, where it belongs.
- Added Keep-a-Changelog compare links at the bottom, so the bracketed `[0.13.0]` headings actually resolve.

**New entries for 0.13.0 changes that were never recorded.** The file's own preamble promises "all notable, behavior-affecting changes", and a 0.13.0 section that silently omitted these would repeat the same defect in a different form — most importantly the first two, which change results for existing runs:

- `#503` — sampler seeded from `cfg.seed`. **Changes training data order for any run with `cfg.seed` set.**
- `#498` — train/val split identical on every rank. **Changes validation metrics**, which were previously measured on frames other ranks had trained on.
- `#510` — `max_action_dim` propagation (`max_action_state` typo)
- `#505` — partial quantile coverage warns instead of raising
- `#496` — delta-action horizon read under the raw action column
- `#507` — RoboCasa server preserves float32 SigLIP embeddings
- `#497` — `train_state_action_representation_only` (opt-in feature)
- `#480` — injectable gRPC request hooks (opt-in feature)

Plus three migration notes covering the data-order change, the validation-metric change, and the `n_action_steps > action_chunk` config-time failure.

Docs-only PRs (#494, #509), test-only (#513) and the `chore(claude)` lessons PRs are deliberately not given entries — they are not behavior-affecting.

## How it was tested

This is a docs-only change; no code paths are touched. The verification that matters is **that no prose was lost in the move**, which was checked mechanically rather than by eye:

```bash
# every non-blank line of the committed file is still present after the restructure
git show HEAD~1:CHANGELOG.md | grep -vE '^\s*$' | sort -u > /tmp/before.txt
grep -vE '^\s*$' CHANGELOG.md   | grep -vE '^\s*$' | sort -u > /tmp/after.txt
comm -23 /tmp/before.txt /tmp/after.txt     # -> empty
```

Result: empty — zero lines lost. Per-block counts confirm the same (all 42 non-blank lines of the `accel` section, 52 of the normalization section, 73 of `Fixed`, and so on).

Attribution spot-checks, both returning 0:

```bash
# no v0.13.0 content left in the 0.12.0 section
sed -n '/^## \[0.12.0\]/,$p' CHANGELOG.md | grep -cE 'repo_id@revision|`accel`|delta_stats_max_rows'
# no v0.12.0 normalization claim inside the 0.13.0 section
sed -n '/^## \[0.13.0\]/,/^## \[0.12.0\]/p' CHANGELOG.md | grep -cE 'config_version\*\* 0 → 1'
```

Also ran:

- `pre-commit run --files CHANGELOG.md` → clean (end-of-file, trailing whitespace, typos, secrets).
- Checked for stray >2-blank runs and trailing whitespace → none.

Every factual claim in the new entries is sourced from the originating PR's own description, not restated from memory.

## How to checkout & try? (for the reviewer)

```bash
git fetch origin claude/changelog-split-releases && git checkout claude/changelog-split-releases
```

The most useful review is the rendered file rather than the diff, since the large deletion block is a relocation:

```bash
grep -n '^## \|^### ' CHANGELOG.md
```

To confirm for yourself that nothing was dropped:

```bash
comm -23 <(git show origin/main:CHANGELOG.md | grep -vE '^\s*$' | sort -u) <(grep -vE '^\s*$' CHANGELOG.md | sort -u)
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
