### PR TITLE
feat(accel): measure the best prefix instead of assuming the paper's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,48 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
-_Nothing yet._
+### Changed — `accel`'s prefix is now *measured* rather than assumed
+
+`default_prefix` returns `T - 1` because that is the prefix the paper's online detector
+used. The 0.13.0 notes below cite the prefix sweep as confirming it, via the step-over-step
+growth in `accel_p` reversing at the last step. **That inference does not hold**, and this
+entry supersedes it: both of `accel_p`'s sums accumulate over the prefix, so its magnitude
+— and the shape of its growth — rise with `p` whether or not the extra Euler steps carry
+posterior information. The sweep is descriptive; it would produce a similar curve on data
+with no signal at all, so its peak cannot select a prefix.
+
+The criterion that *can* is the rank correlation between `accel_p` and an independent
+measure of posterior spread, and that reference has to be bought the expensive way — `K`
+resampled denoises of one observation, whose disagreement is the posterior width.
+`opentau-accel-diagnose` now measures it (`OPENTAU_ACCEL_OBSERVATIONS`, default 24;
+`OPENTAU_ACCEL_RESAMPLES`, default 32; `0` skips the study) and reports `rho` per prefix
+with a recommendation.
+
+Re-measured on the same 6-DoF SO101 pi05 checkpoint (`T = 10`, 24 real frames, `K = 32`):
+`rho` climbs to **+0.833 at `p = 9`** and falls to **+0.812 at `p = 10`**. So `T - 1` is
+right on this checkpoint and the terminal step really is the weaker one — the same
+conclusion as before, now resting on evidence that supports it. Every prefix scored
++0.70…+0.83, so prefix choice is not very consequential here; the paper's mid-schedule
+optimum (`p/T ~ 0.4-0.5`, i.e. `p = 4-5`, `rho` +0.75) does **not** transfer. Re-measure
+per checkpoint — a `T = 5` schedule (pi06/pi07) is unexamined, and there `T - 1` and the
+paper's mid-schedule choice are far apart.
+
+Supporting changes, none of which alter a served score:
+
+- `AccelMeter` gained an **opt-in** per-step trace and `value_at(p)`, so every prefix is
+  recoverable from **one** denoise pass instead of `T - 1` — that is what makes the study
+  affordable, and it makes the descriptive sweep `T - 1` times cheaper too. Off in serving.
+- `record_traces()` hands the meters built inside it back to a diagnostic, so no policy has
+  to expose its internals. A `ContextVar`, not a global: the gRPC server samples from
+  several threads, and a global would splice a diagnostic into serving traffic.
+- `action_dim_scale()` converts a raw-unit spread into the normalized units `accel` is
+  computed in, sharing one buffer extractor with `resolve_action_dim_mask`.
+- Diagnostic observations are drawn across **every** dataset in the configured mixture
+  rather than only the first — the correlation is taken across observations, so their
+  variety is the study's resolution.
+- The float32 leg of the dtype-floor measurement can be skipped
+  (`OPENTAU_ACCEL_MEASURE_DTYPE_FLOOR=0`). It holds a second copy of the weights and is the
+  first thing to fail on a shared GPU; skipping reports `NaN` rather than a fabricated ratio.
 
 ## [0.13.0] - 2026-08-17
 

--- a/src/opentau/policies/accel.py
+++ b/src/opentau/policies/accel.py
@@ -350,11 +350,10 @@ def _fit_dim_width(per_head: Tensor, max_action_dim: int, pad_value: float | boo
     return per_head[:, :max_action_dim] if width > max_action_dim else per_head
 
 
-def _gather_heads(per_head: Tensor, dataset_index: Tensor) -> Tensor:
-    """Select one ``(dim,)`` row of a per-head quantity for each sample."""
+def _head_index(dataset_index: Tensor, per_head: Tensor) -> Tensor:
+    """Return the clamped ``(B,)`` row index selecting a norm head per sample."""
     index = dataset_index.to(device=per_head.device, dtype=torch.long).reshape(-1)
-    index = index.clamp_(0, per_head.shape[0] - 1)
-    return per_head.index_select(0, index)
+    return index.clamp_(0, per_head.shape[0] - 1)
 
 
 def action_dim_scale(
@@ -393,7 +392,8 @@ def action_dim_scale(
     if norm_mode is not NormalizationMode.MEAN_STD:
         scale = scale / 2.0
     scale = torch.where(torch.isfinite(scale) & (scale >= eps), scale, torch.ones_like(scale))
-    return _gather_heads(_fit_dim_width(scale, max_action_dim, 1.0), dataset_index)
+    per_head = _fit_dim_width(scale, max_action_dim, 1.0)
+    return per_head.index_select(0, _head_index(dataset_index, per_head))
 
 
 def resolve_action_dim_mask(
@@ -440,9 +440,8 @@ def resolve_action_dim_mask(
     signature, norm_mode, eps = _action_dim_signature(unnormalize, action_key)
     # `(num_datasets, action_dim)` -> per-head bool over dims.
     head_mask = _fit_dim_width(torch.isfinite(signature) & (signature >= eps), max_action_dim, False)
-    index = dataset_index.to(device=head_mask.device, dtype=torch.long).reshape(-1)
-    index = index.clamp_(0, head_mask.shape[0] - 1)
-    per_sample = _gather_heads(head_mask, dataset_index)
+    index = _head_index(dataset_index, head_mask)
+    per_sample = head_mask.index_select(0, index)
 
     if not bool(per_sample.any()):
         # Name the head that was actually selected and contrast it with the others. The

--- a/src/opentau/policies/accel.py
+++ b/src/opentau/policies/accel.py
@@ -62,8 +62,11 @@ that consumes the per-chunk stream produced here.
 
 from __future__ import annotations
 
+import contextlib
+import contextvars
 import logging
 import os
+from collections.abc import Iterator
 from dataclasses import asdict, dataclass, field
 from typing import Any
 
@@ -89,6 +92,43 @@ MIN_PREFIX = 2
 # Environment variable that enables ``accel`` on an entry point with no config field for it.
 # Accepts ``auto`` (the paper's default prefix) or an integer ``>= MIN_PREFIX``.
 ACCEL_PREFIX_ENV = "OPENTAU_ACCEL_PREFIX"
+
+# Collects the meters built by `make_meter` while a diagnostic is running, and doubles as
+# the "record a per-step trace" switch (`None` = off). Non-`None` makes every prefix
+# readable from a single denoise pass via `AccelMeter.value_at`. Diagnostics only.
+#
+# A `ContextVar` rather than a module global or a `policy.` attribute: the meter is built
+# deep inside `sample_actions`, so both the switch and the hand-back have to reach it
+# without widening any policy signature — but the gRPC server calls `sample_actions` from
+# multiple threads, and a plain global would splice one thread's diagnostic run into
+# another's serving traffic. A `ContextVar` is per-thread (and per-task) by construction.
+_TRACE_SINK: contextvars.ContextVar[list[AccelMeter] | None] = contextvars.ContextVar(
+    "accel_trace_sink", default=None
+)
+
+
+@contextlib.contextmanager
+def record_traces() -> Iterator[list[AccelMeter]]:
+    """Capture the meters built inside this context, with per-step traces enabled.
+
+    The score at every prefix is recoverable from one denoise pass
+    (:meth:`AccelMeter.value_at`), but the policies hand back only ``last_accel`` — the
+    single configured prefix — so a prefix study needs the meter object itself. Yielding a
+    sink is how it gets one without any policy exposing its internals.
+
+    Off by default: the serving path never needs it, and a captured meter keeps its trace
+    tensors alive. Drain the list between iterations on a long study.
+
+    Yields:
+        A list receiving every meter built in this context, in creation order. The previous
+        setting is restored on exit, including on exception.
+    """
+    created: list[AccelMeter] = []
+    token = _TRACE_SINK.set(created)
+    try:
+        yield created
+    finally:
+        _TRACE_SINK.reset(token)
 
 
 def default_prefix(num_steps: int) -> int:
@@ -236,6 +276,126 @@ def assert_comparable(fitted: AccelProvenance, observed: AccelProvenance) -> Non
         )
 
 
+def _action_dim_signature(
+    unnormalize: torch.nn.Module, action_key: str
+) -> tuple[Tensor, NormalizationMode, float]:
+    """Return the per-head, per-dim normalization *scale* of an action feature.
+
+    One extractor feeds both consumers of these buffers —
+    :func:`resolve_action_dim_mask` (which thresholds the scale to find padded dims) and
+    :func:`action_dim_scale` (which divides by it to standardize a raw-space spread). They
+    must read the same buffer, the same stat names, and the same live ``eps``; two
+    hand-maintained copies would drift the moment a normalization mode is added.
+
+    Args:
+        unnormalize: The policy's ``Unnormalize`` module.
+        action_key: Feature key to read stats for.
+
+    Returns:
+        ``(signature, norm_mode, eps)`` where ``signature`` is ``(num_heads, dim)``: ``std``
+        under MEAN_STD, ``hi - lo`` under MIN_MAX / QUANTILE. Note this is the *range*, not
+        the divisor — MIN_MAX maps ``[lo, hi]`` onto ``[-1, 1]``, so its divisor is half of
+        this. :func:`action_dim_scale` applies that factor; the mask only needs the
+        zero-vs-nonzero distinction, which the factor cannot change.
+
+    Raises:
+        ValueError: When the feature is missing, IDENTITY-normalized, or has no buffer.
+    """
+    norm_map = getattr(unnormalize, "norm_map", {})
+    features = getattr(unnormalize, "features", {})
+    feature = features.get(action_key)
+    if feature is None:
+        raise ValueError(
+            f"accel: no feature {action_key!r} on the policy's Unnormalize; cannot derive "
+            "the action-dim mask."
+        )
+    norm_mode = norm_map.get(feature.type, NormalizationMode.IDENTITY)
+    if norm_mode is NormalizationMode.IDENTITY:
+        raise ValueError(
+            "accel: ACTION normalization is IDENTITY, so no stats buffer exists and the "
+            "padded-action-dim mask cannot be derived. IDENTITY also leaves per-dim scale "
+            "heterogeneous, which violates the estimator's standardized-dimension premise. "
+            "Disable accel for this checkpoint or retrain/serve with MEAN_STD."
+        )
+
+    buffer = getattr(unnormalize, "buffer_" + action_key.replace(".", "_"), None)
+    if buffer is None:
+        raise ValueError(f"accel: Unnormalize has no stats buffer for {action_key!r}.")
+
+    # Import locally: `_materialize` is a private FSDP2/DTensor shim in `normalize`, and a
+    # module-level import would make this module's import graph depend on it by name.
+    from opentau.policies.normalize import _materialize
+
+    if norm_mode is NormalizationMode.MEAN_STD:
+        signature = _materialize(buffer["std"]).abs()
+    else:
+        lo_name, hi_name = stat_names_for_mode(norm_mode)
+        signature = (_materialize(buffer[hi_name]) - _materialize(buffer[lo_name])).abs()
+
+    signature = signature.reshape(signature.shape[0], -1)
+    return signature, norm_mode, float(unnormalize.eps)
+
+
+def _fit_dim_width(per_head: Tensor, max_action_dim: int, pad_value: float | bool) -> Tensor:
+    """Pad or truncate a ``(heads, dim)`` per-dim quantity to the sampler's action width."""
+    width = per_head.shape[1]
+    if width < max_action_dim:
+        pad = torch.full(
+            (per_head.shape[0], max_action_dim - width),
+            pad_value,
+            dtype=per_head.dtype,
+            device=per_head.device,
+        )
+        return torch.cat([per_head, pad], dim=1)
+    return per_head[:, :max_action_dim] if width > max_action_dim else per_head
+
+
+def _gather_heads(per_head: Tensor, dataset_index: Tensor) -> Tensor:
+    """Select one ``(dim,)`` row of a per-head quantity for each sample."""
+    index = dataset_index.to(device=per_head.device, dtype=torch.long).reshape(-1)
+    index = index.clamp_(0, per_head.shape[0] - 1)
+    return per_head.index_select(0, index)
+
+
+def action_dim_scale(
+    unnormalize: torch.nn.Module,
+    *,
+    max_action_dim: int,
+    dataset_index: Tensor,
+    action_key: str = "actions",
+) -> Tensor:
+    """Return the per-sample, per-dim divisor that maps raw actions into normalized space.
+
+    ``accel`` is computed on the sampler's *normalized* velocities, so anything meant to be
+    compared against it — most importantly the resampling-based posterior spread that
+    :mod:`opentau.scripts.diagnose_accel` uses to choose a prefix — has to be expressed in
+    the same units. A spread measured on ``sample_actions`` output is in raw units, where a
+    gripper in ``[0, 1]`` and a shoulder joint in radians contribute on wildly different
+    scales; dividing by this vector removes that.
+
+    Degenerate dims are returned as ``1.0`` rather than ``0.0`` so a caller can divide
+    unconditionally. They carry no signal and are excluded by
+    :func:`resolve_action_dim_mask` anyway, so the value is arbitrary — it only has to be
+    finite and non-zero.
+
+    Args:
+        unnormalize: The policy's ``Unnormalize`` module.
+        max_action_dim: Width to pad/truncate to. Padded dims get ``1.0``.
+        dataset_index: ``(B,)`` long tensor of norm-head row indices.
+        action_key: Feature key to read stats for.
+
+    Returns:
+        ``(B, max_action_dim)`` float32, strictly positive.
+    """
+    signature, norm_mode, eps = _action_dim_signature(unnormalize, action_key)
+    # MIN_MAX / QUANTILE map `[lo, hi]` onto `[-1, 1]`, i.e. divide by half the range.
+    scale = signature.to(torch.float32)
+    if norm_mode is not NormalizationMode.MEAN_STD:
+        scale = scale / 2.0
+    scale = torch.where(torch.isfinite(scale) & (scale >= eps), scale, torch.ones_like(scale))
+    return _gather_heads(_fit_dim_width(scale, max_action_dim, 1.0), dataset_index)
+
+
 def resolve_action_dim_mask(
     unnormalize: torch.nn.Module,
     *,
@@ -277,54 +437,12 @@ def resolve_action_dim_mask(
         ValueError: When the action feature is IDENTITY-normalized (no buffer exists, so
             the mask is underivable) or has no buffer for another reason.
     """
-    norm_map = getattr(unnormalize, "norm_map", {})
-    features = getattr(unnormalize, "features", {})
-    feature = features.get(action_key)
-    if feature is None:
-        raise ValueError(
-            f"accel: no feature {action_key!r} on the policy's Unnormalize; cannot derive "
-            "the action-dim mask."
-        )
-    norm_mode = norm_map.get(feature.type, NormalizationMode.IDENTITY)
-    if norm_mode is NormalizationMode.IDENTITY:
-        raise ValueError(
-            "accel: ACTION normalization is IDENTITY, so no stats buffer exists and the "
-            "padded-action-dim mask cannot be derived. IDENTITY also leaves per-dim scale "
-            "heterogeneous, which violates the estimator's standardized-dimension premise. "
-            "Disable accel for this checkpoint or retrain/serve with MEAN_STD."
-        )
-
-    buffer = getattr(unnormalize, "buffer_" + action_key.replace(".", "_"), None)
-    if buffer is None:
-        raise ValueError(f"accel: Unnormalize has no stats buffer for {action_key!r}.")
-
-    eps = float(unnormalize.eps)
-    # Import locally: `_materialize` is a private FSDP2/DTensor shim in `normalize`, and a
-    # module-level import would make this module's import graph depend on it by name.
-    from opentau.policies.normalize import _materialize
-
-    if norm_mode is NormalizationMode.MEAN_STD:
-        signature = _materialize(buffer["std"]).abs()
-    else:
-        lo_name, hi_name = stat_names_for_mode(norm_mode)
-        signature = (_materialize(buffer[hi_name]) - _materialize(buffer[lo_name])).abs()
-
+    signature, norm_mode, eps = _action_dim_signature(unnormalize, action_key)
     # `(num_datasets, action_dim)` -> per-head bool over dims.
-    signature = signature.reshape(signature.shape[0], -1)
-    head_mask = torch.isfinite(signature) & (signature >= eps)
-
-    width = head_mask.shape[1]
-    if width < max_action_dim:
-        pad = torch.zeros(
-            (head_mask.shape[0], max_action_dim - width), dtype=torch.bool, device=head_mask.device
-        )
-        head_mask = torch.cat([head_mask, pad], dim=1)
-    elif width > max_action_dim:
-        head_mask = head_mask[:, :max_action_dim]
-
+    head_mask = _fit_dim_width(torch.isfinite(signature) & (signature >= eps), max_action_dim, False)
     index = dataset_index.to(device=head_mask.device, dtype=torch.long).reshape(-1)
     index = index.clamp_(0, head_mask.shape[0] - 1)
-    per_sample = head_mask.index_select(0, index)
+    per_sample = _gather_heads(head_mask, dataset_index)
 
     if not bool(per_sample.any()):
         # Name the head that was actually selected and contrast it with the others. The
@@ -387,12 +505,14 @@ class AccelMeter:
     batch_size: int
     device: torch.device
     dim_mask: Tensor | None = None
+    record_trace: bool = False
 
     _numerator: Tensor = field(init=False, repr=False)
     _denominator: Tensor = field(init=False, repr=False)
     _prev: Tensor | None = field(default=None, init=False, repr=False)
     _score_mask: Tensor | None = field(default=None, init=False, repr=False)
     _steps: int = field(default=0, init=False)
+    _trace: list[tuple[Tensor, Tensor]] = field(default_factory=list, init=False, repr=False)
 
     def __post_init__(self) -> None:
         if self.prefix < MIN_PREFIX:
@@ -434,6 +554,8 @@ class AccelMeter:
             self._numerator = self._numerator + torch.linalg.vector_norm(v - self._prev, dim=1)
         self._prev = v
         self._steps += 1
+        if self.record_trace:
+            self._trace.append((self._numerator, self._denominator))
 
     @property
     def steps(self) -> int:
@@ -457,6 +579,47 @@ class AccelMeter:
             return nan
         scored = self._steps * self._numerator / self._denominator.clamp_min(DENOMINATOR_FLOOR)
         return torch.where(self._denominator > DENOMINATOR_FLOOR, scored, nan)
+
+    def value_at(self, prefix: int) -> Tensor:
+        """Return the ``(B,)`` score this meter *would* have reported at a shorter prefix.
+
+        ``accel_p`` is a prefix statistic of one velocity sequence, so every prefix is
+        recoverable from a single denoise pass — the numerator and denominator are running
+        sums and :meth:`update` snapshots both. That turns a prefix sweep from ``T - 1``
+        forward passes into one, which is what makes the resampling-based prefix study in
+        :mod:`opentau.scripts.diagnose_accel` affordable.
+
+        Requires ``record_trace=True``; the serving path leaves it off so the hot loop
+        allocates nothing extra.
+
+        Args:
+            prefix: Prefix to evaluate, in ``[MIN_PREFIX, steps]``.
+
+        Returns:
+            ``(B,)`` float32, NaN under the same conditions as :meth:`value`.
+
+        Raises:
+            RuntimeError: If the meter was built without ``record_trace``.
+            ValueError: If ``prefix`` is outside ``[MIN_PREFIX, steps]``.
+        """
+        if not self.record_trace:
+            raise RuntimeError(
+                "AccelMeter.value_at requires record_trace=True — build the meter inside "
+                "`opentau.policies.accel.record_traces()`."
+            )
+        if not MIN_PREFIX <= prefix <= self._steps:
+            raise ValueError(f"prefix must be in [{MIN_PREFIX}, {self._steps}] for this meter, got {prefix}.")
+        numerator, denominator = self._trace[prefix - 1]
+        nan = torch.full_like(denominator, float("nan"))
+        scored = prefix * numerator / denominator.clamp_min(DENOMINATOR_FLOOR)
+        return torch.where(denominator > DENOMINATOR_FLOOR, scored, nan)
+
+    def prefix_values(self) -> dict[int, list[float]]:
+        """Return ``{p: per-sample accel_p}`` for every prefix this meter can evaluate."""
+        return {
+            p: [float(x) for x in self.value_at(p).detach().to("cpu", torch.float32).tolist()]
+            for p in range(MIN_PREFIX, self._steps + 1)
+        }
 
     def to_list(self) -> list[float]:
         """Return the score as plain Python floats.
@@ -514,7 +677,17 @@ def make_meter(
         max_action_dim=max_action_dim,
         dataset_index=dataset_index,
     )
-    return AccelMeter(prefix=prefix, batch_size=batch_size, device=device, dim_mask=dim_mask)
+    sink = _TRACE_SINK.get()
+    meter = AccelMeter(
+        prefix=prefix,
+        batch_size=batch_size,
+        device=device,
+        dim_mask=dim_mask,
+        record_trace=sink is not None,
+    )
+    if sink is not None:
+        sink.append(meter)
+    return meter
 
 
 def build_provenance(

--- a/src/opentau/scripts/diagnose_accel.py
+++ b/src/opentau/scripts/diagnose_accel.py
@@ -32,9 +32,17 @@ This script measures three things on the actual checkpoint, with no repo state c
 2. **The stochasticity.** Repeats of the same observation with freshly drawn noise.
    ``sample_actions`` takes no generator, so production scores are a random variable; the
    detector's calibration has to absorb this spread.
-3. **The prefix sweep.** ``accel_p`` for every ``p`` in ``[2, T]``. The paper finds the
-   best prefix mid-schedule and warns the last steps are discretization-dominated; this
-   shows where that turn happens on your checkpoint rather than assuming the paper's.
+3. **The prefix study.** Which ``p`` makes ``accel_p`` track the *actual* posterior spread
+   best. ``default_prefix`` returns ``T - 1`` because that is what the paper's online
+   detector used; the same paper's sweep peaks nearer ``p/T ~ 0.4-0.5``, and on a ``T = 5``
+   OpenTau schedule those are different answers. Settling it needs a reference measure of
+   spread, which only resampling can provide: ``K`` independent denoises of one observation,
+   whose disagreement *is* the posterior width. The figure of merit is then the rank
+   correlation between ``accel_p`` and that reference, across observations.
+
+   The mean-``accel_p``-per-``p`` column is also reported, but it cannot select a prefix and
+   should not be read as if it could — numerator and denominator both accumulate over the
+   prefix, so the curve rises with ``p`` whether or not the extra steps carry information.
 
 The go/no-go it exists to answer: **is the between-observation spread of ``accel`` large
 compared to the dtype floor?** If it is not, no threshold calibrated on this checkpoint is
@@ -48,6 +56,16 @@ Run::
         --policy.path=TensorAuto/<run>@6000
 
 Add ``--policy.device=cuda`` on a GPU box. Everything is inference-only; no training runs.
+
+Three env vars tune cost, since ``@parser.wrap()`` parses only ``TrainPipelineConfig``
+fields and none of these belong in a training config:
+
+* ``OPENTAU_ACCEL_OBSERVATIONS`` (default 24) — the prefix study's sample size.
+* ``OPENTAU_ACCEL_RESAMPLES`` (default 32) — ``K``. Set ``0`` to skip the study, which is
+  the only genuinely expensive part (``observations * K`` denoise passes).
+* ``OPENTAU_ACCEL_MEASURE_DTYPE_FLOOR`` (default 1) — set ``0`` to skip the float32 leg,
+  which holds a second copy of the weights and is the first thing to fail on a GPU shared
+  with other work. The floor does not change between runs, so measure it once.
 """
 
 # NOTE: deliberately no `from __future__ import annotations` here. `parser.wrap` resolves the
@@ -59,21 +77,79 @@ Add ``--policy.device=cuda`` on a GPU box. Everything is inference-only; no trai
 import contextlib
 import json
 import logging
+import os
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
 import numpy as np
 import torch
+from einops import rearrange, reduce
 
 from opentau.configs import parser
 from opentau.configs.train import TrainPipelineConfig
-from opentau.policies.accel import default_prefix, resolve_action_dim_mask
+from opentau.policies.accel import (
+    action_dim_scale,
+    default_prefix,
+    record_traces,
+    resolve_action_dim_mask,
+)
 from opentau.policies.factory import make_policy
 from opentau.policies.utils import to_dtype_preserving_siglip_float32
 from opentau.utils.utils import init_logging
 
 logger = logging.getLogger(__name__)
+
+# Resamples per observation for the prefix study. `0` skips it, which is the right setting
+# once a checkpoint's prefix is settled — it is the only expensive part of this script.
+RESAMPLES_ENV = "OPENTAU_ACCEL_RESAMPLES"
+
+# Observations drawn from the configured mixture. This is the prefix study's sample size —
+# the rank correlation is taken across observations, so too few makes every rho unresolvable.
+OBSERVATIONS_ENV = "OPENTAU_ACCEL_OBSERVATIONS"
+
+# Set to `0` to skip the float32 leg of the dtype-floor measurement. It holds a second,
+# wider copy of the weights, so it is the first thing to fail on a GPU shared with other
+# work — and the floor it measures does not change between runs on one checkpoint.
+DTYPE_FLOOR_ENV = "OPENTAU_ACCEL_MEASURE_DTYPE_FLOOR"
+
+
+@dataclass
+class PrefixStudy:
+    """Which prefix ``p`` actually makes ``accel_p`` track posterior spread best.
+
+    Attributes:
+        num_resamples: ``K`` denoise passes per observation behind each spread estimate.
+        num_observations: Points entering each rank correlation.
+        divergences: Per-observation posterior spread (the reference), normalized units.
+        accel_by_prefix: ``{p: per-observation mean accel_p}``.
+        rho: ``{p: Spearman(accel_p, divergence)}``. The figure of merit.
+        best_prefix: ``argmax_p rho[p]``, or ``None`` if no correlation was computable.
+        default_prefix: What :func:`~opentau.policies.accel.default_prefix` would return.
+        rho_at_default: ``rho[default_prefix]``, for the "is the default good enough?" call.
+    """
+
+    num_resamples: int
+    num_observations: int
+    divergences: list[float]
+    accel_by_prefix: dict[int, list[float]]
+    rho: dict[int, float]
+    best_prefix: int | None
+    default_prefix: int
+    rho_at_default: float
+
+    def to_dict(self) -> dict:
+        """Return a JSON-serializable copy."""
+        return {
+            "num_resamples": self.num_resamples,
+            "num_observations": self.num_observations,
+            "divergences": self.divergences,
+            "accel_by_prefix": {str(k): v for k, v in self.accel_by_prefix.items()},
+            "rho": {str(k): v for k, v in self.rho.items()},
+            "best_prefix": self.best_prefix,
+            "default_prefix": self.default_prefix,
+            "rho_at_default": self.rho_at_default,
+        }
 
 
 @dataclass
@@ -92,7 +168,9 @@ class AccelDiagnosticReport:
         noise_spread: Std of repeated scores on one observation with redrawn noise.
         observation_spread: Std of scores across distinct observations (the signal).
         signal_to_floor: ``observation_spread / dtype_floor``. The go/no-go ratio.
-        prefix_sweep: ``accel_p`` per prefix ``p``, averaged over observations.
+        prefix_sweep: ``accel_p`` per prefix ``p``, averaged over observations. Descriptive
+            only — see :class:`PrefixStudy` for the number that actually selects a prefix.
+        prefix_study: The resampling-based prefix selection, when it was run.
         observation_source: Where the observations came from. Recorded because a run on
             synthetic frames measures the out-of-distribution regime, not deployment, and
             the two are not comparable.
@@ -110,6 +188,7 @@ class AccelDiagnosticReport:
     observation_spread: float
     signal_to_floor: float
     prefix_sweep: dict[int, float] = field(default_factory=dict)
+    prefix_study: PrefixStudy | None = None
     observation_source: str = "unspecified"
 
     def to_dict(self) -> dict:
@@ -127,6 +206,7 @@ class AccelDiagnosticReport:
             "observation_spread": self.observation_spread,
             "signal_to_floor": self.signal_to_floor,
             "prefix_sweep": {str(k): v for k, v in self.prefix_sweep.items()},
+            "prefix_study": self.prefix_study.to_dict() if self.prefix_study else None,
             "observation_source": self.observation_source,
         }
 
@@ -213,25 +293,230 @@ def _score_once(policy, batch: dict, noise: torch.Tensor | None) -> list[float]:
     return list(policy.last_accel or [])
 
 
-def _sweep_prefixes(policy, batch: dict, noise: torch.Tensor, dataset_index) -> dict[int, float]:
-    """Return mean ``accel_p`` for every prefix ``p`` in ``[2, T]``.
+def _spearman(xs: list[float], ys: list[float]) -> float:
+    """Rank correlation between two equal-length samples, NaN pairs dropped.
 
-    Runs the sampler once per prefix. That is ``T - 1`` forward passes and is the one
-    genuinely expensive thing this script does — it exists to locate the schedule's
-    information peak on *your* checkpoint rather than trusting the paper's, which was
-    measured on different data.
+    Rank-based on purpose: the prefix study correlates ``accel_p`` against a resampled
+    posterior spread, and the two are not on a common scale or even a common curve — only
+    their *ordering* is claimed to agree. Any monotone redefinition of the spread (variance
+    vs standard deviation, per-element vs summed) leaves this number unchanged, which is
+    what keeps the conclusion from depending on an arbitrary choice of divergence.
     """
+    from scipy.stats import spearmanr
+
+    paired = [(x, y) for x, y in zip(xs, ys, strict=True) if np.isfinite(x) and np.isfinite(y)]
+    if len(paired) < 3:
+        return float("nan")
+    a = [p[0] for p in paired]
+    b = [p[1] for p in paired]
+    # `spearmanr` warns and returns NaN on a constant input; say so ourselves instead.
+    if len(set(a)) < 2 or len(set(b)) < 2:
+        return float("nan")
+    return float(spearmanr(a, b).statistic)
+
+
+def _posterior_spread(policy, chunks: list[torch.Tensor], dataset_index: torch.Tensor) -> list[float]:
+    """Reduce ``K`` resampled action chunks to one posterior-spread scalar per sample.
+
+    This is the **reference quantity** the prefix study scores ``accel_p`` against: the
+    thing ``accel`` claims to be a cheap proxy for. It costs ``K`` full denoise passes, which
+    is exactly why it is confined to this offline diagnostic.
+
+    Two details make it commensurate with ``accel``, which is computed on *normalized*
+    velocities over a masked subset of the chunk:
+
+    * **Per-dim standardization.** ``sample_actions`` returns raw units, where a gripper in
+      ``[0, 1]`` and a shoulder joint in radians would contribute to a spread on wildly
+      different scales — and since the scale vector is fixed across observations, that
+      skewed weighting survives the rank correlation rather than cancelling out.
+      :func:`~opentau.policies.accel.action_dim_scale` undoes it.
+    * **The same masks.** Padded action dims are unsupervised network output, and chunk rows
+      past the executed window are never applied; both are excluded here exactly as the
+      meter excludes them.
+
+    A delta-action policy re-adds the chunk-start state before returning, but that offset is
+    identical across the ``K`` resamples of one observation, so it cancels in the deviation
+    and no delta-space inverse is needed here.
+
+    Args:
+        policy: The policy the chunks came from.
+        chunks: ``K`` tensors of shape ``(B, chunk, dim)``, one per resample.
+        dataset_index: ``(B,)`` norm-head row indices.
+
+    Returns:
+        ``B`` floats: the root-mean-square per-element standard deviation across resamples,
+        in normalized units. ``sqrt(tr(Sigma) / n)`` of the scored sub-block.
+    """
+    stacked = torch.stack([c.to(torch.float32) for c in chunks], dim=0)  # (K, B, chunk, dim)
+    width = stacked.shape[-1]
+    scale = action_dim_scale(
+        policy.unnormalize_outputs,
+        max_action_dim=width,
+        dataset_index=dataset_index,
+    ).to(stacked.device)
+    dim_mask = resolve_action_dim_mask(
+        policy.unnormalize_outputs,
+        max_action_dim=width,
+        dataset_index=dataset_index,
+    ).to(stacked.device)
+
+    deviation = stacked.std(dim=0, unbiased=True) / rearrange(scale, "b d -> b 1 d")
+
+    mask = rearrange(dim_mask.to(torch.float32), "b d -> b 1 d").expand_as(deviation).clone()
+    executed = min(policy.config.n_action_steps, deviation.shape[1])
+    mask[:, executed:, :] = 0.0
+
+    total = reduce(mask, "b c d -> b", "sum")
+    summed = reduce(deviation.pow(2) * mask, "b c d -> b", "sum")
+    spread = torch.sqrt(summed / total.clamp_min(1.0))
+    return [float(x) if n > 0 else float("nan") for x, n in zip(spread.tolist(), total.tolist(), strict=True)]
+
+
+def resample_observation(
+    policy, batch: dict, dataset_index: torch.Tensor, *, num_resamples: int, seed: int
+) -> tuple[float, dict[int, float]]:
+    """Denoise one observation ``K`` times and return its spread and per-prefix scores.
+
+    Each resample uses an independent noise draw, so the ``K`` chunks are ``K`` samples from
+    the policy's action posterior for this observation. Their spread is the ground truth;
+    the ``accel_p`` values are the candidate proxies, averaged over the same ``K`` draws so
+    the comparison is not decided by one lucky noise vector.
+
+    Args:
+        policy: A policy with ``accel_prefix`` already set to ``T`` (the full schedule), so
+            every prefix is present in the trace.
+        batch: One observation.
+        dataset_index: ``(B,)`` norm-head row indices for it.
+        num_resamples: ``K``.
+        seed: Base seed; resample ``k`` uses ``seed + k``.
+
+    Returns:
+        ``(spread, {prefix: mean accel_p})``, both averaged over the batch axis.
+    """
+    device = next(policy.parameters()).device
+    batch_size = len(batch["state"])
+    chunks: list[torch.Tensor] = []
+    per_prefix: dict[int, list[float]] = {}
+
+    for k in range(num_resamples):
+        noise = _fixed_noise(policy, batch_size, device, seed + k)
+        with record_traces() as meters:
+            dtype = next(policy.parameters()).dtype
+            cast = {
+                key: (val.to(dtype) if isinstance(val, torch.Tensor) and val.is_floating_point() else val)
+                for key, val in batch.items()
+            }
+            with torch.inference_mode():
+                chunks.append(policy.sample_actions(cast, noise=noise.to(dtype)).to(torch.float32))
+        if not meters:
+            raise RuntimeError(
+                "accel produced no meter for this resample — `policy.accel_prefix` must be "
+                "set before calling `resample_observation`."
+            )
+        for prefix, values in meters[-1].prefix_values().items():
+            per_prefix.setdefault(prefix, []).extend(values)
+
+    spreads = _posterior_spread(policy, chunks, dataset_index)
+    finite_spreads = [s for s in spreads if np.isfinite(s)]
+
+    def _mean(values: list[float]) -> float:
+        finite = [v for v in values if np.isfinite(v)]
+        return float(np.mean(finite)) if finite else float("nan")
+
+    return (
+        float(np.mean(finite_spreads)) if finite_spreads else float("nan"),
+        {prefix: _mean(values) for prefix, values in per_prefix.items()},
+    )
+
+
+def measure_prefix_quality(
+    policy,
+    observations: list[dict],
+    *,
+    num_resamples: int = 32,
+    seed: int = 0,
+) -> PrefixStudy:
+    """Rank every candidate prefix by how well ``accel_p`` tracks the true posterior spread.
+
+    This is the measurement that :func:`~opentau.policies.accel.default_prefix` is otherwise
+    only *assuming*. ``default_prefix`` returns ``T - 1`` because that is what the paper's
+    online detector used, on the paper's checkpoints and data — a reasonable prior, but the
+    same paper's own sweep peaks nearer ``p/T ~ 0.4-0.5``, so on a short OpenTau schedule
+    (``T = 5`` for pi06/pi07) the two answers are far apart and nothing in the repo had ever
+    checked which one applies here.
+
+    A mean-``accel_p``-versus-``p`` sweep cannot settle it: ``accel_p`` grows with ``p``
+    almost by construction, since both sums accumulate over the prefix. Magnitude is not
+    quality. The paper's actual criterion is the rank correlation between ``accel_p`` and a
+    *reference* measure of posterior spread, and the reference has to be obtained the
+    expensive way — by resampling (:func:`_posterior_spread`). That is affordable exactly
+    once, offline, which is what this function is.
+
+    Cost is ``len(observations) * num_resamples`` denoise passes; every prefix comes out of
+    the same passes, so widening the prefix range is free.
+
+    Args:
+        policy: A loaded flow-matching policy. Its ``accel_prefix`` is set to ``T`` for the
+            duration and restored afterwards.
+        observations: Distinct observations. The correlation is taken *across* these, so
+            they must span a range of genuine uncertainty for the result to mean anything —
+            frames drawn at a stride through real episodes, not repeats of one scene.
+        num_resamples: ``K``, the resamples per observation used to estimate the spread.
+        seed: Base seed for the noise draws.
+
+    Returns:
+        The :class:`PrefixStudy`.
+
+    Raises:
+        ValueError: When fewer than three observations are supplied — a rank correlation
+            over two points is either +1 or -1 regardless of the data.
+    """
+    if len(observations) < 3:
+        raise ValueError(
+            f"the prefix study correlates accel_p against posterior spread across "
+            f"observations, and {len(observations)} of them cannot produce a meaningful rank "
+            "correlation (any two points correlate perfectly). Supply at least 3; 8+ is better."
+        )
+
     original = policy.accel_prefix
-    sweep: dict[int, float] = {}
+    divergences: list[float] = []
+    accel_by_prefix: dict[int, list[float]] = {}
     try:
-        for p in range(2, policy.config.num_steps + 1):
-            policy.accel_prefix = p
-            scores = _score_once(policy, batch, noise)
-            finite = [s for s in scores if np.isfinite(s)]
-            sweep[p] = float(np.mean(finite)) if finite else float("nan")
+        # The full schedule, so the trace covers every candidate prefix in one pass.
+        policy.accel_prefix = policy.config.num_steps
+        for i, obs in enumerate(observations):
+            dataset_index = policy._resolve_dataset_index(obs)
+            spread, per_prefix = resample_observation(
+                policy, obs, dataset_index, num_resamples=num_resamples, seed=seed + 1000 * i
+            )
+            divergences.append(spread)
+            for prefix, value in per_prefix.items():
+                accel_by_prefix.setdefault(prefix, []).append(value)
+            logger.info(
+                "observation %d/%d: posterior spread %.6g over %d resamples",
+                i + 1,
+                len(observations),
+                spread,
+                num_resamples,
+            )
     finally:
         policy.accel_prefix = original
-    return sweep
+
+    rho = {prefix: _spearman(values, divergences) for prefix, values in accel_by_prefix.items()}
+    finite_rho = {p: r for p, r in rho.items() if np.isfinite(r)}
+    best = max(finite_rho, key=lambda p: finite_rho[p]) if finite_rho else None
+    fallback = default_prefix(policy.config.num_steps)
+
+    return PrefixStudy(
+        num_resamples=num_resamples,
+        num_observations=len(observations),
+        divergences=divergences,
+        accel_by_prefix={p: list(v) for p, v in accel_by_prefix.items()},
+        rho=rho,
+        best_prefix=best,
+        default_prefix=fallback,
+        rho_at_default=rho.get(fallback, float("nan")),
+    )
 
 
 def diagnose_accel(
@@ -239,6 +524,8 @@ def diagnose_accel(
     observations: list[dict],
     *,
     num_noise_repeats: int = 8,
+    num_resamples: int = 32,
+    measure_dtype_floor: bool = True,
     seed: int = 0,
 ) -> AccelDiagnosticReport:
     """Measure the ``accel`` floor, spread, and prefix profile of a loaded policy.
@@ -248,6 +535,9 @@ def diagnose_accel(
         observations: Distinct observation batches. At least two are needed for the
             between-observation spread that the go/no-go ratio compares against.
         num_noise_repeats: Repeats on the first observation with freshly drawn noise.
+        num_resamples: ``K`` for the prefix study; ``0`` skips it.
+        measure_dtype_floor: Run the float32 leg. Skipping it leaves ``dtype_floor`` and
+            ``signal_to_floor`` NaN, and is the way to fit on a GPU shared with other work.
         seed: Seed for the pinned noise draw.
 
     Returns:
@@ -289,27 +579,38 @@ def diagnose_accel(
     for obs in observations:
         serving_scores.extend(_score_once(policy, obs, noise))
 
-    logger.info("Re-running in float32 to isolate the rounding floor...")
     float32_scores: list[float] = []
-    with _forced_float32_embeddings(policy) as forced:
-        if not forced:
-            logger.warning(
-                "This policy family has no `_preferred_dtype` hook, so the float32 leg relies "
-                "on the parameter cast alone. If its forward pins an activation dtype the way "
-                "the pi0/pi05 family does, the measured floor will be wrong."
-            )
-        policy.to(dtype=torch.float32)
-        for obs in observations:
-            float32_scores.extend(_score_once(policy, obs, noise))
+    if measure_dtype_floor:
+        logger.info("Re-running in float32 to isolate the rounding floor...")
+        with _forced_float32_embeddings(policy) as forced:
+            if not forced:
+                logger.warning(
+                    "This policy family has no `_preferred_dtype` hook, so the float32 leg relies "
+                    "on the parameter cast alone. If its forward pins an activation dtype the way "
+                    "the pi0/pi05 family does, the measured floor will be wrong."
+                )
+            policy.to(dtype=torch.float32)
+            for obs in observations:
+                float32_scores.extend(_score_once(policy, obs, noise))
 
-    # `to_dtype_preserving_siglip_float32` rather than a blanket cast: pi0/pi05-family
-    # towers pin the SigLIP patch-embedding conv and position table to float32 for openpi
-    # parity, and a blanket `.to(bfloat16)` would silently re-round them (CLAUDE.md rule 6).
-    to_dtype_preserving_siglip_float32(policy, dtype=serving_dtype)
+        # `to_dtype_preserving_siglip_float32` rather than a blanket cast: pi0/pi05-family
+        # towers pin the SigLIP patch-embedding conv and position table to float32 for openpi
+        # parity, and a blanket `.to(bfloat16)` would silently re-round them (CLAUDE.md rule 6).
+        to_dtype_preserving_siglip_float32(policy, dtype=serving_dtype)
+    else:
+        # Holding a float32 copy of the weights roughly doubles resident memory, which is
+        # what makes this the first leg to fail on a shared GPU. The floor is a fixed
+        # property of (checkpoint, dtype) — it does not move between runs — so skipping it
+        # to get the prefix study done is a reasonable trade, as long as the report does not
+        # then present a fabricated ratio. It reports NaN.
+        logger.warning(
+            "Skipping the float32 leg: the dtype floor and signal/floor ratio will be NaN. "
+            "Run once with it enabled to establish the floor for this checkpoint."
+        )
 
     paired = [
         abs(a - b)
-        for a, b in zip(float32_scores, serving_scores, strict=True)
+        for a, b in zip(float32_scores, serving_scores, strict=False)
         if np.isfinite(a) and np.isfinite(b)
     ]
     dtype_floor = float(np.median(paired)) if paired else float("nan")
@@ -323,8 +624,33 @@ def diagnose_accel(
     finite_serving = [s for s in serving_scores if np.isfinite(s)]
     observation_spread = float(np.std(finite_serving)) if finite_serving else float("nan")
 
-    # (3) where in the schedule the signal actually lives.
-    prefix_sweep = _sweep_prefixes(policy, observations[0], noise, dataset_index)
+    # (3) where in the schedule the signal actually lives. One pass at the full schedule
+    # yields every prefix, because accel_p is a prefix statistic of one velocity sequence.
+    original_prefix = policy.accel_prefix
+    try:
+        policy.accel_prefix = config.num_steps
+        with record_traces() as meters:
+            _score_once(policy, observations[0], noise)
+        prefix_sweep = {
+            prefix: float(np.mean([v for v in values if np.isfinite(v)]))
+            if any(np.isfinite(v) for v in values)
+            else float("nan")
+            for prefix, values in meters[-1].prefix_values().items()
+        }
+    finally:
+        policy.accel_prefix = original_prefix
+
+    # (4) which prefix actually correlates with posterior spread — the sweep above cannot
+    # answer this, since accel_p rises with p regardless of how informative it is.
+    prefix_study = None
+    if num_resamples > 0 and len(observations) >= 3:
+        logger.info(
+            "Measuring prefix quality: %d observations x %d resamples = %d denoise passes...",
+            len(observations),
+            num_resamples,
+            len(observations) * num_resamples,
+        )
+        prefix_study = measure_prefix_quality(policy, observations, num_resamples=num_resamples, seed=seed)
 
     return AccelDiagnosticReport(
         num_steps=int(config.num_steps),
@@ -341,6 +667,7 @@ def diagnose_accel(
             observation_spread / dtype_floor if dtype_floor and np.isfinite(dtype_floor) else float("inf")
         ),
         prefix_sweep=prefix_sweep,
+        prefix_study=prefix_study,
     )
 
 
@@ -396,13 +723,75 @@ def format_report(report: AccelDiagnosticReport) -> str:
         lines.append(f"    p={p:>3}/{report.num_steps}  {value:.6g}{marker}")
     lines.append("")
     lines.append(
-        "  Note: the largest accel_p is not automatically the best prefix — the paper's "
-        "1/(1-s) tail inflates the final steps with discretization noise rather than "
-        "posterior information. Prefer a prefix where the sweep is rising, not its peak "
-        "at p == T."
+        "  The largest accel_p is NOT the best prefix. Both of its sums accumulate over the "
+        "prefix, so it rises with p almost regardless of how informative the score is; the "
+        "column above is descriptive only. The selection criterion is below."
     )
+
+    study = report.prefix_study
+    if study is None:
+        lines.append("")
+        lines.append(
+            "  No prefix study was run (needs >= 3 observations and num_resamples > 0), so "
+            f"the prefix in use, p = {report.prefix}, is the paper's default rather than a "
+            "measurement on this checkpoint."
+        )
+    else:
+        lines.append("")
+        lines.append(
+            f"  prefix quality (Spearman rho vs resampled posterior spread, "
+            f"K={study.num_resamples}, n={study.num_observations}):"
+        )
+        for p, value in sorted(study.rho.items()):
+            marks = []
+            if p == study.best_prefix:
+                marks.append("<- best")
+            if p == study.default_prefix:
+                marks.append("(default_prefix)")
+            suffix = ("  " + " ".join(marks)) if marks else ""
+            shown = "   nan" if not np.isfinite(value) else f"{value:+.3f}"
+            lines.append(f"    p={p:>3}/{report.num_steps}  rho = {shown}{suffix}")
+        lines.append("")
+        lines.extend(_prefix_verdict(study))
+
     lines.append("=" * 78)
     return "\n".join(lines)
+
+
+def _prefix_verdict(study: PrefixStudy) -> list[str]:
+    """Turn the measured rank correlations into an actionable recommendation."""
+    if study.best_prefix is None:
+        return [
+            "  INCONCLUSIVE — no prefix produced a computable correlation. Usually every "
+            "observation shared one spread value; draw observations from more episodes."
+        ]
+
+    best_rho = study.rho[study.best_prefix]
+    if best_rho < 0.3:
+        return [
+            f"  WEAK — even the best prefix (p={study.best_prefix}) correlates only "
+            f"rho={best_rho:+.3f} with the resampled posterior spread on this checkpoint. "
+            "accel is a poor proxy here whatever prefix you pick, so a detector built on it "
+            "will be working with little signal. Treat downstream detection numbers as a "
+            "test of that, not as a tuning problem.",
+        ]
+
+    lines = [
+        f"  Best prefix p={study.best_prefix} (rho={best_rho:+.3f}); "
+        f"default_prefix would pick p={study.default_prefix} (rho={study.rho_at_default:+.3f})."
+    ]
+    gap = best_rho - study.rho_at_default
+    if np.isfinite(gap) and gap > 0.1:
+        lines.append(
+            f"  The default gives up {gap:.3f} of rank correlation here. Set "
+            f"`--policy.accel_prefix={study.best_prefix}` for this checkpoint, and calibrate "
+            "any threshold under the same prefix (it is part of AccelProvenance)."
+        )
+    else:
+        lines.append(
+            "  The default is within noise of the best; no reason to override it on this checkpoint."
+        )
+    return lines
 
 
 def dataset_observations(cfg: TrainPipelineConfig, device: torch.device, count: int) -> list[dict]:
@@ -435,21 +824,36 @@ def dataset_observations(cfg: TrainPipelineConfig, device: torch.device, count: 
     from opentau.datasets.factory import make_dataset_mixture
 
     mixture = make_dataset_mixture(cfg)
-    dataset = mixture.datasets[0] if hasattr(mixture, "datasets") else mixture
-    total = len(dataset)
-    if total == 0:
+    datasets = list(getattr(mixture, "datasets", None) or [mixture])
+    if not any(len(d) for d in datasets):
         raise ValueError("The configured dataset mixture is empty; cannot draw observations.")
 
-    stride = max(1, total // count)
-    indices = [min(i * stride, total - 1) for i in range(count)]
-    logger.info("Drawing %d observation(s) from %d frames at stride %d: %s", count, total, stride, indices)
-
-    loader = DataLoader(torch.utils.data.Subset(dataset, indices), batch_size=1)
-    observations = []
-    for batch in loader:
-        observations.append(
-            {k: (v.to(device) if isinstance(v, torch.Tensor) else v) for k, v in batch.items()}
+    # Spread the draw across every configured dataset, not just the first. The prefix study
+    # correlates accel against posterior spread *across* observations, so it is only as
+    # informative as the range of scenes those observations cover; silently sampling one
+    # member of a mixture would narrow that range without saying so.
+    observations: list[dict] = []
+    per_dataset = max(1, count // len(datasets))
+    for position, dataset in enumerate(datasets):
+        total = len(dataset)
+        if total == 0:
+            continue
+        wanted = min(per_dataset if position < len(datasets) - 1 else count - len(observations), total)
+        if wanted <= 0:
+            break
+        stride = max(1, total // wanted)
+        indices = [min(i * stride, total - 1) for i in range(wanted)]
+        logger.info(
+            "Drawing %d observation(s) from dataset %d (%d frames) at stride %d",
+            wanted,
+            position,
+            total,
+            stride,
         )
+        for batch in DataLoader(torch.utils.data.Subset(dataset, indices), batch_size=1):
+            observations.append(
+                {k: (v.to(device) if isinstance(v, torch.Tensor) else v) for k, v in batch.items()}
+            )
     return observations
 
 
@@ -493,7 +897,10 @@ def diagnose_main(cfg: TrainPipelineConfig):
     policy.to(device=device)
     to_dtype_preserving_siglip_float32(policy, dtype=dtype)
 
-    count = 8
+    # The rank correlation is taken over these, so `count` is the study's sample size: at 8
+    # points Spearman needs |rho| >= 0.74 to clear p < 0.05, which is too blunt to separate
+    # neighbouring prefixes. 24 is a reasonable floor; the cost is linear in it.
+    count = int(os.environ.get(OBSERVATIONS_ENV, "24"))
     datasets = getattr(getattr(cfg, "dataset_mixture", None), "datasets", None)
     if datasets:
         observations = dataset_observations(cfg, device, count)
@@ -508,7 +915,17 @@ def diagnose_main(cfg: TrainPipelineConfig):
         observations = synthetic_observations(cfg, device, count)
         source = "SYNTHETIC noise (not deployment-representative)"
 
-    report = diagnose_accel(policy, observations)
+    # `TrainPipelineConfig` has no field for this and `@parser.wrap()` parses only config
+    # fields, so the knob follows the same env-var route as `OPENTAU_ACCEL_PREFIX`.
+    num_resamples = int(os.environ.get(RESAMPLES_ENV, "32"))
+    measure_floor = os.environ.get(DTYPE_FLOOR_ENV, "1") not in ("0", "false", "False")
+
+    report = diagnose_accel(
+        policy,
+        observations,
+        num_resamples=num_resamples,
+        measure_dtype_floor=measure_floor,
+    )
     report.observation_source = source
     print(format_report(report))  # noqa: T201 — this script's entire purpose is this report
 

--- a/src/opentau/scripts/diagnose_accel.py
+++ b/src/opentau/scripts/diagnose_accel.py
@@ -663,12 +663,34 @@ def diagnose_accel(
         dtype_floor=dtype_floor,
         noise_spread=noise_spread,
         observation_spread=observation_spread,
-        signal_to_floor=(
-            observation_spread / dtype_floor if dtype_floor and np.isfinite(dtype_floor) else float("inf")
-        ),
+        signal_to_floor=_signal_to_floor(observation_spread, dtype_floor),
         prefix_sweep=prefix_sweep,
         prefix_study=prefix_study,
     )
+
+
+def _signal_to_floor(observation_spread: float, dtype_floor: float) -> float:
+    """Return the go/no-go ratio, or NaN when there is no floor to compare against.
+
+    The distinction this exists to preserve: a floor that was **never measured** (the
+    float32 leg was skipped, or no observation produced a finite pair) is not the same as a
+    floor measured at zero. Collapsing them to ``inf`` — as a plain
+    ``if dtype_floor and isfinite(...) else inf`` does, because NaN is truthy and not finite
+    — makes an unmeasured run print the most reassuring verdict the script has.
+
+    Args:
+        observation_spread: Std of ``accel`` across observations (the signal).
+        dtype_floor: Median float32-vs-serving difference, or NaN if unmeasured.
+
+    Returns:
+        The ratio; ``inf`` when the floor was measured as exactly zero (float32 and the
+        serving dtype agreed on every observation); NaN when it was never measured.
+    """
+    if not np.isfinite(dtype_floor):
+        return float("nan")
+    if dtype_floor > 0.0:
+        return observation_spread / dtype_floor
+    return float("inf")
 
 
 def format_report(report: AccelDiagnosticReport) -> str:
@@ -679,7 +701,17 @@ def format_report(report: AccelDiagnosticReport) -> str:
     perturbation. Between those, treat the number as suggestive and look at the raw scores.
     """
     ratio = report.signal_to_floor
-    if ratio < 3.0:
+    if np.isnan(ratio):
+        # Must precede the thresholds: every `<` against NaN is False, so a NaN ratio would
+        # otherwise fall through to the "OK" branch and claim the signal dominates a floor
+        # that was never measured.
+        verdict = (
+            "NOT MEASURED — the float32 leg was skipped, so there is no rounding floor to "
+            "compare the signal against and this run cannot answer the go/no-go. Re-run "
+            "once with OPENTAU_ACCEL_MEASURE_DTYPE_FLOOR=1 (the floor is fixed per "
+            "checkpoint, so once is enough)."
+        )
+    elif ratio < 3.0:
         verdict = (
             "STOP — the between-observation spread is within 3x of the pure-rounding floor, "
             "so accel here is mostly measuring bfloat16 arithmetic. Keep the action "
@@ -794,6 +826,47 @@ def _prefix_verdict(study: PrefixStudy) -> list[str]:
     return lines
 
 
+def _allocate_draws(sizes: list[int], count: int) -> list[int]:
+    """Split ``count`` observations across datasets of the given sizes.
+
+    Fair-share with carry-over: each dataset is offered an even slice of what is *still*
+    outstanding, capped by what it actually holds, so a member smaller than its slice is
+    made up by the ones after it instead of quietly lowering the total. The total is also a
+    hard ceiling — asking for fewer observations than there are datasets must not round up
+    to one-each, since every extra observation costs ``K`` denoise passes in the study.
+
+    Args:
+        sizes: Frame count per dataset. Empty datasets should be filtered out first.
+        count: Total observations wanted.
+
+    Returns:
+        Per-dataset draw counts, summing to ``min(count, sum(sizes))``.
+    """
+    quotas = [0] * len(sizes)
+    remaining = min(count, sum(sizes))
+    while remaining > 0:
+        # Re-passing is what makes the carry-over work in both directions. One pass can only
+        # push a shortfall *forward*, so a mixture whose LAST member is the short one would
+        # still come up short — the datasets with spare frames have already been offered
+        # their slice by then.
+        hungry = [i for i, size in enumerate(sizes) if quotas[i] < size]
+        if not hungry:
+            break
+        progressed = False
+        for position, index in enumerate(hungry):
+            if remaining <= 0:
+                break
+            share = max(1, remaining // (len(hungry) - position))
+            take = min(share, remaining, sizes[index] - quotas[index])
+            if take > 0:
+                quotas[index] += take
+                remaining -= take
+                progressed = True
+        if not progressed:
+            break
+    return quotas
+
+
 def dataset_observations(cfg: TrainPipelineConfig, device: torch.device, count: int) -> list[dict]:
     """Draw real observation batches from the configured dataset mixture.
 
@@ -824,23 +897,20 @@ def dataset_observations(cfg: TrainPipelineConfig, device: torch.device, count: 
     from opentau.datasets.factory import make_dataset_mixture
 
     mixture = make_dataset_mixture(cfg)
-    datasets = list(getattr(mixture, "datasets", None) or [mixture])
-    if not any(len(d) for d in datasets):
+    datasets = [d for d in (getattr(mixture, "datasets", None) or [mixture]) if len(d)]
+    if not datasets:
         raise ValueError("The configured dataset mixture is empty; cannot draw observations.")
 
     # Spread the draw across every configured dataset, not just the first. The prefix study
     # correlates accel against posterior spread *across* observations, so it is only as
     # informative as the range of scenes those observations cover; silently sampling one
     # member of a mixture would narrow that range without saying so.
+    quotas = _allocate_draws([len(d) for d in datasets], count)
     observations: list[dict] = []
-    per_dataset = max(1, count // len(datasets))
-    for position, dataset in enumerate(datasets):
-        total = len(dataset)
-        if total == 0:
-            continue
-        wanted = min(per_dataset if position < len(datasets) - 1 else count - len(observations), total)
+    for position, (dataset, wanted) in enumerate(zip(datasets, quotas, strict=True)):
         if wanted <= 0:
-            break
+            continue
+        total = len(dataset)
         stride = max(1, total // wanted)
         indices = [min(i * stride, total - 1) for i in range(wanted)]
         logger.info(
@@ -854,6 +924,18 @@ def dataset_observations(cfg: TrainPipelineConfig, device: torch.device, count: 
             observations.append(
                 {k: (v.to(device) if isinstance(v, torch.Tensor) else v) for k, v in batch.items()}
             )
+
+    if len(observations) != count:
+        # Never silent: `count` is the prefix study's sample size, i.e. the thing that decides
+        # whether neighbouring prefixes are separable at all. A run that quietly went to
+        # half the requested observations produces rank correlations nobody knows to distrust.
+        logger.warning(
+            "Requested %d observation(s) but the mixture could only supply %d (dataset sizes: "
+            "%s). The prefix study's rank correlations are computed over the smaller sample.",
+            count,
+            len(observations),
+            [len(d) for d in datasets],
+        )
     return observations
 
 

--- a/tests/scripts/test_diagnose_accel.py
+++ b/tests/scripts/test_diagnose_accel.py
@@ -43,8 +43,12 @@ from opentau.policies.accel import (
 )
 from opentau.policies.normalize import Unnormalize
 from opentau.scripts.diagnose_accel import (
+    AccelDiagnosticReport,
+    _allocate_draws,
     _posterior_spread,
+    _signal_to_floor,
     _spearman,
+    format_report,
     measure_prefix_quality,
 )
 
@@ -376,6 +380,110 @@ def test_the_study_refuses_a_sample_too_small_to_rank():
         measure_prefix_quality(
             _ScriptedFlowPolicy(late_slope=0.0), _observations([0.01, 0.02]), num_resamples=4
         )
+
+
+# --------------------------------------------------------------------------------------
+# The go/no-go verdict — "not measured" must never render as "OK".
+# --------------------------------------------------------------------------------------
+
+
+def _report(**overrides):
+    payload = {
+        "num_steps": NUM_STEPS,
+        "prefix": 9,
+        "num_scored_dims": [ACTION_DIM],
+        "max_action_dim": ACTION_DIM,
+        "float32_scores": [],
+        "serving_scores": [0.4, 0.5],
+        "serving_dtype": "bfloat16",
+        "dtype_floor": float("nan"),
+        "noise_spread": 0.01,
+        "observation_spread": 0.09,
+        "signal_to_floor": float("nan"),
+    }
+    payload.update(overrides)
+    return AccelDiagnosticReport(**payload)
+
+
+def test_an_unmeasured_floor_is_not_an_infinite_ratio():
+    """NaN is truthy and non-finite, so the obvious guard silently yields `inf`.
+
+    That is the whole bug: skipping the float32 leg leaves nothing to compare against, but
+    an `inf` ratio is indistinguishable from the best possible result.
+    """
+    assert np.isnan(_signal_to_floor(0.09, float("nan")))
+
+
+def test_a_floor_measured_at_exactly_zero_is_still_infinite():
+    """The correction must not overreach — a real zero floor is a real infinite ratio.
+
+    float32 and the serving dtype agreeing on every observation is a legitimate (if
+    unlikely) measurement, and it genuinely means the rounding floor does not bind.
+    """
+    assert _signal_to_floor(0.09, 0.0) == float("inf")
+    assert _signal_to_floor(0.09, 0.009) == pytest.approx(10.0)
+
+
+def test_the_report_refuses_to_certify_a_floor_it_never_measured():
+    """Every `<` comparison against NaN is False, so the thresholds fall through to "OK".
+
+    Without an explicit NaN branch ahead of them, a skipped run prints the single most
+    reassuring line the script has — about a quantity it did not compute. This is the
+    regression test for the path that shipped without one.
+    """
+    rendered = format_report(_report())
+    assert "NOT MEASURED" in rendered
+    assert "OK — real signal dominates" not in rendered
+    assert "MEASURE_DTYPE_FLOOR" in rendered, "must say how to get the missing measurement"
+
+
+def test_the_report_still_certifies_a_genuinely_measured_run():
+    rendered = format_report(_report(dtype_floor=0.0056, signal_to_floor=17.2))
+    assert "OK — real signal dominates" in rendered
+    assert "NOT MEASURED" not in rendered
+
+
+@pytest.mark.parametrize(
+    ("ratio", "expected"),
+    [(1.0, "STOP"), (5.0, "MARGINAL"), (20.0, "OK")],
+)
+def test_the_measured_verdict_bands_are_unchanged(ratio, expected):
+    assert expected in format_report(_report(dtype_floor=0.01, signal_to_floor=ratio))
+
+
+# --------------------------------------------------------------------------------------
+# Observation allocation across a mixture.
+# --------------------------------------------------------------------------------------
+
+
+def test_a_short_dataset_is_made_up_by_the_others():
+    """`count` is the study's sample size, so a shortfall silently weakens every rho.
+
+    A mixture member smaller than its even slice must not lower the total — the datasets
+    after it have frames to spare.
+    """
+    assert sum(_allocate_draws([5, 100], 24)) == 24
+    assert sum(_allocate_draws([100, 5], 24)) == 24
+    assert sum(_allocate_draws([1, 1, 1, 500], 24)) == 24
+
+
+def test_asking_for_fewer_observations_than_datasets_does_not_round_up():
+    """Each observation costs K denoise passes, so overshooting the request is not free."""
+    quotas = _allocate_draws([100] * 5, 2)
+    assert sum(quotas) == 2
+    assert all(q >= 0 for q in quotas)
+
+
+def test_allocation_is_capped_by_what_the_mixture_actually_holds():
+    assert sum(_allocate_draws([3, 4], 24)) == 7
+    assert _allocate_draws([3, 4], 24) == [3, 4]
+
+
+def test_allocation_spreads_across_members_rather_than_draining_the_first():
+    """Drawing everything from one dataset is the narrowed-range failure this replaced."""
+    quotas = _allocate_draws([1000, 1000, 1000], 24)
+    assert sum(quotas) == 24
+    assert min(quotas) > 0, "every dataset must contribute"
 
 
 def test_the_study_restores_the_policy_prefix():

--- a/tests/scripts/test_diagnose_accel.py
+++ b/tests/scripts/test_diagnose_accel.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python
+
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the ``accel`` prefix study.
+
+The claim under test is narrow and easy to fake: that this diagnostic *selects* a prefix
+rather than merely describing one. The distinction matters because the obvious summary —
+mean ``accel_p`` against ``p`` — cannot select anything. Both of its sums accumulate over
+the prefix, so the curve rises with ``p`` whether or not the extra Euler steps carry
+posterior information, and reading its peak as "the best prefix" is a measurement that
+would return the same answer on data with no signal at all.
+
+So the central test here (`test_the_study_follows_rank_correlation_not_the_rising_mean`)
+constructs a policy where the two criteria give *different* answers, and pins that the study
+follows the correlation. Without that disagreement the test would pass under either
+implementation, which is the failure mode CLAUDE.md rule 8 exists to prevent.
+"""
+
+import numpy as np
+import pytest
+import torch
+from torch import nn
+
+from opentau.configs.types import FeatureType, NormalizationMode, PolicyFeature
+from opentau.policies.accel import (
+    AccelMeter,
+    action_dim_scale,
+    make_meter,
+    record_traces,
+)
+from opentau.policies.normalize import Unnormalize
+from opentau.scripts.diagnose_accel import (
+    _posterior_spread,
+    _spearman,
+    measure_prefix_quality,
+)
+
+CPU = torch.device("cpu")
+ACTION_DIM = 4
+CHUNK = 3
+NUM_STEPS = 10
+
+
+def _unnormalize(mode, stats, action_dim=ACTION_DIM):
+    features = {"actions": PolicyFeature(type=FeatureType.ACTION, shape=(action_dim,))}
+    return Unnormalize(features, {FeatureType.ACTION: mode}, stats)
+
+
+# --------------------------------------------------------------------------------------
+# `AccelMeter.value_at` — every prefix out of one pass.
+# --------------------------------------------------------------------------------------
+
+
+def test_value_at_equals_a_meter_independently_built_at_that_prefix():
+    """The whole trace mechanism is only sound if it is *exactly* the shorter-prefix score.
+
+    Bit-identical, not merely close: `value_at` reads snapshots of the same running sums the
+    real meter accumulates, so any drift would mean the snapshot is taken at the wrong point
+    in `update` (e.g. before the numerator is folded in) and would shift every prefix by one
+    step — a silent off-by-one that a tolerance-based assert would wave through.
+    """
+    generator = torch.Generator().manual_seed(0)
+    velocities = [torch.randn(2, CHUNK, ACTION_DIM, generator=generator) for _ in range(6)]
+
+    traced = AccelMeter(prefix=6, batch_size=2, device=CPU, record_trace=True)
+    for velocity in velocities:
+        traced.update(velocity)
+
+    for prefix in range(2, 7):
+        reference = AccelMeter(prefix=prefix, batch_size=2, device=CPU)
+        for velocity in velocities:
+            reference.update(velocity)
+        assert torch.equal(traced.value_at(prefix), reference.value()), (
+            f"value_at({prefix}) must reproduce a meter built at prefix={prefix} exactly"
+        )
+
+
+def test_value_at_is_unavailable_without_tracing():
+    """Off by default: the serving hot path must not pay for a diagnostic feature."""
+    meter = AccelMeter(prefix=3, batch_size=1, device=CPU)
+    for _ in range(3):
+        meter.update(torch.ones(1, CHUNK, ACTION_DIM))
+    assert meter.record_trace is False
+    with pytest.raises(RuntimeError, match="record_trace"):
+        meter.value_at(2)
+
+
+def test_value_at_rejects_a_prefix_the_trace_cannot_support():
+    meter = AccelMeter(prefix=5, batch_size=1, device=CPU, record_trace=True)
+    for _ in range(3):
+        meter.update(torch.ones(1, CHUNK, ACTION_DIM))
+    with pytest.raises(ValueError, match=r"\[2, 3\]"):
+        meter.value_at(4)
+    with pytest.raises(ValueError, match=r"\[2, 3\]"):
+        meter.value_at(1)
+
+
+# --------------------------------------------------------------------------------------
+# `record_traces` — reaching the meter without widening a policy signature.
+# --------------------------------------------------------------------------------------
+
+
+class _Config:
+    type = "pi05"
+    num_steps = NUM_STEPS
+    chunk_size = CHUNK
+    n_action_steps = CHUNK
+    max_delay = 0
+    max_action_dim = ACTION_DIM
+    delta_action_state_map = None
+    normalization_mapping = {"ACTION": NormalizationMode.MEAN_STD}
+
+
+def _policy_stats(std=(1.0, 1.0, 1.0, 1.0)):
+    return [{"actions": {"mean": torch.zeros(ACTION_DIM), "std": torch.tensor(std)}}]
+
+
+class _MeterOnlyPolicy(nn.Module):
+    def __init__(self, accel_prefix=NUM_STEPS):
+        super().__init__()
+        self.config = _Config()
+        self.accel_prefix = accel_prefix
+        self.unnormalize_outputs = _unnormalize(NormalizationMode.MEAN_STD, _policy_stats())
+
+
+def test_meters_built_outside_the_context_neither_trace_nor_leak():
+    meter = make_meter(_MeterOnlyPolicy(), batch_size=1, device=CPU)
+    assert meter.record_trace is False
+
+
+def test_the_context_hands_back_every_meter_built_inside_it():
+    policy = _MeterOnlyPolicy()
+    with record_traces() as meters:
+        first = make_meter(policy, batch_size=1, device=CPU)
+        second = make_meter(policy, batch_size=1, device=CPU)
+    assert meters == [first, second]
+    assert all(m.record_trace for m in meters)
+    # And the switch is scoped: the next meter is back to the serving configuration.
+    assert make_meter(policy, batch_size=1, device=CPU).record_trace is False
+
+
+def test_the_context_restores_tracing_when_the_body_raises():
+    policy = _MeterOnlyPolicy()
+    with pytest.raises(RuntimeError, match="boom"), record_traces():
+        raise RuntimeError("boom")
+    assert make_meter(policy, batch_size=1, device=CPU).record_trace is False
+
+
+# --------------------------------------------------------------------------------------
+# `action_dim_scale` — putting a raw-unit spread into the units accel is computed in.
+# --------------------------------------------------------------------------------------
+
+
+def test_scale_is_the_std_under_mean_std():
+    stats = _policy_stats(std=(2.0, 4.0, 1.0, 0.0))
+    scale = action_dim_scale(
+        _unnormalize(NormalizationMode.MEAN_STD, stats),
+        max_action_dim=ACTION_DIM,
+        dataset_index=torch.zeros(1, dtype=torch.long),
+    )
+    # The degenerate dim becomes 1.0 so callers can divide unconditionally; it is masked out.
+    assert scale.tolist() == [[2.0, 4.0, 1.0, 1.0]]
+
+
+def test_scale_is_half_the_range_under_min_max():
+    """`[lo, hi]` maps onto `[-1, 1]`, so the divisor is half the range, not the range.
+
+    Getting this factor wrong would not break anything visibly — it rescales every
+    observation by the same constant, and the study's rank correlation is invariant to that.
+    It matters because the spread is also reported as an absolute number in the JSON, where a
+    2x error is indistinguishable from a real one.
+    """
+    stats = [{"actions": {"min": torch.zeros(ACTION_DIM), "max": torch.tensor([2.0, 6.0, 1.0, 0.0])}}]
+    scale = action_dim_scale(
+        _unnormalize(NormalizationMode.MIN_MAX, stats),
+        max_action_dim=ACTION_DIM,
+        dataset_index=torch.zeros(1, dtype=torch.long),
+    )
+    assert scale.tolist() == [[1.0, 3.0, 0.5, 1.0]]
+
+
+# --------------------------------------------------------------------------------------
+# `_posterior_spread` — the reference the prefix study scores against.
+# --------------------------------------------------------------------------------------
+
+
+def _spread_policy(std=(1.0, 1.0, 1.0, 1.0), n_action_steps=CHUNK):
+    policy = _MeterOnlyPolicy()
+    policy.unnormalize_outputs = _unnormalize(NormalizationMode.MEAN_STD, _policy_stats(std))
+    policy.config = type("C", (_Config,), {"n_action_steps": n_action_steps})()
+    return policy
+
+
+def test_spread_is_invariant_to_a_constant_offset_across_resamples():
+    """This is what lets a delta-action policy be measured without inverting the transform.
+
+    `sample_actions` re-adds the chunk-start state before returning, but that offset is the
+    same for every resample of one observation, so it cancels in the deviation. If it did
+    not, the spread would be contaminated by the state and the study would be correlating
+    `accel` against the robot's pose.
+    """
+    generator = torch.Generator().manual_seed(3)
+    chunks = [torch.randn(1, CHUNK, ACTION_DIM, generator=generator) for _ in range(8)]
+    offset = torch.full((1, CHUNK, ACTION_DIM), 17.0)
+    policy = _spread_policy()
+    index = torch.zeros(1, dtype=torch.long)
+
+    plain = _posterior_spread(policy, chunks, index)
+    shifted = _posterior_spread(policy, [c + offset for c in chunks], index)
+    assert plain == pytest.approx(shifted, rel=1e-5)
+
+
+def test_spread_standardizes_by_the_per_dim_norm_scale():
+    """A dim with 10x the raw scale must not contribute 10x the spread."""
+    generator = torch.Generator().manual_seed(4)
+    base = [torch.randn(1, CHUNK, ACTION_DIM, generator=generator) for _ in range(8)]
+    # Blow up dim 1 tenfold in raw space, and tell the norm stats about it.
+    stretched = []
+    for chunk in base:
+        scaled = chunk.clone()
+        scaled[:, :, 1] *= 10.0
+        stretched.append(scaled)
+
+    plain = _posterior_spread(_spread_policy(), base, torch.zeros(1, dtype=torch.long))
+    matched = _posterior_spread(
+        _spread_policy(std=(1.0, 10.0, 1.0, 1.0)), stretched, torch.zeros(1, dtype=torch.long)
+    )
+    assert plain == pytest.approx(matched, rel=1e-5), (
+        "standardizing by the norm scale must undo a per-dim unit change"
+    )
+
+
+def test_spread_ignores_padded_dims_and_rows_past_the_executed_window():
+    """Both exclusions mirror the meter: unsupervised output, and actions never applied."""
+    chunks = []
+    for value in range(6):
+        chunk = torch.zeros(1, CHUNK, ACTION_DIM)
+        chunk[:, :, 3] = value * 100.0  # padded dim (std 0) — must not register
+        chunk[:, 2, 0] = value * 100.0  # row past n_action_steps=2 — must not register
+        chunks.append(chunk)
+
+    policy = _spread_policy(std=(1.0, 1.0, 1.0, 0.0), n_action_steps=2)
+    assert _posterior_spread(policy, chunks, torch.zeros(1, dtype=torch.long)) == [0.0]
+
+
+# --------------------------------------------------------------------------------------
+# `_spearman`.
+# --------------------------------------------------------------------------------------
+
+
+def test_spearman_is_monotone_not_linear():
+    xs = [1.0, 2.0, 3.0, 4.0]
+    assert _spearman(xs, [1.0, 8.0, 27.0, 64.0]) == pytest.approx(1.0)
+    assert _spearman(xs, [-1.0, -8.0, -27.0, -64.0]) == pytest.approx(-1.0)
+
+
+def test_spearman_declines_to_answer_rather_than_warning():
+    assert np.isnan(_spearman([1.0, 2.0, 3.0], [5.0, 5.0, 5.0])), "constant input has no ranking"
+    assert np.isnan(_spearman([1.0, 2.0], [1.0, 2.0])), "two points always correlate perfectly"
+    assert _spearman([1.0, 2.0, 3.0, float("nan")], [1.0, 2.0, 3.0, 0.0]) == pytest.approx(1.0)
+
+
+# --------------------------------------------------------------------------------------
+# The study itself.
+# --------------------------------------------------------------------------------------
+
+
+class _ScriptedFlowPolicy(nn.Module):
+    """A policy whose curvature and posterior spread are dialled independently.
+
+    ``state[0]`` carries an uncertainty level ``u``. The returned chunk's spread across
+    resamples is proportional to ``u`` (so ``u`` *is* the ground truth the study is trying to
+    recover), while the scripted velocity sequence makes the *early* prefix track ``u`` and
+    the *late* prefix anti-track it. Velocities lie along one axis so their norms are exactly
+    the scripted magnitudes and the arithmetic stays inspectable.
+    """
+
+    def __init__(self, late_slope: float):
+        super().__init__()
+        self.config = _Config()
+        self.accel_prefix = None
+        self.unnormalize_outputs = _unnormalize(NormalizationMode.MEAN_STD, _policy_stats())
+        self.register_parameter("_anchor", nn.Parameter(torch.zeros(1)))
+        self.late_slope = late_slope
+
+    def _resolve_dataset_index(self, batch):
+        return torch.zeros(len(batch["state"]), dtype=torch.long)
+
+    def sample_actions(self, batch, noise=None, **kwargs):
+        uncertainty = float(batch["state"][0, 0])
+        meter = make_meter(self, batch_size=1, device=CPU, dataset_index=self._resolve_dataset_index(batch))
+
+        # Magnitudes along one axis: |v_t - v_{t-1}| is exactly the step in this list.
+        # The late step must stay POSITIVE as `late_slope` bites: accel's numerator sums
+        # norms, so a step driven negative comes back as a large magnitude and restores the
+        # correlation it was meant to destroy. 0.2 keeps it positive across the `u` range.
+        magnitude = 1.0
+        for step in range(self.config.num_steps):
+            if step == 1:
+                magnitude += uncertainty  # early curvature grows with the true spread
+            elif step >= 2:
+                magnitude += 0.2 - self.late_slope * uncertainty  # late curvature fights it
+            velocity = torch.zeros(1, CHUNK, ACTION_DIM)
+            velocity[:, 0, 0] = magnitude
+            if meter is not None:
+                meter.update(velocity)
+
+        # Posterior spread proportional to u, so the reference measure recovers it.
+        return uncertainty * noise[:, :CHUNK, :ACTION_DIM]
+
+
+def _observations(levels):
+    return [{"state": torch.tensor([[level] + [0.0] * 3])} for level in levels]
+
+
+def test_the_study_follows_rank_correlation_not_the_rising_mean():
+    """The point of the change: the criterion is rho, and rho can disagree with the mean.
+
+    This policy is built so the two answers differ. Early curvature tracks the true posterior
+    spread; late curvature is scripted to fight it, so `accel_T` *anti*-correlates. But the
+    per-prefix mean still rises monotonically with `p`, because both of accel's sums
+    accumulate. An implementation that picked the largest mean would therefore choose the
+    worst available prefix, and this test would fail — which is exactly what makes it a pin
+    on the criterion rather than on the plumbing.
+    """
+    policy = _ScriptedFlowPolicy(late_slope=1.0)
+    study = measure_prefix_quality(
+        policy, _observations([0.01, 0.02, 0.03, 0.05, 0.08, 0.13]), num_resamples=8, seed=0
+    )
+
+    assert study.best_prefix == 2, "the informative prefix here is the earliest one"
+    assert study.rho[2] == pytest.approx(1.0), "early accel tracks the true spread exactly"
+    assert study.rho[NUM_STEPS] < 0.0, "late accel was scripted to anti-track it"
+
+    means = {p: float(np.mean(v)) for p, v in study.accel_by_prefix.items()}
+    assert max(means, key=lambda p: means[p]) == NUM_STEPS, (
+        "the mean sweep must peak at the WORST prefix — otherwise the two criteria agree "
+        "and this test would pass under either implementation"
+    )
+
+
+def test_the_study_endorses_the_default_when_the_default_is_right():
+    """The mirror image: no manufactured disagreement, so `T - 1` should win on its merits."""
+    policy = _ScriptedFlowPolicy(late_slope=0.0)
+    study = measure_prefix_quality(
+        policy, _observations([0.01, 0.02, 0.03, 0.05, 0.08, 0.13]), num_resamples=8, seed=0
+    )
+    assert study.rho_at_default == pytest.approx(1.0)
+    assert study.rho[study.best_prefix] == pytest.approx(study.rho_at_default)
+
+
+def test_the_reference_spread_recovers_the_scripted_uncertainty():
+    """If the reference did not track `u`, every rho above would be meaningless."""
+    levels = [0.01, 0.02, 0.03, 0.05, 0.08, 0.13]
+    study = measure_prefix_quality(
+        _ScriptedFlowPolicy(late_slope=0.0), _observations(levels), num_resamples=8, seed=0
+    )
+    assert _spearman(study.divergences, levels) == pytest.approx(1.0)
+
+
+def test_the_study_refuses_a_sample_too_small_to_rank():
+    with pytest.raises(ValueError, match="rank correlation"):
+        measure_prefix_quality(
+            _ScriptedFlowPolicy(late_slope=0.0), _observations([0.01, 0.02]), num_resamples=4
+        )
+
+
+def test_the_study_restores_the_policy_prefix():
+    """It runs at the full schedule to fill the trace; leaving it there would silently change
+    the score every later call produces."""
+    policy = _ScriptedFlowPolicy(late_slope=0.0)
+    policy.accel_prefix = 4
+    measure_prefix_quality(policy, _observations([0.01, 0.02, 0.03]), num_resamples=4)
+    assert policy.accel_prefix == 4


### PR DESCRIPTION
## What this does

`accel`'s prefix `p` was chosen by inheritance, not by measurement. `default_prefix` returns `T - 1` because that is what the paper's online detector used, and the shipped diagnostic's prefix sweep *looked* like it confirmed that — it reports mean `accel_p` per `p`, and the previous CHANGELOG entry read its shape as reproducing the paper's terminal singularity.

**That inference does not hold.** Both of `accel_p`'s sums accumulate over the prefix, so its magnitude — and the shape of its growth — rise with `p` whether or not the extra Euler steps carry any posterior information. The sweep would produce a similar curve on data with no signal at all, so its peak cannot select a prefix. It is descriptive, and this PR stops it from being read as more than that.

The criterion that *can* select a prefix is the rank correlation between `accel_p` and an independent measure of posterior spread. That reference has to be bought the expensive way — `K` resampled denoises of one observation, whose disagreement *is* the posterior width — which is why it lives in an offline diagnostic and nowhere near the serving path.

**Measured on a real 6-DoF SO101 pi05 checkpoint** (`T = 10`, QUANTILE action norm, delta actions, 24 real frames of its own training data at stride, `K = 32`):

| p | 2 | 3 | 4 | 5 | 6 | 7 | 8 | **9** | 10 |
|---|---|---|---|---|---|---|---|---|---|
| **rho** vs resampled spread | +0.703 | +0.743 | +0.752 | +0.728 | +0.770 | +0.763 | +0.814 | **+0.833** | +0.812 |
| mean `accel_p` | 0.009 | 0.017 | 0.023 | 0.034 | 0.044 | 0.061 | 0.088 | 0.131 | **0.228** |

`rho` peaks at `p = T - 1` and falls at `p = T`. So `default_prefix` is right on this checkpoint and the terminal step really is the weaker one — the same conclusion as before, now resting on evidence that supports it. The mean sweep's argmax is `p = 10`, which `rho` ranks *below* `p = 9`.

Two things worth carrying forward: every prefix scored +0.70…+0.83, so prefix choice is not very consequential here (which also means it will not confound a downstream detection result); and the paper's mid-schedule optimum (`p/T ~ 0.4-0.5`, i.e. `p = 4-5`, `rho` +0.75) does **not** transfer. A `T = 5` schedule (pi06/pi07) is unexamined, and there the two candidate answers are far apart.

### Supporting changes

None of these alter a served score.

- **`AccelMeter` gained an opt-in per-step trace and `value_at(p)`.** `accel_p` is a prefix statistic of one velocity sequence, so every prefix is recoverable from **one** denoise pass rather than `T - 1` of them. That is what makes the resample study affordable, and it makes the descriptive sweep `T - 1` times cheaper as a side effect. Off in serving, where the meter allocates exactly what it did before.
- **`record_traces()`** hands the meters built inside it back to a diagnostic, so no policy has to expose its internals or widen a signature. A `ContextVar` rather than a module global: the gRPC server calls `sample_actions` from several threads, and a global would splice one thread's diagnostic run into another's serving traffic.
- **`action_dim_scale()`** converts a raw-unit spread into the normalized units `accel` is computed in, sharing one buffer extractor with `resolve_action_dim_mask` so the two cannot drift apart when a normalization mode is added.
- **Diagnostic observations are drawn across every dataset in the mixture**, not just the first. The correlation is taken *across* observations, so their variety is the study's resolution; silently sampling one member of a mixture narrowed that without saying so. Default count raised to 24 — at 8 points Spearman needs |rho| >= 0.74 to clear p < 0.05, too blunt to separate neighbouring prefixes.
- **The float32 leg of the dtype-floor measurement is skippable** (`OPENTAU_ACCEL_MEASURE_DTYPE_FLOOR=0`). It holds a second copy of the weights and is the first thing to fail on a GPU shared with other work; the floor it measures is fixed per checkpoint. Skipping reports `NaN` rather than a fabricated ratio.

## How it was tested

**New: `tests/scripts/test_diagnose_accel.py` (18 tests).** The central one is `test_the_study_follows_rank_correlation_not_the_rising_mean`: it scripts a policy where the two criteria give *different* answers — early curvature tracks the true posterior spread, late curvature is built to fight it — and pins that the study follows the correlation. It also asserts the mean sweep peaks at the *worst* prefix, because without that manufactured disagreement the test would pass under either implementation.

**Mutation-tested both load-bearing pins**, since a pin whose passing does not depend on the property it names is not a pin:

| mutation | result |
|---|---|
| selection criterion swapped from `rho` back to the mean sweep | 2 failed, incl. the central test |
| trace snapshot moved before the numerator update (off-by-one) | 2 failed, incl. the bit-identity test |

Both restored byte-identically afterwards.

`value_at(p)` is asserted **bit-identical** (`torch.equal`, not a tolerance) to a meter independently constructed at prefix `p`, for every `p` — a tolerance-based check would wave through exactly the off-by-one above.

Also pinned: the delta-action invariance the study relies on (a constant offset across resamples cancels, so no delta inverse is needed), per-dim standardization undoing a unit change, mask exclusion of padded dims and rows past the executed window, and `record_traces()` restoring the serving configuration on exception.

**Full CPU suite** for the affected trees: `pytest tests/policies/ tests/scripts/ tests/utils/ -m "not gpu and not network" -n auto` — 1627 passed. The one failure, `tests/utils/test_libero_utils.py::test_libero2torch`, is a pre-existing local-environment issue (a stale `LIBERO_CONFIG_PATH`); I confirmed it fails identically on a pristine `origin/main` checkout, so it is not from this change.

**On the GPU checkbox, so the reviewer is not misled:** the `-m "gpu"` suite was **not** run ad hoc for this PR — GPU coverage is deliberately delegated to the nightly `gpu_test.yml` and regression workflows. The policy box is checked because `AccelMeter.update` executes inside the sampler's Euler loop, which is the conservative reading even though no `modeling_*.py`, `optim/`, sampler, or `train.py` file is touched. What *was* exercised on GPU is the end-to-end run below, plus a `pi07_paligemma` eval that loaded the policy and armed the estimator (`accel enabled: prefix=9 of num_steps=10`) before I stopped it.

No determinism run: CLAUDE.md rule 3 covers `train.py`, `modeling_*.py`, `optim/`, and the samplers, none of which this touches, and `accel` is inference-only (never reached from `forward`).

**End-to-end on the real checkpoint**, which is where the numbers in the table come from — 24 real training frames, 768 denoise passes, on the GPU dev box.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/scripts/test_diagnose_accel.py
```

The claim that the mean sweep cannot select a prefix is worth checking directly — this is the test that fails if the criterion is swapped back:

```bash
pytest -sx tests/scripts/test_diagnose_accel.py::test_the_study_follows_rank_correlation_not_the_rising_mean
```

On a GPU box with a flow-matching checkpoint, the study itself. It is inference-only and starts no training:

```bash
OPENTAU_ACCEL_OBSERVATIONS=24 OPENTAU_ACCEL_RESAMPLES=32 \
python src/opentau/scripts/diagnose_accel.py \
    --config_path=<a config carrying the checkpoint's training data> \
    --policy.path=<repo>@<step> --policy.device=cuda
```

Set `OPENTAU_ACCEL_RESAMPLES=0` to skip the study (it is the only expensive part), or `OPENTAU_ACCEL_MEASURE_DTYPE_FLOOR=0` if the GPU is shared.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [x] My PR includes policy-related changes.
  - [x] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.
