### PR TITLE
fix(grpc): run compiled sample_actions on one dedicated thread

### DIFF
--- a/src/opentau/scripts/grpc/server.py
+++ b/src/opentau/scripts/grpc/server.py
@@ -56,7 +56,7 @@ import traceback
 from concurrent import futures
 from dataclasses import asdict
 from pprint import pformat
-from typing import Callable, Iterator
+from typing import Any, Callable, Iterator
 
 import numpy as np
 import torch
@@ -132,9 +132,7 @@ class RobotPolicyServicer(robot_inference_pb2_grpc.RobotPolicyServiceServicer):
         # every later sample_actions must share one dedicated thread — otherwise
         # the first real request dies in cudagraph_trees with a bare
         # AssertionError (empty str → "Inference error: ").
-        self._infer_executor = futures.ThreadPoolExecutor(
-            max_workers=1, thread_name_prefix="policy-infer"
-        )
+        self._infer_executor = futures.ThreadPoolExecutor(max_workers=1, thread_name_prefix="policy-infer")
 
         logger.info(f"Initializing policy on device: {self.device}")
 
@@ -303,18 +301,30 @@ class RobotPolicyServicer(robot_inference_pb2_grpc.RobotPolicyServiceServicer):
         if executor is not None:
             executor.shutdown(wait=False)
 
-    def _sample_actions_sync(self, batch, action_prefix, delay):
+    def _sample_actions_sync(
+        self,
+        batch: dict[str, Any],
+        action_prefix: torch.Tensor,
+        delay: torch.Tensor,
+    ) -> torch.Tensor:
         """Run compiled ``sample_actions`` on the CUDA-graph thread.
 
         ``torch.inference_mode`` is thread-local, so it must wrap the call
         inside the infer worker, not on the gRPC handler thread.
+
+        Args:
+            batch: Policy input batch from ``_prepare_observation`` (tensors plus
+                the string-valued ``prompt`` / norm-head keys).
+            action_prefix: Prefix actions to condition the chunk on.
+            delay: Number of prefix steps already executed by the robot.
+
+        Returns:
+            The sampled action chunk, shape ``(1, n_action_steps, action_dim)``.
         """
 
         def _run():
             with torch.inference_mode():
-                return self.policy.sample_actions(
-                    batch, action_prefix=action_prefix, delay=delay
-                )
+                return self.policy.sample_actions(batch, action_prefix=action_prefix, delay=delay)
 
         return self._infer_executor.submit(_run).result()
 
@@ -534,8 +544,10 @@ class RobotPolicyServicer(robot_inference_pb2_grpc.RobotPolicyServiceServicer):
             # atomic with respect to each other, or two concurrent requests interleave as
             # "A samples, B samples, A reads" and A's response carries B's uncertainty --
             # a wrong number silently attributed to the wrong observation, which is worse
-            # than no number at all. The lock is taken ONLY when accel is enabled, so the
-            # default serving path keeps its existing concurrency exactly.
+            # than no number at all. `_infer_executor` already serializes the sampling
+            # itself (one dedicated thread), but it cannot keep the sample and the
+            # `last_accel` read that follows it in one critical section -- that pairing is
+            # the lock's only remaining job, so it is taken ONLY when accel is enabled.
             accel_guard = self._accel_lock if self.accel_prefix else contextlib.nullcontext()
             with accel_guard:
                 action_chunk = self._sample_actions_sync(batch, action_prefix, delay)
@@ -569,7 +581,7 @@ class RobotPolicyServicer(robot_inference_pb2_grpc.RobotPolicyServiceServicer):
             logger.exception("Error during inference")
             # AssertionError() has an empty str(); include the type so the
             # client sees a usable message.
-            detail = f"{type(e).__name__}: {e}".rstrip(": ")
+            detail = f"{type(e).__name__}: {e}" if str(e) else type(e).__name__
             context.abort(grpc.StatusCode.INTERNAL, f"Inference error: {detail}")
 
         response.inference_time_ms = (time.perf_counter() - start_time) * 1000

--- a/src/opentau/scripts/grpc/server.py
+++ b/src/opentau/scripts/grpc/server.py
@@ -127,6 +127,14 @@ class RobotPolicyServicer(robot_inference_pb2_grpc.RobotPolicyServiceServicer):
         # Serializes `sample_actions` with the `last_accel` read that follows it. Only
         # taken when accel is enabled; see `GetActionChunk` for why the pair must be atomic.
         self._accel_lock = threading.Lock()
+        # torch.compile CUDA graphs store TLS on the thread that first runs the
+        # compiled fn. gRPC handlers use a ThreadPoolExecutor, so warmup and
+        # every later sample_actions must share one dedicated thread — otherwise
+        # the first real request dies in cudagraph_trees with a bare
+        # AssertionError (empty str → "Inference error: ").
+        self._infer_executor = futures.ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="policy-infer"
+        )
 
         logger.info(f"Initializing policy on device: {self.device}")
 
@@ -291,6 +299,24 @@ class RobotPolicyServicer(robot_inference_pb2_grpc.RobotPolicyServiceServicer):
         self._replan_event.set()
         if self._planner_thread is not None:
             self._planner_thread.join(timeout=5)
+        executor = getattr(self, "_infer_executor", None)
+        if executor is not None:
+            executor.shutdown(wait=False)
+
+    def _sample_actions_sync(self, batch, action_prefix, delay):
+        """Run compiled ``sample_actions`` on the CUDA-graph thread.
+
+        ``torch.inference_mode`` is thread-local, so it must wrap the call
+        inside the infer worker, not on the gRPC handler thread.
+        """
+
+        def _run():
+            with torch.inference_mode():
+                return self.policy.sample_actions(
+                    batch, action_prefix=action_prefix, delay=delay
+                )
+
+        return self._infer_executor.submit(_run).result()
 
     def _load_policy(self):
         """Load the policy model from pretrained weights."""
@@ -341,14 +367,11 @@ class RobotPolicyServicer(robot_inference_pb2_grpc.RobotPolicyServiceServicer):
         )
         delay = torch.tensor(0, dtype=torch.long, device=self.device)
 
-        with torch.inference_mode():
-            # One warmup call right after compiling
-            # two warmup calls are needed right after compiling
-            # the first warmup call is needed for compiling
-            # the second warmup call is needed for kernel autotuning
-            _ = self.policy.sample_actions(observation, action_prefix=action_prefix, delay=delay)
-            _ = self.policy.sample_actions(observation, action_prefix=action_prefix, delay=delay)
-            logger.info("Policy loaded successfully")
+        # Warmup on the same thread that will serve RPCs (see ``_infer_executor``).
+        # Two calls: the first compiles, the second autotunes kernels.
+        _ = self._sample_actions_sync(observation, action_prefix, delay)
+        _ = self._sample_actions_sync(observation, action_prefix, delay)
+        logger.info("Policy loaded successfully")
 
     def _decode_image(self, camera_image: robot_inference_pb2.CameraImage) -> torch.Tensor:
         """Decode an image from the protobuf message.
@@ -514,8 +537,8 @@ class RobotPolicyServicer(robot_inference_pb2_grpc.RobotPolicyServiceServicer):
             # than no number at all. The lock is taken ONLY when accel is enabled, so the
             # default serving path keeps its existing concurrency exactly.
             accel_guard = self._accel_lock if self.accel_prefix else contextlib.nullcontext()
-            with accel_guard, torch.inference_mode():
-                action_chunk = self.policy.sample_actions(batch, action_prefix=action_prefix, delay=delay)
+            with accel_guard:
+                action_chunk = self._sample_actions_sync(batch, action_prefix, delay)
                 # action_chunk shape: (batch_size=1, n_action_steps, action_dim)
                 # Remove batch dimension and convert to numpy
                 action_chunk = action_chunk.squeeze(0).to("cpu", torch.float32).numpy()
@@ -544,7 +567,10 @@ class RobotPolicyServicer(robot_inference_pb2_grpc.RobotPolicyServiceServicer):
             # Unexpected error during inference
             traceback.print_exc()
             logger.exception("Error during inference")
-            context.abort(grpc.StatusCode.INTERNAL, f"Inference error: {e}")
+            # AssertionError() has an empty str(); include the type so the
+            # client sees a usable message.
+            detail = f"{type(e).__name__}: {e}".rstrip(": ")
+            context.abort(grpc.StatusCode.INTERNAL, f"Inference error: {detail}")
 
         response.inference_time_ms = (time.perf_counter() - start_time) * 1000
         return response

--- a/tests/scripts/test_grpc_planner_server.py
+++ b/tests/scripts/test_grpc_planner_server.py
@@ -135,6 +135,56 @@ class TestRequestHook:
         servicer.policy.sample_actions.assert_called_once()
 
 
+class TestInferenceThread:
+    """Pins the dedicated-infer-thread contract.
+
+    torch.compile keeps its CUDA-graph state in thread-local storage, so warmup
+    and every request must run ``sample_actions`` on one and the same thread. A
+    test that only asserts the policy was called would still pass if inference
+    reverted to the gRPC handler thread, so these assert the thread identity.
+    """
+
+    def _record_calling_thread(self, servicer) -> list[threading.Thread]:
+        # Thread *objects*, not names or idents: a fresh single-worker pool per
+        # call reuses the "policy-infer" name and CPython recycles idents of dead
+        # threads, so only object identity distinguishes "the servicer's worker"
+        # from "some worker".
+        seen: list[threading.Thread] = []
+
+        def _sample(*_args, **_kwargs):
+            seen.append(threading.current_thread())
+            return torch.zeros((1, 2, 3))
+
+        servicer._prepare_observation = MagicMock(return_value=({}, None, None))
+        servicer.policy = MagicMock()
+        servicer.policy.sample_actions.side_effect = _sample
+        return seen
+
+    @staticmethod
+    def _infer_worker(servicer) -> threading.Thread:
+        """The thread the servicer's own infer executor runs work on."""
+        return servicer._infer_executor.submit(threading.current_thread).result()
+
+    def test_sampling_runs_on_the_servicer_infer_thread(self, make_servicer):
+        servicer, _ = make_servicer(enabled=False)
+        seen = self._record_calling_thread(servicer)
+
+        servicer.GetActionChunk(_request(), MagicMock())
+
+        assert len(seen) == 1
+        assert seen[0] is self._infer_worker(servicer)
+        assert seen[0] is not threading.current_thread()
+
+    def test_consecutive_requests_share_one_thread(self, make_servicer):
+        servicer, _ = make_servicer(enabled=False)
+        seen = self._record_calling_thread(servicer)
+
+        servicer.GetActionChunk(_request(), MagicMock())
+        servicer.GetActionChunk(_request(), MagicMock())
+
+        assert seen == [self._infer_worker(servicer)] * 2
+
+
 class TestPlannerEnabled:
     def test_first_request_blocks_and_uses_subtask(self, make_servicer):
         servicer, fake_planner = make_servicer(enabled=True)

--- a/tests/scripts/test_grpc_planner_server.py
+++ b/tests/scripts/test_grpc_planner_server.py
@@ -132,6 +132,7 @@ class TestRequestHook:
         servicer.GetActionChunk(_request(), MagicMock())
 
         assert calls == ["GetActionChunk"]
+        servicer.policy.sample_actions.assert_called_once()
 
 
 class TestPlannerEnabled:


### PR DESCRIPTION
## What this does
Fixes gRPC `GetActionChunk` crashing with an empty `Inference error:` after `torch.compile(mode="max-autotune")`. CUDA graphs are thread-local; warmup ran on the main thread while RPCs ran on the gRPC pool. Route warmup and every `sample_actions` through one dedicated infer thread, and include the exception type in INTERNAL errors.

## How it was tested
- Reproduced on tuner-dev: HealthCheck succeeded, `GetActionChunk` returned `INTERNAL: Inference error:` (empty `AssertionError` from cudagraph TLS).
- Added `TestInferenceThread` in `tests/scripts/test_grpc_planner_server.py`, pinning both halves of the new contract: `sample_actions` runs on the servicer's own infer worker, and consecutive requests land on that same thread. The assertions compare thread *objects*, not names or idents — a fresh per-call pool reuses the `policy-infer` name, and CPython recycles idents of dead threads, so neither would fail on a regression.
- Mutation-tested those two tests locally: inlining the call (back to the gRPC handler thread) and rebuilding the executor per call each make both tests fail; the current implementation passes.
- `pytest -m "not gpu and not network" tests/scripts/ -n auto` → 344 passed. `pre-commit run --all-files` clean.
- The real `torch.compile` + cudagraph path needs a CUDA box and was not re-run here; the CPU tests pin the threading contract only.

## How to checkout & try? (for the reviewer)
```bash
pytest -sx tests/scripts/test_grpc_planner_server.py::TestInferenceThread
```

On a CUDA box, start the gRPC server, then HealthCheck followed by GetActionChunk on a thread-pool RPC (not the process that constructed the servicer).

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
