### PR TITLE
fix(value): learned <val> readout token + single shared norm head

### DIFF
--- a/src/opentau/policies/value/modeling_value.py
+++ b/src/opentau/policies/value/modeling_value.py
@@ -351,6 +351,33 @@ class ValueFunction(PreTrainedPolicy):
         return rearrange(value, "b 1 -> b")
 
     @torch.no_grad()
+    def _resolve_dataset_index(self, batch: dict[str, Tensor]) -> Tensor:
+        """Always row 0: the value function uses ONE shared stats head for every dataset.
+
+        The base implementation derives a per-dataset head from
+        ``(robot_type, control_mode)``, falling back to the dataset NAME whenever either tag
+        is missing -- so a dataset whose ``info.json`` lacks ``control_mode`` silently gets
+        its own head, and one whose tags match nothing on the policy raises. Both happened
+        here: evaluating the 14k checkpoint died with ``norm key '' ... not in this policy's
+        training set ['so_follower::joint']`` because ``aggregate_datasets`` had dropped
+        ``control_mode`` from the merged dataset.
+
+        Per-dataset heads are wrong for this policy anyway. A value is a scalar return
+        estimate, not an action in some robot's units -- it is meant to be comparable ACROSS
+        datasets, which it cannot be if each one is normalized against its own statistics.
+        One shared head keeps values on a single scale and makes the policy insensitive to
+        whether a dataset happens to carry its metadata tags.
+
+        Args:
+            batch: The inference or training batch.
+
+        Returns:
+            A ``(batch,)`` long tensor of zeros.
+        """
+        batch_size, device = self._infer_batch_size_and_device(batch)
+        return torch.zeros(batch_size or 1, dtype=torch.long, device=device or self._model_device())
+
+    @torch.no_grad()
     def predict_value(self, batch: dict[str, Tensor]) -> Tensor:
         """Predict value estimates given environment observations.
 
@@ -604,7 +631,13 @@ class ValueFunction(PreTrainedPolicy):
         """
 
         device = batch["state"].device
-        responses = batch["response"]
+        # Datasets without subtask/response annotations don't emit a "response"
+        # key. Default to empty strings so the response branch is masked out of
+        # the loss (empty -> all-pad -> response CE = 0), i.e. the response head
+        # is effectively disabled for robotic datasets with no subtasks.
+        responses = batch.get("response")
+        if responses is None:
+            responses = [""] * batch["state"].shape[0]
 
         # if '' is found in response then response is not for loss calculation (used for robotic dataset with no subtask), so add pad token to the response.
         response_prompt = [f"{response}" for response in responses]
@@ -743,6 +776,19 @@ class ValueModel(nn.Module):
             # full attention between image, language and response inputs
             num_response_embs = response_emb.shape[1]
             att_masks += [1] * num_response_embs
+
+        # <val>: the readout token, appended LAST so it is always the final position and
+        # never padding. att_mask 1 opens a new block, so it attends over the whole prefix
+        # while nothing attends back to it; the 2D mask keeps pad positions out of its keys,
+        # which is what lets it sit after a padded prompt and still see only real tokens.
+        #
+        # Without it the value was read from hidden_states[:, -1, :], which IS padding once
+        # the prompt is padded to prompt_max_length -- the readout carried no information and
+        # the head could only emit a constant. See SiglipGemmaValueModel.value_token.
+        val_emb = self.siglip_gemma_value.value_token.to(dtype=embs[0].dtype, device=embs[0].device)
+        embs.append(val_emb.expand(bsize, 1, -1))
+        pad_masks.append(torch.ones(bsize, 1, dtype=pad_masks[0].dtype, device=pad_masks[0].device))
+        att_masks += [1]
 
         embs = torch.cat(embs, dim=1)
         pad_masks = torch.cat(pad_masks, dim=1)

--- a/src/opentau/policies/value/modeling_value.py
+++ b/src/opentau/policies/value/modeling_value.py
@@ -763,6 +763,22 @@ class ValueModel(nn.Module):
         num_lang_embs = lang_emb.shape[1]
         att_masks += [0] * num_lang_embs
 
+        # <val>: the readout token, placed right after the prompt and BEFORE any response
+        # block so its attention context is identical in training and inference. att_mask 1
+        # opens a new block, so it attends over the whole prefix (images + prompt) while
+        # nothing before it attends back; the 2D mask keeps pad positions out of its keys,
+        # which is what lets it sit after a padded prompt and still see only real tokens.
+        # Because the response block follows it, <val> never attends to the response -- and
+        # get_value (no response) reads the same token over the same context.
+        #
+        # Without it the value was read from hidden_states[:, -1, :], which IS padding once
+        # the prompt is padded to prompt_max_length -- the readout carried no information and
+        # the head could only emit a constant. See SiglipGemmaValueModel.value_token.
+        val_emb = self.siglip_gemma_value.value_token.to(dtype=embs[0].dtype, device=embs[0].device)
+        embs.append(val_emb.expand(bsize, 1, -1))
+        pad_masks.append(torch.ones(bsize, 1, dtype=pad_masks[0].dtype, device=pad_masks[0].device))
+        att_masks += [1]
+
         if response_tokens is not None:
             response_emb = self.siglip_gemma_value.embed_language_tokens(response_tokens)
 
@@ -773,22 +789,9 @@ class ValueModel(nn.Module):
             embs.append(response_emb)
             pad_masks.append(response_masks)
 
-            # full attention between image, language and response inputs
+            # response attends to the whole prefix and <val>; causal within itself.
             num_response_embs = response_emb.shape[1]
             att_masks += [1] * num_response_embs
-
-        # <val>: the readout token, appended LAST so it is always the final position and
-        # never padding. att_mask 1 opens a new block, so it attends over the whole prefix
-        # while nothing attends back to it; the 2D mask keeps pad positions out of its keys,
-        # which is what lets it sit after a padded prompt and still see only real tokens.
-        #
-        # Without it the value was read from hidden_states[:, -1, :], which IS padding once
-        # the prompt is padded to prompt_max_length -- the readout carried no information and
-        # the head could only emit a constant. See SiglipGemmaValueModel.value_token.
-        val_emb = self.siglip_gemma_value.value_token.to(dtype=embs[0].dtype, device=embs[0].device)
-        embs.append(val_emb.expand(bsize, 1, -1))
-        pad_masks.append(torch.ones(bsize, 1, dtype=pad_masks[0].dtype, device=pad_masks[0].device))
-        att_masks += [1]
 
         embs = torch.cat(embs, dim=1)
         pad_masks = torch.cat(pad_masks, dim=1)

--- a/src/opentau/policies/value/siglip_gemma.py
+++ b/src/opentau/policies/value/siglip_gemma.py
@@ -154,8 +154,8 @@ class SiglipGemmaValueModel(PreTrainedModel):
 
         # Value head: projects final hidden state to discretized value bins
         self.value_head = nn.Linear(640, config.num_value_bins)
-        # Learned <val> readout token, appended as the LAST element of every sequence by
-        # ValueModel.embed_sequence. The value is read from ITS hidden state.
+        # Learned <val> readout token, inserted by ValueModel.embed_sequence right after the
+        # prompt and before any response block. The value is read from ITS hidden state.
         #
         # Why it exists: the readout used to be hidden_states[:, -1, :], described as "the
         # last language token". It is not — prepare_language pads the prompt to
@@ -167,8 +167,9 @@ class SiglipGemmaValueModel(PreTrainedModel):
         # training data and held-out data. The model had learned the only thing available to
         # it, the mean return.
         #
-        # A dedicated token fixes this by construction: it is always present, always the last
-        # position, never padding, and it attends over the whole real prefix.
+        # A dedicated token fixes this by construction: it is always present, never padding,
+        # and it attends over the whole real prefix (and only the prefix, since it precedes
+        # the response block) -- so training and inference read it over identical context.
         self.value_token = nn.Parameter(torch.zeros(1, 1, 640))
         nn.init.normal_(self.value_token, std=0.02)
         # Response head: projects response hidden states to logits for response language
@@ -232,13 +233,14 @@ class SiglipGemmaValueModel(PreTrainedModel):
         )
         hidden_states = outputs.last_hidden_state
 
-        # Value comes from the <val> token, which embed_sequence appends LAST. Training and
-        # inference now read the SAME position; they previously did not (-L-1 here vs -1 in
-        # get_value), so with response_max_length=52 they were 52 tokens apart.
-        classification_hidden = hidden_states[:, -1, :]
-        # The response block sits just before <val>, so every index shifts by one. Same
-        # semantics as before: all response tokens except the last (next-token prediction).
-        response_hidden = hidden_states[:, -self.config.response_max_length - 1 : -2, :]
+        # Value comes from the <val> token. embed_sequence now places it right after the
+        # prompt and BEFORE the response block, so it sits at -(response_max_length + 1)
+        # here. This is the same token, over the same prefix-only context, that get_value
+        # reads at -1 when no response is present -- training and inference stay consistent.
+        classification_hidden = hidden_states[:, -self.config.response_max_length - 1, :]
+        # The response block is the final response_max_length positions; drop the last one
+        # for next-token prediction (labels are response_tokens[:, 1:]).
+        response_hidden = hidden_states[:, -self.config.response_max_length : -1, :]
 
         # Project to logits for discretized values
         value_logits = self.value_head(classification_hidden)
@@ -278,8 +280,9 @@ class SiglipGemmaValueModel(PreTrainedModel):
         )
         hidden_states = outputs.last_hidden_state
 
-        # The <val> token is appended last by embed_sequence, so position -1 is it -- not
-        # padding, as the previous comment ("the last language token") assumed.
+        # get_value runs without a response block, so the <val> token is the final position
+        # (index -1) here -- the same token and same prefix-only context the training
+        # forward reads at -(response_max_length + 1).
         value_hidden = hidden_states[:, -1, :]
 
         # Project to logits for discretized values

--- a/src/opentau/policies/value/siglip_gemma.py
+++ b/src/opentau/policies/value/siglip_gemma.py
@@ -154,6 +154,23 @@ class SiglipGemmaValueModel(PreTrainedModel):
 
         # Value head: projects final hidden state to discretized value bins
         self.value_head = nn.Linear(640, config.num_value_bins)
+        # Learned <val> readout token, appended as the LAST element of every sequence by
+        # ValueModel.embed_sequence. The value is read from ITS hidden state.
+        #
+        # Why it exists: the readout used to be hidden_states[:, -1, :], described as "the
+        # last language token". It is not — prepare_language pads the prompt to
+        # prompt_max_length, so position -1 is padding (measured 2026-08-17: 144 real tokens
+        # of 256, last real token at index 655 of a 768-long sequence). A pad position
+        # carries no information about the images or the prompt, so the head could only ever
+        # emit a constant, and that is exactly what the 14k checkpoint does: identical logits
+        # for different frames (max|delta| = 0.0) and V = -0.1217 on every frame of both the
+        # training data and held-out data. The model had learned the only thing available to
+        # it, the mean return.
+        #
+        # A dedicated token fixes this by construction: it is always present, always the last
+        # position, never padding, and it attends over the whole real prefix.
+        self.value_token = nn.Parameter(torch.zeros(1, 1, 640))
+        nn.init.normal_(self.value_token, std=0.02)
         # Response head: projects response hidden states to logits for response language
         self.response_head = nn.Linear(640, self.gemma.config.vocab_size, bias=False)
 
@@ -215,13 +232,13 @@ class SiglipGemmaValueModel(PreTrainedModel):
         )
         hidden_states = outputs.last_hidden_state
 
-        # Extract the last token's hidden state for value prediction
-        # Use the last token (which should be the last language token)
-
-        # extract token just before response <bos> token
-        classification_hidden = hidden_states[:, -self.config.response_max_length - 1, :]
-        # extract tokens from response <bos> token to just before last token
-        response_hidden = hidden_states[:, -self.config.response_max_length : -1, :]
+        # Value comes from the <val> token, which embed_sequence appends LAST. Training and
+        # inference now read the SAME position; they previously did not (-L-1 here vs -1 in
+        # get_value), so with response_max_length=52 they were 52 tokens apart.
+        classification_hidden = hidden_states[:, -1, :]
+        # The response block sits just before <val>, so every index shifts by one. Same
+        # semantics as before: all response tokens except the last (next-token prediction).
+        response_hidden = hidden_states[:, -self.config.response_max_length - 1 : -2, :]
 
         # Project to logits for discretized values
         value_logits = self.value_head(classification_hidden)
@@ -261,10 +278,8 @@ class SiglipGemmaValueModel(PreTrainedModel):
         )
         hidden_states = outputs.last_hidden_state
 
-        # Extract the last token's hidden state for value prediction
-        # Use the last token (which should be the last language token)
-
-        # extract last token while inference
+        # The <val> token is appended last by embed_sequence, so position -1 is it -- not
+        # padding, as the previous comment ("the last language token") assumed.
         value_hidden = hidden_states[:, -1, :]
 
         # Project to logits for discretized values

--- a/tests/policies/test_value.py
+++ b/tests/policies/test_value.py
@@ -28,9 +28,9 @@ class TestValueFunctionIntegration:
         """
         assert pad_masks.shape[0] == 1
         if inference_mode:
-            assert pad_masks.shape[1] == 768
+            assert pad_masks.shape[1] == 769
         else:
-            assert pad_masks.shape[1] == 820
+            assert pad_masks.shape[1] == 821
         assert pad_masks.dtype == torch.bool
 
         def _check_ones_before_zeros(mask_slice):
@@ -54,8 +54,9 @@ class TestValueFunctionIntegration:
         for i in range(batch_size):
             assert torch.all(pad_masks[i, :512] == 1)  # image tokens should not be padded
             _check_ones_before_zeros(pad_masks[i, 512:768])  # prompt tokens
+            assert pad_masks[i, 768] == 1  # <val> readout token is never padded
             if not inference_mode:
-                _check_ones_before_zeros(pad_masks[i, 768:820])  # response tokens
+                _check_ones_before_zeros(pad_masks[i, 769:821])  # response tokens
 
     def _verify_position_ids(self, position_ids, pad_masks, inference_mode=False):
         """Verify the position ids are correct. They should increment by 1 for each non-padded token and stay the same for padded tokens.
@@ -65,9 +66,9 @@ class TestValueFunctionIntegration:
         """
         assert position_ids.shape[0] == 1
         if inference_mode:
-            assert position_ids.shape[1] == 768
+            assert position_ids.shape[1] == 769
         else:
-            assert position_ids.shape[1] == 820
+            assert position_ids.shape[1] == 821
         assert position_ids.dtype == torch.long
 
         def _check_position_ids_with_padding(position_ids, pad_masks):
@@ -98,33 +99,37 @@ class TestValueFunctionIntegration:
         """
         assert vlm_attention_mask.shape[0] == 1
         if inference_mode:
-            assert vlm_attention_mask.shape[1] == 768
-            assert vlm_attention_mask.shape[2] == 768
+            assert vlm_attention_mask.shape[1] == 769
+            assert vlm_attention_mask.shape[2] == 769
         else:
-            assert vlm_attention_mask.shape[1] == 820
-            assert vlm_attention_mask.shape[2] == 820
+            assert vlm_attention_mask.shape[1] == 821
+            assert vlm_attention_mask.shape[2] == 821
         assert vlm_attention_mask.dtype == torch.bool
 
         batch_size = vlm_attention_mask.shape[0]
         for i in range(batch_size):
             # construct correct attention mask
             # see diagram here: https://drive.google.com/file/d/12lhS72bnQrKyL4iCfEj6SDRSPi1NABBj/view?usp=sharing
-            correct_vlm_attention_mask = torch.ones(820, 820, dtype=torch.bool)
+            #
+            # Sequence layout: images[0:512] | prompt[512:768] | <val>[768] | response[769:821].
+            # The <val> readout sits right after the prompt and BEFORE the response block, so
+            # it attends over the prefix only -- identical context to inference, where the
+            # response block is absent and <val> is simply the last token.
+            correct_vlm_attention_mask = torch.ones(821, 821, dtype=torch.bool)
 
             # pad tokens should not be attended to or attend to any other tokens
-            prompt_start_idx, response_start_idx = 512, 768
-            num_non_padded_prompt_tokens = pad_masks[i, prompt_start_idx:response_start_idx].sum()
+            prompt_start_idx, val_idx, response_start_idx = 512, 768, 769
+            num_non_padded_prompt_tokens = pad_masks[i, prompt_start_idx:val_idx].sum()
             num_non_padded_response_tokens = pad_masks[i, response_start_idx:].sum()
-            correct_vlm_attention_mask[
-                prompt_start_idx + num_non_padded_prompt_tokens : response_start_idx, :
-            ] = 0
-            correct_vlm_attention_mask[
-                :, prompt_start_idx + num_non_padded_prompt_tokens : response_start_idx
-            ] = 0
+            correct_vlm_attention_mask[prompt_start_idx + num_non_padded_prompt_tokens : val_idx, :] = 0
+            correct_vlm_attention_mask[:, prompt_start_idx + num_non_padded_prompt_tokens : val_idx] = 0
             correct_vlm_attention_mask[response_start_idx + num_non_padded_response_tokens :, :] = 0
             correct_vlm_attention_mask[:, response_start_idx + num_non_padded_response_tokens :] = 0
 
-            correct_vlm_attention_mask[:response_start_idx, response_start_idx:] = 0
+            # The prefix (images + prompt) cannot attend forward to <val> or the response.
+            correct_vlm_attention_mask[:val_idx, val_idx:] = 0
+            # <val> attends to the prefix and itself, but not to the response block after it.
+            correct_vlm_attention_mask[val_idx, response_start_idx:] = 0
 
             response_causal_mask = torch.tril(
                 torch.ones(
@@ -139,7 +144,8 @@ class TestValueFunctionIntegration:
             ] = response_causal_mask
 
             if inference_mode:
-                correct_vlm_attention_mask = correct_vlm_attention_mask[:768, :768]
+                # No response block at inference: keep images + prompt + <val>.
+                correct_vlm_attention_mask = correct_vlm_attention_mask[:769, :769]
 
             assert torch.all(vlm_attention_mask[i].cpu() == correct_vlm_attention_mask.cpu())
 


### PR DESCRIPTION
Read the value from a dedicated appended <val> token instead of the last sequence position, which was padding once the prompt is padded to prompt_max_length -- the head could only emit a constant (the mean return). Training and inference now read the same real position.

Also: default missing "response" keys to empty strings (mask response head off for subtask-less datasets) and force dataset_index=0 so the value function uses one shared stats head across all datasets.

## What this does
This PR tries to fix the issue of predicting value from padded token. so, instead it appends a learnable token <val> which is now responsible to predict value.

## How it was tested
Passed all value function tests

## Checklist

- [X] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [X] My PR includes policy-related changes.
  - [X] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
