### PR TITLE
feat(policies): best-of-N action-chunk sampling for pi05 and pi06

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,88 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added — best-of-N action-chunk sampling — **opt-in, default `1`, no `config_version` bump**
+
+A flow-matching policy maps one Gaussian draw to exactly one action chunk, deterministically,
+so drawing `n_candidates` noises yields `n_candidates` distinct chunks and an
+`ActionChunkCritic` (`opentau.policies.candidates`) picks the one that reaches the robot.
+
+**Why it is nearly free.** The VLM prefix pass runs once per *observation*, and the KV cache it
+fills is never written again during denoising — so expanding that cache across candidates lets
+one prefix pass serve all N. Only the action expert's Euler loop widens, and at batch 1 that
+loop is occupancy-bound rather than FLOP-bound, so widening it rides largely free. Measured on
+an RTX 5090 (bf16, sdpa, 3 cameras, 1024 prefix tokens, chunk 50, 10 Euler steps, batch 1, a
+randomly-initialized 3.36B-parameter pi05), fused against naive replication of the observation
+across the batch — one prefix pass per candidate, same result:
+
+* **N=1** — 152.9 ms fused, 154.3 ms naive
+* **N=2** — 153.2 / 187.7 ms, i.e. **1.23x**; +0.1% over the fused path's own N=1
+* **N=4** — 154.8 / 256.1 ms, **1.65x**; +1.2%
+* **N=8** — 155.5 / 392.1 ms, **2.52x**; +1.7%
+* **N=16** — 191.2 / 698.2 ms, **3.65x**; +25%
+* **N=32** — 277.8 ms fused; naive is out of memory
+
+Peak memory is nearly flat for the same reason: **6.41 GiB at N=1 → 6.95 GiB at N=32**, the
+dominant per-candidate allocation being the prefix KV cache at **18 MiB** (MQA — one KV head,
+head_dim 256, 18 layers). Naive replication runs 6.42 → 8.54 GiB by N=16 and OOMs at N=32. The
+useful envelope is therefore **N ≤ 8**, where the feature costs under 2% of wall clock; N=16 is
+where the Euler loop stops riding free.
+
+**`n_candidates` defaults to `1`, and stays off unless an entry point arms it.** At `1` no
+critic is loaded, no candidate code runs, and the sampler is the one that shipped before —
+verified at full size on GPU, where N=1 after the change reproduces the pre-change output
+digest bit-for-bit (`5a0bf2ed20abbcc2`). `configure_candidates` is the only writer of
+`policy.n_candidates`, so a config travelling with a checkpoint cannot self-arm best-of-N in a
+script that never opted in, the same posture as `accel_prefix`. The serving entry points arm
+it; `scripts/eval.py` **refuses** `n_candidates > 1` outright rather than multiplying its
+default batch of 16 by N.
+
+**Only pi05 and pi06 are wired.** Every other family — pi0, pi05_mem, both pi07 low levels,
+cosmos3, cosmos3_nano, the two high-level planners and `value` — raises on `n_candidates > 1`
+rather than accepting the field and ignoring it, which is the failure an operator would read as
+"the critic never fires".
+
+**The only critic available is `"medoid"`**, a parameter-free consensus selector that keeps the
+candidate closest to all the others. It exists so best-of-N is testable and benchmarkable end
+to end before a trained critic does. It needs `n_candidates >= 3` and **raises** below that: at
+N=2 the one pairwise distance is shared, so every score ties and selection would always fall
+back to candidate 0 — best-of-N that silently is not. And it
+**is not a quality model**: it cannot tell a confidently-wrong mode from a correct one, and on a
+genuinely multimodal task it prefers the more *populated* mode rather than the better one. A
+learned critic is a follow-up; an `action_chunk_critic_path` pointing anywhere else raises
+rather than silently falling back.
+
+**All N candidates share one greedy reasoning trace.** The autoregressive `predict_response`
+decode is argmax and therefore noise-independent, and the candidate fan-out sits after it
+(expanding earlier would be overwritten by the response loop's own `fill_kv_cache=True`
+writes). This feature diversifies flow-matching noise only, not reasoning. Documented rather
+than refused — but it does bound what best-of-N can recover from: a wrong reasoning trace is
+wrong in all N chunks.
+
+**`accel` provenance gained `n_candidates`, and it is comparability-relevant.**
+`AccelProvenance.n_candidates` is now part of `COMPARABLE_FIELDS`, so a calibration fitted on an
+N=1 score stream **refuses to apply** to an N>1 stream: best-of-N conditions the emitted chunk
+on a critic, and the selected candidate's score distribution is not the distribution a single
+draw produces. Calibration JSON written before this release still loads — the reader is
+unknown-key tolerant and the field defaults to `1`, which is what those runs were.
+
+**Both new config fields are written into every saved `config.json`.** draccus encodes the whole
+dataclass with no default filtering, so `n_candidates: 1` and `action_chunk_critic_path: null`
+appear in the config of every checkpoint saved from this release onward — including a **legacy
+checkpoint that is fine-tuned, resumed, or converted and re-uploaded**, which gains both keys on
+the way through. A *pinned older OpenTau install* reading such a config rejects it on the
+unknown fields. The checkpoint convert/upload path is where that bites: a checkpoint rewritten
+here and then loaded by an older deployment fails to decode, so move the reader forward or strip
+the two keys by hand.
+
+**One measured limit worth stating, because this change does not cause it.** The pipeline is
+bit-deterministic at a *fixed* batch shape, but the same noise row decoded at a *different*
+batch size differs by ~5e-3 (fused) / ~7e-3 (naive) — 1-2 ULP of bfloat16 (eps 2^-8 = 3.9e-3),
+from batch-shape-dependent cuBLAS kernel selection. It reproduces on unmodified code. That is
+why the N=1 bit-identity above is claimed at a matched batch shape and nowhere else: candidate 0
+at N=4 is **not** bit-identical to the same noise row at N=1, and no care taken inside this
+feature could make it so.
+
 ### Changed — `accel`'s prefix is now *measured* rather than assumed
 
 `default_prefix` returns `T - 1` because that is the prefix the paper's online detector

--- a/src/opentau/configs/policies.py
+++ b/src/opentau/configs/policies.py
@@ -369,6 +369,24 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):
     # Inference-only: it is read at `sample_actions` time and never affects training.
     accel_prefix: int | str | None = None
 
+    # Number of noise candidates to denoise per observation, and the critic that picks the
+    # chunk which actually reaches the robot (`opentau.policies.candidates`). The candidates
+    # share ONE VLM prefix pass -- only the action expert's Euler loop widens -- so at batch 1
+    # a handful of candidates costs a few percent of wall clock rather than a multiple of it.
+    # Defaults to 1, which is exactly today's single-chunk behaviour: no critic is loaded, no
+    # candidate code runs, and the traced graph is unchanged.
+    #
+    # Inference-only: read at `sample_actions` time, never during training. Only meaningful
+    # for flow-matching policies, and only honoured by the serving entry points -- like
+    # `accel_prefix`, these are read exclusively by `configure_candidates`, so a config that
+    # travels with a checkpoint cannot self-arm best-of-N in a script that never opted in.
+    n_candidates: int = 1
+    # HF repo id (a `repo@revision` suffix is accepted) or local path, or the literal
+    # "medoid" for the built-in parameter-free consensus selector. Required once
+    # `n_candidates > 1`; there is deliberately no implicit default, because a silent
+    # fallback would make best-of-N appear to work while selecting on no real signal.
+    action_chunk_critic_path: str | None = None
+
     # When True, training `torch.compile`s the policy's heavy compute submodule
     # (the flow-matching `self.model` for pi05 / pi07) *in place* via
     # `torch.nn.Module.compile`, leaving the host-side preprocessing in the
@@ -469,6 +487,11 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):
                     f"Deprecated config field '{field_name}' must be 0.0, got {value}. "
                     "Non-zero latency config fields are no longer supported."
                 )
+        # Bound only -- deliberately never coerced. `_save_pretrained` encodes the live
+        # object, so silently clamping an out-of-range request would write the user's stated
+        # intent out of the checkpoint's config and make the discrepancy undiscoverable.
+        if self.n_candidates < 1:
+            raise ValueError(f"n_candidates must be >= 1, got {self.n_candidates}.")
 
     def resolved_config_version(self) -> int:
         """Concrete config version, treating the unresolved ``None`` as CURRENT.

--- a/src/opentau/policies/accel.py
+++ b/src/opentau/policies/accel.py
@@ -208,6 +208,10 @@ class AccelProvenance:
             :mod:`opentau.utils.accel_detector`).
         num_scored_dims: Action dims that survived the dim mask, per norm head.
         dataset_index: Norm-head row index per sample, when resolvable.
+        n_candidates: Candidates denoised per observation (``opentau.policies.candidates``).
+            Comparability-relevant: best-of-N conditions the emitted chunk on a critic, so
+            the score distribution of the *selected* candidate is not the distribution a
+            single draw produces, and a threshold calibrated at 1 does not transfer.
     """
 
     policy_type: str
@@ -221,6 +225,7 @@ class AccelProvenance:
     velocity_dtype: str
     num_scored_dims: tuple[int, ...] = ()
     dataset_index: tuple[int, ...] = ()
+    n_candidates: int = 1
 
     # Fields that must agree for two scores to be comparable. `dataset_index` and
     # `num_scored_dims` are deliberately excluded: they vary per sample within one run,
@@ -236,6 +241,7 @@ class AccelProvenance:
         "action_norm_mode",
         "has_delta_action_map",
         "velocity_dtype",
+        "n_candidates",
     )
 
     def to_dict(self) -> dict:

--- a/src/opentau/policies/candidates.py
+++ b/src/opentau/policies/candidates.py
@@ -40,6 +40,7 @@ therefore cannot self-arm best-of-N in a script that never opted in — the same
 from __future__ import annotations
 
 import logging
+import math
 from typing import Any, Protocol, runtime_checkable
 
 import torch
@@ -168,6 +169,41 @@ def select_candidate(scores: Tensor) -> Tensor:
     return torch.where(all_bad, torch.zeros_like(picked), picked)
 
 
+#: Set once a degenerate-score warning has been emitted, so a serving loop reports the
+#: condition without printing a line per request.
+_WARNED_DEGENERATE = False
+
+
+def warn_if_no_candidate_scored(score_rows: list[list[float]]) -> None:
+    """Log once when a batch row's scores were all non-finite.
+
+    :func:`select_candidate` falls back to candidate 0 there rather than raising, because a
+    data-dependent raise inside ``select_action`` would abort one rank while its peers block
+    at the next collective. That fallback must still be *observable* — otherwise a critic
+    returning all-NaN looks exactly like a critic that works and happens to prefer candidate
+    0 every time.
+
+    Takes the already-synced host-side scores rather than the device tensor, so it costs no
+    extra device-to-host round trip beyond the one the caller already paid.
+
+    Args:
+        score_rows: ``(B, N)`` scores as nested Python lists.
+    """
+    global _WARNED_DEGENERATE
+    if _WARNED_DEGENERATE:
+        return
+    bad = [i for i, row in enumerate(score_rows) if not any(math.isfinite(v) for v in row)]
+    if not bad:
+        return
+    _WARNED_DEGENERATE = True
+    logging.warning(
+        "action-chunk critic returned no finite score for batch row(s) %s; those rows fell "
+        "back to candidate 0. Best-of-N is not selecting on anything for them. This is "
+        "logged once per process.",
+        bad,
+    )
+
+
 class MedoidCritic(nn.Module):
     """Reference critic: keep the candidate closest to all the others.
 
@@ -232,7 +268,16 @@ class MedoidCritic(nn.Module):
         keep = keep[:, :action_dim]
 
         normed = candidates.float() / rearrange(scale, "b d -> b 1 1 d")
-        valid = rearrange(keep, "b d -> b 1 1 d") & rearrange(row_mask.to(torch.bool), "... c -> ... c 1")
+        # Name the batch axis explicitly rather than letting an ellipsis pattern right-align
+        # it. A ``(B, chunk)`` row_mask -- which this protocol documents, and which
+        # ``executed_row_mask`` produces for a per-sample ``delay`` -- becomes
+        # ``(B, chunk, 1)`` under ``"... c -> ... c 1"``, whose leading B then lands on the
+        # *candidate* axis of keep's ``(B, 1, 1, D)``: a shape error when B != N, and
+        # silently scoring candidate j against observation j's mask when B == N.
+        row_mask = row_mask.to(torch.bool)
+        if row_mask.ndim != 2:
+            raise ValueError(f"row_mask must be (B, chunk) or (1, chunk); got {tuple(row_mask.shape)}.")
+        valid = rearrange(keep, "b d -> b 1 1 d") & rearrange(row_mask, "b c -> b 1 c 1")
         normed = torch.where(valid, normed, torch.zeros_like(normed))
 
         # (B, N, N) pairwise L2 over the flattened executed rows.
@@ -314,8 +359,10 @@ def configure_candidates(
 
     Precedence uses ``is None`` at every step, never ``or``-truthiness: ``override=1`` is a
     caller deliberately *disabling* a config-enabled N, and an ``or`` chain would fall through
-    it. The resolved value is always written to ``policy.n_candidates``, including the N==1
-    case — returning early without writing would leave a stale value from a previous call.
+    it. Whenever the policy is wired for candidates the resolved value is written to
+    ``policy.n_candidates``, including the N==1 case — returning early without writing would
+    leave a stale value from a previous call. An *unwired* policy is never written to, at any
+    N: it is a no-op at 1 and a refusal above it.
 
     Args:
         policy: The loaded policy wrapper.
@@ -339,12 +386,22 @@ def configure_candidates(
     requested: int | None = override
     if requested is None:
         requested = getattr(getattr(cfg, "policy", cfg), "n_candidates", None)
-    if requested is None:
-        return 1
-
-    n = int(requested)
+    n = 1 if requested is None else int(requested)
     if n < 1:
         raise ValueError(f"n_candidates must be >= 1, got {n}.")
+
+    if n == 1:
+        # Return BEFORE the wiring probe below. `PreTrainedConfig.n_candidates` defaults to
+        # `1` — an int, not `None` — so this is the path every unarmed serving process takes,
+        # for every policy family. Probing here would abort startup of the gRPC / RoboCasa /
+        # inference / benchmark entry points for pi0, pi05_mem, both pi07 families, cosmos3
+        # and value, none of which asked for anything.
+        #
+        # Only write when the attribute already exists: creating it on an unwired family
+        # would make a later `n > 1` call believe that family was wired.
+        if hasattr(policy, "n_candidates"):
+            policy.n_candidates = 1
+        return 1
 
     policy_type = getattr(getattr(cfg, "policy", cfg), "type", type(policy).__name__)
     # A family whose sampler has not been wired would accept the attribute and then never
@@ -354,10 +411,6 @@ def configure_candidates(
             f"n_candidates={n} was requested but policy type {policy_type!r} does not expose "
             "`n_candidates`, i.e. its sampler is not wired for best-of-N candidate sampling."
         )
-
-    if n == 1:
-        policy.n_candidates = 1
-        return 1
 
     resolved = critic
     if resolved is None:

--- a/src/opentau/policies/candidates.py
+++ b/src/opentau/policies/candidates.py
@@ -1,0 +1,422 @@
+#!/usr/bin/env python
+
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Best-of-N action-chunk sampling: fan out over noise, score, keep one chunk.
+
+A flow-matching policy maps one Gaussian draw to exactly one action chunk, deterministically.
+Sampling ``n_candidates`` draws therefore yields ``n_candidates`` distinct chunks, and an
+:class:`ActionChunkCritic` picks the one that reaches the robot.
+
+**Why this is nearly free.** The VLM prefix pass runs once per *observation*, and the KV cache
+it fills is never written again during denoising (``fill_kv_cache=False`` in every
+``denoise_step``). Expanding that cache across candidates lets one prefix pass serve all N,
+so the added cost is only the action expert's Euler loop at a wider batch — and at batch 1
+that loop is occupancy-bound, not FLOP-bound, so widening it rides largely free. Measured on
+an RTX 5090 (bf16, sdpa, 3 cameras, 1024 prefix tokens, chunk 50, 10 steps): N=4 costs 1%
+over N=1, N=8 costs 3%, and the knee is at N=16 (39%). Naive replication of the observation
+across the batch — one prefix pass per candidate — costs 1.66x at N=4 and 2.51x at N=8 for
+the same result, and runs out of memory at N=32 where the fused path does not.
+
+**Off by default, and it stays off unless an entry point arms it.** ``n_candidates`` is
+``1`` on every freshly constructed policy wrapper regardless of what the config says;
+:func:`configure_candidates` is the only writer. A config that travels with a checkpoint
+therefore cannot self-arm best-of-N in a script that never opted in — the same posture as
+``accel_prefix`` (:func:`opentau.policies.accel.configure_accel`).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Protocol, runtime_checkable
+
+import torch
+from einops import rearrange, reduce, repeat
+from torch import Tensor, nn
+
+from opentau.policies.accel import action_dim_scale, resolve_action_dim_mask
+
+#: Selector name that resolves to :class:`MedoidCritic` rather than a checkpoint path.
+MEDOID = "medoid"
+
+
+@runtime_checkable
+class ActionChunkCritic(Protocol):
+    """Scores candidate action chunks so the policy can keep the best one.
+
+    Implementations are independently trained models with their own normalization; both
+    inputs therefore cross this seam in **raw** (un-normalized) units. Coupling a critic to
+    the *policy's* norm head would mean that swapping policy checkpoints silently shifts the
+    critic's input distribution.
+    """
+
+    def score_chunks(
+        self,
+        batch: dict[str, Tensor],
+        candidates: Tensor,
+        *,
+        row_mask: Tensor,
+        dataset_index: Tensor,
+    ) -> Tensor:
+        """Return one score per candidate; higher is better.
+
+        Args:
+            batch: The raw observation batch, ``B`` rows — deliberately *not* expanded to
+                ``B * N``, so a VLM critic can embed the observation once and cross-attend
+                all N chunks rather than re-paying the cost this feature exists to remove.
+            candidates: ``(B, N, chunk, action_dim)`` in raw units.
+            row_mask: ``(B, chunk)`` or ``(1, chunk)`` bool. ``True`` marks a row that will
+                actually be executed — not frozen by real-time chunking, and inside the
+                ``n_action_steps`` window. Rows outside it never reach the robot and
+                scoring them dilutes the signal.
+            dataset_index: ``(B,)`` long, the norm-head row index already resolved by the
+                policy.
+
+        Returns:
+            ``(B, N)`` float32.
+        """
+        ...
+
+
+def expand_candidates(t: Tensor, n: int) -> Tensor:
+    """Interleave-repeat along batch: source row ``i`` becomes rows ``[i*n, (i+1)*n)``.
+
+    The ``.contiguous()`` is required, not defensive tidying. ``einops.repeat`` returns a
+    **stride-0 alias sharing storage** whenever the source batch is 1 — measured on a real
+    pi05 cache slice, a ``(1, 1024, 1, 256)`` source expands to ``stride[0] == 0`` with an
+    unchanged 512 KiB storage — and ``B == 1`` is the entire serving path (``select_action``
+    and the gRPC server both produce exactly that shape). Materializing buys three things:
+    the "never aliases the caller" guarantee this module documents; a stable stride signature
+    across ``B``, so a varying-batch server does not force a Dynamo recompile per shape under
+    ``mode="max-autotune"``; and safety against the ``StaticCache`` optimization anticipated
+    by the TODO in ``paligemma_with_expert.py``, which would write candidate ``i``'s K/V
+    through stride 0 into all N rows with correct shapes and no error.
+
+    Today the aliased and materialized forms produce bit-identical outputs, because nothing
+    writes to the cache. That is a property of the current implementation, not a guarantee.
+    """
+    return repeat(t, "b ... -> (b n) ...", n=n).contiguous()
+
+
+def expand_kv_cache(past_key_values: dict[int, dict[str, Tensor]], n: int) -> dict[int, dict[str, Tensor]]:
+    """Rebuild the prefix KV cache with each entry repeated across candidates.
+
+    Rebuilds rather than mutating: the caller's cache may be reused (and, under
+    ``predict_response``, was just written by the autoregressive loop).
+
+    Note the ``.items()``. The cache is a **dict keyed by layer index**, not the
+    ``list[dict[str, Tensor]]`` its type annotations long claimed; a list comprehension over
+    it silently yields a list of integer keys.
+    """
+    return {
+        layer_idx: {name: expand_candidates(t, n) for name, t in entry.items()}
+        for layer_idx, entry in past_key_values.items()
+    }
+
+
+def collapse_candidates(t: Tensor, n: int) -> Tensor:
+    """Inverse of :func:`expand_candidates`: ``(B*N, ...) -> (B, N, ...)``.
+
+    Paired with ``(b n)`` ordering. A transposed convention is invisible in shapes and shows
+    up only as candidates attributed to the wrong observation once ``B > 1``.
+    """
+    return rearrange(t, "(b n) ... -> b n ...", n=n)
+
+
+def select_candidate(scores: Tensor) -> Tensor:
+    """Argmax over finite scores, with degenerate rows falling back to candidate 0.
+
+    Deliberately **total** — it never raises. ``select_action`` runs on every rank and is
+    followed by gather collectives, so a per-rank data-dependent raise aborts one rank while
+    the others block forever at NCCL. A row whose scores are all non-finite gets candidate 0
+    instead, and the caller warns.
+
+    Two behaviours worth stating because a reader would not assume them:
+
+    * **NaN must not win.** ``torch.argmax`` returns the NaN's index on a raw tensor
+      (measured: ``argmax([1.0, nan, 3.0]) -> 1``), so non-finite entries are replaced with
+      ``-inf`` before the reduction.
+    * **Ties resolve to the lowest index**, which is load-bearing: candidate 0 carries the
+      noise draw the ``n_candidates == 1`` path would have taken, so a degenerate critic
+      degenerates to legacy behaviour rather than to something arbitrary. No RNG is involved
+      anywhere — ``set_seed`` offsets the global stream by ``process_index``, so a random
+      tie-break would desync ranks.
+
+    Args:
+        scores: ``(B, N)``, higher is better.
+
+    Returns:
+        ``(B,)`` long, the chosen candidate index per batch row.
+    """
+    finite = torch.isfinite(scores)
+    masked = torch.where(finite, scores.float(), torch.full_like(scores, float("-inf"), dtype=torch.float32))
+    all_bad = ~finite.any(dim=1)
+    safe = torch.where(rearrange(all_bad, "b -> b 1"), torch.zeros_like(masked), masked)
+    picked = torch.argmax(safe, dim=1)
+    return torch.where(all_bad, torch.zeros_like(picked), picked)
+
+
+class MedoidCritic(nn.Module):
+    """Reference critic: keep the candidate closest to all the others.
+
+    A learning-free stand-in that makes best-of-N testable and benchmarkable end to end
+    before a trained critic exists. The intuition is consensus — with N draws from the same
+    conditional, the chunk minimising total distance to its peers sits in the densest region
+    of the sampled posterior, and outlying draws (the ones a flow model occasionally emits)
+    lose. It is **not** a quality model: it cannot tell a confidently-wrong mode from a
+    correct one, and on a genuinely multimodal task it will prefer the more populated mode
+    rather than the better one.
+
+    It is opt-in by name (``action_chunk_critic_path: "medoid"``) and never a default. An
+    implicit fallback here would be worse than a hard failure: best-of-N would appear to work
+    while selecting on no real signal.
+
+    **The one critic that borrows the policy's norm head.** Raw action dims live on wildly
+    different scales — a gripper in ``[0, 1]`` against a shoulder joint in radians — so an
+    unweighted distance is dominated by whichever dim happens to have the largest units.
+    Having no buffers of its own, this critic divides by the policy's per-dim scale and drops
+    the policy's degenerate dims. That coupling is deliberate and specific to a parameter-free
+    selector; a *trained* critic must carry its own normalization (see
+    :class:`ActionChunkCritic`).
+    """
+
+    def __init__(self, unnormalize: nn.Module, *, max_action_dim: int) -> None:
+        super().__init__()
+        # Held by reference, not registered: this critic owns no parameters, and registering
+        # the policy's own Unnormalize as a child would duplicate it into the critic's
+        # state_dict.
+        object.__setattr__(self, "_unnormalize", unnormalize)
+        self._max_action_dim = max_action_dim
+
+    def score_chunks(
+        self,
+        batch: dict[str, Tensor],
+        candidates: Tensor,
+        *,
+        row_mask: Tensor,
+        dataset_index: Tensor,
+    ) -> Tensor:
+        """Negative mean distance to the other candidates, per :class:`ActionChunkCritic`."""
+        del batch  # consensus is computed over the candidates alone
+        bsize, n_cand, _, action_dim = candidates.shape
+        if n_cand < 3:
+            # At N == 2 every pairwise distance is the same number, so every candidate ties
+            # and selection collapses to candidate 0 — best-of-N that silently is not.
+            raise ValueError(
+                f"{type(self).__name__} needs n_candidates >= 3 to rank anything (got {n_cand}): "
+                "with two candidates the single pairwise distance is shared, every score ties, "
+                "and selection always falls back to candidate 0."
+            )
+
+        scale = action_dim_scale(
+            self._unnormalize, max_action_dim=self._max_action_dim, dataset_index=dataset_index
+        )
+        keep = resolve_action_dim_mask(
+            self._unnormalize, max_action_dim=self._max_action_dim, dataset_index=dataset_index
+        )
+        # sample_actions has already truncated to the real action width, so the scale/mask
+        # vectors (built at max_action_dim) must be cut to match.
+        scale = scale[:, :action_dim]
+        keep = keep[:, :action_dim]
+
+        normed = candidates.float() / rearrange(scale, "b d -> b 1 1 d")
+        valid = rearrange(keep, "b d -> b 1 1 d") & rearrange(row_mask.to(torch.bool), "... c -> ... c 1")
+        normed = torch.where(valid, normed, torch.zeros_like(normed))
+
+        # (B, N, N) pairwise L2 over the flattened executed rows.
+        flat = rearrange(normed, "b n c d -> b n (c d)")
+        dist = torch.cdist(flat, flat)
+        # Exclude the zero self-distance so the mean is over genuine peers.
+        total = reduce(dist, "b n m -> b n", "sum") / max(n_cand - 1, 1)
+        scores = -total
+        if scores.shape != (bsize, n_cand):  # pragma: no cover - shape contract
+            raise RuntimeError(f"expected ({bsize}, {n_cand}) scores, got {tuple(scores.shape)}")
+        return scores
+
+
+def attach_critic(policy: nn.Module, critic: Any) -> None:
+    """Bind ``critic`` to ``policy`` without it becoming part of the policy.
+
+    ``object.__setattr__`` is mandatory rather than stylistic. Plain assignment of an
+    ``nn.Module`` routes through ``nn.Module.__setattr__``, which registers it in
+    ``_modules`` — putting the critic's tensors into ``policy.state_dict()`` (which gets
+    written to checkpoints) and its parameters into ``policy.parameters()`` (which
+    ``get_optim_params`` returns to the optimizer). Both were measured.
+
+    The cost of staying out of ``_modules`` is that ``policy.to(...)`` and
+    ``accelerator.prepare`` do not move the critic, which is why
+    :func:`configure_candidates` takes an explicit ``device`` and places it itself.
+    """
+    object.__setattr__(policy, "_action_chunk_critic", critic)
+
+
+def load_critic(path: str | None, *, policy: nn.Module) -> Any:
+    """Resolve ``action_chunk_critic_path`` to a critic instance.
+
+    Only the built-in :data:`MEDOID` selector exists today. A checkpoint path raises rather
+    than silently falling back, so a config naming a critic that this build cannot load fails
+    at startup instead of selecting on nothing.
+    """
+    if path == MEDOID:
+        return MedoidCritic(policy.unnormalize_outputs, max_action_dim=policy.config.max_action_dim)
+    raise NotImplementedError(
+        f"action_chunk_critic_path={path!r} names a learned critic, which this build cannot "
+        f"load; only the built-in {MEDOID!r} selector is available. Pass "
+        f"action_chunk_critic_path={MEDOID!r} to use consensus selection."
+    )
+
+
+def refuse_candidates(cfg: Any, *, reason: str) -> None:
+    """Raise when a config asks for best-of-N in an entry point that cannot honour it.
+
+    Every script that builds a policy from ``cfg.policy`` either arms candidates or calls
+    this. Silently ignoring the field is the failure mode worth spending a line to prevent:
+    an operator sets ``n_candidates=4``, sees no error, and believes best-of-N is running.
+    """
+    requested = getattr(getattr(cfg, "policy", cfg), "n_candidates", 1) or 1
+    if int(requested) > 1:
+        raise ValueError(f"n_candidates={requested} is not supported here: {reason}")
+
+
+def configure_candidates(
+    policy: nn.Module,
+    cfg: Any,
+    *,
+    device: torch.device | str,
+    dtype: torch.dtype | None = None,
+    critic: Any = None,
+    override: int | None = None,
+) -> int:
+    """Arm best-of-N sampling on ``policy``, if anything asked for it.
+
+    The single enable knob shared by every serving entry point, so the precedence order and
+    the refusals cannot drift between them. Call it *before* an entry point's warmup
+    ``sample_actions`` calls: critic loading, the dtype cast, the shape smoke-test and any
+    out-of-memory then land at startup rather than on the first robot request.
+
+    Resolution order, first non-``None`` wins:
+
+    1. ``override`` — an entry point's own flag.
+    2. ``cfg.policy.n_candidates`` — read through ``getattr`` so a config predating the field
+       still resolves.
+
+    Precedence uses ``is None`` at every step, never ``or``-truthiness: ``override=1`` is a
+    caller deliberately *disabling* a config-enabled N, and an ``or`` chain would fall through
+    it. The resolved value is always written to ``policy.n_candidates``, including the N==1
+    case — returning early without writing would leave a stale value from a previous call.
+
+    Args:
+        policy: The loaded policy wrapper.
+        cfg: The parsed pipeline config; only ``cfg.policy`` is read. Typed loosely to keep
+            this module off the config package's import graph.
+        device: Where to place the critic. Explicit because :func:`attach_critic` keeps it
+            out of ``policy._modules``, so no later ``.to(...)`` will move it; under
+            multi-rank eval each rank needs its own local device.
+        dtype: Cast applied to the critic, routed through the SigLIP-preserving helper.
+        critic: A pre-built critic, bypassing ``action_chunk_critic_path``.
+        override: Entry-point-level request that beats the config.
+
+    Returns:
+        The resolved candidate count.
+
+    Raises:
+        ValueError: When best-of-N is requested but this policy family is not wired for it,
+            or the count is invalid.
+        TypeError: When the resolved critic does not satisfy :class:`ActionChunkCritic`.
+    """
+    requested: int | None = override
+    if requested is None:
+        requested = getattr(getattr(cfg, "policy", cfg), "n_candidates", None)
+    if requested is None:
+        return 1
+
+    n = int(requested)
+    if n < 1:
+        raise ValueError(f"n_candidates must be >= 1, got {n}.")
+
+    policy_type = getattr(getattr(cfg, "policy", cfg), "type", type(policy).__name__)
+    # A family whose sampler has not been wired would accept the attribute and then never
+    # read it — the silent no-op an operator would read as "the critic never fires". Refuse.
+    if not hasattr(policy, "n_candidates"):
+        raise ValueError(
+            f"n_candidates={n} was requested but policy type {policy_type!r} does not expose "
+            "`n_candidates`, i.e. its sampler is not wired for best-of-N candidate sampling."
+        )
+
+    if n == 1:
+        policy.n_candidates = 1
+        return 1
+
+    resolved = critic
+    if resolved is None:
+        path = getattr(getattr(cfg, "policy", cfg), "action_chunk_critic_path", None)
+        if path is None:
+            raise ValueError(
+                f"n_candidates={n} needs a critic to choose between the candidates, but "
+                "action_chunk_critic_path is unset. Set it to "
+                f"{MEDOID!r} for the built-in consensus selector."
+            )
+        resolved = load_critic(path, policy=policy)
+
+    if not isinstance(resolved, ActionChunkCritic):
+        raise TypeError(
+            f"{type(resolved).__name__} does not satisfy the ActionChunkCritic protocol "
+            "(missing `score_chunks`)."
+        )
+
+    if isinstance(resolved, nn.Module):
+        if dtype is not None:
+            # Routed rather than a blanket `.to(dtype)`: a critic with a SigLIP tower has
+            # float32-pinned patch/position embeddings that a blanket cast would re-round.
+            from opentau.policies.utils import to_dtype_preserving_siglip_float32
+
+            to_dtype_preserving_siglip_float32(resolved, dtype=dtype, device=device)
+        else:
+            resolved.to(device)
+        resolved.eval()
+
+    _smoke_critic(resolved, n, policy, device)
+    attach_critic(policy, resolved)
+    policy.n_candidates = n
+    logging.info("best-of-%d candidate sampling armed with %s", n, type(resolved).__name__)
+    return n
+
+
+def _smoke_critic(critic: Any, n: int, policy: nn.Module, device: torch.device | str) -> None:
+    """Call the critic once on dummy inputs so a wrong shape fails at startup.
+
+    ``runtime_checkable`` ``isinstance`` checks method *presence* only — never arity, never
+    return shape — so without this a critic returning ``(B,)`` instead of ``(B, N)`` gets
+    through configuration and fails on the first robot request.
+    """
+    config = policy.config
+    action_dim = config.action_feature.shape[0]
+    probe = torch.zeros(1, n, config.chunk_size, action_dim, device=device)
+    # Distinct rows: an all-zeros probe makes every pairwise distance zero, which a consensus
+    # critic would reject as degenerate rather than as the shape check this is.
+    probe = probe + rearrange(torch.arange(n, device=device, dtype=probe.dtype), "n -> 1 n 1 1")
+    row_mask = torch.ones(1, config.chunk_size, dtype=torch.bool, device=device)
+    scores = critic.score_chunks(
+        {},
+        probe,
+        row_mask=row_mask,
+        dataset_index=torch.zeros(1, dtype=torch.long, device=device),
+    )
+    if not isinstance(scores, Tensor) or scores.shape != (1, n):
+        raise TypeError(
+            f"{type(critic).__name__}.score_chunks must return a (B, N) tensor; got "
+            f"{tuple(scores.shape) if isinstance(scores, Tensor) else type(scores).__name__} "
+            f"for B=1, N={n}."
+        )

--- a/src/opentau/policies/pi05/modeling_pi05.py
+++ b/src/opentau/policies/pi05/modeling_pi05.py
@@ -21,6 +21,7 @@
 """
 
 import builtins
+import dataclasses
 import logging
 import math
 from collections import deque
@@ -40,6 +41,12 @@ from opentau.datasets.grounding.tokenizer_utils import ensure_loc_tokens
 from opentau.policies.accel import AccelMeter, executed_row_mask
 from opentau.policies.accel import build_provenance as build_accel_provenance
 from opentau.policies.accel import make_meter as make_accel_meter
+from opentau.policies.candidates import (
+    collapse_candidates,
+    expand_candidates,
+    expand_kv_cache,
+    select_candidate,
+)
 from opentau.policies.normalize import Normalize, Unnormalize
 from opentau.policies.normalize import resolve_num_datasets as _num_datasets
 from opentau.policies.pi05.configuration_pi05 import PI05Config
@@ -349,6 +356,13 @@ class PI05Policy(PreTrainedPolicy):
         # to have every `sample_actions` call publish `last_accel`.
         self.accel_prefix: int | None = None
 
+        # Best-of-N candidate sampling. Always 1 here, regardless of what `config` says:
+        # `candidates.configure_candidates` is the only writer, so a config that travels with
+        # a checkpoint cannot self-arm best-of-N in a script that never opted in (in-training
+        # eval, benchmarking, MSE scoring). Same posture as `accel_prefix` above.
+        self.n_candidates: int = 1
+        self._action_chunk_critic = None
+
         self.reset()
 
     def reset(self) -> None:
@@ -356,6 +370,8 @@ class PI05Policy(PreTrainedPolicy):
         self._action_queue = deque([], maxlen=self.config.n_action_steps)
         self.last_accel = None
         self.last_accel_provenance = None
+        self.last_accel_candidates = None
+        self.last_candidate_scores = None
 
     @classmethod
     def from_pretrained(
@@ -660,8 +676,10 @@ class PI05Policy(PreTrainedPolicy):
         self.eval()
 
         # Cleared every step so a caller can distinguish "this step re-planned and here is
-        # its score" from "this step popped a queued action". `sample_actions` refills it.
+        # its score" from "this step popped a queued action". `sample_actions` refills them.
         self.last_accel = None
+        self.last_accel_candidates = None
+        self.last_candidate_scores = None
 
         if len(self._action_queue) == 0 or len(self._action_queue) <= self.config.max_delay:
             # Use current queue as action prefix to replenish
@@ -720,6 +738,12 @@ class PI05Policy(PreTrainedPolicy):
         # units (openpi runs `DeltaActions` ahead of `Normalize`), so both the `action_prefix`
         # conversion and the inverse at the end of this method need un-normalized values.
         raw_state = self._raw_state_for_delta(batch)
+        # Likewise the observation the critic scores against. `normalize_inputs` rebinds
+        # `batch` on the next line and the raw dict is not otherwise retained; a critic is an
+        # independently trained model with its own norm buffers, so feeding it the *policy's*
+        # normalized batch would make swapping policy checkpoints silently shift its input
+        # distribution. `Normalize.forward` shallow-copies, so holding this alias is free.
+        raw_batch = batch
         batch = self.normalize_inputs(batch, dataset_index)
 
         images, img_masks = self.prepare_images(batch)
@@ -752,11 +776,25 @@ class PI05Policy(PreTrainedPolicy):
 
         state = self.prepare_state(batch) if self.config.state_type == "continuous" else None
 
+        n_candidates = self.n_candidates
+        if n_candidates > 1 and self._action_chunk_critic is None:
+            # Unreachable in a configured deployment (`configure_candidates` loads the critic
+            # before it writes `n_candidates`); this backstops a hand-set attribute.
+            raise ValueError(
+                f"n_candidates={n_candidates} but no action-chunk critic is attached, so there "
+                "is nothing to choose between the candidates. Arm best-of-N through "
+                "`opentau.policies.candidates.configure_candidates`."
+            )
+        # Every per-sample tensor downstream of the sampler has `B * n_candidates` rows and
+        # must be indexed by a matching norm head; a B-row index would silently normalize
+        # candidate rows against another dataset's statistics once B > 1.
+        sampler_index = dataset_index if n_candidates == 1 else expand_candidates(dataset_index, n_candidates)
+
         accel_meter = make_accel_meter(
             self,
-            batch_size=lang_tokens.shape[0],
+            batch_size=lang_tokens.shape[0] * n_candidates,
             device=lang_tokens.device,
-            dataset_index=dataset_index,
+            dataset_index=sampler_index,
         )
 
         actions = self.model.sample_actions(
@@ -768,13 +806,19 @@ class PI05Policy(PreTrainedPolicy):
             delay,
             noise=noise,
             state=state,
+            n_candidates=n_candidates,
             accel=accel_meter,
         )
 
-        if accel_meter is not None:
+        if accel_meter is not None and n_candidates == 1:
             # `.to_list()` rather than keeping a tensor: anything allocated inside
             # `torch.inference_mode()` stays an inference tensor even after `.clone()`, and
             # the first in-place update a downstream CUSUM accumulator makes would raise.
+            #
+            # Position is load-bearing and unchanged: publishing *before* unnormalize means a
+            # raising unnormalize (inf norm buffers) still leaves `last_accel` populated. The
+            # candidate path cannot publish here because it does not know the selected row
+            # until the critic has scored raw chunks, so it publishes below instead.
             self.last_accel = accel_meter.to_list()
             self.last_accel_provenance = build_accel_provenance(
                 self, accel_meter, dataset_index=dataset_index
@@ -784,16 +828,68 @@ class PI05Policy(PreTrainedPolicy):
         original_action_dim = self.config.action_feature.shape[0]
         actions = actions[:, :, :original_action_dim]
 
-        actions = self.unnormalize_outputs({"actions": actions}, dataset_index)["actions"]
+        actions = self.unnormalize_outputs({"actions": actions}, sampler_index)["actions"]
 
         if raw_state is not None:
             # openpi pairs `DeltaActions` on the input side with `AbsoluteActions` on the output
             # side. Without this half the policy returns displacements that the consumer reads
             # as absolute joint targets — a failure that looks like a badly-trained policy
             # rather than a missing transform.
-            actions = add_chunk_start_state(actions, raw_state, self.config.delta_action_state_map)
+            actions = add_chunk_start_state(
+                actions,
+                raw_state if n_candidates == 1 else expand_candidates(raw_state, n_candidates),
+                self.config.delta_action_state_map,
+            )
+
+        if n_candidates == 1:
+            return actions
+
+        # Scored in raw units, on the executed rows only: frozen real-time-chunking rows are
+        # identical across every candidate by construction, and rows past `n_action_steps` are
+        # replaced by the next re-plan, so both only dilute the signal.
+        candidates = collapse_candidates(actions, n_candidates)
+        scores = self._action_chunk_critic.score_chunks(
+            raw_batch,
+            candidates,
+            row_mask=self.model.executed_rows(delay, actions.device),
+            dataset_index=dataset_index,
+        )
+        selected = select_candidate(scores)
+        actions = candidates[torch.arange(candidates.shape[0], device=candidates.device), selected]
+        self.last_candidate_scores = scores.detach().to(torch.float32).cpu().tolist()
+        if accel_meter is not None:
+            self._publish_accel_for_candidates(accel_meter, sampler_index, n_candidates, selected)
 
         return actions
+
+    def _publish_accel_for_candidates(
+        self, meter: AccelMeter, sampler_index: Tensor, n: int, selected: Tensor
+    ) -> None:
+        """Publish ``last_accel`` for the *selected* candidate, keeping the full grid beside it.
+
+        ``last_accel`` stays length ``B``. That is forced rather than chosen: the gRPC server
+        reads ``float(last_accel[0])`` with no width check, so a ``B * N``-long list would
+        silently report candidate 0's uncertainty for whatever chunk the critic actually
+        picked — a wrong number attributed to the emitted action.
+
+        The provenance is built at ``B * N`` and then sliced, rather than built at ``B``.
+        ``build_provenance`` derives ``num_scored_dims`` internally from the meter's dim mask
+        while taking ``dataset_index`` from its argument, so mixing widths yields one record
+        whose two per-sample tuples have different lengths and cannot be zipped. Slicing both
+        with a single ``rows`` list keeps them aligned by construction.
+        """
+        values = meter.to_list()
+        chosen = selected.tolist()  # one device->host sync, reused below
+        rows = [b * n + chosen[b] for b in range(len(chosen))]
+        self.last_accel_candidates = [values[b * n : (b + 1) * n] for b in range(len(chosen))]
+        self.last_accel = [values[i] for i in rows]
+        full = build_accel_provenance(self, meter, dataset_index=sampler_index)
+        self.last_accel_provenance = dataclasses.replace(
+            full,
+            num_scored_dims=tuple(full.num_scored_dims[i] for i in rows),
+            dataset_index=tuple(full.dataset_index[i] for i in rows),
+            n_candidates=n,
+        )
 
     def _raw_state_for_delta(self, batch: dict[str, Tensor]) -> Tensor | None:
         """Return the un-normalized state needed to invert the delta transform, or ``None``.
@@ -1787,6 +1883,7 @@ class PI05FlowMatching(nn.Module):
         delay: Tensor,
         noise: Tensor | None = None,
         state: Tensor | None = None,
+        n_candidates: int = 1,
         accel: AccelMeter | None = None,
     ) -> Tensor:
         """Do a full inference forward and compute the action.
@@ -1802,6 +1899,16 @@ class PI05FlowMatching(nn.Module):
             state: Optional continuous state tensor of shape (batch_size, max_state_dim).
             indicator_tokens: Optional indicator token tensor.
             indicator_masks: Optional indicator mask tensor.
+            n_candidates: Number of noise candidates to denoise per observation. At the
+                default 1 this method is byte-for-byte today's single-chunk sampler. Above 1
+                the returned tensor has ``batch_size * n_candidates`` rows, ordered
+                candidate-major within each observation (``expand_candidates``' ``(b n)``
+                convention), and the *caller* is responsible for scoring and collapsing them
+                — this method deliberately does not know about the critic, so the inner
+                module stays stateless and the branch stays a compile-time constant.
+                The VLM prefix pass runs once regardless: only the KV cache and the prefix
+                masks are widened, so the added cost is the action expert's Euler loop at a
+                wider batch.
             accel: Optional denoising-acceleration meter. When supplied, the per-step
                 velocities are folded into an uncertainty proxy at zero extra network
                 cost; when ``None`` every added branch is a compile-time constant and the
@@ -1816,8 +1923,24 @@ class PI05FlowMatching(nn.Module):
         device = lang_tokens.device
 
         if noise is None:
-            actions_shape = (bsize, self.config.chunk_size, self.config.max_action_dim)
+            # `bsize * n_candidates` folds to `bsize` at the default, so this is the same
+            # shape tuple and the same single `sample_noise` draw off the same RNG stream.
+            actions_shape = (
+                bsize * n_candidates,
+                self.config.chunk_size,
+                self.config.max_action_dim,
+            )
             noise = self.sample_noise(actions_shape, device)
+        elif n_candidates > 1 and noise.shape[0] != bsize * n_candidates:
+            # Deliberately NOT an unconditional shape check. At n_candidates == 1 every
+            # existing explicit-noise caller (the ONNX export wrapper, diagnose_accel) must
+            # keep today's exact behaviour, including today's silent broadcast. Widening this
+            # into an unguarded assert would break N==1 bit-identity.
+            raise ValueError(
+                f"n_candidates={n_candidates} needs noise with {bsize * n_candidates} rows "
+                f"(got {tuple(noise.shape)}); a {bsize}-row noise would make every candidate "
+                "identical, which is best-of-N that silently is not."
+            )
 
         prefix_embs, prefix_pad_masks, prefix_att_masks, _ = self.embed_prefix(
             images,
@@ -1870,23 +1993,30 @@ class PI05FlowMatching(nn.Module):
                     device,
                 )
 
+        if n_candidates > 1:
+            # Sits AFTER the autoregressive response loop rather than straight after the
+            # prefix forward: `infer_response` rewrites both `past_key_values` and
+            # `prefix_pad_masks` with fill_kv_cache=True, so expanding earlier would be
+            # overwritten. The response decode is greedy-argmax and noise-independent, so all
+            # N candidates legitimately share one reasoning trace — this feature diversifies
+            # flow-matching noise only, not reasoning.
+            #
+            # `denoise_step` re-derives the 2-D attention mask, the cross-attention length
+            # and the position ids from `prefix_pad_masks` alone, so widening these three
+            # tensors is the whole fan-out; nothing in the backbone needs to know.
+            past_key_values = expand_kv_cache(past_key_values, n_candidates)
+            prefix_pad_masks = expand_candidates(prefix_pad_masks, n_candidates)
+            action_prefix = expand_candidates(action_prefix, n_candidates)
+
         # perform denoising steps to get the action
         dt = -1.0 / self.config.num_steps
         dt = torch.tensor(dt, dtype=torch.float32, device=device)
 
         x_t = noise
         time = torch.tensor(1.0, dtype=torch.float32, device=device)
-        prefix_mask = rearrange(torch.arange(self.config.chunk_size, device=device), "c -> 1 c") < delay
+        prefix_mask = self._prefix_freeze_mask(delay, device)
         if accel is not None:
-            accel.set_row_mask(
-                executed_row_mask(
-                    prefix_mask=prefix_mask,
-                    delay=delay,
-                    chunk_size=self.config.chunk_size,
-                    n_action_steps=self.config.n_action_steps,
-                    device=device,
-                )
-            )
+            accel.set_row_mask(self.executed_rows(delay, device))
         while time >= -dt / 2:
             # if delay is greater than 0, then freeze the action prefix at the beginning of action chunk
             x_t = torch.where(rearrange(prefix_mask, "b c -> b c 1"), action_prefix, x_t)
@@ -1911,10 +2041,35 @@ class PI05FlowMatching(nn.Module):
         x_t = torch.where(rearrange(prefix_mask, "b c -> b c 1"), action_prefix, x_t)
         return x_t
 
+    def _prefix_freeze_mask(self, delay: Tensor, device: torch.device) -> Tensor:
+        """``(1, chunk)`` bool marking rows frozen by real-time chunking.
+
+        ``delay`` is a 0-dim tensor on every in-repo path (``select_action`` builds it that
+        way), so this broadcasts against a ``(B * n_candidates, chunk, dim)`` ``x_t`` without
+        needing its own candidate expansion.
+        """
+        return rearrange(torch.arange(self.config.chunk_size, device=device), "c -> 1 c") < delay
+
+    def executed_rows(self, delay: Tensor, device: torch.device) -> Tensor:
+        """Chunk rows that actually reach the robot: not frozen, inside the execution window.
+
+        Shared by the ``accel`` meter and the candidate critic so the two cannot drift apart
+        about which rows carry signal. Scoring a frozen row is meaningless — it is identical
+        across every candidate by construction — and scoring past ``n_action_steps`` scores
+        actions that will be replaced by the next re-plan.
+        """
+        return executed_row_mask(
+            prefix_mask=self._prefix_freeze_mask(delay, device),
+            delay=delay,
+            chunk_size=self.config.chunk_size,
+            n_action_steps=self.config.n_action_steps,
+            device=device,
+        )
+
     def denoise_step(
         self,
         prefix_pad_masks: Tensor,
-        past_key_values: list[dict[str, Tensor]],
+        past_key_values: dict[int, dict[str, Tensor]],
         x_t: Tensor,
         time: Tensor,
     ) -> Tensor:
@@ -1966,13 +2121,13 @@ class PI05FlowMatching(nn.Module):
         prefix_embs: Tensor,
         prefix_pad_masks: Tensor,
         prefix_att_masks: Tensor,
-        past_key_values: list[dict[str, Tensor]],
+        past_key_values: dict[int, dict[str, Tensor]],
         prefix_offsets: Tensor,
         response_tokens: Tensor,
         auto_step: int,
         bsize: int,
         device: torch.device,
-    ) -> tuple[Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, list[dict[str, Tensor]], Tensor]:
+    ) -> tuple[Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, dict[int, dict[str, Tensor]], Tensor]:
         """Perform autoregressive inference for response generation.
 
         This method generates the next token in the response sequence, updating the

--- a/src/opentau/policies/pi05/modeling_pi05.py
+++ b/src/opentau/policies/pi05/modeling_pi05.py
@@ -46,6 +46,7 @@ from opentau.policies.candidates import (
     expand_candidates,
     expand_kv_cache,
     select_candidate,
+    warn_if_no_candidate_scored,
 )
 from opentau.policies.normalize import Normalize, Unnormalize
 from opentau.policies.normalize import resolve_num_datasets as _num_datasets
@@ -857,6 +858,9 @@ class PI05Policy(PreTrainedPolicy):
         selected = select_candidate(scores)
         actions = candidates[torch.arange(candidates.shape[0], device=candidates.device), selected]
         self.last_candidate_scores = scores.detach().to(torch.float32).cpu().tolist()
+        # Reads the list just synced above, so the all-non-finite fallback inside
+        # `select_candidate` is observable without a second device->host round trip.
+        warn_if_no_candidate_scored(self.last_candidate_scores)
         if accel_meter is not None:
             self._publish_accel_for_candidates(accel_meter, sampler_index, n_candidates, selected)
 

--- a/src/opentau/policies/pi06/modeling_pi06.py
+++ b/src/opentau/policies/pi06/modeling_pi06.py
@@ -52,6 +52,7 @@ from opentau.policies.candidates import (
     expand_candidates,
     expand_kv_cache,
     select_candidate,
+    warn_if_no_candidate_scored,
 )
 from opentau.policies.normalize import Normalize, Unnormalize
 from opentau.policies.normalize import resolve_num_datasets as _num_datasets
@@ -746,6 +747,9 @@ class PI06Policy(PreTrainedPolicy):
         selected = select_candidate(scores)
         actions = candidates[torch.arange(candidates.shape[0], device=candidates.device), selected]
         self.last_candidate_scores = scores.detach().to(torch.float32).cpu().tolist()
+        # Reads the list just synced above, so the all-non-finite fallback inside
+        # `select_candidate` is observable without a second device->host round trip.
+        warn_if_no_candidate_scored(self.last_candidate_scores)
         if accel_meter is not None:
             self._publish_accel_for_candidates(accel_meter, sampler_index, n_candidates, selected)
 

--- a/src/opentau/policies/pi06/modeling_pi06.py
+++ b/src/opentau/policies/pi06/modeling_pi06.py
@@ -28,6 +28,7 @@ References:
 """
 
 import builtins
+import dataclasses
 import logging
 import math
 from collections import deque
@@ -46,6 +47,12 @@ from opentau.datasets.grounding.tokenizer_utils import ensure_loc_tokens
 from opentau.policies.accel import AccelMeter, executed_row_mask
 from opentau.policies.accel import build_provenance as build_accel_provenance
 from opentau.policies.accel import make_meter as make_accel_meter
+from opentau.policies.candidates import (
+    collapse_candidates,
+    expand_candidates,
+    expand_kv_cache,
+    select_candidate,
+)
 from opentau.policies.normalize import Normalize, Unnormalize
 from opentau.policies.normalize import resolve_num_datasets as _num_datasets
 from opentau.policies.pi06.configuration_pi06 import PI06Config
@@ -333,6 +340,12 @@ class PI06Policy(PreTrainedPolicy):
         # a much coarser estimate than pi05's ten-step schedule affords.
         self.accel_prefix: int | None = None
 
+        # Best-of-N candidate sampling. Always 1 here regardless of `config`:
+        # `candidates.configure_candidates` is the only writer, so a config travelling with a
+        # checkpoint cannot self-arm best-of-N in a script that never opted in.
+        self.n_candidates: int = 1
+        self._action_chunk_critic = None
+
         self.reset()
 
     def reset(self) -> None:
@@ -340,6 +353,8 @@ class PI06Policy(PreTrainedPolicy):
         self._action_queue = deque([], maxlen=self.config.n_action_steps)
         self.last_accel = None
         self.last_accel_provenance = None
+        self.last_accel_candidates = None
+        self.last_candidate_scores = None
 
     @classmethod
     def from_pretrained(
@@ -599,6 +614,8 @@ class PI06Policy(PreTrainedPolicy):
         # Cleared every step so a caller can distinguish "this step re-planned and here is
         # its score" from "this step popped a queued action". `sample_actions` refills it.
         self.last_accel = None
+        self.last_accel_candidates = None
+        self.last_candidate_scores = None
 
         if len(self._action_queue) == 0 or len(self._action_queue) <= self.config.max_delay:
             action_prefix = None
@@ -644,6 +661,10 @@ class PI06Policy(PreTrainedPolicy):
             )
 
         dataset_index = self._resolve_dataset_index(batch)
+        # Captured before `normalize_inputs` rebinds `batch`: a critic is an independently
+        # trained model with its own norm buffers, so it scores raw observations. The
+        # shallow copy inside `Normalize.forward` makes holding this alias free.
+        raw_batch = batch
         batch = self.normalize_inputs(batch, dataset_index)
 
         images, img_masks = self.prepare_images(batch)
@@ -660,11 +681,23 @@ class PI06Policy(PreTrainedPolicy):
             action_prefix = self.normalize_targets({"actions": action_prefix}, dataset_index)["actions"]
             action_prefix = F.pad(action_prefix, (0, 0, 0, self.config.chunk_size - action_prefix.shape[1]))
 
+        n_candidates = self.n_candidates
+        if n_candidates > 1 and self._action_chunk_critic is None:
+            # Unreachable in a configured deployment; backstops a hand-set attribute.
+            raise ValueError(
+                f"n_candidates={n_candidates} but no action-chunk critic is attached, so there "
+                "is nothing to choose between the candidates. Arm best-of-N through "
+                "`opentau.policies.candidates.configure_candidates`."
+            )
+        # Every per-sample tensor downstream of the sampler has `B * n_candidates` rows and
+        # must be indexed by a matching norm head.
+        sampler_index = dataset_index if n_candidates == 1 else expand_candidates(dataset_index, n_candidates)
+
         accel_meter = make_accel_meter(
             self,
-            batch_size=lang_tokens.shape[0],
+            batch_size=lang_tokens.shape[0] * n_candidates,
             device=lang_tokens.device,
-            dataset_index=dataset_index,
+            dataset_index=sampler_index,
         )
 
         actions = self.model.sample_actions(
@@ -675,13 +708,19 @@ class PI06Policy(PreTrainedPolicy):
             action_prefix,
             delay,
             noise=noise,
+            n_candidates=n_candidates,
             accel=accel_meter,
         )
 
-        if accel_meter is not None:
+        if accel_meter is not None and n_candidates == 1:
             # `.to_list()` rather than keeping a tensor: anything allocated inside
             # `torch.inference_mode()` stays an inference tensor even after `.clone()`, and
             # the first in-place update a downstream CUSUM accumulator makes would raise.
+            #
+            # Position is load-bearing and unchanged: publishing before unnormalize means a
+            # raising unnormalize still leaves `last_accel` populated. The candidate path
+            # cannot publish here -- it does not know the selected row until the critic has
+            # scored raw chunks -- so it publishes below instead.
             self.last_accel = accel_meter.to_list()
             self.last_accel_provenance = build_accel_provenance(
                 self, accel_meter, dataset_index=dataset_index
@@ -689,8 +728,55 @@ class PI06Policy(PreTrainedPolicy):
 
         original_action_dim = self.config.action_feature.shape[0]
         actions = actions[:, :, :original_action_dim]
-        actions = self.unnormalize_outputs({"actions": actions}, dataset_index)["actions"]
+        actions = self.unnormalize_outputs({"actions": actions}, sampler_index)["actions"]
+
+        if n_candidates == 1:
+            return actions
+
+        # Scored in raw units on the executed rows only: frozen rows are identical across
+        # every candidate by construction, and rows past `n_action_steps` are replaced by the
+        # next re-plan, so both only dilute the signal.
+        candidates = collapse_candidates(actions, n_candidates)
+        scores = self._action_chunk_critic.score_chunks(
+            raw_batch,
+            candidates,
+            row_mask=self.model.executed_rows(delay, actions.device),
+            dataset_index=dataset_index,
+        )
+        selected = select_candidate(scores)
+        actions = candidates[torch.arange(candidates.shape[0], device=candidates.device), selected]
+        self.last_candidate_scores = scores.detach().to(torch.float32).cpu().tolist()
+        if accel_meter is not None:
+            self._publish_accel_for_candidates(accel_meter, sampler_index, n_candidates, selected)
+
         return actions
+
+    def _publish_accel_for_candidates(
+        self, meter: AccelMeter, sampler_index: Tensor, n: int, selected: Tensor
+    ) -> None:
+        """Publish ``last_accel`` for the *selected* candidate, keeping the full grid beside it.
+
+        ``last_accel`` stays length ``B``: the gRPC server reads ``float(last_accel[0])`` with
+        no width check, so a ``B * N``-long list would silently report candidate 0's
+        uncertainty for whatever chunk the critic actually picked.
+
+        The provenance is built at ``B * N`` then sliced, because ``build_provenance`` derives
+        ``num_scored_dims`` from the meter's dim mask while taking ``dataset_index`` from its
+        argument -- mixing widths yields a record whose two per-sample tuples cannot be
+        zipped. One ``rows`` list slices both, aligned by construction.
+        """
+        values = meter.to_list()
+        chosen = selected.tolist()  # one device->host sync, reused below
+        rows = [b * n + chosen[b] for b in range(len(chosen))]
+        self.last_accel_candidates = [values[b * n : (b + 1) * n] for b in range(len(chosen))]
+        self.last_accel = [values[i] for i in rows]
+        full = build_accel_provenance(self, meter, dataset_index=sampler_index)
+        self.last_accel_provenance = dataclasses.replace(
+            full,
+            num_scored_dims=tuple(full.num_scored_dims[i] for i in rows),
+            dataset_index=tuple(full.dataset_index[i] for i in rows),
+            n_candidates=n,
+        )
 
     def forward(
         self,
@@ -1301,6 +1387,7 @@ class PI06FlowMatching(nn.Module):
         action_prefix: Tensor,
         delay: Tensor,
         noise: Tensor | None = None,
+        n_candidates: int = 1,
         accel: AccelMeter | None = None,
     ) -> Tensor:
         """Inference: encode prefix once, run `num_steps` Euler steps.
@@ -1328,8 +1415,23 @@ class PI06FlowMatching(nn.Module):
         device = lang_tokens.device
 
         if noise is None:
-            actions_shape = (bsize, self.config.chunk_size, self.config.max_action_dim)
+            # `bsize * n_candidates` folds to `bsize` at the default, so this is the same
+            # shape tuple and the same single `sample_noise` draw off the same RNG stream.
+            actions_shape = (
+                bsize * n_candidates,
+                self.config.chunk_size,
+                self.config.max_action_dim,
+            )
             noise = self.sample_noise(actions_shape, device)
+        elif n_candidates > 1 and noise.shape[0] != bsize * n_candidates:
+            # Deliberately NOT an unconditional shape check: at n_candidates == 1 every
+            # existing explicit-noise caller must keep today's exact behaviour, including
+            # today's silent broadcast.
+            raise ValueError(
+                f"n_candidates={n_candidates} needs noise with {bsize * n_candidates} rows "
+                f"(got {tuple(noise.shape)}); a {bsize}-row noise would make every candidate "
+                "identical, which is best-of-N that silently is not."
+            )
 
         prefix_embs, prefix_pad_masks, prefix_att_masks = self.embed_prefix(
             images, img_masks, lang_tokens, lang_masks
@@ -1374,22 +1476,24 @@ class PI06FlowMatching(nn.Module):
                     device,
                 )
 
+        if n_candidates > 1:
+            # After the autoregressive response loop, not straight after the prefix forward:
+            # `infer_response` rewrites both the cache and `prefix_pad_masks` with
+            # fill_kv_cache=True, so expanding earlier would be overwritten. The response
+            # decode is greedy-argmax and noise-independent, so all N candidates share one
+            # reasoning trace -- this diversifies flow-matching noise only.
+            past_key_values = expand_kv_cache(past_key_values, n_candidates)
+            prefix_pad_masks = expand_candidates(prefix_pad_masks, n_candidates)
+            action_prefix = expand_candidates(action_prefix, n_candidates)
+
         dt = -1.0 / self.config.num_steps
         dt = torch.tensor(dt, dtype=torch.float32, device=device)
 
         x_t = noise
         time = torch.tensor(1.0, dtype=torch.float32, device=device)
-        prefix_mask = rearrange(torch.arange(self.config.chunk_size, device=device), "c -> 1 c") < delay
+        prefix_mask = self._prefix_freeze_mask(delay, device)
         if accel is not None:
-            accel.set_row_mask(
-                executed_row_mask(
-                    prefix_mask=prefix_mask,
-                    delay=delay,
-                    chunk_size=self.config.chunk_size,
-                    n_action_steps=self.config.n_action_steps,
-                    device=device,
-                )
-            )
+            accel.set_row_mask(self.executed_rows(delay, device))
         while time >= -dt / 2:
             x_t = torch.where(rearrange(prefix_mask, "b c -> b c 1"), action_prefix, x_t)
             masked_time = torch.where(prefix_mask, 0, time)
@@ -1406,10 +1510,32 @@ class PI06FlowMatching(nn.Module):
         x_t = torch.where(rearrange(prefix_mask, "b c -> b c 1"), action_prefix, x_t)
         return x_t
 
+    def _prefix_freeze_mask(self, delay: Tensor, device: torch.device) -> Tensor:
+        """``(1, chunk)`` bool marking rows frozen by real-time chunking.
+
+        ``delay`` is a 0-dim tensor on every in-repo path, so this broadcasts against a
+        ``(B * n_candidates, chunk, dim)`` ``x_t`` without its own candidate expansion.
+        """
+        return rearrange(torch.arange(self.config.chunk_size, device=device), "c -> 1 c") < delay
+
+    def executed_rows(self, delay: Tensor, device: torch.device) -> Tensor:
+        """Chunk rows that actually reach the robot: not frozen, inside the execution window.
+
+        Shared by the ``accel`` meter and the candidate critic so the two cannot drift apart
+        about which rows carry signal.
+        """
+        return executed_row_mask(
+            prefix_mask=self._prefix_freeze_mask(delay, device),
+            delay=delay,
+            chunk_size=self.config.chunk_size,
+            n_action_steps=self.config.n_action_steps,
+            device=device,
+        )
+
     def denoise_step(
         self,
         prefix_pad_masks: Tensor,
-        past_key_values: list[dict[str, Tensor]],
+        past_key_values: dict[int, dict[str, Tensor]],
         x_t: Tensor,
         time: Tensor,
     ) -> Tensor:
@@ -1450,13 +1576,13 @@ class PI06FlowMatching(nn.Module):
         prefix_embs: Tensor,
         prefix_pad_masks: Tensor,
         prefix_att_masks: Tensor,
-        past_key_values: list[dict[str, Tensor]],
+        past_key_values: dict[int, dict[str, Tensor]],
         prefix_offsets: Tensor,
         response_tokens: Tensor,
         auto_step: int,
         bsize: int,
         device: torch.device,
-    ) -> tuple[Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, list[dict[str, Tensor]]]:
+    ) -> tuple[Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, dict[int, dict[str, Tensor]]]:
         """Autoregressive response-token generation for one step."""
         eos_token_id = self.language_tokenizer.convert_tokens_to_ids(self.language_tokenizer.eos_token)
         if auto_step == 0:

--- a/src/opentau/scripts/actions_mse_loss.py
+++ b/src/opentau/scripts/actions_mse_loss.py
@@ -26,6 +26,7 @@ from torch.utils.data import DataLoader
 from opentau.configs import parser
 from opentau.configs.train import TrainPipelineConfig
 from opentau.datasets.factory import make_dataset_mixture
+from opentau.policies.candidates import refuse_candidates
 from opentau.policies.factory import get_policy_class
 from opentau.policies.utils import to_dtype_preserving_siglip_float32
 from opentau.utils.random_utils import set_seed
@@ -39,6 +40,16 @@ from opentau.utils.utils import (
 @parser.wrap()
 def inference_main(cfg: TrainPipelineConfig):
     logging.info(pformat(asdict(cfg)))
+    # Unlike the other entry points this one compiles `policy.sample_actions` — the *policy*
+    # level, not the inner sampler — so an armed critic would be traced into the graph.
+    refuse_candidates(
+        cfg,
+        reason="this script torch.compiles the policy-level sample_actions, which would pull "
+        "the critic and the candidate selection inside the traced region; the data-dependent "
+        "argmax would graph-break or bake in a candidate count. It also measures fidelity "
+        "against ground-truth actions, where a best-of-N pick is not the quantity being "
+        "measured. Run it with policy.n_candidates=1.",
+    )
     # build lerobot dataset and dataloader
     datasets = make_dataset_mixture(cfg)
 

--- a/src/opentau/scripts/benchmark_inference.py
+++ b/src/opentau/scripts/benchmark_inference.py
@@ -27,7 +27,14 @@ signature):
   BENCH_COMPILE_MODE=...      # default "max-autotune"
   BENCH_N_WARMUP=5            # post-compile warmup calls
   BENCH_N_TIMED=50            # timed calls after warmup
+  BENCH_N_CANDIDATES=8        # best-of-N fan-out; unset defers to the config
   BENCH_OUTPUT_DIR=...        # default benchmark_results/
+
+``BENCH_N_CANDIDATES`` measures the cost of best-of-N sampling
+(:mod:`opentau.policies.candidates`). It supplies the parameter-free ``medoid`` selector when
+the config names no critic, since what is being timed is the fan-out, not selection quality.
+**2 is rejected**: ``MedoidCritic`` cannot rank two candidates (their single pairwise distance
+is shared, so every score ties), so sweep 1, 4, 8, 16 rather than doubling from 1.
 
 The script writes a single JSON to ``${BENCH_OUTPUT_DIR}/<host>_<policy>_<ts>.json``
 with the config snapshot, host/GPU/driver/torch versions, per-warmup wall-clock
@@ -50,6 +57,7 @@ import torch
 
 from opentau.configs import parser
 from opentau.configs.train import TrainPipelineConfig
+from opentau.policies.candidates import MEDOID, configure_candidates
 from opentau.policies.factory import make_policy
 from opentau.policies.normalize import NormalizationMode
 from opentau.policies.utils import to_dtype_preserving_siglip_float32
@@ -186,6 +194,10 @@ def benchmark_main(cfg: TrainPipelineConfig):
     compile_mode = os.environ.get("BENCH_COMPILE_MODE", "max-autotune")
     n_warmup = int(os.environ.get("BENCH_N_WARMUP", "5"))
     n_timed = int(os.environ.get("BENCH_N_TIMED", "50"))
+    # Unset means "whatever the config says", which is not the same as 1 — `configure_candidates`
+    # resolves `override=None` by falling through, and `override=1` by disabling.
+    n_candidates_env = os.environ.get("BENCH_N_CANDIDATES")
+    n_candidates_override = int(n_candidates_env) if n_candidates_env is not None else None
     out_dir = Path(os.environ.get("BENCH_OUTPUT_DIR", "benchmark_results"))
     out_dir.mkdir(parents=True, exist_ok=True)
 
@@ -198,7 +210,8 @@ def benchmark_main(cfg: TrainPipelineConfig):
     is_hl = _is_high_level(cfg.policy.type)
     logging.info(
         f"Policy type={cfg.policy.type} (high_level={is_hl}), no_compile={no_compile}, "
-        f"compile_mode={compile_mode}, n_warmup={n_warmup}, n_timed={n_timed}"
+        f"compile_mode={compile_mode}, n_warmup={n_warmup}, n_timed={n_timed}, "
+        f"n_candidates={n_candidates_override if n_candidates_override is not None else 'from-config'}"
     )
 
     # Random init path: bypass stats requirement.
@@ -212,6 +225,20 @@ def benchmark_main(cfg: TrainPipelineConfig):
     to_dtype_preserving_siglip_float32(policy, device=device, dtype=torch.bfloat16)
     policy.eval()
     policy.reset()
+
+    # Best-of-N fan-out, armed before the compile so the traced graph and the warmup calls
+    # both see the widened batch — compiling at N=1 and then widening would charge the first
+    # timed call for a recompile and invalidate the measurement. What is being timed is the
+    # fan-out, so supply the parameter-free selector when the config names no critic.
+    if (
+        n_candidates_override is not None
+        and n_candidates_override > 1
+        and cfg.policy.action_chunk_critic_path is None
+    ):
+        cfg.policy.action_chunk_critic_path = MEDOID
+    n_candidates = configure_candidates(
+        policy, cfg, device=device, dtype=torch.bfloat16, override=n_candidates_override
+    )
 
     # Compile + verify. We rebind ``policy.model.sample_actions`` on the
     # instance so the outer ``policy.sample_actions`` wrapper (which calls
@@ -286,6 +313,9 @@ def benchmark_main(cfg: TrainPipelineConfig):
         "cudnn_version": torch.backends.cudnn.version(),
         "policy_type": cfg.policy.type,
         "compile_status": compile_status,
+        # Recorded because a latency number is meaningless without the fan-out it was
+        # measured at; the whole point of the flag is comparing records across N.
+        "n_candidates": n_candidates,
         "n_warmup": n_warmup,
         "n_timed": n_timed,
         "warmup_ms": warmup_ms,

--- a/src/opentau/scripts/diagnose_accel.py
+++ b/src/opentau/scripts/diagnose_accel.py
@@ -94,6 +94,7 @@ from opentau.policies.accel import (
     record_traces,
     resolve_action_dim_mask,
 )
+from opentau.policies.candidates import refuse_candidates
 from opentau.policies.factory import make_policy
 from opentau.policies.utils import to_dtype_preserving_siglip_float32
 from opentau.utils.utils import init_logging
@@ -969,6 +970,19 @@ def diagnose_main(cfg: TrainPipelineConfig):
     """
     init_logging()
     cfg.validate()
+
+    # This study pins the noise itself (`noise=` on every `sample_actions` call) so that the
+    # observation spread it measures is not confounded by the draw. Best-of-N does the
+    # opposite — it fans the draw out and then discards all but one — so the two cannot both
+    # be in effect.
+    refuse_candidates(
+        cfg,
+        reason="this diagnostic controls the noise draw to isolate the observation-driven "
+        "spread of accel, and reads `policy.last_accel` positionally as one score per "
+        "observation. Best-of-N would fan the draw out and publish one score per selected "
+        "candidate, silently changing what every number in the report means. Run it with "
+        "policy.n_candidates=1.",
+    )
 
     logger.info("Loading policy %s from %s", cfg.policy.type, cfg.policy.pretrained_path)
     policy = make_policy(cfg=cfg.policy)

--- a/src/opentau/scripts/eval.py
+++ b/src/opentau/scripts/eval.py
@@ -67,6 +67,7 @@ from opentau.envs.utils import (
     preprocess_observation,
 )
 from opentau.policies.accel import configure_accel
+from opentau.policies.candidates import refuse_candidates
 from opentau.policies.factory import make_policy
 from opentau.policies.pretrained import PreTrainedPolicy
 from opentau.policies.utils import to_dtype_preserving_siglip_float32
@@ -1112,6 +1113,18 @@ def eval_main(cfg: TrainPipelineConfig):
             "a different number of sharded-param all-gathers per rank and hangs at NCCL. Run eval with "
             "replicated params (single GPU / DDP / ZeRO-1/2)."
         )
+
+    # Best-of-N is serving-only for now. Refused here rather than ignored so a checkpoint's
+    # own config, which carries `n_candidates` once a server armed it, cannot quietly change
+    # what an eval measures.
+    refuse_candidates(
+        cfg,
+        reason="best-of-N candidate sampling is wired for the serving entry points only. Eval "
+        f"rolls out {cfg.eval.batch_size} environments per batch, so the fan-out would multiply "
+        "the candidate activations by the eval batch rather than by 1 — a memory profile that "
+        "was never measured. Serve the checkpoint through the gRPC or RoboCasa server to "
+        "evaluate best-of-N, or set policy.n_candidates=1 for this run.",
+    )
 
     details = f"{cfg.env.type}-{cfg.env.task}-{cfg.eval.n_episodes}"
     now = f"{dt.datetime.now():%Y%m%d-%H%M%S}"

--- a/src/opentau/scripts/export_to_onnx.py
+++ b/src/opentau/scripts/export_to_onnx.py
@@ -39,6 +39,7 @@ from torch import Tensor
 
 from opentau.configs import parser
 from opentau.configs.train import TrainPipelineConfig
+from opentau.policies.candidates import refuse_candidates
 from opentau.policies.factory import get_policy_class
 from opentau.policies.pi05.modeling_pi05 import PI05Policy
 from opentau.utils.hub import format_repo_revision, split_repo_revision
@@ -194,6 +195,18 @@ def main(cfg: TrainPipelineConfig):
     """Main export function."""
     device = auto_torch_device()
     dtype = torch.float32
+
+    # `PI05OnnxWrapper` calls `policy.model.sample_actions` directly, so the policy-level
+    # candidate fan-out and the critic are both outside the graph by construction, and the
+    # export has no dynamic axes to widen the batch through anyway.
+    refuse_candidates(
+        cfg,
+        reason="the ONNX wrapper calls the inner sampler directly, bypassing the policy layer "
+        "where candidates are expanded and scored, and the export pins static batch axes. "
+        "Exporting from an n_candidates>1 config would ship a single-candidate graph that "
+        "behaves differently from the server the config describes. Export with "
+        "policy.n_candidates=1.",
+    )
 
     logging.info("Applying monkey patches...")
     for patch in patches:

--- a/src/opentau/scripts/grpc/server.py
+++ b/src/opentau/scripts/grpc/server.py
@@ -70,6 +70,7 @@ from opentau.configs.train import TrainPipelineConfig
 from opentau.datasets.lerobot_dataset import BaseDataset
 from opentau.planner.gemini_er_planner import GeminiERPlanner
 from opentau.policies.accel import configure_accel
+from opentau.policies.candidates import configure_candidates
 from opentau.policies.factory import get_policy_class
 from opentau.policies.utils import to_dtype_preserving_siglip_float32
 from opentau.scripts.grpc import auth, robot_inference_pb2, robot_inference_pb2_grpc
@@ -313,6 +314,11 @@ class RobotPolicyServicer(robot_inference_pb2_grpc.RobotPolicyServiceServicer):
         # graph and any unsupported-checkpoint refusal land at startup, not on the first
         # robot request. `self.accel_prefix` gates the response field.
         self.accel_prefix = configure_accel(self.policy, self.cfg)
+
+        # Best-of-N candidate sampling, off unless the config asks for it. Placed here for
+        # the same reason: the critic is loaded, cast and smoke-called at startup, and the
+        # warmup calls below then trace the widened batch the real requests will use.
+        configure_candidates(self.policy, self.cfg, device=self.device, dtype=self.dtype)
 
         camera_observations = {
             f"camera{i}": torch.zeros((1, 3, *self.cfg.resolution), dtype=self.dtype, device=self.device)

--- a/src/opentau/scripts/high_level_planner_inference.py
+++ b/src/opentau/scripts/high_level_planner_inference.py
@@ -24,6 +24,7 @@ from dotenv import load_dotenv
 from opentau.configs import parser
 from opentau.configs.train import TrainPipelineConfig
 from opentau.planner import HighLevelPlanner, Memory
+from opentau.policies.candidates import refuse_candidates
 from opentau.policies.factory import get_policy_class
 from opentau.policies.utils import to_dtype_preserving_siglip_float32
 from opentau.utils.random_utils import set_seed
@@ -44,6 +45,16 @@ def inference_main(cfg: TrainPipelineConfig):
     """
 
     logging.info(pformat(asdict(cfg)))
+
+    # The planner families decode text autoregressively; there is no flow-matching noise draw
+    # to fan out and no action chunk for a critic to compare.
+    refuse_candidates(
+        cfg,
+        reason="this entry point serves the high-level planner families, which emit a subtask "
+        "string rather than an action chunk, so there is nothing for an action-chunk critic to "
+        "score. Diversifying a planner would mean sampling its decode, which is a different "
+        "feature. Run it with policy.n_candidates=1.",
+    )
 
     # Check device is available
     device = "cuda" if torch.cuda.is_available() else "cpu"

--- a/src/opentau/scripts/inference.py
+++ b/src/opentau/scripts/inference.py
@@ -29,6 +29,7 @@ import torch
 from opentau.configs import parser
 from opentau.configs.train import TrainPipelineConfig
 from opentau.policies.accel import configure_accel
+from opentau.policies.candidates import configure_candidates
 from opentau.policies.factory import get_policy_class
 from opentau.policies.utils import to_dtype_preserving_siglip_float32
 from opentau.utils.random_utils import set_seed
@@ -65,6 +66,11 @@ def inference_main(cfg: TrainPipelineConfig):
     # Done before the warmup calls so the compiled graph and any unsupported-checkpoint
     # refusal both land here rather than on the first timed run.
     accel_prefix = configure_accel(policy, cfg)
+
+    # Best-of-N candidate sampling; also a no-op unless the config asks for it. Same reason
+    # for the placement: critic loading, the dtype cast, the shape smoke-test and any
+    # out-of-memory all land here rather than inside a timed run.
+    configure_candidates(policy, cfg, device=device, dtype=torch.bfloat16)
 
     observation = create_dummy_observation(cfg, device, dtype=torch.bfloat16)
 

--- a/src/opentau/scripts/robocasa/server.py
+++ b/src/opentau/scripts/robocasa/server.py
@@ -84,6 +84,7 @@ import websockets
 from opentau.configs import parser
 from opentau.configs.train import TrainPipelineConfig
 from opentau.policies.accel import configure_accel
+from opentau.policies.candidates import configure_candidates
 from opentau.policies.factory import get_policy_class
 from opentau.policies.utils import to_dtype_preserving_siglip_float32
 from opentau.utils.random_utils import set_seed
@@ -378,6 +379,12 @@ class OpenTauRoboCasaPolicy:
         # Set before the warmup calls below so the compiled graph and any
         # unsupported-checkpoint refusal land at startup, not on the first rollout step.
         self.accel_prefix = configure_accel(self.policy, cfg, override=accel_prefix)
+
+        # Best-of-N candidate sampling, off unless the config asks for it. Before the warmup
+        # so critic loading and the shape smoke-test fail at startup rather than mid-rollout;
+        # a batched request multiplies the candidate memory by the number of environments,
+        # which is exactly the sort of OOM that has to surface before the sim is running.
+        configure_candidates(self.policy, cfg, device=self.device, dtype=self.dtype)
 
         dummy = build_opentau_batch(
             cfg,

--- a/tests/policies/test_accel_wiring_registry.py
+++ b/tests/policies/test_accel_wiring_registry.py
@@ -39,17 +39,43 @@ corruption it names:
    from a re-plan and a consumer records the same score ``n_action_steps`` times.
 5. ``reset`` must clear the accel state, or it leaks across episodes.
 
+Two of those seven — pi05 and pi06 — are additionally wired for best-of-N candidate sampling
+(:mod:`opentau.policies.candidates`), which rides the same sampler signature and publishes the
+same per-plan state, so its structural invariants live here too:
+
+6. ``n_candidates`` must sit **immediately before** ``accel`` in the inner sampler and default
+   to ``1``. Invariant 3 above pins ``accel`` as the trailing parameter for the positional
+   callers; a parameter inserted on the wrong side of it shifts them silently.
+7. The wrapper attribute and the sampler parameter must appear on **exactly** the same
+   policies. Either half alone is a no-op that reports success: an attribute without the
+   parameter fans out nothing, and a parameter without the attribute is unreachable, since
+   ``configure_candidates`` gates on ``hasattr``.
+8. Every family that is *not* wired must refuse ``n_candidates > 1`` rather than accept the
+   config field and ignore it.
+
 A new flow-matching policy that forgets any of this fails here rather than at the point
 where somebody trusts a number it produced.
 """
 
 import ast
+import inspect
 import re
+import textwrap
+import warnings
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
+# The full policy registry, imported rather than copied: that module pins its list against the
+# factory's own `policy_type == "..."` branches, so a second hand-kept copy here would be the
+# "two hand-maintained lists fail open" failure CLAUDE.md rule 5 names — a policy type present
+# in only one copy silently drops out of the sweeps below.
+from test_state_action_representation_only_registry import ALL_POLICY_TYPES
+
 import opentau
+from opentau.policies.candidates import MEDOID, configure_candidates
+from opentau.policies.factory import get_policy_class, make_policy_config
 
 _POLICIES_ROOT = Path(opentau.__file__).parent / "policies"
 
@@ -76,6 +102,23 @@ FLOW_MATCHING_POLICIES = [
 ]
 
 IDS = [entry[0] for entry in FLOW_MATCHING_POLICIES]
+
+#: The subset of :data:`FLOW_MATCHING_POLICIES` wired for best-of-N candidate sampling
+#: (:mod:`opentau.policies.candidates`). Keyed by module path so the tuples stay single-sourced
+#: with the list above. Scoped to pi05 + pi06 for the first release.
+CANDIDATE_WIRED = frozenset({"pi05/modeling_pi05.py", "pi06/modeling_pi06.py"})
+
+CANDIDATE_POLICIES = [entry for entry in FLOW_MATCHING_POLICIES if entry[0] in CANDIDATE_WIRED]
+CANDIDATE_IDS = [entry[0] for entry in CANDIDATE_POLICIES]
+
+#: Policy *types* that route to a wired policy class. ``pi05_continuous_state`` is a deprecated
+#: alias resolving to ``PI05Policy``, so it inherits the wiring and must not be swept as
+#: unwired — a refusal test parametrized over it would assert a refusal that never comes.
+CANDIDATE_WIRED_TYPES = frozenset({"pi05", "pi05_continuous_state", "pi06"})
+UNWIRED_POLICY_TYPES = ALL_POLICY_TYPES - CANDIDATE_WIRED_TYPES
+
+#: Per-plan candidate state published beside ``last_accel``, and cleared wherever it is.
+CANDIDATE_STATE = frozenset({"last_accel_candidates", "last_candidate_scores"})
 
 
 def _tree(rel_path: str) -> ast.Module:
@@ -107,6 +150,60 @@ def _accel_method_calls(node: ast.AST, method: str) -> list[ast.Call]:
         and isinstance(call.func.value, ast.Name)
         and call.func.value.id == "accel"
     ]
+
+
+def _attrs_cleared_to_none(fn: ast.FunctionDef) -> set[str]:
+    """Attribute names that ``fn`` assigns ``None`` to, e.g. ``self.last_accel = None``."""
+    cleared: set[str] = set()
+    for node in ast.walk(fn):
+        if isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+        elif isinstance(node, ast.Assign):
+            targets = node.targets
+        else:
+            continue
+        if isinstance(node.value, ast.Constant) and node.value.value is None:
+            cleared |= {t.attr for t in targets if isinstance(t, ast.Attribute)}
+    return cleared
+
+
+def _assigns_n_candidates(node: ast.AST) -> bool:
+    """Whether ``node`` contains any ``<something>.n_candidates = ...`` assignment."""
+    for child in ast.walk(node):
+        if isinstance(child, ast.AnnAssign):
+            targets = [child.target]
+        elif isinstance(child, ast.Assign):
+            targets = child.targets
+        else:
+            continue
+        if any(isinstance(t, ast.Attribute) and t.attr == "n_candidates" for t in targets):
+            return True
+    return False
+
+
+def _init_defs(tree: ast.Module) -> list[ast.FunctionDef]:
+    return [n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef) and n.name == "__init__"]
+
+
+def _sample_actions_defs(tree: ast.Module) -> list[ast.FunctionDef]:
+    """Every ``sample_actions`` in a module — the wrapper's *and* the inner sampler's."""
+    return [n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef) and n.name == "sample_actions"]
+
+
+def _policy_class(policy_type: str) -> type:
+    with warnings.catch_warnings():
+        # pi05_continuous_state is deprecated but still routable.
+        warnings.simplefilter("ignore", DeprecationWarning)
+        return get_policy_class(policy_type)
+
+
+def _init_assigns_n_candidates(cls: type) -> bool:
+    """Whether an instance of ``cls`` would end up with an ``n_candidates`` attribute.
+
+    Reads the ``__init__`` Python resolves for ``cls``, so a subclass that inherits its
+    constructor (cosmos3_nano, the pi05_continuous_state alias) inherits the answer too.
+    """
+    return _assigns_n_candidates(ast.parse(textwrap.dedent(inspect.getsource(cls.__init__))))
 
 
 def _euler_update_lines(sampler: ast.FunctionDef) -> list[tuple[int, str]]:
@@ -149,6 +246,37 @@ def test_inner_sampler_takes_accel_last_and_defaults_to_none(rel_path, sampler_c
     assert isinstance(defaults[-1], ast.Constant) and defaults[-1].value is None, (
         f"{sampler_cls}.sample_actions: 'accel' must default to None so the feature is off "
         "by default and the traced graph is unchanged"
+    )
+
+
+@pytest.mark.parametrize(("rel_path", "sampler_cls", "policy_cls"), CANDIDATE_POLICIES, ids=CANDIDATE_IDS)
+def test_inner_sampler_takes_n_candidates_before_accel(rel_path, sampler_cls, policy_cls):
+    """``n_candidates`` must sit immediately before ``accel``, defaulting to ``1``.
+
+    The position is load-bearing rather than cosmetic. The test above pins ``accel`` as the
+    *last* parameter and the *last* default as ``None`` — because the ONNX exporter and the
+    compiled-callable rebinds call this method positionally — so those two assertions read the
+    tail of the signature. Appending ``n_candidates`` after ``accel`` would break them
+    outright; slotting it anywhere else leaves them passing while a positional caller silently
+    hands a meter to the candidate count. Adjacency is what keeps both pins reading the
+    parameters they name.
+
+    The default of ``1`` is the other half of the no-op guarantee: it folds ``bsize *
+    n_candidates`` back to ``bsize``, so every pre-existing caller draws the same noise off the
+    same RNG stream and the ``n_candidates > 1`` fan-out is a compile-time constant.
+    """
+    sampler = _method(_tree(rel_path), sampler_cls, "sample_actions")
+    args = sampler.args.args + sampler.args.kwonlyargs
+    assert [a.arg for a in args[-2:]] == ["n_candidates", "accel"], (
+        f"{sampler_cls}.sample_actions must end (..., n_candidates, accel); got {[a.arg for a in args[-3:]]}"
+    )
+
+    defaults = sampler.args.defaults + [d for d in sampler.args.kw_defaults if d is not None]
+    assert len(defaults) >= 2, f"{sampler_cls}.sample_actions: 'n_candidates' must have a default"
+    default = defaults[-2]
+    assert isinstance(default, ast.Constant) and default.value == 1, (
+        f"{sampler_cls}.sample_actions: 'n_candidates' must default to 1 so existing callers "
+        "are byte-identical and best-of-N stays opt-in"
     )
 
 
@@ -267,36 +395,40 @@ def test_select_action_clears_last_accel(rel_path, sampler_cls, policy_cls):
     Without the clear, a consumer reading ``last_accel`` every step records the same score
     ``n_action_steps`` times — inflating the stream and, worse, feeding a conformal
     calibration duplicated samples it treats as independent.
+
+    The candidate state is published on the same schedule and is stale in exactly the same
+    way, so on a wired policy it has to be cleared here too. It is the more dangerous of the
+    two: ``last_candidate_scores`` reread on a queue-pop step attributes a critic's ranking to
+    a step where no critic ran.
     """
-    select = _method(_tree(rel_path), policy_cls, "select_action")
-    clears = [
-        node.lineno
-        for node in ast.walk(select)
-        if isinstance(node, ast.Assign)
-        and isinstance(node.value, ast.Constant)
-        and node.value.value is None
-        and any(
-            isinstance(t, ast.Attribute) and t.attr == "last_accel" and isinstance(t.value, ast.Name)
-            for t in node.targets
+    cleared = _attrs_cleared_to_none(_method(_tree(rel_path), policy_cls, "select_action"))
+    assert "last_accel" in cleared, (
+        f"{policy_cls}.select_action must clear `self.last_accel` so a queue-pop step reads None"
+    )
+    if rel_path in CANDIDATE_WIRED:
+        assert cleared >= CANDIDATE_STATE, (
+            f"{policy_cls}.select_action must also clear {sorted(CANDIDATE_STATE - cleared)}, "
+            f"cleared: {sorted(cleared)}"
         )
-    ]
-    assert clears, f"{policy_cls}.select_action must clear `self.last_accel` so a queue-pop step reads None"
 
 
 @pytest.mark.parametrize(("rel_path", "sampler_cls", "policy_cls"), FLOW_MATCHING_POLICIES, ids=IDS)
 def test_reset_clears_the_accel_state(rel_path, sampler_cls, policy_cls):
-    """``policy.reset()`` runs once per rollout batch; per-episode state must not survive it."""
-    reset = _method(_tree(rel_path), policy_cls, "reset")
-    cleared = {
-        target.attr
-        for node in ast.walk(reset)
-        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Constant) and node.value.value is None
-        for target in node.targets
-        if isinstance(target, ast.Attribute)
-    }
+    """``policy.reset()`` runs once per rollout batch; per-episode state must not survive it.
+
+    ``reset`` is also what ``__init__`` calls to declare these attributes, so a name missing
+    here does not merely leak across episodes — it does not exist until the first re-plan, and
+    a consumer reading it before then gets ``AttributeError`` rather than ``None``.
+    """
+    cleared = _attrs_cleared_to_none(_method(_tree(rel_path), policy_cls, "reset"))
     assert {"last_accel", "last_accel_provenance"} <= cleared, (
         f"{policy_cls}.reset must clear last_accel and last_accel_provenance, cleared: {sorted(cleared)}"
     )
+    if rel_path in CANDIDATE_WIRED:
+        assert cleared >= CANDIDATE_STATE, (
+            f"{policy_cls}.reset must also clear {sorted(CANDIDATE_STATE - cleared)}, "
+            f"cleared: {sorted(cleared)}"
+        )
 
 
 @pytest.mark.parametrize(("rel_path", "sampler_cls", "policy_cls"), FLOW_MATCHING_POLICIES, ids=IDS)
@@ -381,3 +513,87 @@ def test_the_registry_covers_every_denoise_loop_in_the_tree():
     )
     stale = listed - found
     assert not stale, f"These entries no longer have a denoise loop: {sorted(stale)}"
+
+
+def test_exactly_the_wired_policies_declare_n_candidates():
+    """Set equality in both directions, over the whole tree and the whole policy registry.
+
+    Best-of-N is two independent halves — the wrapper's ``self.n_candidates`` attribute and
+    the inner sampler's ``n_candidates`` parameter — and each half alone reports success while
+    doing nothing. An attribute without the parameter fans out no candidates, so the critic
+    scores one chunk against itself; a parameter without the attribute is unreachable, because
+    ``configure_candidates`` gates on ``hasattr`` and would refuse the very family it can
+    serve. So both are derived from the tree independently and pinned to the same set, and the
+    sweep is over every ``modeling_*.py`` rather than over
+    :data:`FLOW_MATCHING_POLICIES` — a planner or ``value`` growing either half has to fail
+    here too, and neither appears in that list.
+
+    The third direction is the *registry*: a policy type routing to an already-wired class
+    (as the ``pi05_continuous_state`` alias does) is wired without any file changing, and
+    would otherwise vanish from the refusal sweep below while never being exercised as wired.
+    """
+    declaring: set[str] = set()
+    sampling: set[str] = set()
+    for path in sorted(_POLICIES_ROOT.rglob("modeling_*.py")):
+        tree = ast.parse(path.read_text())
+        rel = str(path.relative_to(_POLICIES_ROOT))
+        if any(_assigns_n_candidates(fn) for fn in _init_defs(tree)):
+            declaring.add(rel)
+        if any(
+            "n_candidates" in {a.arg for a in fn.args.args + fn.args.kwonlyargs}
+            for fn in _sample_actions_defs(tree)
+        ):
+            sampling.add(rel)
+
+    assert declaring == set(CANDIDATE_WIRED), (
+        f"modules declaring `self.n_candidates` but not listed in CANDIDATE_WIRED: "
+        f"{sorted(declaring - CANDIDATE_WIRED)}; listed but not declaring: "
+        f"{sorted(CANDIDATE_WIRED - declaring)}"
+    )
+    assert sampling == set(CANDIDATE_WIRED), (
+        f"modules whose sample_actions takes `n_candidates` but are not listed in "
+        f"CANDIDATE_WIRED: {sorted(sampling - CANDIDATE_WIRED)}; listed but whose sampler "
+        f"ignores it: {sorted(CANDIDATE_WIRED - sampling)}"
+    )
+
+    routed = {t for t in ALL_POLICY_TYPES if _init_assigns_n_candidates(_policy_class(t))}
+    assert routed == set(CANDIDATE_WIRED_TYPES), (
+        f"policy types resolving to a wired policy class but missing from CANDIDATE_WIRED_TYPES: "
+        f"{sorted(routed - CANDIDATE_WIRED_TYPES)}; listed but not wired: "
+        f"{sorted(CANDIDATE_WIRED_TYPES - routed)}"
+    )
+
+
+@pytest.mark.parametrize("policy_type", sorted(UNWIRED_POLICY_TYPES))
+def test_unwired_family_refuses_n_candidates_greater_than_one(policy_type):
+    """An out-of-scope family must raise, and name itself in the message.
+
+    Refusing matters more than it looks: ``n_candidates`` lives on ``PreTrainedConfig``, so
+    *every* policy config accepts the field. Without the refusal an operator sets it on pi0,
+    sees no error, and believes best-of-N is running — the config is even faithfully written
+    back into the checkpoint's ``config.json``. Naming the type is what makes the error
+    actionable rather than a puzzle about which of a mixture's policies objected.
+
+    ``configure_candidates`` gates on ``hasattr(policy, "n_candidates")``, an *instance*
+    attribute assigned in ``__init__``, and these policies cannot be constructed in a CPU test
+    (billions of parameters). So the stand-in is the real class with ``__init__`` skipped,
+    carrying the attribute if and only if the real ``__init__`` would have assigned it — an
+    unconditional stub would pass this test for pi05 too, which is a pin whose passing does
+    not depend on the property it names. Wiring one of these families flips the premise
+    assertion below and fails here, rather than leaving a refusal that quietly became untrue.
+    """
+    cls = _policy_class(policy_type)
+    assert not _init_assigns_n_candidates(cls), (
+        f"{policy_type} now assigns `self.n_candidates`, so it is no longer unwired; move it "
+        "into CANDIDATE_WIRED_TYPES (and its module into CANDIDATE_WIRED)"
+    )
+    stub = object.__new__(cls)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        policy_cfg = make_policy_config(policy_type)
+    policy_cfg.n_candidates = 4
+    policy_cfg.action_chunk_critic_path = MEDOID
+
+    with pytest.raises(ValueError, match=re.escape(repr(policy_type))):
+        configure_candidates(stub, SimpleNamespace(policy=policy_cfg), device="cpu")

--- a/tests/policies/test_candidate_entry_point_wiring.py
+++ b/tests/policies/test_candidate_entry_point_wiring.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python
+
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Every entry point that can reach the sampler must arm or refuse best-of-N.
+
+``n_candidates`` lives on ``PreTrainedConfig``, so it is serialized into every checkpoint's
+``config.json`` and travels with it. Any script pointed at such a checkpoint therefore *sees*
+the field — and the failure mode worth spending a test on is the one that produces no error at
+all: a script that reads the config, ignores the field, and leaves an operator believing
+best-of-N is running when it is not.
+
+So the rule is binary, and this module pins it structurally. A script that builds a policy from
+``cfg.policy`` **and** reaches that policy's sampler must either
+
+* call :func:`opentau.policies.candidates.configure_candidates` (arm it), or
+* call :func:`opentau.policies.candidates.refuse_candidates` (raise, with a reason naming what
+  would go wrong).
+
+Scripts that build a policy but never touch ``sample_actions`` / ``select_action`` — ``train``,
+``profile_step``, ``find_unused_params``, ``calculate_value``,
+``get_advantage_and_percentiles``, ``compute_max_token_length`` — are out of scope rather than
+allowlisted: with no sampler call there is no sampling to fan out, so there is nothing for the
+field to be silently ignored *by*. That distinction is derived from the tree here, not
+hand-maintained, which is what keeps the two lists below from failing open (CLAUDE.md rule 5).
+
+An AST sweep rather than a behavioural test because the thing being checked is *coverage*:
+constructing a multi-billion-parameter policy once per entry point would pin the same call
+against nine near-identical stubs while still missing the only thing that differs between them
+— whether the call is there at all.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+import opentau
+
+_SCRIPTS_ROOT = Path(opentau.__file__).parent / "scripts"
+
+#: Factory functions that turn ``cfg.policy`` into a policy (or its class).
+_POLICY_BUILDERS = frozenset({"make_policy", "get_policy_class"})
+
+#: Attributes whose presence means the script can reach the flow-matching sampler, and so can
+#: be affected by ``n_candidates``. Both spellings count: ``select_action`` delegates to
+#: ``sample_actions`` after the action queue drains.
+_SAMPLER_ATTRS = frozenset({"sample_actions", "select_action"})
+
+#: Serving entry points that arm best-of-N. Each must call ``configure_candidates`` *before*
+#: its first sampler call, so critic loading, the dtype cast, the shape smoke-test and any
+#: out-of-memory land at startup rather than on the first robot request.
+ARMS_CANDIDATES = [
+    "inference.py",
+    "benchmark_inference.py",
+    "grpc/server.py",
+    "robocasa/server.py",
+]
+
+#: Entry points that reach the sampler but cannot honour best-of-N, mapped to the reason —
+#: recorded here so the list reads as a set of decisions rather than a set of exclusions.
+REFUSES_CANDIDATES = {
+    "eval.py": "serving-only scope; the eval batch would multiply the candidate memory",
+    "export_to_onnx.py": "the ONNX wrapper bypasses the policy layer the critic lives in",
+    "actions_mse_loss.py": "compiles the policy-level sampler, trapping the critic in the graph",
+    "high_level_planner_inference.py": "the planner families emit text, not an action chunk",
+    "diagnose_accel.py": "pins the noise draw that best-of-N exists to fan out",
+}
+
+
+def _reaches_the_sampler_from_cfg_policy(source: str) -> bool:
+    """Whether ``source`` builds a policy out of ``cfg.policy`` and can reach its sampler.
+
+    Both halves are required. Building alone is the training path, which never samples;
+    a sampler reference alone is ``onnx_inference`` / ``tensorrt_inference``, which run an
+    exported artifact and have no policy object to arm.
+
+    Sampler *references* count, not just calls: ``actions_mse_loss`` and every compiling
+    server pass ``policy.sample_actions`` to ``torch.compile`` and invoke the result through a
+    local name, so a call-only matcher would miss exactly the script whose refusal reason is
+    that it compiles the policy-level sampler.
+    """
+    tree = ast.parse(source)
+    builds = False
+    reaches = False
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id in _POLICY_BUILDERS
+        ):
+            args = list(node.args) + [kw.value for kw in node.keywords]
+            builds = builds or any(
+                isinstance(sub, ast.Attribute) and sub.attr == "policy"
+                for arg in args
+                for sub in ast.walk(arg)
+            )
+        elif isinstance(node, ast.Attribute) and node.attr in _SAMPLER_ATTRS:
+            reaches = True
+    return builds and reaches
+
+
+def _entry_points_reaching_the_sampler() -> set[str]:
+    return {
+        path.relative_to(_SCRIPTS_ROOT).as_posix()
+        for path in _SCRIPTS_ROOT.rglob("*.py")
+        if _reaches_the_sampler_from_cfg_policy(path.read_text())
+    }
+
+
+def _calls(tree: ast.AST, name: str) -> list[ast.Call]:
+    """Every ``name(...)`` call, by bare function name."""
+    return [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == name
+    ]
+
+
+def _first_sampler_call_line(tree: ast.AST) -> int | None:
+    """Line of the earliest ``<obj>.sample_actions(...)`` / ``.select_action(...)`` call."""
+    lines = [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr in _SAMPLER_ATTRS
+    ]
+    return min(lines) if lines else None
+
+
+def _tree(rel_path: str) -> ast.Module:
+    return ast.parse((_SCRIPTS_ROOT / rel_path).read_text())
+
+
+def test_every_entry_point_that_reaches_the_sampler_arms_or_refuses_candidates():
+    """The registry itself: no script may silently ignore ``n_candidates``.
+
+    This is the test that has to fail when somebody adds a tenth entry point. It derives the
+    population from the tree and checks it against the two hand-kept lists, so a new server
+    that copies an existing one — imports included — still lands here as an unhandled file
+    rather than as a script that loads an ``n_candidates=8`` checkpoint and quietly serves one
+    candidate.
+
+    The reverse direction matters too: an entry listed but no longer detected is stale, and a
+    stale allowlist entry is how a list stops describing the code it guards.
+    """
+    detected = _entry_points_reaching_the_sampler()
+    handled = set(ARMS_CANDIDATES) | set(REFUSES_CANDIDATES)
+
+    unhandled = detected - handled
+    assert not unhandled, (
+        "These entry points build a policy from `cfg.policy` and reach its sampler, but "
+        "neither arm best-of-N (`configure_candidates`) nor refuse it (`refuse_candidates`), "
+        "so a checkpoint whose config.json carries n_candidates>1 is served as a single "
+        f"candidate with no error: {sorted(unhandled)}"
+    )
+
+    stale = handled - detected
+    assert not stale, (
+        "These are listed in ARMS_CANDIDATES/REFUSES_CANDIDATES but no longer build a policy "
+        f"and reach its sampler; drop them so the lists keep describing the tree: {sorted(stale)}"
+    )
+
+
+def test_the_detector_flags_a_newly_added_entry_point():
+    """Pin the property the registry test's failure depends on.
+
+    A registry test whose scan silently stops matching passes forever while covering nothing,
+    so the conflict is constructed here rather than trusted: a synthetic script in the shape a
+    new server would take must come back detected — which is what makes it show up as
+    ``unhandled`` above until someone adds it to a list.
+    """
+    new_entry_point = (
+        "from opentau.policies.factory import get_policy_class\n"
+        "def serve(cfg):\n"
+        "    policy = get_policy_class(cfg.policy.type).from_pretrained(cfg.policy.pretrained_path)\n"
+        "    return policy.sample_actions({})\n"
+    )
+    assert _reaches_the_sampler_from_cfg_policy(new_entry_point), (
+        "the scan behind test_every_entry_point_that_reaches_the_sampler_arms_or_refuses_"
+        "candidates no longer recognizes a new serving entry point, so that test would pass "
+        "over one instead of failing on it"
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        pytest.param(
+            "from opentau.policies.factory import make_policy\n"
+            "def train(cfg):\n"
+            "    policy = make_policy(cfg=cfg.policy)\n"
+            "    return policy.forward({})\n",
+            id="builds-but-never-samples",
+        ),
+        pytest.param(
+            "import onnxruntime\n"
+            "def run(session, batch):\n"
+            "    return session.run(None, batch)  # exported sample_actions graph\n",
+            id="samples-but-builds-no-policy",
+        ),
+    ],
+)
+def test_the_detector_ignores_scripts_that_are_out_of_scope(source):
+    """The other half of the conflict: a detector that returns ``True`` for everything.
+
+    It would make the registry test pass only because both lists happen to be long enough,
+    and would then demand a pointless refusal line in every training script. Both halves of
+    the ``builds and reaches`` conjunction are exercised, one per case.
+    """
+    assert not _reaches_the_sampler_from_cfg_policy(source)
+
+
+@pytest.mark.parametrize("rel_path", ARMS_CANDIDATES)
+def test_arm_listed_entry_points_actually_call_configure_candidates(rel_path):
+    """A list entry is a claim about the source; check the source makes it true.
+
+    Without this the allowlist is self-certifying — adding a filename would satisfy the
+    registry test whether or not the call was ever written.
+    """
+    assert _calls(_tree(rel_path), "configure_candidates"), (
+        f"{rel_path} is listed in ARMS_CANDIDATES but never calls configure_candidates()"
+    )
+
+
+@pytest.mark.parametrize("rel_path", sorted(REFUSES_CANDIDATES))
+def test_refuse_listed_entry_points_actually_call_refuse_candidates(rel_path):
+    """Same, for the refusal half."""
+    assert _calls(_tree(rel_path), "refuse_candidates"), (
+        f"{rel_path} is listed in REFUSES_CANDIDATES but never calls refuse_candidates()"
+    )
+
+
+def test_no_entry_point_both_arms_and_refuses():
+    """The two lists are alternatives; membership in both is a contradiction, not a belt-and-braces."""
+    both = set(ARMS_CANDIDATES) & set(REFUSES_CANDIDATES)
+    assert not both, f"listed as both arming and refusing best-of-N: {sorted(both)}"
+
+
+@pytest.mark.parametrize("rel_path", ARMS_CANDIDATES)
+def test_candidates_are_armed_before_the_first_sampler_call(rel_path):
+    """Arming after the warmup would defer every startup failure to the first robot request.
+
+    ``configure_candidates`` is where the critic is loaded, moved to the device, cast and
+    smoke-called for its output shape, and where the widened batch first allocates. Every one
+    of those is a startup concern: a server that warms up at N=1 and only fans out on the
+    first real request pays a recompile and can run out of memory with a robot waiting.
+    """
+    tree = _tree(rel_path)
+    arm = _calls(tree, "configure_candidates")
+    assert len(arm) == 1, f"{rel_path}: expected exactly one configure_candidates() call, found {len(arm)}"
+
+    first_sample = _first_sampler_call_line(tree)
+    assert first_sample is not None, f"{rel_path}: no sampler call found; the ordering matcher needs updating"
+    assert arm[0].lineno < first_sample, (
+        f"{rel_path}: configure_candidates() at line {arm[0].lineno} runs after the first "
+        f"sample_actions()/select_action() call at line {first_sample}, so critic loading and "
+        "the candidate fan-out land on a live request instead of at startup"
+    )
+
+
+@pytest.mark.parametrize("rel_path", ARMS_CANDIDATES)
+def test_arming_passes_an_explicit_dtype(rel_path):
+    """``attach_critic`` keeps the critic out of ``policy._modules`` on purpose.
+
+    The cost of that is that no later ``policy.to(...)`` reaches it, so the cast has to be
+    passed in here or never happen. Every one of these entry points runs its policy in
+    bfloat16; a critic silently left in float32 behind it is a dtype mismatch that only
+    surfaces on the first request, and only for a critic that has parameters (the built-in
+    ``MedoidCritic`` has none, so this cannot be caught by exercising today's default).
+    """
+    call = _calls(_tree(rel_path), "configure_candidates")[0]
+    passed = {kw.arg for kw in call.keywords}
+    assert "device" in passed and "dtype" in passed, (
+        f"{rel_path}: configure_candidates() must be given explicit `device=` and `dtype=`; "
+        f"got {sorted(passed)}"
+    )
+
+
+@pytest.mark.parametrize("rel_path", sorted(REFUSES_CANDIDATES))
+def test_refusals_explain_what_would_go_wrong(rel_path):
+    """``reason`` is keyword-only and lands verbatim in the operator's traceback.
+
+    A refusal that only says "unsupported" tells someone who set ``n_candidates=4`` nothing
+    about where to set it instead, which is the whole difference between this and the silent
+    ignore it replaces.
+    """
+    for call in _calls(_tree(rel_path), "refuse_candidates"):
+        reason = next((kw.value for kw in call.keywords if kw.arg == "reason"), None)
+        assert reason is not None, f"{rel_path}: refuse_candidates() must be passed a `reason=`"
+        # Adjacent string literals are folded into one Constant by the parser, but a reason
+        # that interpolates a config value (eval names its own batch size) is a JoinedStr —
+        # measure the literal text in either shape rather than demanding the simpler one.
+        if isinstance(reason, ast.Constant):
+            literal = reason.value
+        elif isinstance(reason, ast.JoinedStr):
+            literal = "".join(p.value for p in reason.values if isinstance(p, ast.Constant))
+        else:
+            raise AssertionError(f"{rel_path}: refuse_candidates(reason=...) must be a string literal")
+        assert len(literal) > 40, (
+            f"{rel_path}: refuse_candidates(reason=...) must be a sentence explaining what "
+            "would go wrong, not a placeholder"
+        )

--- a/tests/policies/test_candidate_policy_wiring.py
+++ b/tests/policies/test_candidate_policy_wiring.py
@@ -1,0 +1,857 @@
+#!/usr/bin/env python
+
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU coverage for best-of-N candidate sampling wired into the pi05 / pi06 samplers.
+
+``tests/policies/test_candidates.py`` pins the helpers in
+:mod:`opentau.policies.candidates` in isolation. These tests pin the *wiring* — the two
+policy families that PR 1 actually threads ``n_candidates`` through — and they are written
+around the three ways this feature goes wrong silently:
+
+1. **It stops being free.** The whole premise is that one VLM prefix pass serves all N
+   candidates, so ``test_prefix_pass_runs_once_regardless_of_n_candidates`` counts the
+   backbone calls. Nothing else in the suite would notice a per-candidate prefix pass: the
+   numbers would be identical and only the latency would move.
+2. **A legacy user feels it anyway.** ``n_candidates`` defaults to 1 and every config that
+   travels with a checkpoint carries the key, so the N==1 path must be untouched — no
+   candidate helper called, the same single noise draw of the same shape, and a 3-D return.
+3. **The fan-out is transposed.** ``(b n)`` versus ``(n b)`` is invisible in every shape,
+   and at ``B == 1`` — the only batch serving produces — it is invisible in the values too.
+   So the equivalence test is parametrized over ``B`` in ``{1, 2, 3}`` with distinct
+   per-observation inputs, which is the only shape where the ordering can be observed.
+
+Built on the same lightweight ``object.__new__`` shell the accel tests use
+(``tests/policies/test_pi05_accel.py``), so no PaliGemma / Gemma 3 weights are loaded: the
+backbone is a stub that returns a KV cache carrying a per-observation signature, and the
+denoise step is a closed-form nonlinear function of ``x_t`` and that signature.
+"""
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+from einops import rearrange, reduce, repeat
+from torch import Tensor, nn
+
+import opentau
+import opentau.policies.pi05.modeling_pi05 as pi05_modeling
+import opentau.policies.pi06.modeling_pi06 as pi06_modeling
+from opentau.configs.types import FeatureType, NormalizationMode, PolicyFeature
+from opentau.policies.candidates import collapse_candidates, configure_candidates
+from opentau.policies.normalize import Unnormalize
+from opentau.policies.pi05.configuration_pi05 import PI05Config
+from opentau.policies.pi06.configuration_pi06 import PI06Config
+from opentau.utils.random_utils import set_seed
+
+CHUNK = 4
+ACTION_DIM = 4
+MAX_ACTION_DIM = 6
+MAX_STATE_DIM = 8
+NUM_STEPS = 4
+PREFIX_TOKENS = 3
+HIDDEN = 8
+HEAD_DIM = 2
+CPU = torch.device("cpu")
+
+#: The three module-level names the samplers import from `candidates`. Monkeypatching must
+#: target these per-module bindings, never the definitions in `candidates` itself — both
+#: modules do `from opentau.policies.candidates import ...`, so patching the source leaves
+#: the already-bound name untouched and a "was it called?" test passes vacuously.
+CANDIDATE_HELPERS = ("expand_candidates", "expand_kv_cache", "select_candidate")
+
+
+@dataclass(frozen=True)
+class Family:
+    """One policy family wired for best-of-N in PR 1."""
+
+    name: str
+    module: ModuleType
+    rel_path: str
+    config_cls: type
+    sampler_cls: type
+    policy_cls: type
+    backbone_attr: str
+    #: pi05's ``embed_prefix`` returns a 4th (adarms) element and its inner ``sample_actions``
+    #: takes ``state=``; pi06's do neither.
+    pi05_shaped: bool
+
+
+FAMILIES = [
+    Family(
+        name="pi05",
+        module=pi05_modeling,
+        rel_path="pi05/modeling_pi05.py",
+        config_cls=PI05Config,
+        sampler_cls=pi05_modeling.PI05FlowMatching,
+        policy_cls=pi05_modeling.PI05Policy,
+        backbone_attr="paligemma_with_expert",
+        pi05_shaped=True,
+    ),
+    Family(
+        name="pi06",
+        module=pi06_modeling,
+        rel_path="pi06/modeling_pi06.py",
+        config_cls=PI06Config,
+        sampler_cls=pi06_modeling.PI06FlowMatching,
+        policy_cls=pi06_modeling.PI06Policy,
+        backbone_attr="gemma3_with_expert",
+        pi05_shaped=False,
+    ),
+]
+
+IDS = [family.name for family in FAMILIES]
+
+
+@pytest.fixture(params=FAMILIES, ids=IDS)
+def family(request) -> Family:
+    return request.param
+
+
+# --------------------------------------------------------------------------------------
+# Shells: a sampler and a policy wrapper with no pretrained weights behind them.
+# --------------------------------------------------------------------------------------
+
+
+def _config(family: Family, **overrides):
+    kwargs = {
+        "n_obs_steps": 1,
+        "chunk_size": CHUNK,
+        "n_action_steps": CHUNK,
+        "max_delay": 0,
+        "num_steps": NUM_STEPS,
+        "max_state_dim": MAX_STATE_DIM,
+        "max_action_dim": MAX_ACTION_DIM,
+        "predict_response": False,
+        "output_features": {"actions": PolicyFeature(type=FeatureType.ACTION, shape=(ACTION_DIM,))},
+    }
+    kwargs.update(overrides)
+    return family.config_cls(**kwargs)
+
+
+class _CountingBackbone(nn.Module):
+    """Stand-in for the VLM that separates the prefix pass from the denoise passes.
+
+    The counters are the point: the fused path's entire justification is that
+    ``fill_kv_cache=True`` runs once per *observation* no matter how many candidates
+    follow, and no assertion on the returned actions can tell the two apart.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.prefix_fill_calls = 0
+        self.denoise_calls = 0
+
+    def forward(self, *, inputs_embeds, fill_kv_cache=False, **kwargs):
+        embs = inputs_embeds[0]
+        if not fill_kv_cache:
+            self.denoise_calls += 1
+            return (None, None), None
+
+        self.prefix_fill_calls += 1
+        # One scalar per observation, carried into the cache so a denoise step can read back
+        # *which* observation its row was conditioned on. A transposed fan-out hands candidate
+        # rows the wrong signature, which is the only way the ordering becomes observable.
+        signature = reduce(embs, "b t h -> b", "mean")
+        cache = {
+            layer: {
+                name: repeat(
+                    signature * (layer + 1), "b -> b t h d", t=PREFIX_TOKENS, h=1, d=HEAD_DIM
+                ).contiguous()
+                for name in ("key_states", "value_states")
+            }
+            # Keyed by layer index, matching the real cache: `expand_kv_cache` iterates
+            # `.items()`, and a list comprehension over it would yield bare ints.
+            for layer in range(2)
+        }
+        return (torch.zeros(embs.shape[0], 1, HIDDEN), None), cache
+
+
+def _flow_matching(family: Family, cfg) -> nn.Module:
+    """An inner sampler whose ``denoise_step`` is a closed-form velocity field.
+
+    Nonlinear in ``x_t`` so two noise draws take genuinely different trajectories (a linear
+    field would make every candidate a scaled copy and hide an ordering bug), and scaled by
+    the per-observation signature so conditioning errors surface as value differences.
+    """
+    fm = object.__new__(family.sampler_cls)
+    nn.Module.__init__(fm)
+    fm.config = cfg
+    backbone = _CountingBackbone()
+    setattr(fm, family.backbone_attr, backbone)
+
+    def embed_prefix(images, img_masks, lang_tokens, lang_masks, state=None):
+        embs = repeat(lang_tokens.to(torch.float32), "b t -> b t h", h=HIDDEN).contiguous()
+        att_masks = torch.zeros(lang_tokens.shape[0], PREFIX_TOKENS, dtype=torch.long)
+        if family.pi05_shaped:
+            return embs, lang_masks, att_masks, None
+        return embs, lang_masks, att_masks
+
+    def denoise_step(prefix_pad_masks, past_key_values, x_t, time):
+        backbone.forward(inputs_embeds=[x_t, None], fill_kv_cache=False)
+        conditioning = past_key_values[0]["key_states"][:, 0, 0, 0]
+        pad = reduce(prefix_pad_masks.to(torch.float32), "r t -> r", "sum")
+        scale = rearrange(conditioning * pad, "r -> r 1 1")
+        step = reduce(time.to(torch.float32), "b c -> b 1 1", "mean")
+        return torch.tanh(x_t * scale) + step
+
+    fm.embed_prefix = embed_prefix
+    fm.denoise_step = denoise_step
+    return fm
+
+
+def _backbone(fm, family: Family) -> _CountingBackbone:
+    return getattr(fm, family.backbone_attr)
+
+
+def _lang_tokens(bsize: int) -> Tensor:
+    """One distinct token value per observation, so each gets its own cache signature."""
+    return repeat(torch.arange(1, bsize + 1), "b -> b t", t=PREFIX_TOKENS).contiguous()
+
+
+def _action_prefix(bsize: int) -> Tensor:
+    """A per-observation constant prefix, distinct across rows."""
+    return repeat(
+        torch.arange(1, bsize + 1, dtype=torch.float32), "b -> b c d", c=CHUNK, d=MAX_ACTION_DIM
+    ).contiguous()
+
+
+def _sample(
+    fm,
+    family: Family,
+    *,
+    lang_tokens: Tensor,
+    action_prefix: Tensor | None = None,
+    noise: Tensor | None = None,
+    delay: int = 0,
+    n_candidates: int = 1,
+    accel=None,
+) -> Tensor:
+    """Call the inner sampler, absorbing pi05's extra ``state`` parameter."""
+    if action_prefix is None:
+        action_prefix = torch.zeros(lang_tokens.shape[0], CHUNK, MAX_ACTION_DIM)
+    extra = {"state": None} if family.pi05_shaped else {}
+    return family.sampler_cls.sample_actions(
+        fm,
+        [],
+        [],
+        lang_tokens,
+        torch.ones_like(lang_tokens, dtype=torch.bool),
+        action_prefix,
+        torch.tensor(delay),
+        noise=noise,
+        n_candidates=n_candidates,
+        accel=accel,
+        **extra,
+    )
+
+
+class _RiggedCritic:
+    """A critic that always prefers a fixed candidate index, and counts its calls.
+
+    ``MedoidCritic`` refuses N < 3 and its ranking depends on the sampled chunks, neither of
+    which suits a wiring test — what these tests need is a *known* answer so the selected row
+    can be identified exactly.
+    """
+
+    def __init__(self, pick: int = 0, *, tie: bool = False) -> None:
+        self.pick = pick
+        self.tie = tie
+        self.calls = 0
+
+    def score_chunks(self, batch, candidates, *, row_mask, dataset_index):
+        self.calls += 1
+        bsize, n_cand = candidates.shape[:2]
+        if self.tie:
+            return torch.zeros(bsize, n_cand)
+        scores = torch.full((bsize, n_cand), -1.0)
+        scores[:, self.pick % n_cand] = 1.0
+        return scores
+
+
+def _unnormalize() -> Unnormalize:
+    """A real ``Unnormalize`` with identity statistics.
+
+    Real rather than stubbed because ``make_meter`` derives the accel dim mask from its
+    buffers, and identity so the sampler's raw output survives to the critic unchanged and
+    can be compared directly. ``ACTION_DIM < MAX_ACTION_DIM`` reproduces the padded tail.
+    """
+    features = {"actions": PolicyFeature(type=FeatureType.ACTION, shape=(ACTION_DIM,))}
+    stats = [{"actions": {"mean": torch.zeros(ACTION_DIM), "std": torch.ones(ACTION_DIM)}}]
+    return Unnormalize(
+        features,
+        {"ACTION": NormalizationMode.MEAN_STD},
+        per_dataset_stats=stats,
+        dataset_names=["ds0"],
+        eps=1e-6,
+    )
+
+
+def _policy(family: Family, cfg=None, *, accel_prefix: int | None = None):
+    """A policy wrapper shell whose ``sample_actions`` / ``select_action`` are the real ones.
+
+    ``n_candidates = 1`` and ``_action_chunk_critic = None`` mirror what ``__init__`` sets;
+    that mirroring is what ``test_wrapper_declares_n_candidates_as_one_in_init`` pins against
+    the source, so the two cannot drift.
+    """
+    cfg = cfg if cfg is not None else _config(family)
+    policy = object.__new__(family.policy_cls)
+    nn.Module.__init__(policy)
+    policy.config = cfg
+    policy.model = _flow_matching(family, cfg)
+    policy.unnormalize_outputs = _unnormalize()
+    # `build_provenance` reads the velocity dtype off `next(policy.parameters())`; a shell
+    # built from buffers alone has none.
+    policy._dtype_probe = nn.Parameter(torch.zeros(1))
+    policy.eval = lambda: None  # bypass nn.Module.eval (no policy __init__ was run)
+    policy._resolve_dataset_index = lambda batch: torch.zeros(batch["state"].shape[0], dtype=torch.long)
+    policy.normalize_inputs = lambda batch, index: dict(batch)
+    policy.normalize_targets = lambda batch, index: dict(batch)
+    policy.prepare_images = lambda batch: ([], [])
+    policy.prepare_language = lambda batch: (
+        batch["lang_tokens"],
+        torch.ones_like(batch["lang_tokens"], dtype=torch.bool),
+    )
+    policy.prepare_state = lambda batch: batch["state"]
+    policy.accel_prefix = accel_prefix
+    policy.n_candidates = 1
+    policy._action_chunk_critic = None
+    family.policy_cls.reset(policy)
+    return policy
+
+
+def _arm(policy, n: int, critic: _RiggedCritic) -> None:
+    """Arm best-of-N the way a serving entry point does, then discard the smoke-test call."""
+    configure_candidates(policy, policy.config, device=CPU, override=n, critic=critic)
+    critic.calls = 0
+
+
+def _batch(bsize: int = 1) -> dict[str, Tensor]:
+    return {
+        "state": torch.zeros(bsize, MAX_STATE_DIM),
+        "lang_tokens": _lang_tokens(bsize),
+    }
+
+
+def _noise(rows: int, seed: int = 0) -> Tensor:
+    generator = torch.Generator(device=CPU).manual_seed(seed)
+    return torch.randn(rows, CHUNK, MAX_ACTION_DIM, generator=generator)
+
+
+# --------------------------------------------------------------------------------------
+# N == 1 invariance: the "legacy user feels nothing" contract.
+# --------------------------------------------------------------------------------------
+
+
+def _raiser(name: str):
+    def boom(*args, **kwargs):
+        raise RuntimeError(f"candidate helper {name} was called")
+
+    return boom
+
+
+def test_n1_never_enters_the_candidate_path(family, monkeypatch):
+    """At N==1 not one candidate helper may run — and each one must really run at N>1.
+
+    The second half is what stops this from passing vacuously. Patching
+    ``opentau.policies.candidates.expand_candidates`` (the definition site) would leave the
+    sampler's already-bound ``from ... import`` name pointing at the original, so the N==1
+    half would pass no matter what the sampler does; the N>1 half fails loudly in that case,
+    which is the only way to know the patch targets are the bindings the code actually uses.
+    """
+    for name in CANDIDATE_HELPERS:
+        monkeypatch.setattr(family.module, name, _raiser(name))
+
+    _policy(family).sample_actions(_batch())  # must not raise
+
+    monkeypatch.undo()
+    for name in CANDIDATE_HELPERS:
+        with monkeypatch.context() as patched:
+            patched.setattr(family.module, name, _raiser(name))
+            policy = _policy(family)
+            _arm(policy, 4, _RiggedCritic(pick=1))
+            with pytest.raises(RuntimeError, match=name):
+                policy.sample_actions(_batch())
+
+
+def test_n1_noise_shape_and_rng_draw_are_unchanged(family):
+    """``bsize * n_candidates`` must fold to ``bsize``: one draw, the same shape, same stream.
+
+    A second draw, or a draw of a different size, silently re-orders the global RNG for every
+    seeded rollout that follows — a reproducibility break with no error and no shape change.
+    """
+    cfg = _config(family)
+    bsize = 2
+    fm = _flow_matching(family, cfg)
+
+    draws: list[tuple[tuple[int, ...], Tensor]] = []
+    real_sample_noise = family.sampler_cls.sample_noise
+
+    def recording_sample_noise(shape, device):
+        drawn = real_sample_noise(fm, shape, device)
+        draws.append((tuple(shape), drawn))
+        return drawn
+
+    fm.sample_noise = recording_sample_noise
+
+    # What the pre-change sampler drew: one `torch.normal` of exactly this shape, taken as
+    # the first consumption of the stream.
+    torch.manual_seed(1234)
+    expected = torch.normal(
+        mean=0.0, std=1.0, size=(bsize, CHUNK, MAX_ACTION_DIM), dtype=torch.float32, device=CPU
+    )
+
+    torch.manual_seed(1234)
+    _sample(fm, family, lang_tokens=_lang_tokens(bsize), n_candidates=1)
+
+    assert [shape for shape, _ in draws] == [(bsize, CHUNK, MAX_ACTION_DIM)]
+    assert torch.equal(draws[0][1], expected)
+
+
+@pytest.mark.parametrize("n_candidates", [1, 2, 4])
+def test_n1_returns_the_same_shape_as_before(family, n_candidates):
+    """The candidate axis must never reach a caller.
+
+    ``select_action`` immediately does ``rearrange(actions, "b c d -> c b d")`` and extends a
+    deque with the result, so a 4-D return would not raise — it would quietly queue one
+    action per candidate and hand the robot the wrong tensor.
+    """
+    policy = _policy(family)
+    if n_candidates > 1:
+        _arm(policy, n_candidates, _RiggedCritic(pick=1))
+
+    actions = policy.sample_actions(_batch(bsize=1))
+
+    assert actions.shape == (1, CHUNK, ACTION_DIM)
+
+
+# --------------------------------------------------------------------------------------
+# Candidate correctness.
+# --------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bsize", [1, 2, 3])
+def test_candidate_i_of_a_fused_run_equals_a_standalone_run_with_that_noise(family, bsize):
+    """Every fused candidate row must equal the standalone run that noise row would produce.
+
+    This is the correctness claim the whole feature rests on: sharing one prefix pass and one
+    KV cache across N candidates changes nothing about what each candidate *is*.
+
+    ``B == 1`` is the only batch shape serving produces and the only one where
+    ``einops.repeat`` aliases (stride 0), so it is worth its own case; ``B >= 2`` with
+    distinct per-observation language tokens is the case that catches a transposed ``(n b)``
+    fan-out, which is invisible at ``B == 1`` and invisible in every shape.
+
+    Bit-identity is asserted because this stub runs float32 on CPU. It would NOT hold in
+    bf16 on GPU: the same noise row decoded at a different batch size differs by ~5e-3 there
+    (1-2 ULP of bf16, from batch-shape-dependent cuBLAS kernel selection), on unmodified code
+    as well. Any cross-batch-shape assertion on real hardware needs a ULP-scale tolerance.
+    """
+    cfg = _config(family)
+    n = 3
+    lang_tokens = _lang_tokens(bsize)
+    action_prefix = _action_prefix(bsize)
+    noise = _noise(bsize * n)
+
+    fused = _sample(
+        _flow_matching(family, cfg),
+        family,
+        lang_tokens=lang_tokens,
+        action_prefix=action_prefix,
+        noise=noise.clone(),
+        n_candidates=n,
+    )
+    assert fused.shape == (bsize * n, CHUNK, MAX_ACTION_DIM)
+
+    for b in range(bsize):
+        for j in range(n):
+            row = b * n + j
+            standalone = _sample(
+                _flow_matching(family, cfg),
+                family,
+                lang_tokens=lang_tokens[b : b + 1],
+                action_prefix=action_prefix[b : b + 1],
+                noise=noise[row : row + 1].clone(),
+                n_candidates=1,
+            )
+            assert torch.equal(fused[row : row + 1], standalone), (
+                f"fused row {row} (observation {b}, candidate {j}) diverged from its standalone run"
+            )
+
+    # The candidates must actually differ, or the equality above would hold under any
+    # ordering at all.
+    grid = collapse_candidates(fused, n)
+    assert not torch.equal(grid[0, 0], grid[0, 1])
+
+
+@pytest.mark.parametrize("n_candidates", [1, 4])
+def test_prefix_pass_runs_once_regardless_of_n_candidates(family, n_candidates):
+    """One VLM prefix pass per observation, N or not — the claim that makes this cheap.
+
+    Nothing else in the suite exercises it: a naive implementation that replicates the
+    observation across the batch and pays N prefix passes returns exactly the same actions
+    and differs only in wall clock and peak memory (measured at N=8: 2.5x slower, and out of
+    memory at N=32 where the fused path is not).
+    """
+    cfg = _config(family)
+    fm = _flow_matching(family, cfg)
+
+    _sample(
+        fm,
+        family,
+        lang_tokens=_lang_tokens(1),
+        noise=_noise(n_candidates),
+        n_candidates=n_candidates,
+    )
+
+    assert _backbone(fm, family).prefix_fill_calls == 1
+    assert _backbone(fm, family).denoise_calls == cfg.num_steps
+
+
+def test_frozen_prefix_rows_are_identical_across_candidates(family):
+    """Real-time-chunking rows are committed actions: every candidate must carry them byte-identically.
+
+    They are frozen by ``torch.where(prefix_mask, action_prefix, x_t)`` inside the loop, so
+    the property holds only if ``action_prefix`` was fanned out in the same ``(b n)`` order
+    as the noise. A transposed expansion gives observation 0's candidates observation 1's
+    committed actions — the robot would then execute a discontinuity at every re-plan.
+    """
+    cfg = _config(family, max_delay=2)
+    bsize, n, delay = 2, 3, 2
+    action_prefix = _action_prefix(bsize)
+
+    fused = _sample(
+        _flow_matching(family, cfg),
+        family,
+        lang_tokens=_lang_tokens(bsize),
+        action_prefix=action_prefix,
+        noise=_noise(bsize * n),
+        delay=delay,
+        n_candidates=n,
+    )
+    grid = collapse_candidates(fused, n)
+
+    for b in range(bsize):
+        for j in range(n):
+            assert torch.equal(grid[b, j, :delay], action_prefix[b, :delay]), (
+                f"observation {b} candidate {j} does not carry its own frozen prefix"
+            )
+
+    # Neither half of the assertion above is vacuous: the two observations carry *different*
+    # prefixes, and the un-frozen rows do differ between candidates.
+    assert not torch.equal(grid[0, 0, :delay], grid[1, 0, :delay])
+    assert not torch.equal(grid[0, 0, delay:], grid[0, 1, delay:])
+
+
+# --------------------------------------------------------------------------------------
+# Policy wiring.
+# --------------------------------------------------------------------------------------
+
+
+def test_n_gt_1_without_a_critic_raises(family):
+    """Best-of-N with nothing to choose with must fail loudly, naming the way in.
+
+    Reachable only by hand-setting the attribute (``configure_candidates`` loads the critic
+    before it writes ``n_candidates``), which is exactly why the message has to point at the
+    supported route rather than describe the internal state.
+    """
+    policy = _policy(family)
+    policy.n_candidates = 3
+
+    with pytest.raises(ValueError, match="configure_candidates"):
+        policy.sample_actions(_batch())
+
+
+def test_a_saved_n4_config_does_not_self_arm_an_unconfigured_policy(family):
+    """A checkpoint's ``config.json`` carries ``n_candidates``; loading it must not arm anything.
+
+    ``n_candidates`` is serialized with the config, so a checkpoint fine-tuned from a
+    best-of-N deployment travels with ``n_candidates: 4``. In-training validation and
+    ``benchmark_inference`` build policies through ``make_policy``, which never calls
+    ``configure_candidates`` — if the sampler read the config directly, those paths would
+    silently fan out 4x, quadrupling the Euler loop's activation memory mid-training.
+    """
+    cfg = _config(family, n_candidates=4, action_chunk_critic_path="medoid")
+    policy = _policy(family, cfg)
+    critic = _RiggedCritic(pick=1)
+    # Attached but never armed: only `configure_candidates` writes `n_candidates`.
+    policy._action_chunk_critic = critic
+
+    actions = policy.sample_actions(_batch(bsize=1))
+
+    assert policy.config.n_candidates == 4, "the config really did ask for best-of-N"
+    assert policy.n_candidates == 1
+    assert critic.calls == 0
+    assert actions.shape == (1, CHUNK, ACTION_DIM)
+
+
+def test_wrapper_declares_n_candidates_as_one_in_init(family):
+    """``__init__`` must set ``self.n_candidates = 1``, not read it off the config.
+
+    Declaring it there is what makes ``configure_candidates``' ``hasattr`` probe meaningful —
+    that probe is how every un-wired policy family refuses ``n_candidates > 1`` — and pinning
+    the literal ``1`` is what the shells in this module mirror.
+    """
+    init = _method(_tree(family.rel_path), family.policy_cls.__name__, "__init__")
+    assigned = _assignments_to(init, "n_candidates")
+
+    assert assigned, f"{family.policy_cls.__name__}.__init__ must declare `self.n_candidates`"
+    assert all(isinstance(node.value, ast.Constant) and node.value.value == 1 for node in assigned), (
+        f"{family.policy_cls.__name__}.__init__ must initialize `self.n_candidates` to the "
+        "literal 1; reading it from `config` would let a checkpoint self-arm best-of-N"
+    )
+
+    critic = _assignments_to(init, "_action_chunk_critic")
+    assert critic and all(
+        isinstance(node.value, ast.Constant) and node.value.value is None for node in critic
+    ), f"{family.policy_cls.__name__}.__init__ must initialize `self._action_chunk_critic` to None"
+
+
+@pytest.mark.parametrize("tie", [False, True], ids=["distinct-scores", "tied-scores"])
+def test_selection_is_identical_across_simulated_process_indices(family, monkeypatch, tie):
+    """The chosen candidate index must be a function of the scores alone, never of the RNG.
+
+    ``set_seed(seed, accelerator=...)`` offsets the global torch RNG by
+    ``process_index * 12345`` on purpose, so anything drawn from it is rank-dependent by
+    construction. ``select_action`` runs on every rank and is followed by gather collectives,
+    so a rank picking a different candidate desyncs the emitted actions with nothing raising.
+
+    The tied case is the one that could break: it is where a tie-break implemented with
+    ``torch.randint`` / ``torch.multinomial`` would diverge, while the lowest-index rule
+    cannot. Noise is passed explicitly so the candidates themselves are identical across the
+    simulated ranks and the selection is the only variable.
+    """
+    picked: list[list[int]] = []
+    real_select = family.module.select_candidate
+
+    def recording_select(scores):
+        chosen = real_select(scores)
+        picked.append(chosen.tolist())
+        return chosen
+
+    monkeypatch.setattr(family.module, "select_candidate", recording_select)
+
+    noise = _noise(4)
+    for process_index in range(4):
+        set_seed(1000, accelerator=MagicMock(process_index=process_index, num_processes=4))
+        policy = _policy(family)
+        _arm(policy, 4, _RiggedCritic(pick=2, tie=tie))
+        policy.sample_actions(_batch(bsize=1), noise=noise.clone())
+
+    assert len(picked) == 4
+    assert all(chosen == picked[0] for chosen in picked), f"selection differs across ranks: {picked}"
+    # Candidate 0 carries the draw the N==1 path would have taken, so a degenerate critic
+    # must degenerate to legacy behaviour rather than to something arbitrary.
+    assert picked[0] == ([0] if tie else [2])
+
+
+def test_last_accel_stays_length_b_and_equals_the_selected_candidate(family):
+    """``last_accel`` must stay ``B``-long and describe the chunk that was actually emitted.
+
+    The gRPC server reads ``float(policy.last_accel[0])`` with no width check, so a ``B * N``
+    list would not raise — it would publish candidate 0's uncertainty alongside whatever
+    chunk the critic picked, a wrong number attributed to the emitted action.
+    """
+    policy = _policy(family, accel_prefix=NUM_STEPS)
+    pick = 2
+    _arm(policy, 4, _RiggedCritic(pick=pick))
+
+    policy.sample_actions(_batch(bsize=1), noise=_noise(4))
+
+    assert len(policy.last_accel) == 1
+    assert len(policy.last_accel_candidates) == 1
+    assert len(policy.last_accel_candidates[0]) == 4
+    assert policy.last_accel[0] == policy.last_accel_candidates[0][pick]
+    # Not vacuous: the candidates score differently, so picking the wrong row would show.
+    assert len(set(policy.last_accel_candidates[0])) > 1
+
+
+def test_last_candidate_state_is_cleared_on_a_queue_pop_step(family):
+    """A queue-pop step must read ``None``, exactly as ``last_accel`` already does.
+
+    One ``sample_actions`` feeds ``n_action_steps`` env steps. Without the clear, a consumer
+    logging the candidate scores every step records the same row ``n_action_steps`` times and
+    reads it as ``n_action_steps`` independent best-of-N decisions.
+    """
+    policy = _policy(family, accel_prefix=NUM_STEPS)
+    _arm(policy, 4, _RiggedCritic(pick=1))
+    batch = _batch(bsize=1)
+
+    policy.select_action(batch)  # re-plans: fills the queue and publishes
+    assert policy.last_candidate_scores is not None
+    assert policy.last_accel_candidates is not None
+
+    policy.select_action(batch)  # pops from the still-full queue: nothing was re-planned
+    assert policy.last_candidate_scores is None
+    assert policy.last_accel_candidates is None
+    assert policy.last_accel is None
+
+
+def test_provenance_tuples_stay_row_aligned_at_n_gt_1(family):
+    """The two per-sample tuples must both be ``B``-long, and the count must be recorded.
+
+    ``build_provenance`` derives ``num_scored_dims`` from the meter (``B * N`` rows here)
+    while taking ``dataset_index`` from its argument, so the two halves are trivially easy to
+    slice to different widths — and a consumer zipping them would then attribute every score
+    to the wrong sample. ``n_candidates`` belongs in ``COMPARABLE_FIELDS`` because best-of-N conditions the
+    emitted chunk on a critic: a threshold calibrated at N=1 does not transfer.
+    """
+    bsize, n = 2, 3
+    policy = _policy(family, accel_prefix=NUM_STEPS)
+    _arm(policy, n, _RiggedCritic(pick=1))
+
+    policy.sample_actions(_batch(bsize=bsize), noise=_noise(bsize * n))
+
+    provenance = policy.last_accel_provenance
+    assert len(provenance.num_scored_dims) == bsize
+    assert len(provenance.dataset_index) == bsize
+    assert provenance.n_candidates == n
+    assert len(policy.last_accel) == bsize
+    assert provenance.num_scored_dims == (ACTION_DIM,) * bsize
+
+
+def test_b_row_noise_with_n_gt_1_raises_naming_both_shapes(family):
+    """A ``B``-row noise at N>1 makes every candidate identical — best-of-N that silently is not.
+
+    It would not raise on its own: the frozen-prefix ``torch.where`` broadcasts a 1-row
+    ``x_t`` against the expanded ``action_prefix``, so the run completes and returns N copies
+    of one chunk for the critic to "choose" between. The message must name both the expected
+    row count and the shape it got, since the caller's bug is one or the other.
+    """
+    cfg = _config(family)
+    bsize, n = 2, 4
+
+    with pytest.raises(ValueError, match=rf"{bsize * n} rows"):
+        _sample(
+            _flow_matching(family, cfg),
+            family,
+            lang_tokens=_lang_tokens(bsize),
+            noise=_noise(bsize),
+            n_candidates=n,
+        )
+
+    with pytest.raises(ValueError, match=rf"\({bsize}, {CHUNK}, {MAX_ACTION_DIM}\)"):
+        _sample(
+            _flow_matching(family, cfg),
+            family,
+            lang_tokens=_lang_tokens(bsize),
+            noise=_noise(bsize),
+            n_candidates=n,
+        )
+
+
+def test_b_row_noise_at_n1_keeps_todays_behaviour(family):
+    """The guard is deliberately NOT extended to N==1, mismatched rows included.
+
+    Today a 1-row noise against a 2-row observation broadcasts silently. That is not obviously
+    good, but the ONNX export wrapper and ``diagnose_accel`` pass explicit noise through this
+    path, and widening the check into an unconditional assert would change N==1 behaviour —
+    the one thing this feature promises not to touch. Fixing it is a separate decision.
+    """
+    cfg = _config(family)
+    bsize = 2
+
+    actions = _sample(
+        _flow_matching(family, cfg),
+        family,
+        lang_tokens=_lang_tokens(bsize),
+        noise=_noise(1),
+        n_candidates=1,
+    )
+
+    assert actions.shape == (bsize, CHUNK, MAX_ACTION_DIM)
+
+
+# --------------------------------------------------------------------------------------
+# AST helpers, shared with the structural pins above.
+# --------------------------------------------------------------------------------------
+
+_POLICIES_ROOT = Path(opentau.__file__).parent / "policies"
+
+
+def _tree(rel_path: str) -> ast.Module:
+    return ast.parse((_POLICIES_ROOT / rel_path).read_text())
+
+
+def _method(tree: ast.Module, class_name: str, method: str) -> ast.FunctionDef:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            for child in node.body:
+                if isinstance(child, ast.FunctionDef | ast.AsyncFunctionDef) and child.name == method:
+                    return child
+    raise AssertionError(f"{class_name}.{method} not found")
+
+
+def _assignments_to(node: ast.AST, attr: str) -> list[ast.Assign | ast.AnnAssign]:
+    """Every ``self.<attr> = ...`` (annotated or not) inside ``node``."""
+    return [
+        stmt
+        for stmt in ast.walk(node)
+        if isinstance(stmt, ast.Assign | ast.AnnAssign)
+        for target in ([stmt.target] if isinstance(stmt, ast.AnnAssign) else stmt.targets)
+        if isinstance(target, ast.Attribute) and target.attr == attr
+    ]
+
+
+def test_every_wrapper_declaring_n_candidates_threads_it_into_its_sampler():
+    """A wrapper that exposes the attribute must actually pass it down.
+
+    ``configure_candidates`` refuses an un-wired family by probing
+    ``hasattr(policy, "n_candidates")``, so declaring the attribute is what tells it a family
+    is ready. A wrapper that declares it and then never forwards it slips past that probe and
+    produces the exact failure the probe exists to prevent: the operator sets
+    ``n_candidates=4``, nothing errors, and one chunk is sampled forever.
+
+    Derived by scanning the tree rather than from a hand-kept list, so a family wired in a
+    later PR is covered the moment it lands (CLAUDE.md rule 5: two hand-maintained lists fail
+    open).
+    """
+    offenders = []
+    scanned = set()
+    for path in _POLICIES_ROOT.rglob("modeling_*.py"):
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ClassDef):
+                continue
+            init = next(
+                (c for c in node.body if isinstance(c, ast.FunctionDef) and c.name == "__init__"), None
+            )
+            if init is None or not _assignments_to(init, "n_candidates"):
+                continue
+            scanned.add(node.name)
+            sampler = next(
+                (c for c in node.body if isinstance(c, ast.FunctionDef) and c.name == "sample_actions"),
+                None,
+            )
+            forwards = sampler is not None and any(
+                any(kw.arg == "n_candidates" for kw in call.keywords)
+                for call in ast.walk(sampler)
+                if isinstance(call, ast.Call)
+            )
+            if not forwards:
+                offenders.append(f"{path.relative_to(_POLICIES_ROOT)}::{node.name}")
+
+    # A scan that matches nothing passes for free, so anchor it on the two families PR 1
+    # wires; if the AST shapes above stop matching, this fails instead of going quiet.
+    assert {"PI05Policy", "PI06Policy"} <= scanned, f"the scan matched nothing useful: {sorted(scanned)}"
+    assert not offenders, (
+        "These policy wrappers declare `self.n_candidates` — which is how "
+        "`configure_candidates` decides a family is wired — but never forward it to their "
+        f"inner sampler, so best-of-N would silently sample one chunk: {offenders}"
+    )

--- a/tests/policies/test_candidates.py
+++ b/tests/policies/test_candidates.py
@@ -26,11 +26,14 @@ precedence that decides whether best-of-N runs at all.
 Built on lightweight shells with no real weights, the same way ``test_pi05_accel.py`` is.
 """
 
+import logging
+
 import pytest
 import torch
 from torch import nn
 
 from opentau.configs.types import FeatureType, NormalizationMode, PolicyFeature
+from opentau.policies import candidates as candidates_mod
 from opentau.policies.candidates import (
     MEDOID,
     ActionChunkCritic,
@@ -453,3 +456,127 @@ def test_refuse_candidates_fires_only_above_one():
     refuse_candidates(_FakeCfg(), reason="batched eval memory")
     # A config predating the field must not trip it either.
     refuse_candidates(object(), reason="batched eval memory")
+
+
+# --------------------------------------------------------------------------------------
+# Regressions from the #525 review.
+# --------------------------------------------------------------------------------------
+
+
+def test_an_unwired_family_is_a_noop_at_the_default_n_of_one():
+    """The default must not abort startup for a family that was never wired.
+
+    `PreTrainedConfig.n_candidates` defaults to `1` -- an int, not `None` -- so the config
+    lookup always resolves and the "nothing asked for candidates" early return never fires
+    on a real config. A wiring probe placed before the `n == 1` return therefore raised for
+    every unwired family at the default, breaking startup of every serving entry point for
+    pi0, pi05_mem, both pi07 families, cosmos3 and value.
+
+    `test_configure_refuses_a_policy_family_that_is_not_wired` cannot catch this: it only
+    ever passes `n_candidates=4`.
+    """
+    policy = _FakePolicy(wired=False)
+    assert configure_candidates(policy, _FakeCfg(n_candidates=1), device=CPU) == 1
+
+
+def test_configure_never_creates_n_candidates_on_an_unwired_family():
+    """The N==1 no-op must not leave the attribute behind.
+
+    Writing `policy.n_candidates = 1` on an unwired policy would make the wiring probe on a
+    later `n > 1` call believe that family had been wired all along, turning a loud refusal
+    into a silent fan-out the sampler ignores.
+    """
+    policy = _FakePolicy(wired=False)
+    configure_candidates(policy, _FakeCfg(n_candidates=1), device=CPU)
+    assert not hasattr(policy, "n_candidates")
+
+    # And the refusal still fires afterwards, which is the property the no-op protects.
+    with pytest.raises(ValueError, match="not wired"):
+        configure_candidates(policy, _FakeCfg(n_candidates=4, action_chunk_critic_path=MEDOID), device=CPU)
+
+
+@pytest.mark.parametrize("n_cand", [3, 4], ids=["batch_ne_candidates", "batch_eq_candidates"])
+def test_medoid_honours_a_per_observation_row_mask(n_cand):
+    """A ``(B, chunk)`` mask must mask observation *b*, not candidate *b*.
+
+    The protocol documents ``(B, chunk)`` and ``executed_row_mask`` produces it for a
+    per-sample ``delay``. Under an ellipsis rearrange the mask's leading axis right-aligned
+    onto the *candidate* axis: a shape error when B != N, and -- the dangerous half --
+    silently scoring candidate j against observation j's mask when B == N.
+
+    The masks here differ per observation, which is what makes the B == N case observable
+    at all: with one shared mask a transposed axis produces identical numbers and the test
+    cannot fail. The reference is the per-observation ``(1, chunk)`` path, which is
+    independently covered by `test_medoid_honours_the_row_mask`.
+    """
+    batch, chunk, dim = 4, 4, 2
+    critic = _medoid([1.0] * dim)
+
+    # Candidate n differs from its peers on every chunk row, so which row is masked changes
+    # the pairwise distances -- otherwise masking would be unobservable either way.
+    candidates = torch.zeros(batch, n_cand, chunk, dim)
+    for n in range(n_cand):
+        for c in range(chunk):
+            candidates[:, n, c, :] = float(n * 10 + c)
+
+    # Observation b hides chunk row b: a different mask per row of the batch.
+    mask = torch.ones(batch, chunk, dtype=torch.bool)
+    for b in range(batch):
+        mask[b, b % chunk] = False
+
+    batched = critic.score_chunks(
+        {}, candidates, row_mask=mask, dataset_index=torch.zeros(batch, dtype=torch.long)
+    )
+    assert batched.shape == (batch, n_cand)
+
+    for b in range(batch):
+        reference = critic.score_chunks(
+            {},
+            candidates[b : b + 1],
+            row_mask=mask[b : b + 1],
+            dataset_index=torch.zeros(1, dtype=torch.long),
+        )
+        assert torch.allclose(batched[b], reference[0]), (
+            f"observation {b} scored differently in the batched call than on its own, so the "
+            "per-observation mask is not reaching the right rows"
+        )
+
+
+def test_medoid_rejects_a_row_mask_that_is_not_two_dimensional():
+    critic = _medoid([1.0, 1.0])
+    candidates = torch.zeros(1, 3, 2, 2)
+    with pytest.raises(ValueError, match="row_mask must be"):
+        critic.score_chunks(
+            {},
+            candidates,
+            row_mask=torch.ones(2, dtype=torch.bool),
+            dataset_index=torch.zeros(1, dtype=torch.long),
+        )
+
+
+def test_a_degenerate_score_row_warns_so_the_fallback_is_observable(caplog, monkeypatch):
+    """`select_candidate` falls back to candidate 0 silently; the caller must say so.
+
+    Without this an all-NaN critic is indistinguishable from a working critic that happens
+    to prefer candidate 0 on every request.
+    """
+    monkeypatch.setattr(candidates_mod, "_WARNED_DEGENERATE", False)
+    nan = float("nan")
+
+    with caplog.at_level(logging.WARNING):
+        candidates_mod.warn_if_no_candidate_scored([[nan, nan], [1.0, 2.0]])
+    assert "candidate 0" in caplog.text
+    assert "[0]" in caplog.text, "the warning should name which rows were degenerate"
+
+    # Once per process, so a serving loop does not print a line per request.
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        candidates_mod.warn_if_no_candidate_scored([[nan, nan]])
+    assert caplog.text == ""
+
+
+def test_healthy_scores_never_warn(caplog, monkeypatch):
+    monkeypatch.setattr(candidates_mod, "_WARNED_DEGENERATE", False)
+    with caplog.at_level(logging.WARNING):
+        candidates_mod.warn_if_no_candidate_scored([[1.0, float("nan")], [0.0, 3.0]])
+    assert caplog.text == ""

--- a/tests/policies/test_candidates.py
+++ b/tests/policies/test_candidates.py
@@ -1,0 +1,455 @@
+#!/usr/bin/env python
+
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU coverage for the best-of-N primitives in ``opentau.policies.candidates``.
+
+The sampler-side wiring is pinned separately; these tests pin the module itself, and
+specifically the properties whose violation is invisible in a shape assertion: the ``(b n)``
+fan-out *ordering* (a transposed convention has identical shapes and only misattributes
+candidates once ``B > 1``), the ``.contiguous()`` that stops the expanded KV cache from
+aliasing at ``B == 1``, the selector's NaN-safety, the medoid's row mask, and the arming
+precedence that decides whether best-of-N runs at all.
+
+Built on lightweight shells with no real weights, the same way ``test_pi05_accel.py`` is.
+"""
+
+import pytest
+import torch
+from torch import nn
+
+from opentau.configs.types import FeatureType, NormalizationMode, PolicyFeature
+from opentau.policies.candidates import (
+    MEDOID,
+    ActionChunkCritic,
+    MedoidCritic,
+    attach_critic,
+    collapse_candidates,
+    configure_candidates,
+    expand_candidates,
+    expand_kv_cache,
+    load_critic,
+    refuse_candidates,
+    select_candidate,
+)
+from opentau.policies.normalize import Unnormalize
+
+CPU = torch.device("cpu")
+ACTION_DIM = 4
+CHUNK = 4
+
+
+# --------------------------------------------------------------------------------------
+# Expansion / collapse helpers.
+# --------------------------------------------------------------------------------------
+
+
+def test_expansion_is_candidate_major():
+    """``(b n)`` means source row ``i`` occupies rows ``[i*n, (i+1)*n)``, contiguously.
+
+    Distinct per-row values are the whole point: a shape-only assertion passes just as
+    happily under the transposed ``(n b)`` convention, which is the bug being pinned — it
+    silently pairs candidate ``j`` of observation ``i`` with observation ``j``'s prefix.
+    """
+    source = torch.tensor([[10.0, 11.0], [20.0, 21.0], [30.0, 31.0]])
+
+    expanded = expand_candidates(source, 2)
+
+    assert expanded.shape == (6, 2)
+    assert expanded.tolist() == [
+        [10.0, 11.0],
+        [10.0, 11.0],
+        [20.0, 21.0],
+        [20.0, 21.0],
+        [30.0, 31.0],
+        [30.0, 31.0],
+    ]
+
+
+def test_expansion_materializes_instead_of_aliasing_at_batch_one():
+    """``B == 1`` is the entire serving path, and it is exactly where ``einops.repeat``
+    hands back a stride-0 alias over the caller's storage. Both halves are asserted: the raw
+    repeat *would* have aliased, and the helper does not. Without the first half the pin does
+    not depend on the property it names — it would pass on a plain ``torch.clone`` too.
+    """
+    from einops import repeat
+
+    source = torch.arange(8, dtype=torch.float32).reshape(1, 4, 2)
+
+    aliased = repeat(source, "b ... -> (b n) ...", n=3)
+    assert aliased.stride()[0] == 0, "einops.repeat broadcasts rather than copying at B == 1"
+    assert aliased.data_ptr() == source.data_ptr(), "...over the caller's own storage"
+
+    expanded = expand_candidates(source, 3)
+
+    assert expanded.stride()[0] != 0
+    assert expanded.data_ptr() != source.data_ptr()
+    assert expanded.is_contiguous()
+    assert torch.equal(expanded, aliased), "materializing must not change the values"
+
+
+def test_collapse_round_trips_the_expansion():
+    source = torch.arange(12, dtype=torch.float32).reshape(3, 2, 2)
+
+    collapsed = collapse_candidates(expand_candidates(source, 4), 4)
+
+    assert collapsed.shape == (3, 4, 2, 2)
+    for candidate in range(4):
+        assert torch.equal(collapsed[:, candidate], source)
+
+
+def test_kv_cache_expansion_walks_the_dict_and_leaves_it_alone():
+    """The cache is a dict keyed by layer index, not a list — iterating it the wrong way
+    yields integers. The caller's cache is reused after this call (under ``predict_response``
+    the autoregressive loop just wrote it), so it must come back untouched.
+    """
+    key = torch.tensor([[[1.0, 2.0]]])
+    value = torch.tensor([[[3.0, 4.0]]])
+    cache = {0: {"key_states": key, "value_states": value}}
+
+    expanded = expand_kv_cache(cache, 3)
+
+    assert isinstance(expanded, dict)
+    assert list(expanded.keys()) == [0]
+    assert expanded[0]["key_states"].shape == (3, 1, 2)
+    assert expanded[0]["value_states"].shape == (3, 1, 2)
+    assert torch.equal(expanded[0]["key_states"], key.expand(3, 1, 2))
+
+    assert expanded is not cache and expanded[0] is not cache[0]
+    assert cache[0]["key_states"] is key and key.shape == (1, 1, 2)
+
+
+# --------------------------------------------------------------------------------------
+# `select_candidate` — total, NaN-safe, lowest-index ties.
+# --------------------------------------------------------------------------------------
+
+
+def test_a_nan_score_never_wins():
+    """Raw ``torch.argmax([1.0, nan, 3.0])`` returns 1 — the NaN — so the selector has to
+    replace non-finite entries before reducing, or a critic that produces one NaN hands the
+    robot that candidate."""
+    assert select_candidate(torch.tensor([[1.0, float("nan"), 3.0]])).tolist() == [2]
+
+
+def test_negative_infinity_behaves_like_nan():
+    assert select_candidate(torch.tensor([[1.0, float("-inf"), 3.0]])).tolist() == [2]
+    assert select_candidate(torch.tensor([[float("-inf"), 2.0, float("-inf")]])).tolist() == [1]
+
+
+def test_an_all_non_finite_row_falls_back_to_candidate_zero_without_raising():
+    """``select_action`` runs on every rank and is followed by gather collectives, so a
+    data-dependent raise here aborts one rank and blocks the rest at NCCL forever."""
+    assert select_candidate(torch.tensor([[float("nan"), float("nan")]])).tolist() == [0]
+    assert select_candidate(torch.tensor([[float("-inf"), float("-inf")]])).tolist() == [0]
+
+
+def test_ties_resolve_to_the_lowest_index():
+    """Load-bearing: candidate 0 carries the noise draw the ``n_candidates == 1`` path would
+    have taken, so a degenerate critic degenerates to legacy behaviour."""
+    assert select_candidate(torch.tensor([[2.0, 2.0, 1.0]])).tolist() == [0]
+    assert select_candidate(torch.tensor([[1.0, 5.0, 5.0]])).tolist() == [1]
+
+
+def test_a_degenerate_row_does_not_contaminate_its_neighbours():
+    """The fallback is per row. A batched server sees healthy and degenerate observations in
+    one call, and a whole-batch fallback would silently disable best-of-N for all of them."""
+    scores = torch.tensor([[float("nan"), float("nan"), float("nan")], [1.0, 7.0, 3.0]])
+
+    assert select_candidate(scores).tolist() == [0, 1]
+
+
+# --------------------------------------------------------------------------------------
+# `MedoidCritic` — the parameter-free reference selector.
+# --------------------------------------------------------------------------------------
+
+
+def _medoid(std, *, max_action_dim=None):
+    """A ``MedoidCritic`` over a one-head ``Unnormalize`` with the given per-dim ``std``."""
+    dim = len(std)
+    features = {"actions": PolicyFeature(type=FeatureType.ACTION, shape=(dim,))}
+    unnormalize = Unnormalize(
+        features,
+        {"ACTION": NormalizationMode.MEAN_STD},
+        per_dataset_stats=[{"actions": {"mean": torch.zeros(dim), "std": torch.tensor(std)}}],
+        dataset_names=["ds0"],
+    )
+    return MedoidCritic(unnormalize, max_action_dim=max_action_dim or dim)
+
+
+def _score(critic, candidates, *, row_mask=None):
+    chunk = candidates.shape[2]
+    if row_mask is None:
+        row_mask = torch.ones(1, chunk, dtype=torch.bool)
+    return critic.score_chunks(
+        {}, candidates, row_mask=row_mask, dataset_index=torch.zeros(1, dtype=torch.long)
+    )
+
+
+def _chunks(rows_per_candidate, *, dim=2):
+    """``(1, N, chunk, dim)`` where candidate ``i`` has constant value ``rows[i][r]`` on row
+    ``r``."""
+    return torch.tensor([[[[v] * dim for v in rows] for rows in rows_per_candidate]])
+
+
+def test_medoid_satisfies_the_critic_protocol():
+    assert isinstance(_medoid([1.0, 1.0]), ActionChunkCritic)
+
+
+def test_medoid_refuses_two_candidates_because_every_score_ties():
+    """At N == 2 there is one pairwise distance and both candidates carry it, so selection
+    always collapses to candidate 0 — best-of-N that silently is not. Constructed at exactly
+    N == 2, the boundary the check guards."""
+    candidates = _chunks([[0.0, 0.0], [5.0, 5.0]])
+    assert candidates.shape[1] == 2
+
+    with pytest.raises(ValueError, match="ties"):
+        _score(_medoid([1.0, 1.0]), candidates)
+
+
+def test_medoid_ranks_the_outlier_last_and_a_clustered_candidate_first():
+    """Candidate 0 sits far from the other two, which sit close together.
+
+    The outlier is placed at index 0 deliberately: a critic that emitted constant scores, or
+    one whose sign was flipped, would also land on index 0 via the tie fallback, and this
+    test would not notice. So the assertions pin all three of the winner, the loser, and
+    what a flipped sign would have chosen.
+    """
+    critic = _medoid([1.0, 1.0])
+    candidates = _chunks([[10.0, 10.0], [0.0, 0.0], [0.25, 0.25]])
+
+    scores = _score(critic, candidates)
+
+    assert scores.shape == (1, 3)
+    assert select_candidate(scores).tolist() == [2]
+    assert int(scores.argmin(dim=1)) == 0, "the outlier must score lowest"
+    # Sign check: negate the scores and the outlier wins, which is what a `+total` medoid
+    # would do on every observation.
+    assert int(torch.argmax(-scores, dim=1)) == 0
+
+
+def test_medoid_honours_the_row_mask():
+    """Candidates 0 and 1 are identical on the executed rows and differ only outside them,
+    so they must score identically. Un-masking the same tensors separates them, which is what
+    makes this a pin on the mask rather than on the arithmetic.
+    """
+    critic = _medoid([1.0, 1.0])
+    # Rows 0-1 executed, rows 2-3 not. Candidate 1 differs from candidate 0 only on 2-3.
+    candidates = _chunks([[0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 7.0, 7.0], [1.0, 1.0, 0.0, 0.0]])
+    executed = torch.tensor([[True, True, False, False]])
+
+    masked = _score(critic, candidates, row_mask=executed)
+    unmasked = _score(critic, candidates)
+
+    assert masked[0, 0].item() == masked[0, 1].item()
+    assert unmasked[0, 0].item() != unmasked[0, 1].item()
+
+
+def test_medoid_drops_the_degenerate_action_dims():
+    """The pad tail is unsupervised network output. Two candidates differing only there are
+    the same chunk as far as the robot is concerned, and must not be ranked apart."""
+    critic = _medoid([1.0, 0.0])  # dim 1 is zero-variance, i.e. padding
+    candidates = torch.tensor([[[[0.0, 0.0]], [[0.0, 9.0]], [[3.0, 0.0]]]])
+
+    scores = _score(critic, candidates)
+
+    assert scores[0, 0].item() == scores[0, 1].item()
+
+
+# --------------------------------------------------------------------------------------
+# `configure_candidates` — the single arming knob.
+# --------------------------------------------------------------------------------------
+
+
+class _FakeConfig:
+    type = "pi05"
+    chunk_size = CHUNK
+    max_action_dim = ACTION_DIM
+    action_feature = PolicyFeature(type=FeatureType.ACTION, shape=(ACTION_DIM,))
+
+    def __init__(self, n_candidates=1, action_chunk_critic_path=None):
+        self.n_candidates = n_candidates
+        self.action_chunk_critic_path = action_chunk_critic_path
+
+
+class _FakeCfg:
+    def __init__(self, **kwargs):
+        self.policy = _FakeConfig(**kwargs)
+
+
+class _FakePolicy(nn.Module):
+    """A wired policy shell: it exposes ``n_candidates`` and a real ``Unnormalize``."""
+
+    def __init__(self, *, wired=True):
+        super().__init__()
+        self.config = _FakeConfig()
+        self.weight = nn.Parameter(torch.zeros(1))
+        stats = [{"actions": {"mean": torch.zeros(ACTION_DIM), "std": torch.tensor([1.0, 2.0, 0.0, 0.0])}}]
+        features = {"actions": PolicyFeature(type=FeatureType.ACTION, shape=(ACTION_DIM,))}
+        self.unnormalize_outputs = Unnormalize(
+            features,
+            {"ACTION": NormalizationMode.MEAN_STD},
+            per_dataset_stats=stats,
+            dataset_names=["ds0"],
+        )
+        if wired:
+            self.n_candidates = 1
+
+
+class _ShapeBrokenCritic:
+    """Protocol-shaped but returns ``(B,)`` instead of ``(B, N)``."""
+
+    def score_chunks(self, batch, candidates, *, row_mask, dataset_index):
+        return torch.zeros(candidates.shape[0])
+
+
+def test_configure_writes_one_even_when_nothing_asks_for_candidates():
+    """The N == 1 write is not redundant: returning early would leave whatever a previous
+    call put there, so a policy re-configured for a second deployment would keep serving
+    best-of-N nobody asked for."""
+    policy = _FakePolicy()
+    policy.n_candidates = 4  # stale value from a previous arming
+
+    assert configure_candidates(policy, _FakeCfg(n_candidates=1), device=CPU) == 1
+    assert policy.n_candidates == 1
+
+
+def test_override_of_one_beats_a_config_asking_for_four():
+    """The actual conflict, both directions. ``override=1`` is a caller deliberately
+    *disabling* a config-enabled N, so the precedence has to be ``is None`` rather than
+    ``or``-truthiness — an ``or`` chain falls straight through a 1 and arms best-of-N against
+    the caller's explicit instruction.
+    """
+    policy = _FakePolicy()
+    cfg = _FakeCfg(n_candidates=4, action_chunk_critic_path=MEDOID)
+
+    assert configure_candidates(policy, cfg, device=CPU, override=1) == 1
+    assert policy.n_candidates == 1
+    assert getattr(policy, "_action_chunk_critic", None) is None, "no critic may be loaded at N == 1"
+
+    # ...and the other side of the same conflict: an override above 1 beats a config of 1.
+    disabled = _FakeCfg(n_candidates=1, action_chunk_critic_path=MEDOID)
+    assert configure_candidates(policy, disabled, device=CPU, override=3) == 3
+    assert policy.n_candidates == 3
+    assert isinstance(policy._action_chunk_critic, MedoidCritic)
+
+
+def test_configure_refuses_a_policy_family_that_is_not_wired():
+    """pi0, pi07, cosmos3 and friends accept an unread attribute and then never fan out —
+    the silent no-op an operator would read as 'the critic never fires'."""
+    policy = _FakePolicy(wired=False)
+    assert not hasattr(policy, "n_candidates")
+
+    with pytest.raises(ValueError, match="not wired"):
+        configure_candidates(policy, _FakeCfg(n_candidates=4, action_chunk_critic_path=MEDOID), device=CPU)
+
+
+def test_configure_refuses_candidates_without_a_critic():
+    """There is deliberately no implicit fallback selector: best-of-N choosing on no signal
+    would look like it works."""
+    with pytest.raises(ValueError, match="action_chunk_critic_path"):
+        configure_candidates(_FakePolicy(), _FakeCfg(n_candidates=4), device=CPU)
+
+
+def test_configure_rejects_a_non_critic():
+    with pytest.raises(TypeError, match="score_chunks"):
+        configure_candidates(_FakePolicy(), _FakeCfg(n_candidates=4), device=CPU, critic=object())
+
+
+def test_configure_catches_a_wrong_return_shape_at_startup():
+    """``runtime_checkable`` ``isinstance`` checks method *presence* only — never the return
+    shape — so a critic scoring ``(B,)`` passes the protocol test and would otherwise fail on
+    the first robot request instead of at boot."""
+    with pytest.raises(TypeError, match=r"\(B, N\)"):
+        configure_candidates(_FakePolicy(), _FakeCfg(n_candidates=4), device=CPU, critic=_ShapeBrokenCritic())
+
+
+def test_configure_reads_the_real_policy_config_fields():
+    """Draccus JSON is the repo's primary interface, so the fields have to be real dataclass
+    members — and off by default, since a checkpoint's own config must not self-arm."""
+    from opentau.policies.pi05.configuration_pi05 import PI05Config
+
+    cfg = _FakeCfg()
+    cfg.policy = PI05Config()
+
+    assert cfg.policy.n_candidates == 1
+    assert cfg.policy.action_chunk_critic_path is None
+
+    policy = _FakePolicy()
+    cfg.policy.n_candidates = 3
+    cfg.policy.action_chunk_critic_path = MEDOID
+    assert configure_candidates(policy, cfg, device=CPU) == 3
+
+
+# --------------------------------------------------------------------------------------
+# `attach_critic` / `load_critic` / `refuse_candidates`.
+# --------------------------------------------------------------------------------------
+
+
+class _ParametricCritic(nn.Module):
+    """A critic with weights of its own — the case where registration actually shows up."""
+
+    def __init__(self):
+        super().__init__()
+        self.head = nn.Linear(2, 2)
+
+    def score_chunks(self, batch, candidates, *, row_mask, dataset_index):
+        return torch.zeros(candidates.shape[:2])
+
+
+def test_attach_critic_keeps_it_out_of_the_state_dict_and_the_optimizer():
+    """Plain assignment routes through ``nn.Module.__setattr__``, which registers the critic
+    in ``_modules`` — writing its tensors into every checkpoint and handing its parameters to
+    ``get_optim_params``. Both halves are asserted, so the pin depends on the property it
+    names rather than on the critic happening to be parameter-free.
+    """
+    policy = _FakePolicy()
+    before_keys = set(policy.state_dict().keys())
+    before_params = len(list(policy.parameters()))
+
+    attach_critic(policy, _ParametricCritic())
+
+    assert policy._action_chunk_critic is not None
+    assert set(policy.state_dict().keys()) == before_keys
+    assert len(list(policy.parameters())) == before_params
+    assert "_action_chunk_critic" not in policy._modules
+
+    # The same assignment done plainly does change both.
+    contrast = _FakePolicy()
+    contrast._action_chunk_critic = _ParametricCritic()
+    assert set(contrast.state_dict().keys()) != before_keys
+    assert len(list(contrast.parameters())) > before_params
+
+
+def test_load_critic_resolves_the_builtin_selector_and_nothing_else():
+    policy = _FakePolicy()
+
+    assert isinstance(load_critic(MEDOID, policy=policy), MedoidCritic)
+
+    with pytest.raises(NotImplementedError, match=MEDOID):
+        load_critic("TensorAuto/some-learned-critic", policy=policy)
+    with pytest.raises(NotImplementedError):
+        load_critic(None, policy=policy)
+
+
+def test_refuse_candidates_fires_only_above_one():
+    """Entry points that cannot honour best-of-N must say so. Silently ignoring the field is
+    the failure mode: the operator sets it, sees no error, and believes it is running."""
+    with pytest.raises(ValueError, match="batched eval"):
+        refuse_candidates(_FakeCfg(n_candidates=2), reason="batched eval memory")
+
+    refuse_candidates(_FakeCfg(n_candidates=1), reason="batched eval memory")
+    refuse_candidates(_FakeCfg(), reason="batched eval memory")
+    # A config predating the field must not trip it either.
+    refuse_candidates(object(), reason="batched eval memory")


### PR DESCRIPTION
## What this does

Adds **best-of-N action-chunk sampling** to pi05 and pi06 (🗃️ Feature).

A flow-matching policy maps one Gaussian draw to exactly one action chunk, deterministically. So drawing `n_candidates` noises yields `n_candidates` distinct chunks, and an `ActionChunkCritic` picks the one that reaches the robot.

**The candidates share a single VLM prefix pass.** The prefix KV cache is never written again during denoising (`fill_kv_cache=False` in every `denoise_step`), so expanding it across candidates lets one prefix pass serve all N. Only the action expert's Euler loop widens — and at batch 1 that loop is occupancy-bound rather than FLOP-bound, so widening it rides largely free.

Measured on an RTX 5090 (bf16, sdpa, 3 cameras, 1024 prefix tokens, chunk 50, 10 Euler steps, batch 1), fused against naive replication of the observation across the batch — one prefix pass per candidate, same result:

| N | fused | naive | speedup | overhead vs own N=1 | fused peak | naive peak |
|---|---|---|---|---|---|---|
| 1 | 152.9 ms | 154.3 ms | 1.01x | — | 6.41 GiB | 6.42 GiB |
| 2 | 153.2 | 187.7 | 1.23x | +0.1% | 6.41 | 6.56 |
| 4 | 154.8 | 256.1 | 1.65x | +1.2% | 6.41 | 6.84 |
| 8 | 155.5 | 392.1 | 2.52x | +1.7% | 6.45 | 7.41 |
| 16 | 191.2 | 698.2 | 3.65x | +25% | 6.62 | 8.54 |
| 32 | 277.8 | OOM | — | +82% | 6.95 | — |

**Eight candidates cost under 2% of wall clock.** The knee is between 8 and 16. Peak memory is nearly flat because the only per-candidate allocation is the prefix KV cache at 18 MiB (MQA: one KV head, head_dim 256, 18 layers); naive replication OOMs at N=32 where the fused path does not.

### The default path is unchanged

`n_candidates` defaults to `1`, and a policy wrapper is constructed with `1` regardless of what its config says — `configure_candidates` is the only writer, so a config travelling with a checkpoint cannot self-arm best-of-N in a script that never opted in. Same posture as `accel_prefix`.

At N=1 no critic is loaded, no candidate code runs, and the sampler is the one that shipped before. Verified at full size on GPU: N=1 after the change reproduces the pre-change output digest bit-for-bit (`5a0bf2ed20abbcc2`), from an identically-seeded model (weights hash `144933185b9ff63f`, same venv, same worktree, only the source differing).

**No `config_version` bump.** The field gates nothing about training and does not change what a given noise draw decodes to; `config_version` gates normalization conventions only.

### Scope and the things it deliberately refuses

- **Only pi05 and pi06 are wired.** Every other family — pi0, pi05_mem, both pi07 low levels, cosmos3, cosmos3_nano, the two high-level planners and `value` — raises on `n_candidates > 1` rather than accepting the field and ignoring it, which is the failure an operator would read as "the critic never fires".
- **Serving-only.** The serving entry points arm it; `scripts/eval.py` refuses, rather than multiplying its default batch of 16 by N into a memory profile nobody has measured. Every script that builds a policy from `cfg.policy` and reaches the sampler now either arms or refuses; a registry test fails on any new one that does neither.
- **The only critic is `"medoid"`**, a parameter-free consensus selector that keeps the candidate closest to all the others. It exists so best-of-N is testable and benchmarkable end to end before a trained critic does. It requires `n_candidates >= 3` and raises below that — at N=2 the single pairwise distance is shared, every score ties, and selection would always fall back to candidate 0. It is **not** a quality model: on a genuinely multimodal task it prefers the more populated mode rather than the better one. A learned critic is a follow-up.
- **All N candidates share one greedy reasoning trace.** The autoregressive `predict_response` decode is argmax and therefore noise-independent, and the fan-out sits after it. This diversifies flow-matching noise only, not reasoning — so a wrong reasoning trace is wrong in all N chunks. Documented rather than refused.

### Two consequences worth a reviewer's attention

1. **Both new fields are written into every saved `config.json`.** draccus encodes the whole dataclass with no default filtering, so a legacy checkpoint that is fine-tuned, resumed, or converted and re-uploaded gains `n_candidates` and `action_chunk_critic_path` on the way through. A pinned older install reading such a config rejects it on the unknown fields; the checkpoint convert/upload path is where that bites.
2. **`AccelProvenance` gained `n_candidates`, and it is in `COMPARABLE_FIELDS`** — an accel calibration fitted at N=1 now refuses to apply to an N>1 stream, because best-of-N conditions the emitted chunk on a critic. Calibration JSON written before this change still loads and defaults to 1.

Also fixes the `past_key_values` type annotations in pi05/pi06, which claimed `list[dict[str, Tensor]]` for what is a dict keyed by layer index — the expansion helper depends on knowing which.

## How it was tested

**CPU suite** (`pytest -m "not gpu and not network" -n auto`), including four new test modules:

- `tests/policies/test_candidates.py` — 24 tests over the module itself: `(b n)` ordering pinned by exact values (a transposed convention fails it), the einops stride-0 aliasing at B==1 asserted in both directions, NaN/tie/all-non-finite selection, medoid outlier ranking and `row_mask` honouring, and the arming precedence conflict exercised with **both** inputs present.
- `tests/policies/test_candidate_policy_wiring.py` — 43 tests over pi05 and pi06: N=1 never enters the candidate path (patching the per-module bindings, and re-proving each raiser fires at N=2), fused candidate *i* equals a standalone run with that noise for B in {1,2,3}, the prefix pass runs exactly once regardless of N, frozen real-time-chunking rows identical across candidates, cross-rank selection stability, and `last_accel` staying length B.
- `tests/policies/test_candidate_entry_point_wiring.py` — 27 tests; AST-scans `scripts/` and fails on any entry point that builds a policy and reaches the sampler but neither arms nor refuses.
- `tests/policies/test_accel_wiring_registry.py` — extended with registry pins for the sampler parameter position and for exactly-the-wired-policies declaring the attribute.

Tests were **mutation-checked, not just run green**: transposing the fan-out to `(n b)` turns six equivalence and frozen-prefix cases red (B=1 correctly stays green, which is why the equivalence test is parametrized over B); replacing `select_candidate` with a random tie-break breaks the cross-rank pin; removing an entry point from the arm allowlist turns the registry test red.

Full CPU run: **2922 passed**. Six non-passes were traced to the environment, not this change — five were `ModuleNotFoundError: No module named 'libero'` from syncing without the `libero` extra (all pass once it is installed), and `test_utils_benchmark.py::test_context_manager_usage` passes when run serially. One residual failure, `test_libero_utils.py::test_libero2torch`, is a missing LIBERO data asset.

**GPU**, `pytest -m "gpu" -n 0` over the eight affected test files on a single CUDA device: **2 passed, 2 failed**. Both failures are `torch.OutOfMemoryError` loading Gemma3-4B in `tests/policies/test_pi06.py`, on a card that was sharing ~19 GiB with unrelated work. They are **not caused by this change** — verified by stashing the entire diff and re-running, which reproduces the same two OOMs on the baseline. The nightly regression suite runs in CI; it was not run by hand here.

Separately, on the same device with a real trained 6-DoF pi05 checkpoint carrying two norm heads:

- N=1 before vs after the change: bit-identical output digest.
- Full policy path at N=4 through `configure_candidates` -> `sample_actions` -> unnormalize -> critic -> selection: return stays `(B, chunk, action_dim)` with no candidate axis leaking to callers, the critic ranked all four distinctly, and disarming back to N=1 reproduces the original chunk exactly.
- The latency and memory table above.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/policies/test_candidates.py tests/policies/test_candidate_policy_wiring.py
```

```bash
pytest -sx tests/policies/test_candidate_entry_point_wiring.py tests/policies/test_accel_wiring_registry.py
```

Benchmark the fan-out on a GPU box (flags ride on env vars in this script, matching its existing convention; note that 2 is rejected, so sweep 1/4/8/16):

```bash
BENCH_N_CANDIDATES=8 python src/opentau/scripts/benchmark_inference.py --config_path=configs/examples/pi05_training_config.json
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [x] My PR includes policy-related changes.
  - [x] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
