### PR TITLE
chore: drop an internal host name from a source comment

### DIFF
--- a/src/opentau/envs/factory.py
+++ b/src/opentau/envs/factory.py
@@ -167,7 +167,7 @@ def make_envs(
     _ensure_nvidia_egl_icd()
     _pin_egl_render_device()
 
-    # "spawn" is more robust (and, for libero on oracle, the only option) than "fork".
+    # "spawn" is more robust than "fork" (and on some cluster setups, the only option).
     # Caveat is that the entry point must be protected by `if __name__ == "__main__":`.
     env_cls = (
         partial(gym.vector.AsyncVectorEnv, context="spawn") if use_async_envs else gym.vector.SyncVectorEnv


### PR DESCRIPTION
## What this does

Rewords one source comment in `src/opentau/envs/factory.py` so it no longer names a specific deployment environment (📝 Documentation).

The comment explains why the async vector env uses the `"spawn"` start method rather than `"fork"`. That technical point is unchanged and still stated — the parenthetical noting that some setups offer no alternative is simply phrased in general terms now instead of naming one.

Comment-only. No code, no behaviour, no public API.

## How it was tested

The change is a single comment, so there is nothing behavioural to exercise. Ran the surrounding suite and the hooks to confirm nothing regressed:

- `pytest -m "not gpu and not network" -n auto tests/envs/test_factory.py` — 16 passed.
- `pre-commit run --files src/opentau/envs/factory.py` — all hooks pass.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/envs/test_factory.py
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
