### PR TITLE
fix(tests): compare candidate arming by execution order, not file offset

### DIFF
--- a/tests/policies/test_candidate_entry_point_wiring.py
+++ b/tests/policies/test_candidate_entry_point_wiring.py
@@ -171,13 +171,42 @@ def _sampler_reaching_functions(tree: ast.AST) -> set[str]:
         reaching = grown
 
 
+def _walk_skipping_nested_defs(fn: ast.AST) -> list[ast.AST]:
+    """Nodes under ``fn``, without descending into nested ``def`` bodies.
+
+    A nested function's body does not run where it is written, so its sampler calls belong
+    to its call site — which :func:`_sampler_reaching_functions` already resolves by name,
+    nested defs included. Descending would put the sampling back at the definition and
+    reintroduce the file-offset bug one level down.
+
+    ``lambda`` bodies *are* descended into: an anonymous function carries no name for that
+    resolution to key on, so treating it as executing in place fails loud rather than open.
+
+    Args:
+        fn: The function whose body is scanned.
+
+    Returns:
+        Every descendant node of ``fn`` except those inside a nested named function.
+    """
+    out: list[ast.AST] = []
+    stack = list(ast.iter_child_nodes(fn))
+    while stack:
+        node = stack.pop()
+        out.append(node)
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        stack.extend(ast.iter_child_nodes(node))
+    return out
+
+
 def _first_sampling_line_within(fn: ast.AST, sampler_reaching: set[str]) -> int | None:
     """Line inside ``fn`` at which sampling first actually *happens*.
 
     A ``sample_actions(...)`` written in a helper does not execute where it is written —
     it executes where that helper is **called**. So a call to a sampler-reaching helper
     counts at its call site, which is the whole difference between this and comparing raw
-    file offsets.
+    file offsets. That holds for helpers nested inside ``fn`` too, hence
+    :func:`_walk_skipping_nested_defs`.
 
     Args:
         fn: The function whose body is scanned.
@@ -188,7 +217,7 @@ def _first_sampling_line_within(fn: ast.AST, sampler_reaching: set[str]) -> int 
         The earliest line in ``fn`` that samples, or ``None`` if it never does.
     """
     lines = []
-    for sub in ast.walk(fn):
+    for sub in _walk_skipping_nested_defs(fn):
         if not isinstance(sub, ast.Call):
             continue
         if (
@@ -459,6 +488,54 @@ class Servicer:
     )
 
     assert sample_line is not None and arm_line < sample_line
+
+
+def test_a_warmup_closure_inside_the_arming_function_samples_at_its_call_site():
+    """The same bug one nesting level down — ``ast.walk`` descends into nested ``def`` bodies.
+
+    A warmup factored into a closure *inside* the arming function put the sampling back at
+    the closure's definition, so correct code read as ``arm=7, sample=5``. Caught in review
+    of this PR, which is the point: the fix had to cover the shape it was named after, not
+    just the one that broke ``main``.
+    """
+    arm_line, sample_line, _ = _ordering_verdict(
+        """
+class Servicer:
+    def _load_policy(self):
+        def _warm(batch):
+            return self.policy.sample_actions(batch)
+
+        configure_candidates(self.policy, self.cfg, device="cuda", dtype=None)
+        _ = _warm({})
+"""
+    )
+
+    assert sample_line is not None
+    assert arm_line < sample_line, (
+        "a closure nested in the arming function was read as sampling at its definition; it "
+        f"samples where it is called (line {sample_line}), not where it is written"
+    )
+
+
+def test_a_warmup_closure_called_before_arming_is_still_caught():
+    """The other direction for the nested case — skipping nested bodies must not fail open."""
+    arm_line, sample_line, _ = _ordering_verdict(
+        """
+class Servicer:
+    def _load_policy(self):
+        def _warm(batch):
+            return self.policy.sample_actions(batch)
+
+        _ = _warm({})
+        configure_candidates(self.policy, self.cfg, device="cuda", dtype=None)
+"""
+    )
+
+    assert sample_line is not None, (
+        "the closure's call site must still count as sampling; dropping nested defs entirely "
+        "would make a warmup-before-arming refactor invisible"
+    )
+    assert arm_line > sample_line
 
 
 def test_an_arming_function_that_never_samples_is_reported_not_passed():

--- a/tests/policies/test_candidate_entry_point_wiring.py
+++ b/tests/policies/test_candidate_entry_point_wiring.py
@@ -129,16 +129,89 @@ def _calls(tree: ast.AST, name: str) -> list[ast.Call]:
     ]
 
 
-def _first_sampler_call_line(tree: ast.AST) -> int | None:
-    """Line of the earliest ``<obj>.sample_actions(...)`` / ``.select_action(...)`` call."""
-    lines = [
-        node.lineno
-        for node in ast.walk(tree)
-        if isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Attribute)
-        and node.func.attr in _SAMPLER_ATTRS
-    ]
+def _function_defs(tree: ast.AST) -> dict[str, ast.FunctionDef]:
+    """Every ``def`` in the module by bare name, methods included."""
+    return {
+        node.name: node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef)
+    }
+
+
+def _called_names(node: ast.AST) -> set[str]:
+    """Bare names of everything ``node`` calls, as ``f()`` or ``self.f()``."""
+    names = set()
+    for sub in ast.walk(node):
+        if not isinstance(sub, ast.Call):
+            continue
+        if isinstance(sub.func, ast.Name):
+            names.add(sub.func.id)
+        elif isinstance(sub.func, ast.Attribute):
+            names.add(sub.func.attr)
+    return names
+
+
+def _samples_directly(node: ast.AST) -> bool:
+    """Whether ``node`` contains a literal ``<obj>.sample_actions(...)`` call."""
+    return any(
+        isinstance(sub, ast.Call) and isinstance(sub.func, ast.Attribute) and sub.func.attr in _SAMPLER_ATTRS
+        for sub in ast.walk(node)
+    )
+
+
+def _sampler_reaching_functions(tree: ast.AST) -> set[str]:
+    """Names of functions that reach the sampler, directly or through a helper they call.
+
+    Iterated to a fixed point so a chain of helpers resolves, not just one hop.
+    """
+    defs = _function_defs(tree)
+    reaching = {name for name, fn in defs.items() if _samples_directly(fn)}
+    while True:
+        grown = reaching | {name for name, fn in defs.items() if _called_names(fn) & reaching}
+        if grown == reaching:
+            return reaching
+        reaching = grown
+
+
+def _first_sampling_line_within(fn: ast.AST, sampler_reaching: set[str]) -> int | None:
+    """Line inside ``fn`` at which sampling first actually *happens*.
+
+    A ``sample_actions(...)`` written in a helper does not execute where it is written —
+    it executes where that helper is **called**. So a call to a sampler-reaching helper
+    counts at its call site, which is the whole difference between this and comparing raw
+    file offsets.
+
+    Args:
+        fn: The function whose body is scanned.
+        sampler_reaching: Names of functions that reach the sampler, from
+            :func:`_sampler_reaching_functions`.
+
+    Returns:
+        The earliest line in ``fn`` that samples, or ``None`` if it never does.
+    """
+    lines = []
+    for sub in ast.walk(fn):
+        if not isinstance(sub, ast.Call):
+            continue
+        if (
+            isinstance(sub.func, ast.Attribute)
+            and sub.func.attr in _SAMPLER_ATTRS
+            or isinstance(sub.func, ast.Attribute)
+            and sub.func.attr in sampler_reaching
+            or isinstance(sub.func, ast.Name)
+            and sub.func.id in sampler_reaching
+        ):
+            lines.append(sub.lineno)
     return min(lines) if lines else None
+
+
+def _enclosing_function(tree: ast.AST, target: ast.Call) -> ast.FunctionDef | None:
+    """The innermost ``def`` whose body contains ``target``."""
+    best = None
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        if any(sub is target for sub in ast.walk(node)) and (best is None or node.lineno > best.lineno):
+            best = node
+    return best
 
 
 def _tree(rel_path: str) -> ast.Module:
@@ -258,17 +331,157 @@ def test_candidates_are_armed_before_the_first_sampler_call(rel_path):
     smoke-called for its output shape, and where the widened batch first allocates. Every one
     of those is a startup concern: a server that warms up at N=1 and only fans out on the
     first real request pays a recompile and can run out of memory with a robot waiting.
+
+    Ordering is resolved by *execution*, not by file offset. Comparing raw line numbers
+    reads a sampler call written in a helper as happening where it is written — so factoring
+    the warmup into a method defined above the arming call reads as "samples before arming"
+    while the runtime order is unchanged. ``grpc/server.py`` did exactly that (#523) and the
+    file-offset form of this test went red on a correct server.
     """
     tree = _tree(rel_path)
     arm = _calls(tree, "configure_candidates")
     assert len(arm) == 1, f"{rel_path}: expected exactly one configure_candidates() call, found {len(arm)}"
 
-    first_sample = _first_sampler_call_line(tree)
-    assert first_sample is not None, f"{rel_path}: no sampler call found; the ordering matcher needs updating"
+    arming_fn = _enclosing_function(tree, arm[0])
+    assert arming_fn is not None, (
+        f"{rel_path}: configure_candidates() is called at module level; the ordering matcher "
+        "assumes it runs inside the startup function that also warms the sampler up"
+    )
+
+    first_sample = _first_sampling_line_within(arming_fn, _sampler_reaching_functions(tree))
+    assert first_sample is not None, (
+        f"{rel_path}: {arming_fn.name}() arms best-of-N but never reaches the sampler, so this "
+        "test would pass without checking anything. Arming and the warmup have been split "
+        "across functions — update the matcher to compare them at their common caller."
+    )
     assert arm[0].lineno < first_sample, (
         f"{rel_path}: configure_candidates() at line {arm[0].lineno} runs after the first "
-        f"sample_actions()/select_action() call at line {first_sample}, so critic loading and "
+        f"sampling reached at line {first_sample} in {arming_fn.name}(), so critic loading and "
         "the candidate fan-out land on a live request instead of at startup"
+    )
+
+
+def _ordering_verdict(source: str) -> tuple[int, int | None, str]:
+    """Run the ordering matcher over a synthetic script.
+
+    Args:
+        source: Module source in the shape of a serving entry point.
+
+    Returns:
+        ``(arming line, first line in the arming function that samples, arming function name)``.
+        The middle element is ``None`` when the arming function never reaches the sampler.
+    """
+    tree = ast.parse(source)
+    arm = _calls(tree, "configure_candidates")[0]
+    arming_fn = _enclosing_function(tree, arm)
+    return (
+        arm.lineno,
+        _first_sampling_line_within(arming_fn, _sampler_reaching_functions(tree)),
+        arming_fn.name,
+    )
+
+
+#: The shape ``grpc/server.py`` took in #523: the warmup is factored into a helper *defined
+#: above* the arming call, so the sampler call's file offset is smaller while the runtime
+#: order is unchanged. Kept as one string with the two variants below differing only in
+#: where the arming line sits, so the pair isolates ordering and nothing else.
+_WARMUP_VIA_HELPER_DEFINED_ABOVE = """
+class Servicer:
+    def _sample_sync(self, batch):
+        return self.policy.sample_actions(batch)
+
+    def _load_policy(self):
+        self.policy = make_policy(cfg=self.cfg.policy)
+        configure_candidates(self.policy, self.cfg, device="cuda", dtype=None)
+        _ = self._sample_sync({})
+"""
+
+_ARMED_AFTER_THE_WARMUP = """
+class Servicer:
+    def _sample_sync(self, batch):
+        return self.policy.sample_actions(batch)
+
+    def _load_policy(self):
+        self.policy = make_policy(cfg=self.cfg.policy)
+        _ = self._sample_sync({})
+        configure_candidates(self.policy, self.cfg, device="cuda", dtype=None)
+"""
+
+
+def test_a_helper_defined_above_the_arming_call_samples_at_its_call_site():
+    """The regression that broke `main`: file offset is not execution order.
+
+    Under the old ``min(lineno)`` matcher the helper's own ``sample_actions`` line won,
+    reporting that a correct server sampled before it armed. Reverting
+    :func:`_first_sampling_line_within` to that form turns this red.
+    """
+    arm_line, sample_line, fn_name = _ordering_verdict(_WARMUP_VIA_HELPER_DEFINED_ABOVE)
+
+    assert fn_name == "_load_policy"
+    assert sample_line is not None
+    assert arm_line < sample_line, (
+        "the warmup helper's definition was read as the sampling site; sampling happens where "
+        f"the helper is called (line {sample_line}), not where it is written"
+    )
+
+
+def test_arming_after_the_warmup_is_still_caught():
+    """The other direction — the fix must not become "never disagree".
+
+    Same two methods, same helper indirection, only the arming call moves below the warmup.
+    Without this, relaxing the matcher into a tautology would fail nothing.
+    """
+    arm_line, sample_line, _ = _ordering_verdict(_ARMED_AFTER_THE_WARMUP)
+
+    assert sample_line is not None
+    assert arm_line > sample_line, (
+        "arming written after the warmup call must still read as late; the ordering check is "
+        "the only thing keeping critic loading off the first robot request"
+    )
+
+
+def test_a_chain_of_helpers_resolves_to_the_outermost_call_site():
+    """``_sampler_reaching_functions`` iterates to a fixed point, so depth doesn't matter."""
+    arm_line, sample_line, _ = _ordering_verdict(
+        """
+class Servicer:
+    def _inner(self, batch):
+        return self.policy.sample_actions(batch)
+
+    def _outer(self, batch):
+        return self._inner(batch)
+
+    def _load_policy(self):
+        self.policy = make_policy(cfg=self.cfg.policy)
+        configure_candidates(self.policy, self.cfg, device="cuda", dtype=None)
+        _ = self._outer({})
+"""
+    )
+
+    assert sample_line is not None and arm_line < sample_line
+
+
+def test_an_arming_function_that_never_samples_is_reported_not_passed():
+    """A vacuous pin is the failure mode this whole module exists to avoid.
+
+    If a refactor splits arming and the warmup across functions, the matcher must say so
+    rather than return "nothing sampled here" and let the assertion succeed by default.
+    """
+    _, sample_line, _ = _ordering_verdict(
+        """
+class Servicer:
+    def _load_policy(self):
+        self.policy = make_policy(cfg=self.cfg.policy)
+        configure_candidates(self.policy, self.cfg, device="cuda", dtype=None)
+
+    def _warmup(self):
+        _ = self.policy.sample_actions({})
+"""
+    )
+
+    assert sample_line is None, (
+        "arming and the warmup now sit in different functions; the ordering test must fail "
+        "loudly and ask for a common-caller comparison instead of passing vacuously"
     )
 
 


### PR DESCRIPTION
## What this does

Fixes the gating CPU test currently failing on `main`.

`test_candidates_are_armed_before_the_first_sampler_call` (added in #525) checked that
`configure_candidates` runs before the sampler by comparing **raw line numbers**:

```python
assert arm[0].lineno < first_sample   # first_sample = min(lineno) over every .sample_actions(...)
```

File offset stops tracking execution order the moment a sampler call is factored into a
helper. #523 did exactly that — it extracted `_sample_actions_sync` in `grpc/server.py` and
placed it *above* `_load_policy` — so the matcher read a correct server as sampling before it
armed:

```
AssertionError: grpc/server.py: configure_candidates() at line 357 runs after the first
sample_actions()/select_action() call at line 328
```

The runtime order was never wrong. `__init__` calls `_load_policy`, which arms at 357 and only
then warms up at 388-389 via `self._sample_actions_sync(...)`; the call at line 328 lives in
that helper's body and does not execute until 388 calls it.

Neither PR could have caught this alone — #523 introduced the helper, #525 introduced the
test, they merged 2h46m apart, and `main` does not require branches to be up to date before
merging, so the combination was never run.

**The fix:** resolve sampling to its *execution* site. The matcher now finds the function that
arms, computes the set of functions that reach the sampler (to a fixed point, so helper chains
resolve), and counts a call to any of them at its **call site**. It also fails loudly instead
of vacuously if arming and the warmup are ever split across functions, rather than quietly
checking nothing.

No source change — the four serving entry points were already correct.

## How it was tested

`tests/policies/test_candidate_entry_point_wiring.py`: 33 passed (was 30, 1 failing).
Full `tests/policies/` CPU subset: **1220 passed, 2 skipped**.

Six tests added, each constructing a case the matcher could get wrong:

- `test_a_helper_defined_above_the_arming_call_samples_at_its_call_site` — the regression
  itself, in the shape #523 gave `grpc/server.py`.
- `test_arming_after_the_warmup_is_still_caught` — same source, arming moved below the warmup,
  so the fix cannot quietly become "never disagree".
- `test_a_chain_of_helpers_resolves_to_the_outermost_call_site` — pins the fixed-point walk.
- `test_an_arming_function_that_never_samples_is_reported_not_passed` — pins the vacuity guard.
- `test_a_warmup_closure_inside_the_arming_function_samples_at_its_call_site` — the same bug
  one nesting level down, raised in review of this PR: `ast.walk` descends into nested `def`
  bodies, so a warmup factored into a closure *inside* the arming function read as
  `arm=7, sample=5` on correct code.
- `test_a_warmup_closure_called_before_arming_is_still_caught` — the fail-open direction for
  that fix.

Both directions were mutation-verified rather than assumed (CLAUDE.md rule 8 — a pin that
stays green under the reverted bug is not a pin):

| Mutation | Goes red |
|---|---|
| Drop helper resolution (back to file-offset behavior) | the regression pin, the chain pin, and the real `grpc/server.py` case |
| Make the matcher a tautology | the arming-after-warmup pin and the vacuity guard |
| Revert the nested-def scan to `ast.walk` | the nested-closure pin |
| Exclude nested defs from the reaching set (fail-open) | both nested-closure pins |

## How to checkout & try? (for the reviewer)

```bash
gh pr checkout 528 && pytest -sx tests/policies/test_candidate_entry_point_wiring.py
```

Confirm it reproduces on `main` first:

```bash
git checkout main && pytest -sx tests/policies/test_candidate_entry_point_wiring.py -k armed_before
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
