### PR TITLE
feat(train): legacy norm-key remap, trainable-only snapshots, LIBERO task fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,6 +195,34 @@ zero-initialized and the position ids are built so the action block keeps the Ro
 without registers, which is as close as this gets — only `n_register_tokens=0` is bit-identical to
 stock π₀.₅.
 
+### Added — `save_trainable_params`, kept-forever trainable-only checkpoint snapshots — **opt-in, default `False`**
+
+Every saving step additionally writes `output_dir/trainable_params/step_<id>.safetensors`
+holding only the `requires_grad=True` parameters. The snapshots sit outside the
+`checkpoints/` tree, so `last_checkpoint_only` pruning never touches them: a mostly-frozen
+run (`train_ttt_only` trains 85M of 3.4B parameters) keeps a per-save-step parameter
+history at ~2% of full-checkpoint cost, while full resumable state stays latest-only.
+Restoring a step = build the policy from the run's base checkpoint, then
+`load_state_dict(load_file(snapshot), strict=False)`. Requires replicated parameters —
+DDP or DeepSpeed ZeRO-1/2; the run **raises at startup** under ZeRO-3/FSDP, where each
+rank's `named_parameters` are shards and the snapshot would be silently truncated.
+
+### Fixed
+
+- **Pre-rename π₀.₅ checkpoints load again: legacy `normalize_actions.*` state-dict keys
+  are remapped to `normalize_discrete_actions.*`.** Checkpoints saved before the
+  discrete-action normalizer rename (e.g. `TensorAuto/tPi0.5-libero`) carried their
+  discrete min/max stats under the old module name; on the stat-less eval path the
+  current module's buffers stayed `+inf` and `make_policy`'s `_check_norm_stats_loaded`
+  rejected the checkpoint. The remap lives in `PI05Policy._fix_pytorch_state_dict_keys`
+  next to the other legacy-key fixes.
+- **Multi-rank LIBERO eval with `env.task_ids: null` no longer crashes with
+  `TypeError: int() argument must be ... not 'Task'`.** `LiberoEnv.gym_kwargs`
+  materialized "all tasks" as `_get_suite(suite).tasks` — Task objects — before the
+  per-rank modulo split, and `create_libero_envs` then called `int()` on them. It now
+  distributes the index range. Explicit `task_ids` lists (every production config) were
+  unaffected; the all-tasks default under an accelerator always crashed.
+
 ## [0.13.0] - 2026-08-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,11 +197,13 @@ stock π₀.₅.
 
 ### Added — `save_trainable_params`, kept-forever trainable-only checkpoint snapshots — **opt-in, default `False`**
 
-Every saving step additionally writes `output_dir/trainable_params/step_<id>.safetensors`
-holding only the `requires_grad=True` parameters. The snapshots sit outside the
-`checkpoints/` tree, so `last_checkpoint_only` pruning never touches them: a mostly-frozen
-run (`train_ttt_only` trains 85M of 3.4B parameters) keeps a per-save-step parameter
-history at ~2% of full-checkpoint cost, while full resumable state stays latest-only.
+Every `save_freq` steps (and after the last step) a safetensors snapshot holding only the
+`requires_grad=True` parameters is written to `output_dir/trainable_params/step_<id>.safetensors`.
+The snapshots sit outside the `checkpoints/` tree, so `last_checkpoint_only` pruning never
+touches them, and — like `running_best_count` — they fire independently of `save_checkpoint`,
+so a snapshots-only run is possible: a mostly-frozen run (`train_ttt_only` trains 85M of 3.4B
+parameters) keeps a per-save-step parameter history at ~2% of full-checkpoint cost, while full
+resumable state stays latest-only.
 Restoring a step = build the policy from the run's base checkpoint, then
 `load_state_dict(load_file(snapshot), strict=False)`. Requires replicated parameters —
 DDP or DeepSpeed ZeRO-1/2; the run **raises at startup** under ZeRO-3/FSDP, where each

--- a/src/opentau/configs/train.py
+++ b/src/opentau/configs/train.py
@@ -131,6 +131,13 @@ class TrainPipelineConfig(HubMixin):
         save_freq: Frequency of checkpoint saving in training iterations. Checkpoints
             are saved every `save_freq` steps and after the last training step.
             Defaults to 20,000.
+        save_trainable_params: If True, every saving step additionally writes a
+            safetensors snapshot holding only the `requires_grad=True` parameters to
+            `output_dir/trainable_params/step_<id>.safetensors`. Snapshots are exempt
+            from `last_checkpoint_only` pruning, giving mostly-frozen runs (e.g.
+            `train_ttt_only`) a cheap kept-forever parameter history. Requires
+            replicated parameters (DDP or DeepSpeed ZeRO-1/2); raises at startup
+            under ZeRO-3/FSDP. Defaults to False.
         use_policy_training_preset: If True, use optimizer and scheduler presets from
             the policy configuration. Defaults to False.
         optimizer: Configuration for the optimizer. Required if
@@ -200,6 +207,15 @@ class TrainPipelineConfig(HubMixin):
     save_checkpoint: bool = True
     # Checkpoint is saved every `save_freq` training iterations and after the last training step.
     save_freq: int = 20_000
+    # At every saving step, additionally write a small safetensors snapshot holding ONLY the
+    # parameters with requires_grad=True (e.g. the 85M TTT parameters of a `train_ttt_only`
+    # run, against a 3.4B frozen base) to `output_dir/trainable_params/`. These snapshots are
+    # never pruned — `last_checkpoint_only` does not touch them — so a mostly-frozen run can
+    # keep a per-save-step parameter history at ~2% of the full-checkpoint cost. Restoring a
+    # step = load the base checkpoint, then `load_state_dict(snapshot, strict=False)`.
+    # Requires replicated parameters (DDP or ZeRO-1/2); raises at startup under ZeRO-3/FSDP,
+    # where each rank only holds a shard.
+    save_trainable_params: bool = False
     use_policy_training_preset: bool = False
     optimizer: OptimizerConfig | None = None
     scheduler: LRSchedulerConfig | None = None

--- a/src/opentau/configs/train.py
+++ b/src/opentau/configs/train.py
@@ -131,11 +131,13 @@ class TrainPipelineConfig(HubMixin):
         save_freq: Frequency of checkpoint saving in training iterations. Checkpoints
             are saved every `save_freq` steps and after the last training step.
             Defaults to 20,000.
-        save_trainable_params: If True, every saving step additionally writes a
-            safetensors snapshot holding only the `requires_grad=True` parameters to
-            `output_dir/trainable_params/step_<id>.safetensors`. Snapshots are exempt
-            from `last_checkpoint_only` pruning, giving mostly-frozen runs (e.g.
-            `train_ttt_only`) a cheap kept-forever parameter history. Requires
+        save_trainable_params: If True, every `save_freq` steps (and after the last
+            step) write a safetensors snapshot holding only the `requires_grad=True`
+            parameters to `output_dir/trainable_params/step_<id>.safetensors`.
+            Snapshots are exempt from `last_checkpoint_only` pruning and — like
+            `running_best_count` — independent of `save_checkpoint`, so a
+            snapshots-only run is possible; mostly-frozen runs (e.g.
+            `train_ttt_only`) get a cheap kept-forever parameter history. Requires
             replicated parameters (DDP or DeepSpeed ZeRO-1/2); raises at startup
             under ZeRO-3/FSDP. Defaults to False.
         use_policy_training_preset: If True, use optimizer and scheduler presets from
@@ -207,12 +209,14 @@ class TrainPipelineConfig(HubMixin):
     save_checkpoint: bool = True
     # Checkpoint is saved every `save_freq` training iterations and after the last training step.
     save_freq: int = 20_000
-    # At every saving step, additionally write a small safetensors snapshot holding ONLY the
-    # parameters with requires_grad=True (e.g. the 85M TTT parameters of a `train_ttt_only`
-    # run, against a 3.4B frozen base) to `output_dir/trainable_params/`. These snapshots are
-    # never pruned — `last_checkpoint_only` does not touch them — so a mostly-frozen run can
-    # keep a per-save-step parameter history at ~2% of the full-checkpoint cost. Restoring a
-    # step = load the base checkpoint, then `load_state_dict(snapshot, strict=False)`.
+    # Every `save_freq` steps (and after the last step), write a small safetensors snapshot
+    # holding ONLY the parameters with requires_grad=True (e.g. the 85M TTT parameters of a
+    # `train_ttt_only` run, against a 3.4B frozen base) to `output_dir/trainable_params/`.
+    # These snapshots are never pruned — `last_checkpoint_only` does not touch them — and,
+    # like `running_best_count`, they fire independently of `save_checkpoint`, so a
+    # snapshots-only run is possible. A mostly-frozen run keeps a per-save-step parameter
+    # history at roughly one-fiftieth of the full-checkpoint cost. Restoring a step = load the base
+    # checkpoint, then `load_state_dict(snapshot, strict=False)`.
     # Requires replicated parameters (DDP or ZeRO-1/2); raises at startup under ZeRO-3/FSDP,
     # where each rank only holds a shard.
     save_trainable_params: bool = False

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -900,9 +900,7 @@ class BaseDataset(torch.utils.data.Dataset):
             # `n_obs_history` alone made a sequence batch fail this assertion
             # with "Expected image camera0 to have shape (3, H, W) ... Got
             # torch.Size([4, 3, 224, 224])".
-            expect_temporal = (
-                self.n_obs_history is not None or getattr(self, "sequence_length", 1) > 1
-            )
+            expect_temporal = self.n_obs_history is not None or getattr(self, "sequence_length", 1) > 1
         if expect_temporal:
             expected_ndim = 4
             expected_c_dim = 1

--- a/src/opentau/envs/configs.py
+++ b/src/opentau/envs/configs.py
@@ -284,8 +284,14 @@ class LiberoEnv(EnvConfig):
         else:
             from opentau.envs.libero import _get_suite
 
+            # ``task_ids=None`` means "all tasks in the suite" — materialize it as the
+            # *index* range, not ``.tasks`` (a list of Task objects): the modulo split
+            # below hands its elements to ``create_libero_envs``, whose
+            # ``_select_task_ids`` calls ``int()`` on each and raises ``TypeError``
+            # on a Task. Explicit configs always passed ints, so only the
+            # ``None``-under-multi-rank path ever hit this.
             task_ids = {
-                suite: _get_suite(suite).tasks if self.task_ids is None else self.task_ids
+                suite: (list(range(len(_get_suite(suite).tasks))) if self.task_ids is None else self.task_ids)
                 for suite in suite_names
             }
             logging.info(f"[LIBERO environment] Before distributing, using {task_ids=}.")

--- a/src/opentau/policies/pi05/modeling_pi05.py
+++ b/src/opentau/policies/pi05/modeling_pi05.py
@@ -640,6 +640,16 @@ class PI05Policy(PreTrainedPolicy):
                 new_key = key.replace("action_time_mlp_in.", "time_mlp_in.")
             elif key.startswith("action_time_mlp_out."):
                 new_key = key.replace("action_time_mlp_out.", "time_mlp_out.")
+
+            # Legacy discrete-action normalizer name. Checkpoints saved before the
+            # `normalize_actions` -> `normalize_discrete_actions` rename (e.g.
+            # TensorAuto/tPi0.5-libero) carry the discrete min/max stats under the
+            # old prefix. Without this remap those buffers land as unexpected keys,
+            # the module's own buffers stay +inf when no dataset stats are supplied
+            # (the eval/inference path), and `make_policy`'s
+            # `_check_norm_stats_loaded` rejects the checkpoint at load time.
+            if key.startswith("normalize_actions."):
+                new_key = key.replace("normalize_actions.", "normalize_discrete_actions.", 1)
             if key.startswith("state_proj.") and model_config.state_type == "discrete":
                 logging.warning(f"Skipping state_proj key in discrete state mode: {key}")
                 continue

--- a/src/opentau/policies/pi05_mem/modeling_pi05.py
+++ b/src/opentau/policies/pi05_mem/modeling_pi05.py
@@ -635,6 +635,15 @@ class PI05MemPolicy(PreTrainedPolicy):
                 new_key = key.replace("action_time_mlp_in.", "time_mlp_in.")
             elif key.startswith("action_time_mlp_out."):
                 new_key = key.replace("action_time_mlp_out.", "time_mlp_out.")
+
+            # Legacy discrete-action normalizer name — same remap as pi05's copy
+            # of this method (this class duplicates it rather than inheriting),
+            # so pre-rename checkpoints (e.g. TensorAuto/tPi0.5-libero) warm-start
+            # pi05_mem without their discrete min/max stats landing as
+            # unexpected keys and the module's own buffers staying +inf.
+            if key.startswith("normalize_actions."):
+                new_key = key.replace("normalize_actions.", "normalize_discrete_actions.", 1)
+
             if "patch_embedding" in key:
                 logging.warning(f"Vision embedding key might need handling: {key}")
 

--- a/src/opentau/policies/pi06/modeling_pi06.py
+++ b/src/opentau/policies/pi06/modeling_pi06.py
@@ -585,6 +585,13 @@ class PI06Policy(PreTrainedPolicy):
             elif new_key.startswith("action_time_mlp_out."):
                 new_key = new_key.replace("action_time_mlp_out.", "time_mlp_out.")
 
+            # Legacy discrete-action normalizer name — same remap as pi05's copy of
+            # this hand-duplicated method, so a pre-rename π₀.₅ checkpoint
+            # warm-starting π₀.₆ carries its discrete min/max stats over instead of
+            # dropping them as unexpected keys.
+            if new_key.startswith("normalize_actions."):
+                new_key = new_key.replace("normalize_actions.", "normalize_discrete_actions.", 1)
+
             # `state_proj` doesn't exist in either π0.5 or π0.6 — drop silently.
             if new_key.startswith("state_proj."):
                 logging.warning(f"Skipping state_proj key in pi06 mode: {new_key}")

--- a/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07/low_level/modeling_pi07_low_level.py
@@ -698,6 +698,14 @@ class PI07LowLevelPolicy(PreTrainedPolicy):
                 new_key = key.replace("action_time_mlp_in.", "time_mlp_in.")
             elif key.startswith("action_time_mlp_out."):
                 new_key = key.replace("action_time_mlp_out.", "time_mlp_out.")
+
+            # Legacy discrete-action normalizer name — same remap as pi05's copy of
+            # this hand-duplicated method, so a pre-rename π₀.₅-lineage checkpoint
+            # warm-starting the pi07 low level carries its discrete min/max stats
+            # over instead of dropping them as unexpected keys.
+            if key.startswith("normalize_actions."):
+                new_key = key.replace("normalize_actions.", "normalize_discrete_actions.", 1)
+
             if "patch_embedding" in key:
                 logging.warning(f"Vision embedding key might need handling: {key}")
 

--- a/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
+++ b/src/opentau/policies/pi07_paligemma/low_level/modeling_pi07_low_level.py
@@ -739,6 +739,13 @@ class PI07PaligemmaLowLevelPolicy(PreTrainedPolicy):
             elif key.startswith("action_time_mlp_out."):
                 new_key = key.replace("action_time_mlp_out.", "time_mlp_out.")
 
+            # Legacy discrete-action normalizer name — same remap as pi05's copy of
+            # this hand-duplicated method, so a pre-rename π₀.₅ checkpoint
+            # warm-starting the pi07_paligemma low level carries its discrete
+            # min/max stats over instead of dropping them as unexpected keys.
+            if key.startswith("normalize_actions."):
+                new_key = key.replace("normalize_actions.", "normalize_discrete_actions.", 1)
+
             # Handle vision tower embedding layer potential differences
             if "patch_embedding" in key:
                 # Some checkpoints might have this, but current model expects different structure

--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -66,6 +66,7 @@ from opentau.utils.train_utils import (
     load_training_step,
     prune_old_checkpoints,
     reseed_new_ranks_on_resume,
+    resolve_periodic_save_flags,
     save_checkpoint,
     save_running_best_state,
     save_trainable_params_snapshot,
@@ -1172,12 +1173,12 @@ def train(cfg: TrainPipelineConfig):
         current_success = None
         current_val_loss = None
         is_log_step = cfg.log_freq > 0 and step % cfg.log_freq == 0
-        is_saving_step = (step % cfg.save_freq == 0 or step == cfg.steps) and cfg.save_checkpoint
-        # Deliberately NOT gated on `save_checkpoint`, mirroring `running_best_count`:
-        # a snapshots-only run (small per-step history, no full resumable state) is a
-        # legitimate configuration, and gating on `save_checkpoint` would turn the
-        # opt-in flag into a silent no-op there.
-        is_snapshot_step = (step % cfg.save_freq == 0 or step == cfg.steps) and cfg.save_trainable_params
+        # The snapshot flag is deliberately independent of `save_checkpoint`
+        # (mirroring `running_best_count`) — the helper's docstring and its test
+        # pin that contract.
+        is_saving_step, is_snapshot_step = resolve_periodic_save_flags(
+            step, cfg.steps, cfg.save_freq, cfg.save_checkpoint, cfg.save_trainable_params
+        )
         is_eval_step = cfg.eval_freq > 0 and step % cfg.eval_freq == 0
         is_val_step = cfg.val_freq > 0 and step % cfg.val_freq == 0
 

--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -1173,6 +1173,11 @@ def train(cfg: TrainPipelineConfig):
         current_val_loss = None
         is_log_step = cfg.log_freq > 0 and step % cfg.log_freq == 0
         is_saving_step = (step % cfg.save_freq == 0 or step == cfg.steps) and cfg.save_checkpoint
+        # Deliberately NOT gated on `save_checkpoint`, mirroring `running_best_count`:
+        # a snapshots-only run (small per-step history, no full resumable state) is a
+        # legitimate configuration, and gating on `save_checkpoint` would turn the
+        # opt-in flag into a silent no-op there.
+        is_snapshot_step = (step % cfg.save_freq == 0 or step == cfg.steps) and cfg.save_trainable_params
         is_eval_step = cfg.eval_freq > 0 and step % cfg.eval_freq == 0
         is_val_step = cfg.val_freq > 0 and step % cfg.val_freq == 0
 
@@ -1211,18 +1216,6 @@ def train(cfg: TrainPipelineConfig):
                 logging.info(f"Checkpoint policy after step {step}")
                 cfg.policy.pretrained_path = checkpoint_dir
                 save_checkpoint(checkpoint_dir, step, cfg)
-                if cfg.save_trainable_params:
-                    # Kept-forever trainable-only snapshot, written OUTSIDE the
-                    # checkpoints/ tree so `prune_old_checkpoints` never sees it.
-                    # Startup validation already rejected sharded-parameter
-                    # backends, so the unwrapped module holds full parameters.
-                    snapshot_path = save_trainable_params_snapshot(
-                        accelerator.unwrap_model(policy),
-                        cfg.output_dir / "trainable_params",
-                        step,
-                        cfg.steps,
-                    )
-                    logging.info(f"Saved trainable-only parameter snapshot to {snapshot_path}")
                 if cfg.last_checkpoint_only:
                     # Protect running-best checkpoints from the latest-only prune. Read live each
                     # save so bests created since the last save are not deleted.
@@ -1247,6 +1240,21 @@ def train(cfg: TrainPipelineConfig):
                         accelerator.num_processes - len(missing_ranks),
                         accelerator.num_processes,
                     )
+
+        if is_snapshot_step and accelerator.is_main_process:
+            # Kept-forever trainable-only snapshot, written OUTSIDE the checkpoints/
+            # tree so `prune_old_checkpoints` never sees it, and independent of the
+            # full-checkpoint block above so it fires even with `save_checkpoint=False`.
+            # Rank-0-only with no barrier: parameters are replicated (the startup
+            # validation rejected sharded backends) and the copy to CPU completes
+            # before this rank re-enters the training loop.
+            snapshot_path = save_trainable_params_snapshot(
+                accelerator.unwrap_model(policy),
+                cfg.output_dir / "trainable_params",
+                step,
+                cfg.steps,
+            )
+            logging.info(f"Saved trainable-only parameter snapshot to {snapshot_path}")
 
         if is_val_step and val_dataloader is not None:
             policy.eval()

--- a/src/opentau/scripts/train.py
+++ b/src/opentau/scripts/train.py
@@ -68,6 +68,7 @@ from opentau.utils.train_utils import (
     reseed_new_ranks_on_resume,
     save_checkpoint,
     save_running_best_state,
+    save_trainable_params_snapshot,
 )
 from opentau.utils.utils import (
     encode_accelerator_state_dict,
@@ -898,6 +899,19 @@ def train(cfg: TrainPipelineConfig):
             )
         eval_subgoal_generator = make_subgoal_generator(cfg)
 
+    if cfg.save_trainable_params and (
+        accelerator.distributed_type == accelerate.DistributedType.FSDP
+        or _deepspeed_zero_stage(accelerator) >= 3
+    ):
+        # Fail here rather than at the first saving step: under ZeRO-3/FSDP each
+        # rank's named_parameters are shards, so the snapshot would be silently
+        # truncated — and dying `save_freq` steps into a run wastes the run.
+        raise ValueError(
+            "save_trainable_params requires replicated parameters (DDP or DeepSpeed "
+            "ZeRO-1/2); under ZeRO-3/FSDP each rank only holds a parameter shard. "
+            "Disable save_trainable_params or switch the accelerate config."
+        )
+
     logging.info("Creating policy")
     # FSDP needs the policy built in fp32 so its ``MixedPrecision(
     # param_dtype=bf16, reduce_dtype=bf16, buffer_dtype=bf16)`` policy can
@@ -1197,6 +1211,18 @@ def train(cfg: TrainPipelineConfig):
                 logging.info(f"Checkpoint policy after step {step}")
                 cfg.policy.pretrained_path = checkpoint_dir
                 save_checkpoint(checkpoint_dir, step, cfg)
+                if cfg.save_trainable_params:
+                    # Kept-forever trainable-only snapshot, written OUTSIDE the
+                    # checkpoints/ tree so `prune_old_checkpoints` never sees it.
+                    # Startup validation already rejected sharded-parameter
+                    # backends, so the unwrapped module holds full parameters.
+                    snapshot_path = save_trainable_params_snapshot(
+                        accelerator.unwrap_model(policy),
+                        cfg.output_dir / "trainable_params",
+                        step,
+                        cfg.steps,
+                    )
+                    logging.info(f"Saved trainable-only parameter snapshot to {snapshot_path}")
                 if cfg.last_checkpoint_only:
                     # Protect running-best checkpoints from the latest-only prune. Read live each
                     # save so bests created since the last save are not deleted.

--- a/src/opentau/utils/train_utils.py
+++ b/src/opentau/utils/train_utils.py
@@ -42,6 +42,7 @@ from opentau.utils.random_utils import load_rng_state, save_rng_state
 
 if TYPE_CHECKING:
     import accelerate
+    import torch
 
 
 def log_output_dir(out_dir):
@@ -130,6 +131,62 @@ def save_checkpoint(
     cfg.save_pretrained(checkpoint_dir)
     save_training_step(step, checkpoint_dir)
     save_rng_state(checkpoint_dir)
+
+
+def save_trainable_params_snapshot(
+    policy: "torch.nn.Module",
+    output_dir: Path,
+    step: int,
+    total_steps: int,
+) -> Path:
+    """Write only the ``requires_grad=True`` parameters to a safetensors file.
+
+    The point is a kept-forever, per-save-step parameter history for runs that
+    freeze most of the model (``train_ttt_only`` trains 85M of 3.4B parameters):
+    a full checkpoint is ~50x the size and `last_checkpoint_only` prunes it, so
+    dumping just the trainable subset is what makes "keep every checkpoint"
+    affordable. Frozen parameters and buffers are reproducible from the base
+    checkpoint the run warm-started from; only the trained subset is history.
+
+    Restoring a step: build the policy from the run's base checkpoint, then
+    ``policy.load_state_dict(load_file(snapshot), strict=False)``.
+
+    The caller is responsible for only invoking this where each rank holds the
+    full parameters (DDP, DeepSpeed ZeRO-1/2) and on one rank only — under
+    ZeRO-3/FSDP the local ``named_parameters`` are shards and the snapshot
+    would be silently truncated. ``train.py`` guards this at startup.
+
+    Args:
+        policy: The unwrapped policy module.
+        output_dir: Directory for snapshots (created if needed). Deliberately
+            distinct from the ``checkpoints/`` tree so pruning never sees it.
+        step: Current training step.
+        total_steps: Total steps for zero-padded naming.
+
+    Returns:
+        Path of the written snapshot.
+
+    Raises:
+        ValueError: If the policy has no trainable parameters — a snapshot of
+            nothing means the run's freeze flags are wrong, which should fail
+            loudly rather than write empty files every ``save_freq`` steps.
+    """
+    from safetensors.torch import save_file
+
+    trainable = {
+        name: param.detach().cpu().contiguous()
+        for name, param in policy.named_parameters()
+        if param.requires_grad
+    }
+    if not trainable:
+        raise ValueError(
+            "save_trainable_params is enabled but the policy has no requires_grad=True "
+            "parameters. Check the run's freeze flags."
+        )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path = output_dir / f"step_{get_step_identifier(step, total_steps)}.safetensors"
+    save_file(trainable, str(path))
+    return path
 
 
 def find_missing_rng_state_ranks(checkpoint_dir: Path, world_size: int) -> list[int]:

--- a/src/opentau/utils/train_utils.py
+++ b/src/opentau/utils/train_utils.py
@@ -133,6 +133,39 @@ def save_checkpoint(
     save_rng_state(checkpoint_dir)
 
 
+def resolve_periodic_save_flags(
+    step: int,
+    total_steps: int,
+    save_freq: int,
+    save_checkpoint: bool,
+    save_trainable_params: bool,
+) -> tuple[bool, bool]:
+    """Decides ``(is_saving_step, is_snapshot_step)`` for one training step.
+
+    Both fire on the same cadence — every ``save_freq`` steps and after the last
+    step — but gate on *independent* flags: full checkpoints on
+    ``save_checkpoint``, trainable-only snapshots on ``save_trainable_params``.
+    The independence is the contract (mirroring ``running_best_count``, which
+    also works with ``save_checkpoint=False``): a snapshots-only run must write
+    snapshots, not silently no-op because full checkpointing is off. Extracted
+    into a pure helper precisely so a test can pin that — a refactor that
+    re-nests the snapshot under the checkpoint flag fails the suite instead of
+    shipping the no-op.
+
+    Args:
+        step: The just-completed training step (1-based, as in the train loop).
+        total_steps: ``cfg.steps``; the final step always saves.
+        save_freq: Cadence in steps.
+        save_checkpoint: Whether full checkpoints are enabled.
+        save_trainable_params: Whether trainable-only snapshots are enabled.
+
+    Returns:
+        ``(is_saving_step, is_snapshot_step)``.
+    """
+    periodic = step % save_freq == 0 or step == total_steps
+    return periodic and save_checkpoint, periodic and save_trainable_params
+
+
 def save_trainable_params_snapshot(
     policy: "torch.nn.Module",
     output_dir: Path,

--- a/tests/envs/test_configs.py
+++ b/tests/envs/test_configs.py
@@ -279,3 +279,54 @@ class TestEnvConfigMetadataField:
         assert isinstance(config.metadata, EnvMetadataConfig)
         assert config.metadata.speed is None
         assert config.metadata.control_mode is None
+
+
+class TestLiberoEnvTaskDistribution:
+    """`LiberoEnv.gym_kwargs` must always hand integer task ids downstream.
+
+    Regression: with ``task_ids=None`` under an accelerator, the pre-split dict
+    was filled with ``_get_suite(suite).tasks`` — Task *objects* — so the
+    modulo split forwarded Tasks into ``create_libero_envs``, whose
+    ``_select_task_ids`` does ``int(task)`` and died with ``TypeError``.
+    Explicit ``task_ids`` configs always passed ints, which is why every
+    production run (explicit lists) missed it and only the
+    all-tasks-multi-rank path (e.g. a 4-suite baseline eval) hit it.
+    """
+
+    class _FakeAccelerator:
+        num_processes = 8
+        process_index = 3
+
+    @staticmethod
+    def _fake_suite(n_tasks: int):
+        class _Suite:
+            tasks = [object() for _ in range(n_tasks)]  # opaque Task stand-ins
+
+        return _Suite()
+
+    def _gym_kwargs_with(self, monkeypatch, task_ids):
+        import sys
+        import types
+
+        from opentau.envs import configs as env_configs
+        from opentau.envs.configs import LiberoEnv
+
+        monkeypatch.setattr(env_configs, "get_proc_accelerator", lambda: self._FakeAccelerator())
+        stub = types.ModuleType("opentau.envs.libero")
+        stub._get_suite = lambda suite: self._fake_suite(10)
+        monkeypatch.setitem(sys.modules, "opentau.envs.libero", stub)
+        return LiberoEnv(task="libero_10", task_ids=task_ids).gym_kwargs
+
+    def test_none_task_ids_distribute_as_ints(self, monkeypatch):
+        kwargs = self._gym_kwargs_with(monkeypatch, task_ids=None)
+        distributed = kwargs["task_ids"]["libero_10"]
+        # rank 3 of 8 over 10 tasks -> [3]
+        assert distributed == [3]
+        assert all(isinstance(t, int) for t in distributed)
+
+    def test_explicit_task_ids_distribute_as_ints(self, monkeypatch):
+        kwargs = self._gym_kwargs_with(monkeypatch, task_ids=[0, 1, 2, 3, 4, 5, 6, 8])
+        distributed = kwargs["task_ids"]["libero_10"]
+        # rank 3 of 8 over an 8-element list -> the element at index 3
+        assert distributed == [3]
+        assert all(isinstance(t, int) for t in distributed)

--- a/tests/policies/test_pi05_legacy_key_remap.py
+++ b/tests/policies/test_pi05_legacy_key_remap.py
@@ -33,17 +33,24 @@ import torch
 from opentau.policies.pi05.modeling_pi05 import PI05Policy
 from opentau.policies.pi05_mem.modeling_pi05 import PI05MemPolicy
 from opentau.policies.pi06.modeling_pi06 import PI06Policy
+from opentau.policies.pi07.low_level.modeling_pi07_low_level import PI07LowLevelPolicy
 from opentau.policies.pi07_paligemma.low_level.modeling_pi07_low_level import (
     PI07PaligemmaLowLevelPolicy,
 )
 
 # EVERY hand-duplicated copy of the method that owns a `normalize_discrete_actions`
-# module and supports a pi05 warm-start must carry the remap: pi05's (which
-# pi05_ttt inherits), pi05_mem's, pi06's (its docstring advertises `lerobot/pi05`
-# warm-starts), and the pi07_paligemma low level's. Sweeping a subset is exactly
-# the miss-by-omission CLAUDE.md rule 6 documents — the first two passes of this
-# very sweep each missed copies.
-POLICY_CLASSES = [PI05Policy, PI05MemPolicy, PI06Policy, PI07PaligemmaLowLevelPolicy]
+# module and supports a pi05-lineage warm-start must carry the remap: pi05's
+# (which pi05_ttt inherits), pi05_mem's, pi06's (its docstring advertises
+# `lerobot/pi05` warm-starts), and both pi07 low levels'. Sweeping a subset is
+# exactly the miss-by-omission CLAUDE.md rule 6 documents — the first passes of
+# this very sweep each missed copies.
+POLICY_CLASSES = [
+    PI05Policy,
+    PI05MemPolicy,
+    PI06Policy,
+    PI07LowLevelPolicy,
+    PI07PaligemmaLowLevelPolicy,
+]
 
 
 def _run_fix(policy_cls, state_dict: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:

--- a/tests/policies/test_pi05_legacy_key_remap.py
+++ b/tests/policies/test_pi05_legacy_key_remap.py
@@ -32,23 +32,29 @@ import torch
 
 from opentau.policies.pi05.modeling_pi05 import PI05Policy
 from opentau.policies.pi05_mem.modeling_pi05 import PI05MemPolicy
+from opentau.policies.pi06.modeling_pi06 import PI06Policy
+from opentau.policies.pi07_paligemma.low_level.modeling_pi07_low_level import (
+    PI07PaligemmaLowLevelPolicy,
+)
 
-# Both copies of the hand-duplicated method must carry the remap: pi05's (which
-# pi05_ttt inherits) and pi05_mem's. Sweeping only one is exactly the
-# miss-by-omission CLAUDE.md rule 6 documents.
-POLICY_CLASSES = [PI05Policy, PI05MemPolicy]
+# EVERY hand-duplicated copy of the method that owns a `normalize_discrete_actions`
+# module and supports a pi05 warm-start must carry the remap: pi05's (which
+# pi05_ttt inherits), pi05_mem's, pi06's (its docstring advertises `lerobot/pi05`
+# warm-starts), and the pi07_paligemma low level's. Sweeping a subset is exactly
+# the miss-by-omission CLAUDE.md rule 6 documents — the first two passes of this
+# very sweep each missed copies.
+POLICY_CLASSES = [PI05Policy, PI05MemPolicy, PI06Policy, PI07PaligemmaLowLevelPolicy]
 
 
 def _run_fix(policy_cls, state_dict: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
     """Invokes the real (unbound) key-fixing method with a minimal stub self/config."""
     # `self` is only consulted by the adaRMS branches (via `self.model...`); give it
     # a shape those branches can read without triggering the skip.
+    expert_tower = SimpleNamespace(gemma_expert=SimpleNamespace(config=SimpleNamespace(use_adarms=False)))
+    # pi05/pi05_mem/pi07_paligemma consult `paligemma_with_expert`; pi06 consults
+    # `gemma3_with_expert` — provide both so one stub serves every copy.
     stub_self = SimpleNamespace(
-        model=SimpleNamespace(
-            paligemma_with_expert=SimpleNamespace(
-                gemma_expert=SimpleNamespace(config=SimpleNamespace(use_adarms=False))
-            )
-        )
+        model=SimpleNamespace(paligemma_with_expert=expert_tower, gemma3_with_expert=expert_tower)
     )
     stub_config = SimpleNamespace(state_type="continuous")
     return policy_cls._fix_pytorch_state_dict_keys(stub_self, state_dict, stub_config)

--- a/tests/policies/test_pi05_legacy_key_remap.py
+++ b/tests/policies/test_pi05_legacy_key_remap.py
@@ -27,12 +27,19 @@ run without building a 3.4B-parameter model.
 
 from types import SimpleNamespace
 
+import pytest
 import torch
 
 from opentau.policies.pi05.modeling_pi05 import PI05Policy
+from opentau.policies.pi05_mem.modeling_pi05 import PI05MemPolicy
+
+# Both copies of the hand-duplicated method must carry the remap: pi05's (which
+# pi05_ttt inherits) and pi05_mem's. Sweeping only one is exactly the
+# miss-by-omission CLAUDE.md rule 6 documents.
+POLICY_CLASSES = [PI05Policy, PI05MemPolicy]
 
 
-def _run_fix(state_dict: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+def _run_fix(policy_cls, state_dict: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
     """Invokes the real (unbound) key-fixing method with a minimal stub self/config."""
     # `self` is only consulted by the adaRMS branches (via `self.model...`); give it
     # a shape those branches can read without triggering the skip.
@@ -44,15 +51,17 @@ def _run_fix(state_dict: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         )
     )
     stub_config = SimpleNamespace(state_type="continuous")
-    return PI05Policy._fix_pytorch_state_dict_keys(stub_self, state_dict, stub_config)
+    return policy_cls._fix_pytorch_state_dict_keys(stub_self, state_dict, stub_config)
 
 
-def test_legacy_discrete_normalizer_keys_are_remapped():
+@pytest.mark.parametrize("policy_cls", POLICY_CLASSES)
+def test_legacy_discrete_normalizer_keys_are_remapped(policy_cls):
     fixed = _run_fix(
+        policy_cls,
         {
             "normalize_actions.buffer_actions.min": torch.zeros(32),
             "normalize_actions.buffer_actions.max": torch.ones(32),
-        }
+        },
     )
     assert set(fixed) == {
         "normalize_discrete_actions.buffer_actions.min",
@@ -60,7 +69,8 @@ def test_legacy_discrete_normalizer_keys_are_remapped():
     }
 
 
-def test_current_discrete_normalizer_keys_pass_through_unchanged():
+@pytest.mark.parametrize("policy_cls", POLICY_CLASSES)
+def test_current_discrete_normalizer_keys_pass_through_unchanged(policy_cls):
     keys = {
         "normalize_discrete_actions.buffer_actions.min": torch.zeros(32),
         "normalize_discrete_actions.buffer_actions.max": torch.ones(32),
@@ -68,13 +78,14 @@ def test_current_discrete_normalizer_keys_pass_through_unchanged():
         "normalize_targets.buffer_actions.mean": torch.zeros(32),
         "unnormalize_outputs.buffer_actions.std": torch.ones(32),
     }
-    fixed = _run_fix(dict(keys))
+    fixed = _run_fix(policy_cls, dict(keys))
     assert set(fixed) == set(keys)
 
 
-def test_remap_hits_only_the_module_prefix():
+@pytest.mark.parametrize("policy_cls", POLICY_CLASSES)
+def test_remap_hits_only_the_module_prefix(policy_cls):
     # A key merely *containing* the substring elsewhere must not be rewritten:
     # startswith-anchored, first occurrence only.
     weird = "model.some_module.normalize_actions.weight"
-    fixed = _run_fix({weird: torch.zeros(1)})
+    fixed = _run_fix(policy_cls, {weird: torch.zeros(1)})
     assert set(fixed) == {weird}

--- a/tests/policies/test_pi05_legacy_key_remap.py
+++ b/tests/policies/test_pi05_legacy_key_remap.py
@@ -1,0 +1,80 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Legacy `normalize_actions.*` keys must remap to `normalize_discrete_actions.*`.
+
+Checkpoints saved before the discrete-action normalizer was renamed (e.g.
+``TensorAuto/tPi0.5-libero``, saved 2026-06) carry ``normalize_actions.buffer_actions.{min,max}``.
+Current pi05 has no module of that name, so without a remap those stats load as
+*unexpected keys*, the model's ``normalize_discrete_actions`` buffers stay at
+their ``+inf`` placeholder on the stat-less eval path, and ``make_policy``'s
+``_check_norm_stats_loaded`` rejects the checkpoint. The remap lives in
+``PI05Policy._fix_pytorch_state_dict_keys``; these tests call that method
+directly (with a stub ``self``, which the touched branches never read) so they
+run without building a 3.4B-parameter model.
+"""
+
+from types import SimpleNamespace
+
+import torch
+
+from opentau.policies.pi05.modeling_pi05 import PI05Policy
+
+
+def _run_fix(state_dict: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+    """Invokes the real (unbound) key-fixing method with a minimal stub self/config."""
+    # `self` is only consulted by the adaRMS branches (via `self.model...`); give it
+    # a shape those branches can read without triggering the skip.
+    stub_self = SimpleNamespace(
+        model=SimpleNamespace(
+            paligemma_with_expert=SimpleNamespace(
+                gemma_expert=SimpleNamespace(config=SimpleNamespace(use_adarms=False))
+            )
+        )
+    )
+    stub_config = SimpleNamespace(state_type="continuous")
+    return PI05Policy._fix_pytorch_state_dict_keys(stub_self, state_dict, stub_config)
+
+
+def test_legacy_discrete_normalizer_keys_are_remapped():
+    fixed = _run_fix(
+        {
+            "normalize_actions.buffer_actions.min": torch.zeros(32),
+            "normalize_actions.buffer_actions.max": torch.ones(32),
+        }
+    )
+    assert set(fixed) == {
+        "normalize_discrete_actions.buffer_actions.min",
+        "normalize_discrete_actions.buffer_actions.max",
+    }
+
+
+def test_current_discrete_normalizer_keys_pass_through_unchanged():
+    keys = {
+        "normalize_discrete_actions.buffer_actions.min": torch.zeros(32),
+        "normalize_discrete_actions.buffer_actions.max": torch.ones(32),
+        "normalize_inputs.buffer_state.min": torch.zeros(32),
+        "normalize_targets.buffer_actions.mean": torch.zeros(32),
+        "unnormalize_outputs.buffer_actions.std": torch.ones(32),
+    }
+    fixed = _run_fix(dict(keys))
+    assert set(fixed) == set(keys)
+
+
+def test_remap_hits_only_the_module_prefix():
+    # A key merely *containing* the substring elsewhere must not be rewritten:
+    # startswith-anchored, first occurrence only.
+    weird = "model.some_module.normalize_actions.weight"
+    fixed = _run_fix({weird: torch.zeros(1)})
+    assert set(fixed) == {weird}

--- a/tests/utils/test_train_utils.py
+++ b/tests/utils/test_train_utils.py
@@ -598,3 +598,36 @@ class TestSaveTrainableParamsSnapshot:
         path = save_trainable_params_snapshot(module, tmp_path, step=10, total_steps=100)
         loaded = load_file(str(path))
         assert set(loaded) == {"weight", "bias"}
+
+
+class TestResolvePeriodicSaveFlags:
+    """The snapshot flag must be independent of `save_checkpoint` — the contract
+    that makes a snapshots-only run possible instead of a silent no-op."""
+
+    @staticmethod
+    def _flags(**kw):
+        from opentau.utils.train_utils import resolve_periodic_save_flags
+
+        defaults = {
+            "step": 1000,
+            "total_steps": 20000,
+            "save_freq": 1000,
+            "save_checkpoint": True,
+            "save_trainable_params": True,
+        }
+        defaults.update(kw)
+        return resolve_periodic_save_flags(**defaults)
+
+    def test_snapshot_fires_with_save_checkpoint_disabled(self):
+        # THE pinned contract: snapshots-only run still snapshots.
+        assert self._flags(save_checkpoint=False) == (False, True)
+
+    def test_checkpoint_fires_with_snapshots_disabled(self):
+        assert self._flags(save_trainable_params=False) == (True, False)
+
+    def test_both_fire_on_cadence_and_neither_off_cadence(self):
+        assert self._flags() == (True, True)
+        assert self._flags(step=999) == (False, False)
+
+    def test_final_step_saves_regardless_of_cadence(self):
+        assert self._flags(step=20000, save_freq=1234) == (True, True)

--- a/tests/utils/test_train_utils.py
+++ b/tests/utils/test_train_utils.py
@@ -537,3 +537,64 @@ def test_prune_protected_none_is_backward_compatible(tmp_path):
 
     assert latest.exists()
     assert not old.exists()
+
+
+class TestSaveTrainableParamsSnapshot:
+    """`save_trainable_params_snapshot` writes exactly the requires_grad subset."""
+
+    @staticmethod
+    def _module_with_frozen_half():
+        import torch
+
+        module = torch.nn.Sequential(torch.nn.Linear(4, 3), torch.nn.Linear(3, 2))
+        for param in module[0].parameters():
+            param.requires_grad_(False)
+        return module
+
+    def test_snapshot_holds_exactly_the_trainable_names(self, tmp_path):
+        import torch
+        from safetensors.torch import load_file
+
+        from opentau.utils.train_utils import save_trainable_params_snapshot
+
+        module = self._module_with_frozen_half()
+        path = save_trainable_params_snapshot(
+            module, tmp_path / "trainable_params", step=1000, total_steps=20000
+        )
+
+        assert path.exists()
+        loaded = load_file(str(path))
+        expected = {name for name, p in module.named_parameters() if p.requires_grad}
+        assert set(loaded) == expected == {"1.weight", "1.bias"}
+        for name, tensor in loaded.items():
+            assert torch.equal(tensor, dict(module.named_parameters())[name].detach().cpu())
+
+    def test_snapshot_name_uses_zero_padded_step(self, tmp_path):
+        from opentau.utils.train_utils import save_trainable_params_snapshot
+
+        module = self._module_with_frozen_half()
+        path = save_trainable_params_snapshot(module, tmp_path, step=1000, total_steps=20000)
+        assert path.name == f"step_{get_step_identifier(1000, 20000)}.safetensors"
+
+    def test_fully_frozen_module_raises(self, tmp_path):
+        import pytest
+        import torch
+
+        from opentau.utils.train_utils import save_trainable_params_snapshot
+
+        module = torch.nn.Linear(4, 3)
+        for param in module.parameters():
+            param.requires_grad_(False)
+        with pytest.raises(ValueError, match="no requires_grad=True"):
+            save_trainable_params_snapshot(module, tmp_path, step=10, total_steps=100)
+
+    def test_buffers_are_excluded(self, tmp_path):
+        import torch
+        from safetensors.torch import load_file
+
+        from opentau.utils.train_utils import save_trainable_params_snapshot
+
+        module = torch.nn.BatchNorm1d(4)  # has running_mean/running_var buffers
+        path = save_trainable_params_snapshot(module, tmp_path, step=10, total_steps=100)
+        loaded = load_file(str(path))
+        assert set(loaded) == {"weight", "bias"}


### PR DESCRIPTION
## What this does

Three enablers for real pi05_ttt (RoboTTT, arXiv:2607.15275) training runs that warm-start from pre-rename π₀.₅ checkpoints and need a per-step parameter history plus multi-rank LIBERO sim eval. (🗃️ Feature + 🐛 Bug)

1. **Legacy norm-key remap (🐛).** `PI05Policy._fix_pytorch_state_dict_keys` now remaps `normalize_actions.*` state-dict keys to `normalize_discrete_actions.*`. Checkpoints saved before the discrete-action normalizer rename (e.g. `TensorAuto/tPi0.5-libero`) carried their discrete min/max stats under the old module name; on the stat-less eval path the current module's buffers stayed `+inf` and `make_policy`'s `_check_norm_stats_loaded` rejected the checkpoint outright.
2. **`save_trainable_params` (🗃️).** New `TrainPipelineConfig` flag (default `False`): every saving step additionally writes `output_dir/trainable_params/step_<id>.safetensors` holding only the `requires_grad=True` parameters, outside the `checkpoints/` tree so `last_checkpoint_only` pruning never touches it. A `train_ttt_only` run (85M trainable of 3.4B) keeps a kept-forever per-save-step parameter history at ~2% of full-checkpoint cost; full resumable state stays latest-only. Raises at startup under ZeRO-3/FSDP, where per-rank `named_parameters` are shards and the snapshot would be silently truncated.
3. **LIBERO task distribution fix (🐛).** `LiberoEnv.gym_kwargs` with `task_ids: null` under an accelerator filled the pre-split dict with `_get_suite(suite).tasks` — Task *objects* — so the per-rank modulo split handed Tasks to `create_libero_envs`, whose `_select_task_ids` calls `int()` on each and raised `TypeError`. It now distributes the index range. Explicit `task_ids` configs (every production run) were unaffected; the all-tasks-multi-rank path (e.g. a 4-suite baseline eval) always crashed.

CHANGELOG entries included under `[Unreleased]`.

## How it was tested

- Added `tests/policies/test_pi05_legacy_key_remap.py` (legacy keys remapped, current keys untouched, prefix-anchored), `TestSaveTrainableParamsSnapshot` in `tests/utils/test_train_utils.py` (exact trainable-name set, zero-padded naming, all-frozen raises, buffers excluded), and `TestLiberoEnvTaskDistribution` in `tests/envs/test_configs.py` (None and explicit task_ids both distribute ints per rank).
- CPU suite: `tests/policies` + `tests/utils` + `tests/configs` + `tests/envs` green locally and in the training container (1838 + 222 passed).
- GPU: `pytest -m gpu -n 0 tests/policies/test_pi05_ttt_gpu.py` — 7 passed on an 8×A100 node (internal GPU cluster).
- End-to-end: an 8-rank `eval.py` run of `TensorAuto/tPi0.5-libero` across all four LIBERO suites (the exact path items 1 and 3 unblock) — the pre-fix code crashed at env construction, the post-fix run completes at 97.5% overall (matching the checkpoint's historical 97.8%); two 8-rank ZeRO-2 pi05_ttt smoke training runs exercising `save_trainable_params` + in-training LIBERO eval end-to-end (snapshots written at every save step, exactly the `requires_grad` set at 170.7MB vs multi-GB full checkpoints, `last_checkpoint_only` pruning leaves them untouched).
- Determinism (CLAUDE.md rule 3): two seeded 8-rank smoke twins under `eager` attention are bit-identical at every step (8/8). Under `sdpa` the twins are bit-identical at step 1 (and the CE term — which flows only through frozen weights — stays bit-identical for several steps) with ~1e-5 MSE drift from step 2 on: divergence enters only via backward accumulation, i.e. the known nondeterministic flash-attention backward, a pre-existing property of `sdpa` unrelated to this diff.
- A long pi05_ttt training run on `TensorAuto/libero` (warm start `TensorAuto/tPi0.5-libero`, `train_ttt_only`) is running off this branch: first save/eval cycle verified healthy — in-training LIBERO eval at step 1000 reads 96.9% vs the 96.25% stock-π₀.₅ baseline on the same task subset, checkpoints + trainable snapshots + hub upload all flowing.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/policies/test_pi05_legacy_key_remap.py tests/envs/test_configs.py::TestLiberoEnvTaskDistribution
```
```bash
pytest -sx tests/utils/test_train_utils.py::TestSaveTrainableParamsSnapshot
```
Loading the pre-rename checkpoint no longer requires safetensors surgery:
```bash
python -c "
from opentau.policies.pi05.modeling_pi05 import PI05Policy
p = PI05Policy.from_pretrained('TensorAuto/tPi0.5-libero')
import torch
assert torch.isfinite(p.normalize_discrete_actions.buffer_actions.min).all()
print('discrete-action stats loaded:', p.normalize_discrete_actions.buffer_actions.min.shape)
"
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [x] My PR includes policy-related changes.
  - [x] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
