### PR TITLE
fix(datasets): sequence-mode batches >1 collate across episode boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,6 +224,15 @@ rank's `named_parameters` are shards and the snapshot would be silently truncate
   per-rank modulo split, and `create_libero_envs` then called `int()` on them. It now
   distributes the index range. Explicit `task_ids` lists (every production config) were
   unaffected; the all-tasks default under an accelerator always crashed.
+- **Sequence-mode training with `dataloader_batch_size > 1` no longer crashes in
+  `default_collate` with `Trying to resize storage that is not resizable`.** The fetch
+  layer attaches per-step state pad flags only to samples whose query window crossed an
+  episode boundary; interior samples fell through to a fixed `(1,)` `obs_history_is_pad`
+  fallback, so a batch mixing interior and boundary sequence samples carried `(1,)` against
+  `(sequence_length,)` and could not collate. Both fallback sites (the base emission and the
+  history-drop branch) now emit through `BaseDataset._obs_history_pad_fallback`, sized by the
+  active temporal mode. Invisible at `batch_size == 1` — the only shape the `pi05_ttt`
+  sequence loader had run at — and a no-op for history-mode and single-step configs.
 
 ## [0.13.0] - 2026-08-17
 

--- a/src/opentau/datasets/lerobot_dataset.py
+++ b/src/opentau/datasets/lerobot_dataset.py
@@ -1057,10 +1057,8 @@ class BaseDataset(torch.utils.data.Dataset):
         state_pad_key = f"{state_raw_key}_is_pad" if state_raw_key else None
         if state_pad_key and state_pad_key in item:
             standard_item["obs_history_is_pad"] = item[state_pad_key]
-        elif self.n_obs_history is not None:
-            standard_item["obs_history_is_pad"] = torch.zeros(self.n_obs_history, dtype=torch.bool)
         else:
-            standard_item["obs_history_is_pad"] = torch.tensor([False], dtype=torch.bool)
+            standard_item["obs_history_is_pad"] = self._obs_history_pad_fallback(padded=False)
 
         # Emit optional keys (memory, next_memory, speed, mistake, quality,
         # robot_type, control_mode, subgoalK) with their _is_pad siblings,
@@ -1174,6 +1172,36 @@ class BaseDataset(torch.utils.data.Dataset):
                 standard_item["actions"], standard_item["state"], self.delta_action_state_map
             )
 
+    def _obs_history_pad_fallback(self, padded: bool) -> torch.Tensor:
+        """Build ``obs_history_is_pad`` when the fetch layer produced no state pad flags.
+
+        The passthrough branch in :meth:`_to_standard_data_format` forwards the fetch
+        layer's per-step state pad flags, whose length is the temporal layout:
+        ``n_obs_history`` frames in history mode, ``sequence_length`` timesteps in
+        sequence mode, and a single step otherwise. The fetch layer only attaches
+        those flags to samples whose query window actually crossed an episode
+        boundary, so interior samples fall through to this fallback — and it must
+        emit the *same* length, because one interior and one boundary sample land in
+        the same ``default_collate`` batch. A fixed ``(1,)`` here against the
+        passthrough's ``(T,)`` kills the batch with "Trying to resize storage that
+        is not resizable" — invisible at ``batch_size == 1``, which was the only
+        batch shape the sequence loader had run at before.
+
+        Args:
+            padded: Flag value to fill with — ``True`` marks every step padded
+                (the history-drop branch), ``False`` marks none padded.
+
+        Returns:
+            A bool tensor of shape ``(n_obs_history,)``, ``(sequence_length,)``, or
+            ``(1,)`` depending on the active temporal mode, filled with ``padded``.
+        """
+        if self.n_obs_history is not None:
+            length = self.n_obs_history
+        else:
+            seq_len = getattr(self, "sequence_length", 1) or 1
+            length = seq_len if seq_len > 1 else 1
+        return torch.full((length,), padded, dtype=torch.bool)
+
     def _emit_optional_keys(self, item: dict, standard_item: dict) -> None:
         """Emit optional memory/subgoal/metadata keys with training-time dropout.
 
@@ -1245,15 +1273,12 @@ class BaseDataset(torch.utils.data.Dataset):
         # The current step — current state and current camera frame — is kept.
         drop_hist = _roll(self.history_state_drop_prob)
         if drop_hist:
-            if self.n_obs_history is not None:
-                standard_item["obs_history_is_pad"] = torch.ones(self.n_obs_history, dtype=torch.bool)
-                if self.n_obs_history > 1:
-                    for k in range(self.num_cams):
-                        cam_key = f"camera{k}"
-                        if cam_key in standard_item:
-                            standard_item[cam_key][:-1] = 0
-            else:
-                standard_item["obs_history_is_pad"] = torch.tensor([True], dtype=torch.bool)
+            standard_item["obs_history_is_pad"] = self._obs_history_pad_fallback(padded=True)
+            if self.n_obs_history is not None and self.n_obs_history > 1:
+                for k in range(self.num_cams):
+                    cam_key = f"camera{k}"
+                    if cam_key in standard_item:
+                        standard_item[cam_key][:-1] = 0
 
         # (2) Subgoal drop. A single ``subgoal_is_pad`` flag covers every slot
         # because subgoals are either all present (annotated and not dropped)

--- a/tests/datasets/test_sequence_emission.py
+++ b/tests/datasets/test_sequence_emission.py
@@ -239,3 +239,65 @@ class TestNumpyRoundTrip:
         grid = arr.reshape(4, 10)
         assert np.all(np.diff(grid, axis=1) > 0)
         assert np.allclose(np.diff(grid[:, 0]), 1 / 20.0)
+
+
+class TestObsHistoryPadFallback:
+    """The interior-sample fallback must match the boundary passthrough's shape.
+
+    The fetch layer attaches per-step state pad flags only to samples whose
+    query window crossed an episode boundary; interior samples fall through to
+    ``BaseDataset._obs_history_pad_fallback``. Both kinds land in one
+    ``default_collate`` batch, so the fallback length must equal the
+    passthrough length in every temporal mode — a fixed ``(1,)`` against the
+    passthrough's ``(sequence_length,)`` crashed every ``batch_size > 1``
+    sequence run with "Trying to resize storage that is not resizable"
+    (invisible at batch 1, the only batch shape pi05_ttt had run at).
+    """
+
+    @staticmethod
+    def _stub(sequence_length: int = 1, n_obs_history: int | None = None):
+        from opentau.datasets.lerobot_dataset import BaseDataset
+
+        ds = object.__new__(BaseDataset)
+        ds.sequence_length = sequence_length
+        ds.n_obs_history = n_obs_history
+        return ds
+
+    def test_sequence_mode_matches_the_boundary_passthrough_shape(self):
+        seq_len = 32
+        ds = self._stub(sequence_length=seq_len)
+        fallback = ds._obs_history_pad_fallback(padded=False)
+        assert fallback.shape == (seq_len,)
+        assert fallback.dtype == torch.bool and not fallback.any()
+
+    def test_interior_and_boundary_samples_collate(self):
+        """The actual crash case: one interior + one boundary sample in a batch."""
+        from torch.utils.data import default_collate
+
+        seq_len = 32
+        ds = self._stub(sequence_length=seq_len)
+        interior = {"obs_history_is_pad": ds._obs_history_pad_fallback(padded=False)}
+        boundary_passthrough = torch.zeros(seq_len, dtype=torch.bool)
+        boundary_passthrough[-3:] = True  # window ran off the episode end
+        boundary = {"obs_history_is_pad": boundary_passthrough}
+        batch = default_collate([interior, boundary])
+        assert batch["obs_history_is_pad"].shape == (2, seq_len)
+        assert batch["obs_history_is_pad"][1, -3:].all()
+
+    def test_history_mode_is_unchanged(self):
+        ds = self._stub(n_obs_history=5)
+        torch.testing.assert_close(
+            ds._obs_history_pad_fallback(padded=False), torch.zeros(5, dtype=torch.bool)
+        )
+        torch.testing.assert_close(ds._obs_history_pad_fallback(padded=True), torch.ones(5, dtype=torch.bool))
+
+    def test_plain_mode_is_byte_identical_to_the_pre_fix_fallback(self):
+        ds = self._stub(sequence_length=1)
+        torch.testing.assert_close(ds._obs_history_pad_fallback(padded=False), torch.tensor([False]))
+        torch.testing.assert_close(ds._obs_history_pad_fallback(padded=True), torch.tensor([True]))
+
+    def test_history_drop_marks_every_sequence_timestep(self):
+        """The drop branch (padded=True) must also be sequence-shaped."""
+        ds = self._stub(sequence_length=8)
+        dropped = ds._obs_history_pad_fallback(padded=True)
+        assert dropped.shape == (8,) and dropped.all()


### PR DESCRIPTION
## What this does

Fixes a latent crash in the #532 trajectory-sequence dataloader: any sequence-mode run with `dataloader_batch_size > 1` died in `default_collate` with `RuntimeError: Trying to resize storage that is not resizable`.

**Root cause.** The fetch layer attaches per-step state pad flags (`<state>_is_pad`) only to samples whose query window actually crossed an episode boundary. Interior samples fell through to a fixed-shape fallback, `torch.tensor([False])` — so one batch could carry `obs_history_is_pad` of shape `(1,)` (interior) next to `(sequence_length,)` (boundary), which `default_collate` cannot stack. Invisible at `batch_size == 1` — the only batch shape the `pi05_ttt` sequence loader had ever run at (paper recipe = 1/rank).

**Fix.** Both emission sites — the base emission in `_to_standard_data_format` and the history-drop branch in `_emit_optional_keys` — now route through a new `BaseDataset._obs_history_pad_fallback(padded)`, sized by the active temporal mode: `(n_obs_history,)` in history mode, `(sequence_length,)` in sequence mode, `(1,)` otherwise. Byte-identical to the old behavior for history-mode and single-step configs; model-side behavior is unchanged either way (`pi05`/`pi05_ttt` never read the key — only `pi05_mem` consumes it, in its own `n_obs_history` mode, which is untouched).

## How it was tested

- New `TestObsHistoryPadFallback` in `tests/datasets/test_sequence_emission.py` pins the actual failure: an interior-fallback sample and a boundary-passthrough sample collated in one `default_collate` batch (crashes without the fix), plus shape/value parity for history mode and the pre-fix single-step behavior, and the history-drop (all-True) branch under sequence mode.
- Full `tests/datasets/` CPU suite: 740 passed, 7 skipped.
- End-to-end on an internal 8-GPU node (ZeRO-2, bf16): a 30-step `pi05_ttt` sequence run (`sequence_length=32`, 3-camera dataset, `dataloader_batch_size=6`) that previously crashed at the first batch now completes cleanly — in-training sim evals, trainable-parameter snapshots, and checkpoint pruning all exercised; a long real training run at batch 7/rank is running on the same code.
- The shape census that located the bug: 400 sequence samples drawn through the real mixture dataloader showed exactly one key with mixed shapes (`obs_history_is_pad`: `[1]` vs `[32]`); all others uniform.

## How to checkout & try? (for the reviewer)

```bash
git fetch origin claude/seq-loader-obs-history-pad-fallback
git checkout claude/seq-loader-obs-history-pad-fallback
uv run pytest tests/datasets/test_sequence_emission.py -q
```

Or reproduce the pre-fix crash on any LeRobot dataset: set `dataset_mixture.sequence_length: 32`, `sequence_stride: 1`, `dataloader_batch_size: 4` with `policy.type: pi05_ttt` and iterate the train dataloader — without this patch the first batch containing both an interior and an episode-boundary sample raises in `default_collate`.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.
