### PR TITLE
feat(envs): explicit RoboCasa kitchen-scene list via env.layout_and_style_ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,6 +209,18 @@ Restoring a step = build the policy from the run's base checkpoint, then
 DDP or DeepSpeed ZeRO-1/2; the run **raises at startup** under ZeRO-3/FSDP, where each
 rank's `named_parameters` are shards and the snapshot would be silently truncated.
 
+### Added — `env.layout_and_style_ids`, explicit RoboCasa kitchen-scene lists — **opt-in, default `null`**
+
+Evaluate (or train-eval) in an explicit list of `[layout_id, style_id]` kitchen scenes instead
+of a `split`-derived set. RoboCasa's `pretrain` split spans 2,500 kitchen combos while a task
+fine-tune's demos typically cover a small subset, so a split-wide eval measures scene
+generalization; this field measures the in-distribution number on the policy's actual training
+kitchens (readable from a dataset's `extras/*/ep_meta.json`). robocasa's `create_env` split
+branches overwrite `layout_and_style_ids`, so the wrapper sends an explicit list with
+`split=None` and forwards the object-instance split directly — mapping `"all"` to `None`, the
+only spelling its object sampler accepts. `null` (default) keeps split-derived sampling
+unchanged.
+
 ### Fixed
 
 - **Pre-rename π₀.₅ checkpoints load again: legacy `normalize_actions.*` state-dict keys

--- a/src/opentau/envs/configs.py
+++ b/src/opentau/envs/configs.py
@@ -353,6 +353,12 @@ class RoboCasaEnv(EnvConfig):
             ``"target"``). Defaults to ``"pretrain"`` when left ``None`` — every
             task-group shortcut and concrete single-task config resolves to the
             pretrain kitchen-scene distribution; set explicitly to override.
+        layout_and_style_ids: Explicit list of ``[layout_id, style_id]`` kitchen-scene
+            pairs to sample from, overriding the ``split``-derived kitchen set (the
+            robocasa ``create_env`` precedence). Use to evaluate on a policy's exact
+            training kitchens (in-distribution) instead of the whole split — e.g. the
+            demo scenes recorded in a dataset's ``extras/*/ep_meta.json``. ``None``
+            (default) keeps the split-derived sampling.
         obj_registries: Object-mesh registries to sample assets from. Defaults to
             ``["lightwheel"]`` (the pack the asset downloader ships by default);
             add ``"objaverse"`` only after downloading that ~30GB pack.
@@ -385,6 +391,7 @@ class RoboCasaEnv(EnvConfig):
     visualization_height: int = 512
     visualization_width: int = 512
     split: str | None = None
+    layout_and_style_ids: list[list[int]] | None = None
     obj_registries: list[str] = field(default_factory=lambda: ["lightwheel"])
     assets_root: str | None = None
     auto_download_assets: bool = True
@@ -440,4 +447,6 @@ class RoboCasaEnv(EnvConfig):
         }
         if self.split is not None:
             kwargs["split"] = self.split
+        if self.layout_and_style_ids is not None:
+            kwargs["layout_and_style_ids"] = self.layout_and_style_ids
         return kwargs

--- a/src/opentau/envs/configs.py
+++ b/src/opentau/envs/configs.py
@@ -411,6 +411,18 @@ class RoboCasaEnv(EnvConfig):
     def __post_init__(self):
         if self.fps <= 0:
             raise ValueError(f"RoboCasa env.fps (control frequency in Hz) must be positive, got {self.fps}")
+        if self.layout_and_style_ids is not None:
+            if not self.layout_and_style_ids:
+                raise ValueError(
+                    "layout_and_style_ids must be a non-empty list of [layout_id, style_id] "
+                    "pairs, or null for split-derived kitchen sampling."
+                )
+            for pair in self.layout_and_style_ids:
+                if not isinstance(pair, (list, tuple)) or len(pair) != 2:
+                    raise ValueError(
+                        f"layout_and_style_ids entries must be [layout_id, style_id] pairs; got "
+                        f"{pair!r}. For a single scene write [[layout, style]], not a flat list."
+                    )
         if self.obs_type not in ("pixels", "pixels_agent_pos"):
             raise ValueError(f"Unsupported obs_type: {self.obs_type}")
 

--- a/src/opentau/envs/robocasa.py
+++ b/src/opentau/envs/robocasa.py
@@ -563,6 +563,11 @@ class RoboCasaEnv(gym.Env):
             visualization_height: Height of visualization frames.
             split: RoboCasa dataset split (``None``/``"all"``/``"pretrain"``/``"target"``);
                 ``None`` resolves to ``"pretrain"`` at env construction.
+            layout_and_style_ids: Explicit ``[layout_id, style_id]`` kitchen-scene
+                pairs to sample from instead of the ``split``-derived kitchen sets
+                (``split`` then still selects the object-instance split). ``None``
+                keeps the split-derived sampling. See the config-side docstring
+                (``RoboCasaEnv.layout_and_style_ids`` in ``envs/configs.py``).
             episode_length: Max steps per episode (``_max_episode_steps``); defaults to 1000.
             obj_registries: Object-mesh registries to sample assets from.
             episode_index: Per-worker index (``0..n_envs-1``) used as the
@@ -676,7 +681,10 @@ class RoboCasaEnv(gym.Env):
                 # with `split=None`; the object-instance split (the only other
                 # thing `split` controls) is preserved by passing it directly.
                 extra_env_kwargs["layout_and_style_ids"] = [list(p) for p in self.layout_and_style_ids]
-                extra_env_kwargs["obj_instance_split"] = split_arg
+                # Mirror create_env's own split branches: "all" maps to
+                # obj_instance_split=None there, and robocasa's object sampler
+                # accepts only "pretrain"/"target"/None.
+                extra_env_kwargs["obj_instance_split"] = None if split_arg == "all" else split_arg
                 split_arg = None
             self._env = RoboCasaGymEnv(
                 env_name=self.task,

--- a/src/opentau/envs/robocasa.py
+++ b/src/opentau/envs/robocasa.py
@@ -543,6 +543,7 @@ class RoboCasaEnv(gym.Env):
         visualization_width: int = 512,
         visualization_height: int = 512,
         split: str | None = None,
+        layout_and_style_ids: Sequence[Sequence[int]] | None = None,
         episode_length: int | None = None,
         obj_registries: Sequence[str] = DEFAULT_OBJ_REGISTRIES,
         episode_index: int = 0,
@@ -582,6 +583,12 @@ class RoboCasaEnv(gym.Env):
         self.visualization_width = visualization_width
         self.visualization_height = visualization_height
         self.split = split
+        # Normalize to hashable tuples; None keeps the split-derived kitchen sampling.
+        self.layout_and_style_ids = (
+            tuple(tuple(int(x) for x in pair) for pair in layout_and_style_ids)
+            if layout_and_style_ids is not None
+            else None
+        )
         self.obj_registries = tuple(obj_registries)
         self.episode_index = int(episode_index)
 
@@ -661,12 +668,23 @@ class RoboCasaEnv(gym.Env):
             # None/"all"/"pretrain"/"target" are valid). create_robocasa_envs resolves
             # the split for the eval path; default to "pretrain" here too so a direct
             # RoboCasaEnv(split=None) construction stays valid and consistent.
+            extra_env_kwargs: dict[str, Any] = {}
+            split_arg = self.split if self.split is not None else "pretrain"
+            if self.layout_and_style_ids is not None:
+                # robocasa's `create_env` split branches OVERWRITE
+                # `layout_and_style_ids`, so an explicit scene list must travel
+                # with `split=None`; the object-instance split (the only other
+                # thing `split` controls) is preserved by passing it directly.
+                extra_env_kwargs["layout_and_style_ids"] = [list(p) for p in self.layout_and_style_ids]
+                extra_env_kwargs["obj_instance_split"] = split_arg
+                split_arg = None
             self._env = RoboCasaGymEnv(
                 env_name=self.task,
                 camera_widths=self.observation_width,
                 camera_heights=self.observation_height,
-                split=self.split if self.split is not None else "pretrain",
+                split=split_arg,
                 obj_registries=self.obj_registries,
+                **extra_env_kwargs,
             )
 
             ep_meta = self._env.env.get_ep_meta()
@@ -794,6 +812,7 @@ def _make_env_fns(
     visualization_width: int,
     visualization_height: int,
     split: str | None,
+    layout_and_style_ids: Sequence[Sequence[int]] | None,
     episode_length: int | None,
     obj_registries: Sequence[str],
 ) -> list[Callable[[], RoboCasaEnv]]:
@@ -815,6 +834,7 @@ def _make_env_fns(
             visualization_width=visualization_width,
             visualization_height=visualization_height,
             split=split,
+            layout_and_style_ids=layout_and_style_ids,
             episode_length=episode_length,
             obj_registries=obj_registries,
             episode_index=episode_index,
@@ -925,6 +945,7 @@ def create_robocasa_envs(
     visualization_width = gym_kwargs.pop("visualization_width", 512)
     visualization_height = gym_kwargs.pop("visualization_height", 512)
     split = gym_kwargs.pop("split", None)
+    layout_and_style_ids = gym_kwargs.pop("layout_and_style_ids", None)
 
     camera_names = _parse_camera_names(camera_name)
     task_names, group_split = _resolve_tasks(str(task))
@@ -972,6 +993,7 @@ def create_robocasa_envs(
             visualization_width=visualization_width,
             visualization_height=visualization_height,
             split=split,
+            layout_and_style_ids=layout_and_style_ids,
             episode_length=task_episode_length,
             obj_registries=obj_registries,
         )

--- a/tests/envs/test_robocasa.py
+++ b/tests/envs/test_robocasa.py
@@ -1094,3 +1094,19 @@ def test_robocasa_autodownload_and_rollout_from_relocated_root(monkeypatch):
         assert "pixels" in obs
     finally:
         env.close()
+
+
+class TestLayoutAndStyleIdsValidation:
+    """Malformed scene lists must fail at config parse, not in a spawn worker."""
+
+    def test_empty_list_rejected(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            RoboCasaEnv(layout_and_style_ids=[])
+
+    def test_flat_list_rejected(self):
+        with pytest.raises(ValueError, match="flat list"):
+            RoboCasaEnv(layout_and_style_ids=[11, 26])
+
+    def test_pairs_accepted(self):
+        cfg = RoboCasaEnv(layout_and_style_ids=[[11, 26], [12, 15]])
+        assert cfg.layout_and_style_ids == [[11, 26], [12, 15]]

--- a/tests/envs/test_robocasa.py
+++ b/tests/envs/test_robocasa.py
@@ -26,6 +26,8 @@ Real sim rollouts are validated separately on a CUDA box.
 import contextlib
 import json
 import os
+import sys
+import types
 from functools import partial
 from pathlib import Path
 from unittest.mock import Mock, patch
@@ -129,6 +131,83 @@ class TestRoboCasaConfig:
 
     def test_gym_kwargs_omits_split_when_none(self):
         assert "split" not in RoboCasaEnv().gym_kwargs
+
+    def test_gym_kwargs_carries_layout_and_style_ids(self):
+        cfg = RoboCasaEnv(layout_and_style_ids=[[11, 26], [12, 15]])
+        assert cfg.gym_kwargs["layout_and_style_ids"] == [[11, 26], [12, 15]]
+
+    def test_gym_kwargs_omits_layout_and_style_ids_when_none(self):
+        assert "layout_and_style_ids" not in RoboCasaEnv().gym_kwargs
+
+
+class TestEnsureEnvSplitRerouting:
+    """`_ensure_env`'s split handling when an explicit kitchen list is set.
+
+    robocasa's `create_env` split branches OVERWRITE `layout_and_style_ids`, so
+    the wrapper must send the list with `split=None` and carry the
+    object-instance split separately — and `"all"` must reroute to
+    `obj_instance_split=None`, since the object sampler accepts only
+    `"pretrain"`/`"target"`/`None` (forwarding `"all"` verbatim raises in the
+    spawn worker at object-sampling time).
+    """
+
+    @pytest.mark.parametrize(
+        ("split", "expected_obj_split"),
+        [("pretrain", "pretrain"), ("target", "target"), ("all", None), (None, "pretrain")],
+    )
+    def test_explicit_scene_list_reroutes_split(self, split, expected_obj_split, monkeypatch):
+        from opentau.envs import robocasa as robocasa_mod
+
+        captured: dict = {}
+
+        class _FakeGymEnv:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+                self.env = types.SimpleNamespace(get_ep_meta=lambda: {"lang": "close it"})
+
+        # `_ensure_env` imports RoboCasaGymEnv lazily from
+        # `robocasa.wrappers.gym_wrapper`, so patch the module it imports from.
+        fake_mod = types.ModuleType("robocasa.wrappers.gym_wrapper")
+        fake_mod.RoboCasaGymEnv = _FakeGymEnv
+        fake_pkg = types.ModuleType("robocasa.wrappers")
+        fake_root = types.ModuleType("robocasa")
+        monkeypatch.setitem(sys.modules, "robocasa", fake_root)
+        monkeypatch.setitem(sys.modules, "robocasa.wrappers", fake_pkg)
+        monkeypatch.setitem(sys.modules, "robocasa.wrappers.gym_wrapper", fake_mod)
+        env = robocasa_mod.RoboCasaEnv(
+            task="CloseCabinet",
+            camera_name=["robot0_eye_in_hand"],
+            split=split,
+            layout_and_style_ids=[[11, 26]],
+        )
+        env._ensure_env()
+        assert captured["split"] is None
+        assert captured["obj_instance_split"] == expected_obj_split
+        assert captured["layout_and_style_ids"] == [[11, 26]]
+
+    def test_no_scene_list_keeps_split_verbatim(self, monkeypatch):
+        from opentau.envs import robocasa as robocasa_mod
+
+        captured: dict = {}
+
+        class _FakeGymEnv:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+                self.env = types.SimpleNamespace(get_ep_meta=lambda: {"lang": "close it"})
+
+        # `_ensure_env` imports RoboCasaGymEnv lazily from
+        # `robocasa.wrappers.gym_wrapper`, so patch the module it imports from.
+        fake_mod = types.ModuleType("robocasa.wrappers.gym_wrapper")
+        fake_mod.RoboCasaGymEnv = _FakeGymEnv
+        fake_pkg = types.ModuleType("robocasa.wrappers")
+        fake_root = types.ModuleType("robocasa")
+        monkeypatch.setitem(sys.modules, "robocasa", fake_root)
+        monkeypatch.setitem(sys.modules, "robocasa.wrappers", fake_pkg)
+        monkeypatch.setitem(sys.modules, "robocasa.wrappers.gym_wrapper", fake_mod)
+        env = robocasa_mod.RoboCasaEnv(task="CloseCabinet", camera_name=["robot0_eye_in_hand"], split="all")
+        env._ensure_env()
+        assert captured["split"] == "all"
+        assert "layout_and_style_ids" not in captured
 
 
 class TestMakeEnvConfigRoboCasa:


### PR DESCRIPTION
## What this does

Adds `env.layout_and_style_ids` to the RoboCasa env config: an explicit list of `[layout_id, style_id]` kitchen-scene pairs to evaluate in, overriding the `split`-derived kitchen sets. The list is threaded from the config through `create_robocasa_envs` and the gym wrapper into robocasa's `create_env`.

**Why.** RoboCasa's `pretrain` split spans 50x50 = 2,500 kitchen combos, while a task fine-tune's demos typically cover a small subset (the CloseCabinet set: 105 human demos across 104 distinct kitchens, recorded in the dataset's `extras/*/ep_meta.json`). A split-wide eval therefore measures *scene generalization*, and there was no way to measure the *in-distribution* number on a policy's actual training kitchens. This field closes that gap — it explains, for example, a 65% README-era report versus 33-44% under split-wide eval for the same checkpoint.

One robocasa interaction handled explicitly: `create_env`'s `split` branches **overwrite** `layout_and_style_ids`, so an explicit list travels with `split=None` while the object-instance split (the only other thing `split` controls) is passed directly — the config's `split` semantics are preserved for object sampling.

## How it was tested

- Config-level: the field round-trips through draccus and `gym_kwargs` (pairs list preserved, absent by default).
- End-to-end on an internal 8-GPU cluster: a 104-episode eval of a CloseCabinet checkpoint restricted to its 104 training kitchens scored **55.8%**, versus 32.8%/43.75% (two seed sets, n=64) for the same checkpoint split-wide — the restriction is demonstrably effective, and the in-distribution number lands where the original training-era report put it.
- `tests/envs/` CPU suite: 210 passed (3 pre-existing local-environment failures unrelated to this change, green in CI on the same base).

## How to checkout & try? (for the reviewer)

```bash
git fetch origin claude/robocasa-scene-ids-passthrough
git checkout claude/robocasa-scene-ids-passthrough
uv run pytest tests/envs/ -m "not gpu and not network" -q
```

In an eval config: `"env": {"type": "robocasa", "task": "CloseCabinet", "layout_and_style_ids": [[11, 26], [12, 15]], ...}` — episodes then sample scenes only from the listed kitchens.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.
