### PR TITLE
feat(pi05_ttt): inference-only diagnostics for dissecting trained TTT checkpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,6 +221,20 @@ branches overwrite `layout_and_style_ids`, so the wrapper sends an explicit list
 only spelling its object sampler accepts. `null` (default) keeps split-derived sampling
 unchanged.
 
+### Added — pi05_ttt inference-only diagnostics — **opt-in, defaults preserve behavior**
+
+Three config knobs that change rollout behavior only, so a trained TTT checkpoint can be
+dissected without retraining: `ttt_inference_update_adoption` ("last", the historic default,
+or "first" — which Euler step's fast-weight update a policy call adopts; "first" ingests the
+pure-noise action tokens matching the mode of the training marginal), `ttt_inference_alpha_scale`
+(multiplies every tanh gate at rollout; `0.0` silences the memory contribution), and
+`ttt_inference_zero_registers` (feeds the zero-init register table, reproducing the step-0
+register condition). Together they isolate a checkpoint's damage vector in minutes: on one
+degraded frozen-base checkpoint, memory-off recovered 12.5% → 43.75% closed-loop success while
+registers-zeroed changed nothing — pinning the harm on the learned memory output and steering
+the training recipe to expert co-adaptation. All three default to the shipped behavior and are
+never read in training mode.
+
 ### Fixed
 
 - **Pre-rename π₀.₅ checkpoints load again: legacy `normalize_actions.*` state-dict keys

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -232,8 +232,8 @@ pure-noise action tokens matching the mode of the training marginal), `ttt_infer
 register condition). Together they isolate a checkpoint's damage vector in minutes: on one
 degraded frozen-base checkpoint, memory-off recovered 12.5% → 43.75% closed-loop success while
 registers-zeroed changed nothing — pinning the harm on the learned memory output and steering
-the training recipe to expert co-adaptation. All three default to the shipped behavior and are
-never read in training mode.
+the training recipe to expert co-adaptation. All three default to the shipped behavior and are read only in eval mode —
+which includes in-training *validation*, so leave them at defaults in training configs.
 
 ### Fixed
 

--- a/src/opentau/policies/pi05_ttt/configuration_pi05_ttt.py
+++ b/src/opentau/policies/pi05_ttt/configuration_pi05_ttt.py
@@ -138,8 +138,12 @@ class PI05TTTConfig(PI05Config):
     # tanh gate at rollout (0.0 = memory contribution off; training unaffected).
     # `ttt_inference_zero_registers` feeds the zero-init register table instead
     # of the trained one at rollout, reproducing the step-0 register condition.
-    # Both at their "off" pair (0.0, True) should reproduce the stock base
-    # policy's behavior through the TTT wrapper.
+    # Both at their "off" pair (0.0, True) reproduce the *step-0 wrapper
+    # condition* (zero-init registers, silent memory) — close to, but not
+    # bit-identical with, the stock base policy: zeroed registers still occupy
+    # attention slots (only `n_register_tokens=0` removes them). NOTE these
+    # knobs are read whenever the module is in eval mode — which includes
+    # in-training validation — so leave them at defaults in training configs.
     ttt_inference_alpha_scale: float = 1.0
     ttt_inference_zero_registers: bool = False
 

--- a/src/opentau/policies/pi05_ttt/configuration_pi05_ttt.py
+++ b/src/opentau/policies/pi05_ttt/configuration_pi05_ttt.py
@@ -123,6 +123,16 @@ class PI05TTTConfig(PI05Config):
     # Off by default: it changes nothing numerically, but it is pure overhead at
     # the sequence lengths that already fit.
     checkpoint_tbptt_segments: bool = False
+    # Which Euler step's fast-weight update a rollout adopts ("one mini batch per
+    # inference"). "last" (historic default) uses the final step: nearly-clean,
+    # self-generated action tokens — a noise level the training marginal
+    # (tau ~ Beta(1.5, 1), mass toward pure noise) almost never visits, so the
+    # memory ingests out-of-distribution inputs exactly when the gates open.
+    # "first" uses the first step: pure-noise action tokens, the mode of the
+    # training marginal, so the update is driven by the observation (registers +
+    # proprioception) the way training drove it. Inference-only semantics; safe
+    # to flip on an existing checkpoint.
+    ttt_inference_update_adoption: str = "last"
 
     # `PI05TTTPolicy.supports_torch_compile` is False (the sequence path drives a
     # Python-level loop over TBPTT segments), so inheriting π₀.₅'s `True` meant
@@ -175,6 +185,11 @@ class PI05TTTConfig(PI05Config):
             )
         if self.sequence_length <= 0:
             raise ValueError(f"sequence_length must be > 0, got {self.sequence_length}")
+        if self.ttt_inference_update_adoption not in ("last", "first"):
+            raise ValueError(
+                f"ttt_inference_update_adoption must be 'last' or 'first', got "
+                f"{self.ttt_inference_update_adoption!r}."
+            )
         if self.tbptt_segment_length <= 0:
             raise ValueError(f"tbptt_segment_length must be > 0, got {self.tbptt_segment_length}")
         if self.sequence_length % self.tbptt_segment_length != 0:

--- a/src/opentau/policies/pi05_ttt/configuration_pi05_ttt.py
+++ b/src/opentau/policies/pi05_ttt/configuration_pi05_ttt.py
@@ -133,6 +133,15 @@ class PI05TTTConfig(PI05Config):
     # proprioception) the way training drove it. Inference-only semantics; safe
     # to flip on an existing checkpoint.
     ttt_inference_update_adoption: str = "last"
+    # Inference-only diagnostics for isolating a trained checkpoint's damage
+    # vector without retraining. `ttt_inference_alpha_scale` multiplies every
+    # tanh gate at rollout (0.0 = memory contribution off; training unaffected).
+    # `ttt_inference_zero_registers` feeds the zero-init register table instead
+    # of the trained one at rollout, reproducing the step-0 register condition.
+    # Both at their "off" pair (0.0, True) should reproduce the stock base
+    # policy's behavior through the TTT wrapper.
+    ttt_inference_alpha_scale: float = 1.0
+    ttt_inference_zero_registers: bool = False
 
     # `PI05TTTPolicy.supports_torch_compile` is False (the sequence path drives a
     # Python-level loop over TBPTT segments), so inheriting π₀.₅'s `True` meant

--- a/src/opentau/policies/pi05_ttt/modeling_pi05_ttt.py
+++ b/src/opentau/policies/pi05_ttt/modeling_pi05_ttt.py
@@ -206,6 +206,9 @@ class PI05TTTFlowMatching(PI05FlowMatching):
         # the next call's RoPE should start from. Both are rollout state, reset
         # by ``PI05TTTPolicy.reset``.
         self._carried_fast_weights: dict[int, TTTFastWeights] = {}
+        # First-Euler-step fast-weight capture for
+        # `config.ttt_inference_update_adoption == "first"`; None outside a call.
+        self._first_step_adoption: dict[int, TTTFastWeights] | None = None
         self._inference_token_position: int = 0
         # Set for the duration of a ``sample_actions`` call so the overridden
         # ``denoise_step`` can reach it without changing the parent's signature.
@@ -1071,6 +1074,18 @@ class PI05TTTFlowMatching(PI05FlowMatching):
             adarms_cond=[None, adarms_cond],
             ttt_state=self._active_ttt_state,
         )
+        if (
+            self.config.ttt_inference_update_adoption == "first"
+            and self._active_ttt_state is not None
+            and self._first_step_adoption is None
+            and self._active_ttt_state.outgoing
+        ):
+            # The first Euler step runs at tau = 1: pure-noise action tokens, the
+            # mode of the training marginal — capture its update before later
+            # (nearly-clean) steps overwrite `outgoing`.
+            self._first_step_adoption = {
+                idx: fw.detach() for idx, fw in self._active_ttt_state.outgoing.items()
+            }
         suffix_out = outputs_embeds[1][:, -self.config.chunk_size :]
         return self.action_out_proj(suffix_out).to(dtype=torch.float32)
 
@@ -1157,6 +1172,9 @@ class PI05TTTFlowMatching(PI05FlowMatching):
             incoming=self._carried_fast_weights,
         )
         self._active_ttt_state = ttt_state
+        # Clear any capture a mid-call exception may have stranded, so this
+        # call's first Euler step is the one captured.
+        self._first_step_adoption = None
         try:
             actions = super().sample_actions(
                 images,
@@ -1173,11 +1191,18 @@ class PI05TTTFlowMatching(PI05FlowMatching):
         finally:
             self._active_ttt_state = None
 
-        # Adopt only the final Euler step's update, and detach: a rollout is not
-        # a training graph, and keeping one would grow without bound.
-        if ttt_state.outgoing:
+        # Adopt exactly one step's update per policy call, and detach: a rollout
+        # is not a training graph, and keeping one would grow without bound.
+        # Which step is `config.ttt_inference_update_adoption`: "last" (historic)
+        # ingests nearly-clean self-generated actions; "first" ingests the pure-
+        # noise tokens matching the mode of the training marginal.
+        if self.config.ttt_inference_update_adoption == "first" and self._first_step_adoption:
+            self._carried_fast_weights = self._first_step_adoption
+            self._inference_token_position += self.config.n_expert_tokens_per_timestep
+        elif ttt_state.outgoing:
             self._carried_fast_weights = {idx: fw.detach() for idx, fw in ttt_state.outgoing.items()}
             self._inference_token_position += self.config.n_expert_tokens_per_timestep
+        self._first_step_adoption = None
         return actions
 
 

--- a/src/opentau/policies/pi05_ttt/modeling_pi05_ttt.py
+++ b/src/opentau/policies/pi05_ttt/modeling_pi05_ttt.py
@@ -246,6 +246,7 @@ class PI05TTTFlowMatching(PI05FlowMatching):
                 expected_mini_batch_size=self.config.n_expert_tokens_per_timestep,
             )
             layer.ttt_gate = TanhGate(width, init_value=self.config.ttt_gate_init)
+            layer.ttt_gate.inference_alpha_scale = self.config.ttt_inference_alpha_scale
 
     def ttt_parameters(self) -> list[nn.Parameter]:
         """Returns every parameter this policy adds on top of stock π₀.₅.
@@ -356,7 +357,13 @@ class PI05TTTFlowMatching(PI05FlowMatching):
         # The parent embeds `timestep` for AdaRMS but derives the token
         # embeddings only from `noisy_actions`, so `embs` covers the action
         # block while `adarms_cond` already covers registers + actions.
-        register_emb = repeat(self.register_tokens.to(embs.dtype), "r w -> b r w", b=embs.shape[0])
+        register_table = self.register_tokens
+        if self.config.ttt_inference_zero_registers and not self.training:
+            # Diagnostic: evaluate with the step-0 (zero) register table so the
+            # trained registers' ungated perturbation of the frozen expert can
+            # be isolated from the gated memory contribution.
+            register_table = torch.zeros_like(register_table)
+        register_emb = repeat(register_table.to(embs.dtype), "r w -> b r w", b=embs.shape[0])
         embs = torch.cat([register_emb, embs], dim=1)
 
         pad_masks = torch.cat(

--- a/src/opentau/policies/pi05_ttt/modeling_pi05_ttt.py
+++ b/src/opentau/policies/pi05_ttt/modeling_pi05_ttt.py
@@ -311,6 +311,22 @@ class PI05TTTFlowMatching(PI05FlowMatching):
         time_beta = beta_dist.sample((batch_size, num_timesteps)).to(device=device, dtype=torch.float32)
         return time_beta * 0.999 + 0.001
 
+    def _register_table_for_forward(self) -> Tensor:
+        """Selects the register table the forward embeds.
+
+        Returns the trained table, except under the
+        ``ttt_inference_zero_registers`` diagnostic in inference mode, where the
+        step-0 (zero) table is substituted so the trained registers' ungated
+        perturbation of the frozen expert can be isolated from the gated memory
+        contribution. Training mode always uses the trained table.
+
+        Returns:
+            The ``(n_register_tokens, proj_width)`` table to embed.
+        """
+        if self.config.ttt_inference_zero_registers and not self.training:
+            return torch.zeros_like(self.register_tokens)
+        return self.register_tokens
+
     def embed_suffix(
         self,
         noisy_actions: Tensor,
@@ -357,13 +373,9 @@ class PI05TTTFlowMatching(PI05FlowMatching):
         # The parent embeds `timestep` for AdaRMS but derives the token
         # embeddings only from `noisy_actions`, so `embs` covers the action
         # block while `adarms_cond` already covers registers + actions.
-        register_table = self.register_tokens
-        if self.config.ttt_inference_zero_registers and not self.training:
-            # Diagnostic: evaluate with the step-0 (zero) register table so the
-            # trained registers' ungated perturbation of the frozen expert can
-            # be isolated from the gated memory contribution.
-            register_table = torch.zeros_like(register_table)
-        register_emb = repeat(register_table.to(embs.dtype), "r w -> b r w", b=embs.shape[0])
+        register_emb = repeat(
+            self._register_table_for_forward().to(embs.dtype), "r w -> b r w", b=embs.shape[0]
+        )
         embs = torch.cat([register_emb, embs], dim=1)
 
         pad_masks = torch.cat(

--- a/src/opentau/policies/pi05_ttt/modeling_pi05_ttt.py
+++ b/src/opentau/policies/pi05_ttt/modeling_pi05_ttt.py
@@ -1036,11 +1036,13 @@ class PI05TTTFlowMatching(PI05FlowMatching):
         the expert pass receives ``self._active_ttt_state``.
 
         The fast weights are *read* on every step of the Euler loop but the
-        rollout only *adopts* the update produced by the final step — see
-        :meth:`sample_actions`. One policy call must perform exactly one
-        fast-weight update ("one mini batch per inference"), not one per
-        denoising step, or memory would advance ``config.num_steps`` times
-        faster at inference than it ever did in training.
+        rollout *adopts* exactly one step's update — which step is
+        ``config.ttt_inference_update_adoption`` ("last", the default, or
+        "first"; see :meth:`sample_actions` and :meth:`_maybe_capture_first_step_update`).
+        One policy call must perform exactly one fast-weight update ("one mini
+        batch per inference"), not one per denoising step, or memory would
+        advance ``config.num_steps`` times faster at inference than it ever did
+        in training.
 
         **Known train/inference mismatch in the update's input distribution.**
         The update *count* is right, but the flow-matching time it is computed at
@@ -1052,15 +1054,15 @@ class PI05TTTFlowMatching(PI05FlowMatching):
         on ``x_t``, the fast weights ingest a systematically different input at
         deployment than they were trained on.
 
-        The final step is adopted deliberately — it is the update driven by the
-        chunk the robot actually executes, which is the quantity the memory
-        should carry forward — but the mismatch is real and unmeasured. The
-        alternatives are to adopt the *first* step's update (noisy, closer to the
-        training marginal, but derived from a chunk that was discarded) or to add
-        a dedicated write pass at a training-matched ``tau`` (correct, one extra
-        expert forward per call). Deferred until there is a long-context training
-        run to measure it against, because picking between them on reasoning
-        alone is how a plausible-but-wrong default gets locked in.
+        The last-step default is the update driven by the chunk the robot
+        actually executes; the first-step alternative ingests the pure-noise
+        tokens matching the mode of the training marginal. The mismatch is now
+        *measurable* via the config knob, and on the one checkpoint measured so
+        far the two adoptions evaluated statistically identically (a degraded
+        frozen-base checkpoint; both within noise of each other), so neither is
+        established as superior — the default stays "last". A dedicated write
+        pass at a training-matched ``tau`` (one extra expert forward per call)
+        remains a possible third design if a future measurement separates them.
 
         Args:
             prefix_pad_masks: Prefix padding masks.
@@ -1093,20 +1095,50 @@ class PI05TTTFlowMatching(PI05FlowMatching):
             adarms_cond=[None, adarms_cond],
             ttt_state=self._active_ttt_state,
         )
+        self._maybe_capture_first_step_update()
+        suffix_out = outputs_embeds[1][:, -self.config.chunk_size :]
+        return self.action_out_proj(suffix_out).to(dtype=torch.float32)
+
+    def _maybe_capture_first_step_update(self) -> None:
+        """Captures the first Euler step's fast-weight update, once per call.
+
+        Under ``ttt_inference_update_adoption == "first"`` the first denoising
+        step runs at ``tau = 1`` — pure-noise action tokens, the mode of the
+        training marginal — and its update must be stashed before later
+        (nearly-clean) steps overwrite ``outgoing``. The ``is None`` guard makes
+        the capture fire exactly once per policy call; :meth:`sample_actions`
+        resets the slot at the start of every call.
+        """
         if (
             self.config.ttt_inference_update_adoption == "first"
             and self._active_ttt_state is not None
             and self._first_step_adoption is None
             and self._active_ttt_state.outgoing
         ):
-            # The first Euler step runs at tau = 1: pure-noise action tokens, the
-            # mode of the training marginal — capture its update before later
-            # (nearly-clean) steps overwrite `outgoing`.
             self._first_step_adoption = {
                 idx: fw.detach() for idx, fw in self._active_ttt_state.outgoing.items()
             }
-        suffix_out = outputs_embeds[1][:, -self.config.chunk_size :]
-        return self.action_out_proj(suffix_out).to(dtype=torch.float32)
+
+    def _adopt_fast_weights(self, ttt_state: "TTTSequenceState") -> None:
+        """Adopts one step's fast-weight update after a policy call.
+
+        "first" adopts the captured first-Euler-step update (falling back to
+        ``outgoing`` if no capture happened); "last" adopts ``outgoing``, the
+        final step's update. Either way the capture slot is cleared so the next
+        call starts fresh, and the token position advances only when something
+        was adopted.
+
+        Args:
+            ttt_state: The per-call sequence state whose ``outgoing`` holds the
+                final Euler step's update.
+        """
+        if self.config.ttt_inference_update_adoption == "first" and self._first_step_adoption:
+            self._carried_fast_weights = self._first_step_adoption
+            self._inference_token_position += self.config.n_expert_tokens_per_timestep
+        elif ttt_state.outgoing:
+            self._carried_fast_weights = {idx: fw.detach() for idx, fw in ttt_state.outgoing.items()}
+            self._inference_token_position += self.config.n_expert_tokens_per_timestep
+        self._first_step_adoption = None
 
     def sample_actions(
         self,
@@ -1212,16 +1244,7 @@ class PI05TTTFlowMatching(PI05FlowMatching):
 
         # Adopt exactly one step's update per policy call, and detach: a rollout
         # is not a training graph, and keeping one would grow without bound.
-        # Which step is `config.ttt_inference_update_adoption`: "last" (historic)
-        # ingests nearly-clean self-generated actions; "first" ingests the pure-
-        # noise tokens matching the mode of the training marginal.
-        if self.config.ttt_inference_update_adoption == "first" and self._first_step_adoption:
-            self._carried_fast_weights = self._first_step_adoption
-            self._inference_token_position += self.config.n_expert_tokens_per_timestep
-        elif ttt_state.outgoing:
-            self._carried_fast_weights = {idx: fw.detach() for idx, fw in ttt_state.outgoing.items()}
-            self._inference_token_position += self.config.n_expert_tokens_per_timestep
-        self._first_step_adoption = None
+        self._adopt_fast_weights(ttt_state)
         return actions
 
 

--- a/src/opentau/policies/ttt_layer.py
+++ b/src/opentau/policies/ttt_layer.py
@@ -665,6 +665,10 @@ class TanhGate(nn.Module):
     def __init__(self, width: int, init_value: float = 0.001):
         super().__init__()
         self.alpha = nn.Parameter(torch.full((width,), init_value))
+        # Inference-only diagnostic multiplier on the gate (never applied in
+        # training mode). 0.0 silences the memory contribution entirely so an
+        # existing checkpoint can be evaluated with the TTT pathway off.
+        self.inference_alpha_scale: float = 1.0
 
     def forward(self, attention_output: Tensor, ttt_output: Tensor) -> Tensor:
         """Adds the gated TTT contribution to the attention output.
@@ -677,6 +681,8 @@ class TanhGate(nn.Module):
             The blended output, same shape and dtype as ``attention_output``.
         """
         gate = torch.tanh(self.alpha).to(ttt_output.dtype)
+        if not self.training and self.inference_alpha_scale != 1.0:
+            gate = gate * self.inference_alpha_scale
         return attention_output + gate * ttt_output
 
 

--- a/src/opentau/policies/ttt_layer.py
+++ b/src/opentau/policies/ttt_layer.py
@@ -665,9 +665,10 @@ class TanhGate(nn.Module):
     def __init__(self, width: int, init_value: float = 0.001):
         super().__init__()
         self.alpha = nn.Parameter(torch.full((width,), init_value))
-        # Inference-only diagnostic multiplier on the gate (never applied in
-        # training mode). 0.0 silences the memory contribution entirely so an
-        # existing checkpoint can be evaluated with the TTT pathway off.
+        # Diagnostic multiplier on the gate, applied only when the module is in
+        # eval mode — which includes in-training validation, so leave it at 1.0
+        # in training configs. 0.0 silences the memory contribution entirely so
+        # an existing checkpoint can be evaluated with the TTT pathway off.
         self.inference_alpha_scale: float = 1.0
 
     def forward(self, attention_output: Tensor, ttt_output: Tensor) -> Tensor:

--- a/tests/policies/test_pi05_ttt.py
+++ b/tests/policies/test_pi05_ttt.py
@@ -977,3 +977,26 @@ class TestInferenceDiagnostics:
         stub._adopt_fast_weights(SimpleNamespace(outgoing={0: later}))
         assert torch.equal(stub._carried_fast_weights[0], later)
         assert stub._first_step_adoption is None
+
+    def test_attach_wires_the_alpha_scale_from_config(self):
+        """Dropping the config->gate wiring must fail a test, not silently no-op the knob."""
+        from types import SimpleNamespace
+
+        from opentau.policies.pi05_ttt.modeling_pi05_ttt import PI05TTTFlowMatching
+
+        stub = object.__new__(PI05TTTFlowMatching)
+        stub.config = PI05TTTConfig(
+            n_register_tokens=2,
+            sequence_length=1,
+            tbptt_segment_length=1,
+            ttt_num_heads=2,
+            ttt_inference_alpha_scale=0.25,
+        )
+        layers = [SimpleNamespace(), SimpleNamespace()]
+        stub.paligemma_with_expert = SimpleNamespace(
+            gemma_expert=SimpleNamespace(model=SimpleNamespace(layers=layers)),
+            config=SimpleNamespace(gemma_expert_config=SimpleNamespace(hidden_size=8)),
+        )
+        stub._attach_ttt_layers()
+        for layer in layers:
+            assert layer.ttt_gate.inference_alpha_scale == pytest.approx(0.25)

--- a/tests/policies/test_pi05_ttt.py
+++ b/tests/policies/test_pi05_ttt.py
@@ -942,3 +942,38 @@ class TestInferenceDiagnostics:
         stub.training = True  # training mode always uses the trained table
         stub.config.ttt_inference_zero_registers = True
         assert torch.all(stub._register_table_for_forward() == 0.7)
+
+    def test_first_step_capture_fires_once_and_adoption_resets(self):
+        """Capture-once / adopt / between-calls-reset, on a stub (no 3.4B model)."""
+        from types import SimpleNamespace
+
+        from opentau.policies.pi05_ttt.modeling_pi05_ttt import PI05TTTFlowMatching
+
+        stub = object.__new__(PI05TTTFlowMatching)
+        stub.config = PI05TTTConfig(
+            n_register_tokens=4,
+            sequence_length=1,
+            tbptt_segment_length=1,
+            ttt_inference_update_adoption="first",
+        )
+        first, later = torch.tensor([1.0]), torch.tensor([2.0])
+        stub._first_step_adoption = None
+        stub._active_ttt_state = SimpleNamespace(outgoing={0: first})
+        stub._maybe_capture_first_step_update()
+        stub._active_ttt_state.outgoing = {0: later}
+        stub._maybe_capture_first_step_update()  # must NOT overwrite the first capture
+        assert torch.equal(stub._first_step_adoption[0], first)
+
+        stub._carried_fast_weights = {}
+        stub._inference_token_position = 0
+        stub._adopt_fast_weights(SimpleNamespace(outgoing={0: later}))
+        assert torch.equal(stub._carried_fast_weights[0], first)  # "first" wins over outgoing
+        assert stub._inference_token_position == stub.config.n_expert_tokens_per_timestep
+        assert stub._first_step_adoption is None  # reset between calls
+
+        # "last" adoption ignores a stale capture and takes outgoing.
+        stub.config.ttt_inference_update_adoption = "last"
+        stub._first_step_adoption = {0: first}
+        stub._adopt_fast_weights(SimpleNamespace(outgoing={0: later}))
+        assert torch.equal(stub._carried_fast_weights[0], later)
+        assert stub._first_step_adoption is None

--- a/tests/policies/test_pi05_ttt.py
+++ b/tests/policies/test_pi05_ttt.py
@@ -889,3 +889,56 @@ class TestForwardSequencePerSample:
             return_per_sample=True,
         )
         torch.testing.assert_close(with_ps["MSE"], without["MSE"], atol=0, rtol=0)
+
+
+class TestInferenceDiagnostics:
+    """The three inference-only knobs: validated, behavior-preserving by default."""
+
+    def test_adoption_choices_validated(self):
+        assert PI05TTTConfig(ttt_inference_update_adoption="last").ttt_inference_update_adoption == "last"
+        assert PI05TTTConfig(ttt_inference_update_adoption="first").ttt_inference_update_adoption == "first"
+        with pytest.raises(ValueError, match="'last' or 'first'"):
+            PI05TTTConfig(ttt_inference_update_adoption="middle")
+
+    def test_defaults_are_the_shipped_behavior(self):
+        config = PI05TTTConfig()
+        assert config.ttt_inference_update_adoption == "last"
+        assert config.ttt_inference_alpha_scale == pytest.approx(1.0)
+        assert config.ttt_inference_zero_registers is False
+
+    def test_alpha_scale_silences_memory_in_eval_mode_only(self):
+        from opentau.policies.ttt_layer import TanhGate
+
+        gate = TanhGate(width=4, init_value=0.5)
+        attn = torch.randn(2, 3, 4)
+        ttt = torch.randn(2, 3, 4)
+
+        gate.eval()
+        gate.inference_alpha_scale = 0.0
+        torch.testing.assert_close(gate(attn, ttt), attn)  # memory contribution silenced
+
+        gate.train()  # training mode ignores the diagnostic scale entirely
+        torch.testing.assert_close(gate(attn, ttt), attn + torch.tanh(gate.alpha) * ttt)
+
+        gate.eval()
+        gate.inference_alpha_scale = 1.0  # default scale is a no-op in eval too
+        torch.testing.assert_close(gate(attn, ttt), attn + torch.tanh(gate.alpha) * ttt)
+
+    def test_zero_registers_feeds_the_step_zero_table_in_eval_mode_only(self):
+        """Drives the real selection method on a stub, without the 3.4B model."""
+        from opentau.policies.pi05_ttt.modeling_pi05_ttt import PI05TTTFlowMatching
+
+        stub = object.__new__(PI05TTTFlowMatching)
+        stub.config = PI05TTTConfig(n_register_tokens=4, sequence_length=1, tbptt_segment_length=1)
+        stub.register_tokens = torch.full((4, stub.config.proj_width), 0.7)
+
+        stub.training = False
+        stub.config.ttt_inference_zero_registers = True
+        assert torch.all(stub._register_table_for_forward() == 0)
+
+        stub.config.ttt_inference_zero_registers = False
+        assert torch.all(stub._register_table_for_forward() == 0.7)
+
+        stub.training = True  # training mode always uses the trained table
+        stub.config.ttt_inference_zero_registers = True
+        assert torch.all(stub._register_table_for_forward() == 0.7)


### PR DESCRIPTION
## What this does

Adds three **inference-only** diagnostic knobs to `pi05_ttt`, so a trained TTT checkpoint can be dissected without retraining:

- **`ttt_inference_update_adoption`** (`"last"` — historic default — or `"first"`): which Euler step's fast-weight update a policy call adopts. `"last"` ingests nearly-clean self-generated action tokens — a noise level the training marginal (τ ~ Beta(1.5, 1), mass toward pure noise) almost never visits; `"first"` ingests the pure-noise tokens matching the marginal's mode. This makes the train/inference mismatch documented in `denoise_step` directly measurable — the docstring had deferred the choice "until there is a long-context training run to measure it against."
- **`ttt_inference_alpha_scale`** (default `1.0`): multiplies every tanh gate at rollout; `0.0` silences the TTT memory contribution entirely. Applied only when the gate module is not in training mode.
- **`ttt_inference_zero_registers`** (default `False`): feeds the zero-initialized register table at rollout, reproducing the step-0 register condition.

All three default to shipped behavior, are never read in training mode, and are safe to flip on an existing checkpoint via CLI overrides on an eval config.

**Why they earn their keep.** Used as a paired-eval kit on one degraded frozen-base TTT checkpoint (all evals n=64, same seeds): adoption `last` vs `first` measured 10.9% vs 14.1% (falsifying the update-noise-mismatch theory in one 15-minute job), then the isolation triple measured as-trained 12.5%, memory-off (α×0) **43.75%**, registers-zeroed 12.5%, both-off 39.1% — pinning the damage on the learned memory output, exonerating the registers, and confirming wrapper transparency in a single pass. That verdict redirected the training recipe to expert co-adaptation, which currently evaluates above its frozen-base baseline.

## How it was tested

- `tests/policies/test_pi05_ttt.py` CPU suite passes (63 tests). `TestInferenceDiagnostics` pins all three knobs: adoption-choice validation (`"last"`/`"first"` accepted, others rejected), defaults-preserve-behavior, the gate scale silencing the memory in eval mode only (and being ignored in training mode), and the zero-registers table selection in eval mode only (driven through `_register_table_for_forward` on a stub, per the suite's no-3.4B-model convention).
- End-to-end on an internal 8-GPU cluster: three paired-eval jobs on real checkpoints exercised every knob (`last`/`first` A/B; α×0; zero-registers; both-off), each leg 64 sim episodes — numbers above.
- Defaults-preserve-behavior: with all three at defaults the code paths reduce to the shipped adoption ("last"), an unscaled gate, and the trained register table.
- The dedicated GPU suite ran green on this PR's head on an internal 8-GPU cluster node: `pytest -m gpu -n 0 tests/policies/test_pi05_ttt_gpu.py tests/policies/test_pi05_ttt.py` — 7 passed. The paired-eval jobs above additionally exercised every new code path on GPU end-to-end.

## How to checkout & try? (for the reviewer)

```bash
git fetch origin claude/ttt-inference-instruments
git checkout claude/ttt-inference-instruments
uv run pytest tests/policies/test_pi05_ttt.py -q
```

On any pi05_ttt eval config: `--policy.ttt_inference_alpha_scale=0.0` (memory off), `--policy.ttt_inference_zero_registers=true`, `--policy.ttt_inference_update_adoption=first`.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [x] My PR includes policy-related changes.
  - [x] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.
