### PR TITLE
feat(grpc)!: rename api-key auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -274,6 +274,29 @@ which includes in-training *validation*, so leave them at defaults in training c
   fits the dataset's shortest episodes. The stride-1 recipe used by the original pi05_ttt
   validation is deliberately rejected now — it silently optimizes the copy shortcut.
 
+### Changed — gRPC api-key auth renamed to `x-bicameral-api-key` / `BICAMERAL_INFERENCE_API_KEY` — **breaking on both, no `config_version` bump**
+
+`ApiKeyInterceptor` reads the key from the `x-bicameral-api-key` metadata
+header, and the `UNAUTHENTICATED` message names that header. `interceptor_from_env`
+reads the expected key from `BICAMERAL_INFERENCE_API_KEY`. The previous
+`x-tuner-api-key` and `TUNER_INFERENCE_API_KEY` are gone rather than accepted
+alongside: a dual-header transition leaves a second, unrouted spelling that
+whatever sits in front of this server never sees.
+
+Migration, and the two failure modes are not alike:
+
+* **Clients** send `x-bicameral-api-key` instead. A client left on the old
+  header fails closed, with `UNAUTHENTICATED` naming the header it should have
+  sent. A proxy in front of the server should be renamed too rather than made
+  to translate between the two.
+* **Whoever launches the server** sets `BICAMERAL_INFERENCE_API_KEY` instead.
+  This one fails *open*: auth is opt-in, so a launcher still exporting the old
+  name leaves the variable unset, and an unset variable means no interceptor
+  and an unauthenticated server. There is no error to notice. Rename the
+  launcher and the server together.
+
+Servers that never enabled authentication are unaffected.
+
 ## [0.13.0] - 2026-08-17
 
 ### Added

--- a/src/opentau/scripts/grpc/auth.py
+++ b/src/opentau/scripts/grpc/auth.py
@@ -15,11 +15,16 @@
 """Optional API-key authentication for the robot inference gRPC server.
 
 Authentication is opt-in: it is activated only when the
-``TUNER_INFERENCE_API_KEY`` environment variable is set to a non-empty value.
-When active, every RPC must carry the matching key in the ``x-tuner-api-key``
-metadata header; otherwise the call is rejected with ``UNAUTHENTICATED``.
-When the variable is unset/empty the server runs with no authentication (the
-historical behavior), so this is fully backward compatible.
+``BICAMERAL_INFERENCE_API_KEY`` environment variable is set to a non-empty
+value. When active, every RPC must carry the matching key in the
+``x-bicameral-api-key`` metadata header; otherwise the call is rejected with
+``UNAUTHENTICATED``. When the variable is unset/empty the server runs with no
+authentication (the historical behavior), so this is fully backward
+compatible.
+
+That default cuts both ways: whoever launches this server owns the variable's
+spelling, and getting it wrong does not fail loudly — it starts an unprotected
+server. Rename it on both sides at once.
 
 This module deliberately depends only on ``grpc`` (not torch / the policy
 stack) so the auth logic can be unit-tested cheaply, CPU-only.
@@ -35,12 +40,12 @@ import grpc
 
 logger = logging.getLogger(__name__)
 
-API_KEY_HEADER = "x-tuner-api-key"
-API_KEY_ENV = "TUNER_INFERENCE_API_KEY"
+API_KEY_HEADER = "x-bicameral-api-key"
+API_KEY_ENV = "BICAMERAL_INFERENCE_API_KEY"
 
 
 def extract_api_key(metadata) -> str | None:
-    """Return the ``x-tuner-api-key`` value from gRPC invocation metadata.
+    """Return the ``x-bicameral-api-key`` value from gRPC invocation metadata.
 
     Args:
         metadata: Iterable of ``(key, value)`` pairs (gRPC invocation
@@ -73,7 +78,7 @@ def is_authorized(metadata, expected_key: str) -> bool:
 
 
 class ApiKeyInterceptor(grpc.ServerInterceptor):
-    """Server interceptor that requires a valid ``x-tuner-api-key`` header.
+    """Server interceptor that requires a valid ``x-bicameral-api-key`` header.
 
     RPCs whose metadata is missing the header or carries a wrong key are
     aborted with ``grpc.StatusCode.UNAUTHENTICATED`` before reaching the
@@ -100,7 +105,7 @@ class ApiKeyInterceptor(grpc.ServerInterceptor):
 
 
 def interceptor_from_env() -> ApiKeyInterceptor | None:
-    """Build an :class:`ApiKeyInterceptor` from ``TUNER_INFERENCE_API_KEY``.
+    """Build an :class:`ApiKeyInterceptor` from ``BICAMERAL_INFERENCE_API_KEY``.
 
     Returns:
         An interceptor when the env var is set to a non-empty (stripped)

--- a/src/opentau/scripts/grpc/server.py
+++ b/src/opentau/scripts/grpc/server.py
@@ -695,7 +695,7 @@ def serve(cfg: TrainPipelineConfig, request_hook: RequestHook | None = None):
     """
     server_cfg = cfg.server
 
-    # Optional API-key auth, activated by the TUNER_INFERENCE_API_KEY env var.
+    # Optional API-key auth, activated by the BICAMERAL_INFERENCE_API_KEY env var.
     # When unset, the server keeps its historical no-auth behavior.
     interceptors = []
     auth_interceptor = auth.interceptor_from_env()

--- a/tests/scripts/test_grpc_auth.py
+++ b/tests/scripts/test_grpc_auth.py
@@ -39,11 +39,35 @@ def test_extract_api_key():
     assert auth.extract_api_key(None) is None
 
 
+def test_the_pre_rename_header_is_not_accepted():
+    # The gateway in front of this server sends x-bicameral-api-key only;
+    # honoring the old spelling would keep a second, unrouted way in.
+    md = (("x-tuner-api-key", "secret"),)
+    assert auth.extract_api_key(md) is None
+    assert auth.is_authorized(md, "secret") is False
+
+
 def test_is_authorized():
     md = ((auth.API_KEY_HEADER, "secret"),)
     assert auth.is_authorized(md, "secret") is True
     assert auth.is_authorized(md, "wrong") is False
     assert auth.is_authorized((), "secret") is False
+
+
+def test_the_env_var_names_are_the_published_ones():
+    # Both names are a contract with code that lives outside this repo, so the
+    # constants are pinned to their literals rather than only used through the
+    # constant. The env var matters most: auth is opt-in, so a launcher that
+    # exports the pre-rename name leaves it unset and starts an unauthenticated
+    # server. Nothing about that failure is visible.
+    assert auth.API_KEY_ENV == "BICAMERAL_INFERENCE_API_KEY"
+    assert auth.API_KEY_HEADER == "x-bicameral-api-key"
+
+
+def test_the_pre_rename_env_var_does_not_enable_auth(monkeypatch):
+    monkeypatch.delenv(auth.API_KEY_ENV, raising=False)
+    monkeypatch.setenv("TUNER_INFERENCE_API_KEY", "secret")
+    assert auth.interceptor_from_env() is None
 
 
 def test_interceptor_from_env(monkeypatch):
@@ -122,7 +146,14 @@ def test_valid_key_passes_through_streaming():
         server.stop(None)
 
 
-@pytest.mark.parametrize("metadata", [(), (("x-tuner-api-key", "wrong"),)])
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        (),
+        ((auth.API_KEY_HEADER, "wrong"),),
+        (("x-tuner-api-key", "secret"),),  # right key, pre-rename header
+    ],
+)
 def test_missing_or_wrong_key_unauthenticated(metadata):
     server, port = _start_echo_server(auth.ApiKeyInterceptor("secret"))
     try:
@@ -133,7 +164,14 @@ def test_missing_or_wrong_key_unauthenticated(metadata):
         server.stop(None)
 
 
-@pytest.mark.parametrize("metadata", [(), (("x-tuner-api-key", "wrong"),)])
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        (),
+        ((auth.API_KEY_HEADER, "wrong"),),
+        (("x-tuner-api-key", "secret"),),  # right key, pre-rename header
+    ],
+)
 def test_missing_or_wrong_key_unauthenticated_streaming(metadata):
     # The deny handler is unary_unary only, but context.abort() fires before the
     # request stream is read, so it must reject stream_stream RPCs too.


### PR DESCRIPTION
## What this does

Renames the gRPC api-key authentication to product-neutral-free names, on both halves at once:

| | before | after |
|---|---|---|
| metadata header the client sends | `x-tuner-api-key` | `x-bicameral-api-key` |
| env var the launcher exports | `TUNER_INFERENCE_API_KEY` | `BICAMERAL_INFERENCE_API_KEY` |

Neither old name is accepted alongside the new one. A dual-name transition was written first and then dropped: it leaves a second, unrouted spelling reaching the server, and the whole reason the caller renamed was to have exactly one way in.

**The two halves fail in opposite directions, which is the part worth reviewing.**

* A **client** left on `x-tuner-api-key` fails **closed**. `UNAUTHENTICATED` comes back naming the header it should have sent, so the fix is self-describing.
* A **launcher** left on `TUNER_INFERENCE_API_KEY` fails **open**. Authentication here is opt-in — `interceptor_from_env()` returns `None` when the variable is unset — so a name this server does not recognise is indistinguishable from a deliberate decision to run without auth. The result is an inference server exposed with no interceptor at all, and nothing is logged.

Because of that second case, both constants are now pinned to their literal values in the tests rather than only exercised through the constant. A test that reads `auth.API_KEY_ENV` and sets it will keep passing after a rename that silently disables authentication for every deployment; that is not a pin.

Caller-side note for whoever deploys this: the launcher that exports the variable lives in a different repository, so the rename has to land in the same rollout as the image. That side is handled in the corresponding backend change, which asserts the exported name against `API_KEY_ENV` read out of this repo's source.

`config_version` is unaffected — no trained behavior changes. Servers that never set the variable are unaffected either way.

(📝 Documentation) (🗃️ Feature)

## How it was tested

- Added `test_the_env_var_names_are_the_published_ones` in `tests/scripts/test_grpc_auth.py`, pinning both `API_KEY_ENV` and `API_KEY_HEADER` to their literals.
- Added `test_the_pre_rename_env_var_does_not_enable_auth`, which sets `TUNER_INFERENCE_API_KEY` and asserts `interceptor_from_env()` still returns `None` — the fail-open case above, stated as a test so a future "let's also accept the old name" change has to argue with it.
- Added `test_the_pre_rename_header_is_not_accepted`, asserting that the *correct* key under the old header is rejected, not merely that a wrong key is.
- Extended the two `test_missing_or_wrong_key_unauthenticated` parametrizations (unary and streaming) with the right key under the pre-rename header.
- Full file: `15 passed`. `pre-commit run` clean on every touched file.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/scripts/test_grpc_auth.py
```

To see the fail-open case directly — the server starts unauthenticated under the old variable name, and answers an unauthenticated call:

```bash
BICAMERAL_INFERENCE_API_KEY= TUNER_INFERENCE_API_KEY=secret python -c "
from opentau.scripts.grpc.auth import interceptor_from_env
print('interceptor:', interceptor_from_env())   # None -> no auth
"
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.
