### PR TITLE
feat(grpc)!: rename api-key auth to x-api-key / INFERENCE_API_KEY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -274,6 +274,29 @@ which includes in-training *validation*, so leave them at defaults in training c
   fits the dataset's shortest episodes. The stride-1 recipe used by the original pi05_ttt
   validation is deliberately rejected now — it silently optimizes the copy shortcut.
 
+### Changed — gRPC api-key auth renamed to `x-opentau-api-key` / `OPENTAU_INFERENCE_API_KEY` — **breaking on both, no `config_version` bump**
+
+`ApiKeyInterceptor` reads the key from the `x-opentau-api-key` metadata
+header, and the `UNAUTHENTICATED` message names that header. `interceptor_from_env`
+reads the expected key from `OPENTAU_INFERENCE_API_KEY`. The previous
+`x-tuner-api-key` and `TUNER_INFERENCE_API_KEY` are gone rather than accepted
+alongside: a dual-header transition leaves a second, unrouted spelling that
+whatever sits in front of this server never sees.
+
+Migration, and the two failure modes are not alike:
+
+* **Clients** send `x-opentau-api-key` instead. A client left on the old
+  header fails closed, with `UNAUTHENTICATED` naming the header it should have
+  sent. A proxy in front of the server should be renamed too rather than made
+  to translate between the two.
+* **Whoever launches the server** sets `OPENTAU_INFERENCE_API_KEY` instead.
+  This one fails *open*: auth is opt-in, so a launcher still exporting the old
+  name leaves the variable unset, and an unset variable means no interceptor
+  and an unauthenticated server. There is no error to notice. Rename the
+  launcher and the server together.
+
+Servers that never enabled authentication are unaffected.
+
 ## [0.13.0] - 2026-08-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -274,22 +274,22 @@ which includes in-training *validation*, so leave them at defaults in training c
   fits the dataset's shortest episodes. The stride-1 recipe used by the original pi05_ttt
   validation is deliberately rejected now — it silently optimizes the copy shortcut.
 
-### Changed — gRPC api-key auth renamed to `x-opentau-api-key` / `OPENTAU_INFERENCE_API_KEY` — **breaking on both, no `config_version` bump**
+### Changed — gRPC api-key auth renamed to `x-api-key` / `INFERENCE_API_KEY` — **breaking on both, no `config_version` bump**
 
-`ApiKeyInterceptor` reads the key from the `x-opentau-api-key` metadata
+`ApiKeyInterceptor` reads the key from the `x-api-key` metadata
 header, and the `UNAUTHENTICATED` message names that header. `interceptor_from_env`
-reads the expected key from `OPENTAU_INFERENCE_API_KEY`. The previous
+reads the expected key from `INFERENCE_API_KEY`. The previous
 `x-tuner-api-key` and `TUNER_INFERENCE_API_KEY` are gone rather than accepted
 alongside: a dual-header transition leaves a second, unrouted spelling that
 whatever sits in front of this server never sees.
 
 Migration, and the two failure modes are not alike:
 
-* **Clients** send `x-opentau-api-key` instead. A client left on the old
+* **Clients** send `x-api-key` instead. A client left on the old
   header fails closed, with `UNAUTHENTICATED` naming the header it should have
   sent. A proxy in front of the server should be renamed too rather than made
   to translate between the two.
-* **Whoever launches the server** sets `OPENTAU_INFERENCE_API_KEY` instead.
+* **Whoever launches the server** sets `INFERENCE_API_KEY` instead.
   This one fails *open*: auth is opt-in, so a launcher still exporting the old
   name leaves the variable unset, and an unset variable means no interceptor
   and an unauthenticated server. There is no error to notice. Rename the

--- a/src/opentau/scripts/grpc/auth.py
+++ b/src/opentau/scripts/grpc/auth.py
@@ -15,9 +15,9 @@
 """Optional API-key authentication for the robot inference gRPC server.
 
 Authentication is opt-in: it is activated only when the
-``OPENTAU_INFERENCE_API_KEY`` environment variable is set to a non-empty
+``INFERENCE_API_KEY`` environment variable is set to a non-empty
 value. When active, every RPC must carry the matching key in the
-``x-opentau-api-key`` metadata header; otherwise the call is rejected with
+``x-api-key`` metadata header; otherwise the call is rejected with
 ``UNAUTHENTICATED``. When the variable is unset/empty the server runs with no
 authentication (the historical behavior).
 
@@ -39,12 +39,12 @@ import grpc
 
 logger = logging.getLogger(__name__)
 
-API_KEY_HEADER = "x-opentau-api-key"
-API_KEY_ENV = "OPENTAU_INFERENCE_API_KEY"
+API_KEY_HEADER = "x-api-key"
+API_KEY_ENV = "INFERENCE_API_KEY"
 
 
 def extract_api_key(metadata) -> str | None:
-    """Return the ``x-opentau-api-key`` value from gRPC invocation metadata.
+    """Return the ``x-api-key`` value from gRPC invocation metadata.
 
     Args:
         metadata: Iterable of ``(key, value)`` pairs (gRPC invocation
@@ -77,7 +77,7 @@ def is_authorized(metadata, expected_key: str) -> bool:
 
 
 class ApiKeyInterceptor(grpc.ServerInterceptor):
-    """Server interceptor that requires a valid ``x-opentau-api-key`` header.
+    """Server interceptor that requires a valid ``x-api-key`` header.
 
     RPCs whose metadata is missing the header or carries a wrong key are
     aborted with ``grpc.StatusCode.UNAUTHENTICATED`` before reaching the
@@ -104,7 +104,7 @@ class ApiKeyInterceptor(grpc.ServerInterceptor):
 
 
 def interceptor_from_env() -> ApiKeyInterceptor | None:
-    """Build an :class:`ApiKeyInterceptor` from ``OPENTAU_INFERENCE_API_KEY``.
+    """Build an :class:`ApiKeyInterceptor` from ``INFERENCE_API_KEY``.
 
     Returns:
         An interceptor when the env var is set to a non-empty (stripped)

--- a/src/opentau/scripts/grpc/auth.py
+++ b/src/opentau/scripts/grpc/auth.py
@@ -15,11 +15,15 @@
 """Optional API-key authentication for the robot inference gRPC server.
 
 Authentication is opt-in: it is activated only when the
-``TUNER_INFERENCE_API_KEY`` environment variable is set to a non-empty value.
-When active, every RPC must carry the matching key in the ``x-tuner-api-key``
-metadata header; otherwise the call is rejected with ``UNAUTHENTICATED``.
-When the variable is unset/empty the server runs with no authentication (the
-historical behavior), so this is fully backward compatible.
+``OPENTAU_INFERENCE_API_KEY`` environment variable is set to a non-empty
+value. When active, every RPC must carry the matching key in the
+``x-opentau-api-key`` metadata header; otherwise the call is rejected with
+``UNAUTHENTICATED``. When the variable is unset/empty the server runs with no
+authentication (the historical behavior).
+
+That default cuts both ways: whoever launches this server owns the variable's
+spelling, and getting it wrong does not fail loudly — it starts an unprotected
+server. Rename it on both sides at once.
 
 This module deliberately depends only on ``grpc`` (not torch / the policy
 stack) so the auth logic can be unit-tested cheaply, CPU-only.
@@ -35,12 +39,12 @@ import grpc
 
 logger = logging.getLogger(__name__)
 
-API_KEY_HEADER = "x-tuner-api-key"
-API_KEY_ENV = "TUNER_INFERENCE_API_KEY"
+API_KEY_HEADER = "x-opentau-api-key"
+API_KEY_ENV = "OPENTAU_INFERENCE_API_KEY"
 
 
 def extract_api_key(metadata) -> str | None:
-    """Return the ``x-tuner-api-key`` value from gRPC invocation metadata.
+    """Return the ``x-opentau-api-key`` value from gRPC invocation metadata.
 
     Args:
         metadata: Iterable of ``(key, value)`` pairs (gRPC invocation
@@ -73,7 +77,7 @@ def is_authorized(metadata, expected_key: str) -> bool:
 
 
 class ApiKeyInterceptor(grpc.ServerInterceptor):
-    """Server interceptor that requires a valid ``x-tuner-api-key`` header.
+    """Server interceptor that requires a valid ``x-opentau-api-key`` header.
 
     RPCs whose metadata is missing the header or carries a wrong key are
     aborted with ``grpc.StatusCode.UNAUTHENTICATED`` before reaching the
@@ -100,7 +104,7 @@ class ApiKeyInterceptor(grpc.ServerInterceptor):
 
 
 def interceptor_from_env() -> ApiKeyInterceptor | None:
-    """Build an :class:`ApiKeyInterceptor` from ``TUNER_INFERENCE_API_KEY``.
+    """Build an :class:`ApiKeyInterceptor` from ``OPENTAU_INFERENCE_API_KEY``.
 
     Returns:
         An interceptor when the env var is set to a non-empty (stripped)

--- a/src/opentau/scripts/grpc/server.py
+++ b/src/opentau/scripts/grpc/server.py
@@ -695,7 +695,7 @@ def serve(cfg: TrainPipelineConfig, request_hook: RequestHook | None = None):
     """
     server_cfg = cfg.server
 
-    # Optional API-key auth, activated by the TUNER_INFERENCE_API_KEY env var.
+    # Optional API-key auth, activated by the OPENTAU_INFERENCE_API_KEY env var.
     # When unset, the server keeps its historical no-auth behavior.
     interceptors = []
     auth_interceptor = auth.interceptor_from_env()

--- a/src/opentau/scripts/grpc/server.py
+++ b/src/opentau/scripts/grpc/server.py
@@ -695,7 +695,7 @@ def serve(cfg: TrainPipelineConfig, request_hook: RequestHook | None = None):
     """
     server_cfg = cfg.server
 
-    # Optional API-key auth, activated by the OPENTAU_INFERENCE_API_KEY env var.
+    # Optional API-key auth, activated by the INFERENCE_API_KEY env var.
     # When unset, the server keeps its historical no-auth behavior.
     interceptors = []
     auth_interceptor = auth.interceptor_from_env()

--- a/tests/scripts/test_grpc_auth.py
+++ b/tests/scripts/test_grpc_auth.py
@@ -39,11 +39,34 @@ def test_extract_api_key():
     assert auth.extract_api_key(None) is None
 
 
+def test_the_pre_rename_header_is_not_accepted():
+    # Honoring the old spelling would keep a second, unrouted way in.
+    md = (("x-tuner-api-key", "secret"),)
+    assert auth.extract_api_key(md) is None
+    assert auth.is_authorized(md, "secret") is False
+
+
 def test_is_authorized():
     md = ((auth.API_KEY_HEADER, "secret"),)
     assert auth.is_authorized(md, "secret") is True
     assert auth.is_authorized(md, "wrong") is False
     assert auth.is_authorized((), "secret") is False
+
+
+def test_the_env_var_names_are_the_published_ones():
+    # Both names are a contract with code that lives outside this repo, so the
+    # constants are pinned to their literals rather than only used through the
+    # constant. The env var matters most: auth is opt-in, so a launcher that
+    # exports the pre-rename name leaves it unset and starts an unauthenticated
+    # server. Nothing about that failure is visible.
+    assert auth.API_KEY_ENV == "OPENTAU_INFERENCE_API_KEY"
+    assert auth.API_KEY_HEADER == "x-opentau-api-key"
+
+
+def test_the_pre_rename_env_var_does_not_enable_auth(monkeypatch):
+    monkeypatch.delenv(auth.API_KEY_ENV, raising=False)
+    monkeypatch.setenv("TUNER_INFERENCE_API_KEY", "secret")
+    assert auth.interceptor_from_env() is None
 
 
 def test_interceptor_from_env(monkeypatch):
@@ -122,7 +145,14 @@ def test_valid_key_passes_through_streaming():
         server.stop(None)
 
 
-@pytest.mark.parametrize("metadata", [(), (("x-tuner-api-key", "wrong"),)])
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        (),
+        ((auth.API_KEY_HEADER, "wrong"),),
+        (("x-tuner-api-key", "secret"),),  # right key, pre-rename header
+    ],
+)
 def test_missing_or_wrong_key_unauthenticated(metadata):
     server, port = _start_echo_server(auth.ApiKeyInterceptor("secret"))
     try:
@@ -133,7 +163,14 @@ def test_missing_or_wrong_key_unauthenticated(metadata):
         server.stop(None)
 
 
-@pytest.mark.parametrize("metadata", [(), (("x-tuner-api-key", "wrong"),)])
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        (),
+        ((auth.API_KEY_HEADER, "wrong"),),
+        (("x-tuner-api-key", "secret"),),  # right key, pre-rename header
+    ],
+)
 def test_missing_or_wrong_key_unauthenticated_streaming(metadata):
     # The deny handler is unary_unary only, but context.abort() fires before the
     # request stream is read, so it must reject stream_stream RPCs too.

--- a/tests/scripts/test_grpc_auth.py
+++ b/tests/scripts/test_grpc_auth.py
@@ -59,8 +59,8 @@ def test_the_env_var_names_are_the_published_ones():
     # constant. The env var matters most: auth is opt-in, so a launcher that
     # exports the pre-rename name leaves it unset and starts an unauthenticated
     # server. Nothing about that failure is visible.
-    assert auth.API_KEY_ENV == "OPENTAU_INFERENCE_API_KEY"
-    assert auth.API_KEY_HEADER == "x-opentau-api-key"
+    assert auth.API_KEY_ENV == "INFERENCE_API_KEY"
+    assert auth.API_KEY_HEADER == "x-api-key"
 
 
 def test_the_pre_rename_env_var_does_not_enable_auth(monkeypatch):


### PR DESCRIPTION
## What this does
Breaking rename of the optional gRPC api-key contract. The interceptor now
reads `x-api-key` and `INFERENCE_API_KEY`. The previous `x-tuner-api-key` /
`TUNER_INFERENCE_API_KEY` names are not accepted alongside: a dual-name
transition leaves a second spelling that whatever sits in front of this
server never sees or filters.

The two halves fail in opposite directions, which is why the names are pinned
to their literals in tests rather than only used through the constants:

* A client left on `x-tuner-api-key` fails closed (`UNAUTHENTICATED` names
  the header it should have sent).
* A launcher left on `TUNER_INFERENCE_API_KEY` fails open: auth is opt-in, so
  an unrecognised variable is an unset one, and an unset one starts a server
  with no interceptor. There is no error to notice. Rename the launcher and
  the server together.

Servers that never enabled authentication are unaffected. No `config_version`
bump — this is serving-side only.

## How it was tested
- `pre-commit run --files` on the four changed files (ruff, format, bandit, typos).
- `pytest -sx tests/scripts/test_grpc_auth.py` — 15 passed, including the new
  pins that the published names are the literals and that the pre-rename
  header/env var do not authenticate.

## How to checkout & try? (for the reviewer)
```bash
pytest -sx tests/scripts/test_grpc_auth.py
```

With auth enabled, a client must send `x-api-key`:
```bash
export INFERENCE_API_KEY=secret
# then start the gRPC server as usual; RPCs without x-api-key are UNAUTHENTICATED
```

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.

### Note: Before submitting this PR, please read the [contributor guideline](https://github.com/TensorAuto/OpenTau/blob/main/CONTRIBUTING.md).
