### PR TITLE
feat(datasets): pair demonstration+rollout episodes for one-shot imitation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,6 +235,41 @@ registers-zeroed changed nothing — pinning the harm on the learned memory outp
 the training recipe to expert co-adaptation. All three default to the shipped behavior and are read only in eval mode —
 which includes in-training *validation*, so leave them at defaults in training configs.
 
+### Added — `pair_episodes`, paired-episode sequences for one-shot in-context imitation — **opt-in, default `False`, no `config_version` bump**
+
+`PairedSequenceDataset` (`opentau.datasets.paired_sequence`) emits one sample as *two* episodes
+of the same task concatenated along the timestep axis — episode A the demonstration, episode B
+the rollout — with `loss_mask` zero across A and one across B. A's timesteps still update a
+TTT policy's fast weights but carry no imitation target, so the gradient on B can only fall by
+having absorbed something from A. This is the data side of one-shot in-context imitation: the
+supervised signal measures whether a demonstration in context makes the rollout easier.
+
+Enabled with `dataset_mixture.pair_episodes: true`, which wraps each mixture entry — one entry
+is one pairing key, so a pair never crosses keys. Two knobs decide the rest:
+
+* **`dataset.ambiguous_prompt`** (optional) replaces both halves' instruction. Required for
+  *within-task* ambiguity, where episodes of a key differ only in their target: the episode's
+  own prompt would name that target and make the demonstration redundant. It must be **omitted**
+  for *cross-task* transfer, where the prompt supplies WHAT and the demonstration supplies HOW —
+  overwriting it there erases the task identity. The loader cannot tell these apart, so it warns
+  and lets the config's author own the choice.
+* **`policy.sequence_length` must be `2 ×` the mixture's**, since the mixture is configured
+  per-half and the policy sees the concatenation. `validate()` applies the doubling, so a
+  correct paired config is accepted and a mismatched one is rejected at config time.
+
+Nothing is written to disk — a pair exists as a tensor for one training step; materializing them
+would run to ~100 TB. The draw is a pure function of `(seed, index)`, so the pairs are fixed
+within a run and identical across ranks and resumes.
+
+**Two constraints are enforced rather than documented,** because both failed silently in
+practice. `val_freq > 0` is **rejected** with pairing: the split is `random_split`, which
+partitions frames rather than episodes, so both halves keep every episode and a paired val subset
+would pair across the training half — hold out episodes as a separate dataset entry instead. And
+a draw that cannot satisfy `forbid_same_scene` falls back to a random *distinct* pair rather than
+a fixed one; the earlier fixed fallback collapsed an entire key onto a single pair while the logs
+still reported thousands available. A construction-time probe now logs `PAIR DIVERSITY COLLAPSE`
+when the reachable pair space is not being covered.
+
 ### Fixed
 
 - **Pre-rename π₀.₅ checkpoints load again: legacy `normalize_actions.*` state-dict keys

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -261,7 +261,14 @@ Nothing is written to disk — a pair exists as a tensor for one training step; 
 would run to ~100 TB. The draw is a pure function of `(seed, index)`, so the pairs are fixed
 within a run and identical across ranks and resumes.
 
-**Two constraints are enforced rather than documented,** because both failed silently in
+**Pairing requires `sequence_length > 1`** and is rejected below it: the concatenation needs a
+timestep axis, which the base loader only emits above 1 — at 1 there is no `loss_mask` and
+`state` keeps its bare `(state_dim,)` shape. Only temporal keys are concatenated, from an
+explicit allowlist rather than by testing whether a tensor's leading dim equals the timestep
+count; that test is a shape coincidence, and it silently doubled `img_is_pad` (`(num_cams,)`)
+and subgoal images (`(3, H, W)`) on a 3-camera run at `sequence_length: 3`.
+
+**Two further constraints are enforced rather than documented,** because both failed silently in
 practice. `val_freq > 0` is **rejected** with pairing: the split is `random_split`, which
 partitions frames rather than episodes, so both halves keep every episode and a paired val subset
 would pair across the training half — hold out episodes as a separate dataset entry instead. And

--- a/src/opentau/configs/default.py
+++ b/src/opentau/configs/default.py
@@ -177,6 +177,20 @@ class DatasetConfig:
     root: str | None = None
     episodes: list[int] | None = None
     excluded_episodes: list[int] | None = None
+
+    # One-shot in-context imitation: the instruction to substitute on *both*
+    # halves of a demonstration+rollout pair. Only read when
+    # `DatasetMixtureConfig.pair_episodes` is set.
+    #
+    # Set it for WITHIN-TASK ambiguity, where the episodes of this entry differ
+    # only in their target ("Open the drawer." rather than "Open the left
+    # drawer."). There the episode's own instruction would name the target and
+    # make the demonstration redundant.
+    #
+    # Leave it None for CROSS-TASK transfer, where the prompt names the task and
+    # the demonstration supplies the handling of an unfamiliar object. Blanking
+    # the prompt there would erase the task identity the policy needs.
+    ambiguous_prompt: str | None = None
     image_transforms: ImageTransformsConfig = field(default_factory=ImageTransformsConfig)
     revision: str | None = None
     use_imagenet_stats: bool = True
@@ -648,6 +662,14 @@ class DatasetMixtureConfig:
     # `policy.action_delta_indices` and the stride is never read.
     sequence_length: int = 1
     sequence_stride: int | None = None
+
+    # Emit demonstration+rollout pairs instead of single windows. Each dataset
+    # entry supplies one pairing key; the loader draws two distinct episodes
+    # from it and concatenates them, so the policy sees `2 * sequence_length`
+    # timesteps with the first half masked out of the loss.
+    #
+    # Nothing is materialized: the pair is a tensor for one step.
+    pair_episodes: bool = False
 
     # Training-time dropout probabilities for optional sample keys.
     history_state_drop_prob: float = 0.3

--- a/src/opentau/configs/train.py
+++ b/src/opentau/configs/train.py
@@ -495,6 +495,20 @@ class TrainPipelineConfig(HubMixin):
                 # `episode_data_index`, `epi2idx`) the paired loader indexes with.
                 # Splitting for pairing has to be done per *episode*, upstream of
                 # here; until it is, refuse rather than emit a meaningless metric.
+                # Pairing concatenates along a timestep axis, which only exists
+                # above `sequence_length == 1` -- there the base loader emits no
+                # `loss_mask` and `state` keeps its bare `(state_dim,)` shape.
+                # Caught here because a policy without a `sequence_length` field
+                # skips the doubled-length check below, so nothing else on the
+                # config path would reject it.
+                if self.dataset_mixture.pair_episodes and (self.dataset_mixture.sequence_length or 1) <= 1:
+                    raise ValueError(
+                        "pair_episodes is on with dataset_mixture.sequence_length="
+                        f"{self.dataset_mixture.sequence_length}. Pairing concatenates two "
+                        "episodes along a timestep axis, which the base dataset only emits "
+                        "above 1. Set sequence_length to the per-half timestep count."
+                    )
+
                 if self.dataset_mixture.pair_episodes and self.val_freq > 0:
                     raise ValueError(
                         f"pair_episodes is on with val_freq={self.val_freq}. The validation "

--- a/src/opentau/configs/train.py
+++ b/src/opentau/configs/train.py
@@ -485,6 +485,25 @@ class TrainPipelineConfig(HubMixin):
             # first batch — after the dataset has been built and the model
             # loaded, which is a slow way to learn about a typo.
             if self.dataset_mixture is not None:
+                # `val_freq > 0` and `pair_episodes` cannot both hold. The split
+                # is `torch.utils.data.random_split`, which partitions *frames*:
+                # both halves therefore still claim every episode, so a paired
+                # val subset would draw its pairs from episodes whose frames are
+                # in the training half — the split would measure nothing. It also
+                # cannot be built at all, because the `Subset` it returns exposes
+                # none of the episode-level attributes (`episodes`,
+                # `episode_data_index`, `epi2idx`) the paired loader indexes with.
+                # Splitting for pairing has to be done per *episode*, upstream of
+                # here; until it is, refuse rather than emit a meaningless metric.
+                if self.dataset_mixture.pair_episodes and self.val_freq > 0:
+                    raise ValueError(
+                        f"pair_episodes is on with val_freq={self.val_freq}. The validation "
+                        "split partitions frames, not episodes, so both halves keep every "
+                        "episode and a paired val subset would pair across the training "
+                        "half. Set val_freq=0 and hold out episodes explicitly (a separate "
+                        "dataset entry with its own `episodes` list) to measure held-out loss."
+                    )
+
                 policy_seq = getattr(self.policy, "sequence_length", None)
                 # With `pair_episodes` the mixture emits one *half* per episode
                 # and the paired loader concatenates two, so the policy sees

--- a/src/opentau/configs/train.py
+++ b/src/opentau/configs/train.py
@@ -486,12 +486,25 @@ class TrainPipelineConfig(HubMixin):
             # loaded, which is a slow way to learn about a typo.
             if self.dataset_mixture is not None:
                 policy_seq = getattr(self.policy, "sequence_length", None)
-                if policy_seq is not None and policy_seq != self.dataset_mixture.sequence_length:
+                # With `pair_episodes` the mixture emits one *half* per episode
+                # and the paired loader concatenates two, so the policy sees
+                # twice what the mixture is configured for. Without this a
+                # correct paired config is rejected here.
+                emitted = self.dataset_mixture.sequence_length
+                if self.dataset_mixture.pair_episodes:
+                    emitted *= 2
+                if policy_seq is not None and policy_seq != emitted:
+                    pairing = (
+                        " (pair_episodes doubles the mixture's "
+                        f"{self.dataset_mixture.sequence_length} to {emitted})"
+                        if self.dataset_mixture.pair_episodes
+                        else ""
+                    )
                     raise ValueError(
-                        f"policy.sequence_length ({policy_seq}) != "
-                        f"dataset_mixture.sequence_length ({self.dataset_mixture.sequence_length}). "
-                        "The policy decides how many timesteps it segments; the mixture decides "
-                        "how many it emits. Set them to the same value."
+                        f"policy.sequence_length ({policy_seq}) != emitted timesteps "
+                        f"({emitted}){pairing}. The policy decides how many timesteps it "
+                        "segments; the mixture decides how many it emits. Set them to "
+                        "the same value."
                     )
 
             # The policy's ``n_obs_steps`` determines the T dimension its

--- a/src/opentau/datasets/factory.py
+++ b/src/opentau/datasets/factory.py
@@ -822,8 +822,10 @@ def _maybe_pair(dataset, dataset_cfg: DatasetConfig, cfg: TrainPipelineConfig):
         The dataset, wrapped when pairing is enabled.
 
     Raises:
-        ValueError: If pairing is on but the subset has no ambiguous prompt, or
-            has fewer than two episodes to pair.
+        ValueError: If pairing is on but the subset resolves to fewer than two
+            episodes to pair. A missing ``ambiguous_prompt`` only warns: it is
+            required for within-task ambiguity but wrong for cross-task
+            transfer, and this cannot tell the two apart.
     """
     if not cfg.dataset_mixture.pair_episodes:
         return dataset

--- a/src/opentau/datasets/factory.py
+++ b/src/opentau/datasets/factory.py
@@ -801,6 +801,77 @@ def _validate_metadata_requirements(cfg: TrainPipelineConfig, datasets: list, la
         )
 
 
+def _maybe_pair(dataset, dataset_cfg: DatasetConfig, cfg: TrainPipelineConfig):
+    """Wraps one subset in the paired loader when ``pair_episodes`` is set.
+
+    One dataset entry is one pairing key: the loader draws two distinct
+    episodes from *this* subset and concatenates them, so a pair can never
+    cross keys and the demonstration always describes the same variant as the
+    rollout.
+
+    Wrapping happens here rather than inside ``WeightedDatasetMixture`` so the
+    mixture's weighting and hierarchical sampling keep operating on whole
+    subsets, unchanged.
+
+    Args:
+        dataset: The constructed subset.
+        dataset_cfg: Its config, supplying the ambiguous prompt.
+        cfg: The pipeline config.
+
+    Returns:
+        The dataset, wrapped when pairing is enabled.
+
+    Raises:
+        ValueError: If pairing is on but the subset has no ambiguous prompt, or
+            has fewer than two episodes to pair.
+    """
+    if not cfg.dataset_mixture.pair_episodes:
+        return dataset
+
+    from opentau.datasets.paired_sequence import PairedSequenceDataset
+
+    key = dataset_cfg.repo_id or "subset"
+    if dataset_cfg.episodes:
+        key = f"{key}#{len(dataset_cfg.episodes)}eps"
+    if not dataset_cfg.ambiguous_prompt:
+        # Two legitimate designs reach here, and only one is a mistake.
+        #
+        # WITHIN-TASK ambiguity (e.g. NavigateKitchen): every episode of the key
+        # shares a skill and differs only in target, so the episode's own prompt
+        # names that target and the demonstration becomes redundant. An
+        # ambiguous prompt is mandatory there.
+        #
+        # CROSS-TASK transfer (e.g. robolab bowl -> mug): the prompt supplies
+        # WHAT and the demonstration supplies HOW for an object the model has
+        # not manipulated. Overwriting the prompt would destroy the task
+        # identity the model needs. Leaving it is correct.
+        #
+        # The loader cannot tell these apart, so warn rather than refuse and
+        # let the experiment's author own the choice.
+        logging.warning(
+            "pair_episodes is on for %s with no `ambiguous_prompt`, so each half keeps "
+            "its episode's own instruction. This is correct ONLY for cross-task transfer, "
+            "where the prompt names the task and the demonstration shows how. If the "
+            "episodes of this key differ only in their target, the prompt names that "
+            "target and the demonstration is redundant — set `ambiguous_prompt`.",
+            key,
+        )
+    episodes = list(getattr(dataset, "episodes", None) or dataset_cfg.episodes or [])
+    if len(episodes) < 2:
+        raise ValueError(
+            f"pair_episodes is on but {key} resolves to {len(episodes)} episode(s); "
+            "pairing needs at least two."
+        )
+    return PairedSequenceDataset(
+        base=dataset,
+        pairing_keys={key: episodes},
+        # None -> PairedSequenceDataset leaves each sample's own prompt in place.
+        prompts={key: dataset_cfg.ambiguous_prompt},
+        samples_per_epoch=len(dataset),
+        seed=cfg.seed or 0,
+    )
+
+
 def make_dataset_mixture(
     cfg: TrainPipelineConfig, return_advantage_input: bool = False
 ) -> Union[WeightedDatasetMixture, Tuple[WeightedDatasetMixture, WeightedDatasetMixture]]:
@@ -823,10 +894,10 @@ def make_dataset_mixture(
     for dataset_cfg in cfg.dataset_mixture.datasets:
         res = make_dataset(dataset_cfg, cfg, return_advantage_input=return_advantage_input)
         if isinstance(res, tuple):
-            datasets.append(res[0])
-            val_datasets.append(res[1])
+            datasets.append(_maybe_pair(res[0], dataset_cfg, cfg))
+            val_datasets.append(_maybe_pair(res[1], dataset_cfg, cfg))
         else:
-            datasets.append(res)
+            datasets.append(_maybe_pair(res, dataset_cfg, cfg))
 
     _validate_metadata_requirements(cfg, datasets, label="train")
     if val_datasets:

--- a/src/opentau/datasets/factory.py
+++ b/src/opentau/datasets/factory.py
@@ -849,8 +849,9 @@ def _maybe_pair(dataset, dataset_cfg: DatasetConfig, cfg: TrainPipelineConfig):
         # The loader cannot tell these apart, so warn rather than refuse and
         # let the experiment's author own the choice.
         logging.warning(
-            "pair_episodes is on for %s with no `ambiguous_prompt`, so each half keeps "
-            "its episode's own instruction. This is correct ONLY for cross-task transfer, "
+            "pair_episodes is on for %s with no `ambiguous_prompt`, so the sample keeps the "
+            "rollout half's own instruction (a pair carries one prompt; the demonstration's "
+            "is dropped). This is correct ONLY for cross-task transfer, "
             "where the prompt names the task and the demonstration shows how. If the "
             "episodes of this key differ only in their target, the prompt names that "
             "target and the demonstration is redundant — set `ambiguous_prompt`.",
@@ -865,8 +866,12 @@ def _maybe_pair(dataset, dataset_cfg: DatasetConfig, cfg: TrainPipelineConfig):
     return PairedSequenceDataset(
         base=dataset,
         pairing_keys={key: episodes},
-        # None -> PairedSequenceDataset leaves each sample's own prompt in place.
-        prompts={key: dataset_cfg.ambiguous_prompt},
+        # `or None` keeps the two layers agreeing on what "no override" means:
+        # the falsy check above already treated `""` as absent and warned, but
+        # `__getitem__` gates on `is not None` and would have blanked both
+        # halves' prompt instead of leaving the rollout's in place.
+        # None -> PairedSequenceDataset leaves the sample's own prompt in place.
+        prompts={key: dataset_cfg.ambiguous_prompt or None},
         samples_per_epoch=len(dataset),
         seed=cfg.seed or 0,
     )

--- a/src/opentau/datasets/paired_sequence.py
+++ b/src/opentau/datasets/paired_sequence.py
@@ -95,6 +95,37 @@ class PairedSequenceDataset(Dataset):
         }
     )
 
+    # Keys carrying a leading *timestep* axis, and therefore the only ones a
+    # pair concatenates. Everything else is taken from B unchanged.
+    #
+    # This is an allowlist rather than "leading dim == timestep count" because
+    # that test is a shape coincidence: `img_is_pad` is `(num_cams,)` and a
+    # `subgoal{k}` image is `(3, H, W)`, so a 3-camera run at
+    # `sequence_length == 3` silently doubled both and still collated. An
+    # allowlist that omits a temporal key fails loudly instead -- the halves
+    # disagree on length downstream -- which is the failure mode to prefer.
+    _TEMPORAL_KEYS = frozenset(
+        {
+            "state",
+            "actions",
+            "action_is_pad",
+            "loss_mask",
+            "obs_history_is_pad",
+        }
+    )
+
+    @classmethod
+    def _is_temporal(cls, key: str) -> bool:
+        """Whether ``key`` carries a leading timestep axis.
+
+        Args:
+            key: A sample key.
+
+        Returns:
+            True if the key's leading axis is time and the pair concatenates it.
+        """
+        return key in cls._TEMPORAL_KEYS or key.startswith("camera")
+
     def __init__(
         self,
         base: LeRobotDataset,
@@ -104,6 +135,9 @@ class PairedSequenceDataset(Dataset):
         seed: int = 0,
         forbid_same_scene: bool = True,
     ) -> None:
+        # Set before anything else: `__getattr__` forwards unknown attributes to
+        # the wrapped dataset, so a miss here would delegate rather than raise.
+        self._warned_keys: set[str] = set()
         thin = {k: len(v) for k, v in pairing_keys.items() if len(v) < 2}
         if thin:
             raise ValueError(f"pairing keys need >=2 episodes to pair; too thin: {thin}")
@@ -282,16 +316,31 @@ class PairedSequenceDataset(Dataset):
         out: dict[str, Any] = {}
         for k, vb in b.items():
             va = a.get(k)
+            tensors = isinstance(vb, torch.Tensor) and isinstance(va, torch.Tensor) and vb.ndim >= 1
             if (
                 k not in self._SCALAR_PASSTHROUGH
-                and isinstance(vb, torch.Tensor)
-                and isinstance(va, torch.Tensor)
-                and vb.ndim >= 1
+                and tensors
+                and self._is_temporal(k)
                 and va.shape[0] == t_a
                 and vb.shape[0] == t_b
             ):
                 out[k] = torch.cat([va, vb], dim=0)
             else:
+                if tensors and not self._is_temporal(k) and va.shape[0] == t_a and k not in self._warned_keys:
+                    # Not concatenated, but its leading dim coincides with the
+                    # timestep count -- either a genuinely temporal key missing
+                    # from the allowlist, or a fixed-size tensor colliding by
+                    # accident. Both want eyes, and neither should be guessed at
+                    # silently, so say it once per key per process.
+                    self._warned_keys.add(k)
+                    logging.warning(
+                        "paired sample: key %r is not in the temporal allowlist but its leading "
+                        "dim (%d) equals the timestep count, so only the rollout half's copy is "
+                        "kept. If %r is temporal, add it to PairedSequenceDataset._TEMPORAL_KEYS.",
+                        k,
+                        t_a,
+                        k,
+                    )
                 out[k] = vb
 
         out["loss_mask"] = torch.cat([torch.zeros(t_a, dtype=torch.bool), torch.ones(t_b, dtype=torch.bool)])
@@ -349,11 +398,23 @@ class PairedSequenceDataset(Dataset):
         Raises:
             ValueError: If no key carries a usable timestep axis.
         """
-        for k in ("loss_mask", "state", "actions", "camera0"):
-            v = item.get(k)
-            if isinstance(v, torch.Tensor) and v.ndim >= 1:
-                return int(v.shape[0])
+        # `loss_mask` ONLY, and deliberately so. It is the one key the base
+        # dataset emits *because* the sample is a sequence: `_reshape_to_sequence`
+        # early-returns at `sequence_length <= 1` without emitting it, so its
+        # absence is exactly the condition this guard exists to catch.
+        #
+        # Falling back to `state`/`actions`/`camera0` here defeated the guard
+        # entirely: at `sequence_length == 1` those keys are still present but
+        # carry no time axis (`state` is `(max_state_dim,)`), so the fallback
+        # returned the *feature* dim, both halves agreed, and pairing emitted a
+        # corrupted sample -- `state` concatenated along its feature axis to
+        # `(2 * state_dim,)` and a `loss_mask` of length `2 * state_dim` -- in
+        # place of the intended error.
+        v = item.get("loss_mask")
+        if isinstance(v, torch.Tensor) and v.ndim >= 1:
+            return int(v.shape[0])
         raise ValueError(
-            "cannot determine the timestep count; the base dataset is not emitting "
-            "sequences (is dataset_mixture.sequence_length set above 1?)"
+            "cannot determine the timestep count: the base dataset emitted no `loss_mask`, "
+            "so it is not emitting sequences. Pairing concatenates along a timestep axis "
+            "that does not exist here -- set dataset_mixture.sequence_length above 1."
         )

--- a/src/opentau/datasets/paired_sequence.py
+++ b/src/opentau/datasets/paired_sequence.py
@@ -22,8 +22,14 @@ gradient on B can therefore only fall by having absorbed something from A.
 
 **Nothing is written to disk.** The pair exists as a tensor for one training
 step. Materializing ~146k pairs at 196 timesteps and 3 cameras would be on the
-order of 100 TB, and would freeze one arbitrary draw of a pair space the sampler
-otherwise re-draws every epoch.
+order of 100 TB.
+
+The draw is a pure function of ``(seed, index)``, so within a run the
+``samples_per_epoch`` pairs are *fixed* and replayed identically each epoch —
+that is what makes ranks agree and resumes reproducible (see ``seed`` below).
+The set is a sample of the pair space, not the whole of it; widening or
+re-drawing it means raising ``samples_per_epoch`` or changing ``seed``, which
+costs nothing here and would cost a re-materialization on disk.
 
 **Why this cannot be a config flag on the existing loader.**
 :class:`~opentau.datasets.lerobot_dataset.LeRobotDataset` builds a window from

--- a/src/opentau/datasets/paired_sequence.py
+++ b/src/opentau/datasets/paired_sequence.py
@@ -1,0 +1,353 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Two episodes of one task, joined into a single supervised sequence.
+
+This is the data side of one-shot in-context imitation. A sample is episode A
+(the demonstration) followed by episode B (the rollout), concatenated along the
+timestep axis, with ``loss_mask`` zero across A and one across B. A's timesteps
+still update the TTT fast weights; only B's carry an imitation target. The
+gradient on B can therefore only fall by having absorbed something from A.
+
+**Nothing is written to disk.** The pair exists as a tensor for one training
+step. Materializing ~146k pairs at 196 timesteps and 3 cameras would be on the
+order of 100 TB, and would freeze one arbitrary draw of a pair space the sampler
+otherwise re-draws every epoch.
+
+**Why this cannot be a config flag on the existing loader.**
+:class:`~opentau.datasets.lerobot_dataset.LeRobotDataset` builds a window from
+``delta_timestamps``, which clamps at episode boundaries by design — the padding
+behaviour that ``_reshape_to_sequence`` reports through ``*_is_pad``. A pair
+spans two *different* episodes, so it cannot be expressed as one window however
+the offsets are written. This class calls the base dataset twice instead, which
+keeps every downstream guarantee (image standardization, action padding, the
+sequence reshape) rather than re-deriving them.
+
+**Why the prompt is overwritten.** The pairing key is the thing the prompt must
+hide. For ``OpenDrawer`` the episodes say "open the left drawer" / "open the
+right drawer"; the sample says "Open the drawer." on *both* halves. If the
+instruction named the target, the demonstration would be redundant and the model
+would learn to ignore it — the failure this whole design exists to prevent.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import torch
+from torch.utils.data import Dataset
+
+from opentau.datasets.lerobot_dataset import LeRobotDataset
+
+
+class PairedSequenceDataset(Dataset):
+    """Draws two episodes of one pairing key and returns them as one sequence.
+
+    Args:
+        base: Dataset to read windows from. Its ``sequence_length`` must be the
+            per-half length, i.e. half the sequence the policy will see.
+        pairing_keys: ``{key: [episode_index, ...]}``. A pair is always drawn
+            within a single key, so the key is exactly what the demonstration
+            conveys and the prompt withholds.
+        prompts: ``{key: instruction}`` with the varying slot removed.
+        samples_per_epoch: Length reported to the sampler. Pairs are drawn on
+            demand, so this sets epoch size rather than the size of anything
+            stored.
+        seed: Base seed for pair draws. Combined with the sample index so a
+            given index yields the same pair on every rank and every epoch,
+            which keeps distributed runs and resumes reproducible.
+        forbid_same_scene: Reject a draw whose two episodes share a scene id, so
+            the pair cannot be solved by copying A's motion frame-for-frame.
+
+    Raises:
+        ValueError: If a key has fewer than two episodes, or ``prompts`` is
+            missing a key.
+    """
+
+    #: Keys carrying no timestep axis; taken from B, the supervised half.
+    _SCALAR_PASSTHROUGH = frozenset(
+        {
+            "dataset_index",
+            "dataset_repo_id",
+            "robot_type",
+            "control_mode",
+            "episode_index",
+            "frame_index",
+            "real_action_dim",
+        }
+    )
+
+    def __init__(
+        self,
+        base: LeRobotDataset,
+        pairing_keys: dict[str, list[int]],
+        prompts: dict[str, str],
+        samples_per_epoch: int = 100_000,
+        seed: int = 0,
+        forbid_same_scene: bool = True,
+    ) -> None:
+        thin = {k: len(v) for k, v in pairing_keys.items() if len(v) < 2}
+        if thin:
+            raise ValueError(f"pairing keys need >=2 episodes to pair; too thin: {thin}")
+        missing = sorted(set(pairing_keys) - set(prompts))
+        if missing:
+            raise ValueError(f"no ambiguous prompt supplied for keys: {missing}")
+
+        self.base = base
+        self.keys = sorted(pairing_keys)
+        self.pairing_keys = {k: list(v) for k, v in pairing_keys.items()}
+        self.prompts = prompts
+        self.samples_per_epoch = samples_per_epoch
+        self.seed = seed
+        self.forbid_same_scene = forbid_same_scene
+
+        # Row index of each episode's final frame. The base loader anchors a
+        # window at its last timestep, so anchoring here makes each half cover
+        # its episode end-to-end rather than an arbitrary interior slice.
+        self._last_row = self._build_last_row_index()
+
+        # A scene filter that can never be satisfied is worse than none: every
+        # draw falls through to the fallback. Say so, loudly, at construction.
+        if self.forbid_same_scene:
+            degenerate = [
+                k for k, eps in self.pairing_keys.items() if len({self._scene_of(e) for e in eps}) <= 1
+            ]
+            if degenerate:
+                logging.warning(
+                    "forbid_same_scene is on, but %d/%d pairing key(s) have a single "
+                    "scene id across every episode, so the filter can never be "
+                    "satisfied and each draw falls back to a random distinct pair: %s. "
+                    "The scene constraint is doing nothing for these keys — set "
+                    "forbid_same_scene=False, or supply a real per-episode scene id.",
+                    len(degenerate),
+                    len(self.pairing_keys),
+                    degenerate[:6],
+                )
+
+        # The pair count logged below is an UPPER BOUND. A filter or fallback bug
+        # can silently collapse the draws onto a handful of pairs while that
+        # number stays reassuringly large -- which is exactly what happened
+        # (plan doc 11.30: two runs trained on one pair per key). Measure what
+        # `_draw` actually produces.
+        probe = min(1000, max(200, 8 * len(self.keys)))
+        drawn = {self._draw(i) for i in range(probe)}
+        reachable = min(probe, sum(len(v) * (len(v) - 1) for v in self.pairing_keys.values()))
+        if len(drawn) < 0.25 * reachable:
+            logging.error(
+                "PAIR DIVERSITY COLLAPSE: %d probe draws produced only %d distinct "
+                "(key, demo, rollout) triples, against %d reachable. The model will "
+                "see far fewer examples than the pair count below implies. Check "
+                "forbid_same_scene and the _draw fallback before training.",
+                probe,
+                len(drawn),
+                reachable,
+            )
+        else:
+            logging.info("pair diversity ok: %d distinct triples from %d probe draws", len(drawn), probe)
+
+        total = sum(len(v) * (len(v) - 1) for v in self.pairing_keys.values())
+        logging.info(
+            "PairedSequenceDataset: %d keys, %d episodes, %d ordered pairs available, %d samples/epoch",
+            len(self.keys),
+            sum(len(v) for v in self.pairing_keys.values()),
+            total,
+            samples_per_epoch,
+        )
+
+    def _build_last_row_index(self) -> dict[int, int]:
+        """Maps episode index to the row index of its last frame.
+
+        Returns:
+            ``{episode_index: row}``.
+
+        Raises:
+            RuntimeError: If the base dataset has not built its episode index.
+            KeyError: If a requested episode is absent from the base dataset.
+        """
+        if self.base.episode_data_index is None or self.base.epi2idx is None:
+            raise RuntimeError("base dataset has no episode_data_index; construct it before wrapping")
+        out: dict[int, int] = {}
+        for eps in self.pairing_keys.values():
+            for e in eps:
+                if e not in self.base.epi2idx:
+                    raise KeyError(
+                        f"episode {e} is in the manifest but not in the base dataset — "
+                        "the config's `episodes` list and the manifest have diverged"
+                    )
+                out[e] = int(self.base.episode_data_index["to"][self.base.epi2idx[e]].item()) - 1
+        return out
+
+    def __len__(self) -> int:
+        return self.samples_per_epoch
+
+    def _draw(self, index: int) -> tuple[str, int, int]:
+        """Chooses a key and two distinct episodes for one sample.
+
+        Derived from ``seed`` and ``index`` alone — never from global RNG state —
+        so every rank draws the same pair for the same index and a resume
+        reproduces the run.
+
+        Args:
+            index: Sample index.
+
+        Returns:
+            ``(key, episode_a, episode_b)``.
+        """
+        g = torch.Generator().manual_seed(self.seed * 1_000_003 + index)
+        key = self.keys[int(torch.randint(len(self.keys), (1,), generator=g))]
+        eps = self.pairing_keys[key]
+
+        for _ in range(16):
+            i, j = torch.randint(len(eps), (2,), generator=g).tolist()
+            if i == j:
+                continue
+            a, b = eps[i], eps[j]
+            if not self.forbid_same_scene or self._scene_of(a) != self._scene_of(b):
+                return key, a, b
+
+        # The scene constraint is a quality filter; distinctness is the actual
+        # invariant. Fall back to a random DISTINCT pair rather than a fixed
+        # one -- when every episode of a key shares a scene id the loop above
+        # can never succeed, and a deterministic fallback then collapses the
+        # whole key onto a single pair for every sample. That is silent: the
+        # logged "N ordered pairs available" stays large while the model sees
+        # one example, which looks exactly like a very fast-learning run until
+        # rollout success falls off a cliff.
+        i = int(torch.randint(len(eps), (1,), generator=g))
+        j = (i + 1 + int(torch.randint(len(eps) - 1, (1,), generator=g))) % len(eps)
+        return key, eps[i], eps[j]
+
+    def _scene_of(self, episode: int) -> Any:
+        """Scene identifier for an episode, or the episode itself if unavailable.
+
+        Args:
+            episode: Episode index.
+
+        Returns:
+            A hashable scene id. Falls back to the episode index, which makes
+            the same-scene filter a no-op rather than silently rejecting every
+            pair when the metadata lacks a scene field.
+        """
+        info = getattr(self.base.meta, "episodes", {}).get(episode, {})
+        for field in ("scene_id", "scene", "source_prefix"):
+            if field in info:
+                return info[field]
+        return episode
+
+    def __getitem__(self, index: int) -> dict[str, Any]:
+        """Builds one demonstration+rollout sample.
+
+        Args:
+            index: Sample index.
+
+        Returns:
+            The concatenated sample. Timestep-axis tensors are joined A-then-B;
+            ``loss_mask`` is False across A and True across B; ``prompt`` is the
+            key's ambiguous instruction on both halves.
+
+        Raises:
+            ValueError: If the two halves disagree on their timestep count,
+                which would silently misalign the mask against the sequence.
+        """
+        key, ep_a, ep_b = self._draw(index)
+        a = self.base[self._last_row[ep_a]]
+        b = self.base[self._last_row[ep_b]]
+
+        t_a = self._timesteps(a)
+        t_b = self._timesteps(b)
+        if t_a != t_b:
+            raise ValueError(
+                f"halves disagree on timestep count ({t_a} vs {t_b}) for key {key}; "
+                "the base dataset's sequence_length must be fixed across episodes"
+            )
+
+        out: dict[str, Any] = {}
+        for k, vb in b.items():
+            va = a.get(k)
+            if (
+                k not in self._SCALAR_PASSTHROUGH
+                and isinstance(vb, torch.Tensor)
+                and isinstance(va, torch.Tensor)
+                and vb.ndim >= 1
+                and va.shape[0] == t_a
+                and vb.shape[0] == t_b
+            ):
+                out[k] = torch.cat([va, vb], dim=0)
+            else:
+                out[k] = vb
+
+        out["loss_mask"] = torch.cat([torch.zeros(t_a, dtype=torch.bool), torch.ones(t_b, dtype=torch.bool)])
+        # Both halves, not just B: the demonstration must not be labelled with
+        # the answer either.
+        #
+        # A ``None`` prompt means the caller deliberately declined to overwrite
+        # it -- cross-task transfer, where the instruction names the task and
+        # the demonstration supplies the unfamiliar object's handling. Keeping
+        # B's own prompt is then correct; blanking it would erase the task
+        # identity the model needs.
+        if self.prompts[key] is not None:
+            out["prompt"] = self.prompts[key]
+        out["pairing_key"] = key
+        return out
+
+    def __getattr__(self, name: str) -> Any:
+        """Delegates anything unknown to the wrapped dataset.
+
+        ``WeightedDatasetMixture`` and ``_TaggedDataset`` reach for ``meta``,
+        ``repo_id``, ``shallow_copy_with_dropout`` and friends. Forwarding makes
+        this a transparent wrapper rather than something every consumer has to
+        be taught about.
+
+        Only called for attributes not found normally, so it cannot shadow this
+        class's own behaviour.
+
+        Args:
+            name: Attribute name.
+
+        Returns:
+            The attribute from the wrapped dataset.
+
+        Raises:
+            AttributeError: If the wrapped dataset lacks it too.
+        """
+        # `object.__getattribute__` avoids recursing through this hook while
+        # `self.base` is still being set in __init__.
+        try:
+            base = object.__getattribute__(self, "base")
+        except AttributeError as exc:  # pragma: no cover - construction order
+            raise AttributeError(name) from exc
+        return getattr(base, name)
+
+    @staticmethod
+    def _timesteps(item: dict[str, Any]) -> int:
+        """Reads the timestep count from a base-dataset sample.
+
+        Args:
+            item: One sample from the base dataset.
+
+        Returns:
+            Number of timesteps.
+
+        Raises:
+            ValueError: If no key carries a usable timestep axis.
+        """
+        for k in ("loss_mask", "state", "actions", "camera0"):
+            v = item.get(k)
+            if isinstance(v, torch.Tensor) and v.ndim >= 1:
+                return int(v.shape[0])
+        raise ValueError(
+            "cannot determine the timestep count; the base dataset is not emitting "
+            "sequences (is dataset_mixture.sequence_length set above 1?)"
+        )

--- a/src/opentau/datasets/paired_sequence.py
+++ b/src/opentau/datasets/paired_sequence.py
@@ -298,7 +298,8 @@ class PairedSequenceDataset(Dataset):
         Returns:
             The concatenated sample. Timestep-axis tensors are joined A-then-B;
             ``loss_mask`` is False across A and True across B; ``prompt`` is the
-            key's ambiguous instruction on both halves.
+            key's ambiguous instruction when one was supplied, and otherwise the
+            rollout half's own instruction (see ``prompts``).
 
         Raises:
             ValueError: If the two halves disagree on their timestep count,

--- a/src/opentau/datasets/paired_sequence.py
+++ b/src/opentau/datasets/paired_sequence.py
@@ -67,7 +67,10 @@ class PairedSequenceDataset(Dataset):
         pairing_keys: ``{key: [episode_index, ...]}``. A pair is always drawn
             within a single key, so the key is exactly what the demonstration
             conveys and the prompt withholds.
-        prompts: ``{key: instruction}`` with the varying slot removed.
+        prompts: ``{key: instruction}`` with the varying slot removed, applied
+            to both halves. ``None`` for a key means keep each sample's own
+            prompt -- the cross-task-transfer case, where the instruction names
+            the task and overwriting it would erase the task identity.
         samples_per_epoch: Length reported to the sampler. Pairs are drawn on
             demand, so this sets epoch size rather than the size of anything
             stored.
@@ -130,7 +133,7 @@ class PairedSequenceDataset(Dataset):
         self,
         base: LeRobotDataset,
         pairing_keys: dict[str, list[int]],
-        prompts: dict[str, str],
+        prompts: dict[str, str | None],
         samples_per_epoch: int = 100_000,
         seed: int = 0,
         forbid_same_scene: bool = True,

--- a/tests/datasets/test_paired_sequence.py
+++ b/tests/datasets/test_paired_sequence.py
@@ -207,6 +207,115 @@ class TestScalarPassthrough:
         assert s["dataset_index"].ndim == 0
 
 
+class TestNonSequenceBaseIsRejected:
+    """A `sequence_length <= 1` base has no timestep axis to concatenate along.
+
+    The earlier guard read the timestep count from whichever of
+    `loss_mask`/`state`/`actions`/`camera0` came first. At `sequence_length == 1`
+    the base emits no `loss_mask` and `state` is `(max_state_dim,)`, so it
+    returned the *feature* dim: both halves agreed, nothing raised, and the pair
+    was concatenated along the feature axis. These pin the two independent places
+    that now stop it -- the loader itself, and the config before a run starts.
+    """
+
+    class _Seq1Base:
+        """A base dataset at `sequence_length == 1`: no `loss_mask`, flat `state`."""
+
+        def __init__(self, episodes):
+            self._episodes = list(episodes)
+            rows = {e: i for i, e in enumerate(self._episodes)}
+            self.epi2idx = rows
+            self.episode_data_index = {
+                "from": torch.tensor([rows[e] for e in self._episodes]),
+                "to": torch.tensor([rows[e] + 1 for e in self._episodes]),
+            }
+            self.meta = SimpleNamespace(episodes={e: {} for e in self._episodes})
+            self._by_row = {v: k for k, v in rows.items()}
+
+        def __len__(self):
+            return len(self._episodes)
+
+        def __getitem__(self, row):
+            e = self._by_row[row]
+            return {
+                "state": torch.full((32,), float(e)),  # (max_state_dim,) -- no time axis
+                "actions": torch.full((50, 7), float(e)),
+                "prompt": "x",
+                "episode_index": torch.tensor(e),
+                "dataset_index": torch.tensor(0),
+            }
+
+    def test_loader_raises_instead_of_corrupting(self):
+        ds = PairedSequenceDataset(
+            base=self._Seq1Base(EPISODES),
+            pairing_keys={"k": list(EPISODES)},
+            prompts={"k": None},
+            samples_per_epoch=4,
+            seed=0,
+        )
+        with pytest.raises(ValueError, match="no `loss_mask`"):
+            ds[0]
+
+    def test_validate_rejects_unit_sequence_length(self, tmp_path):
+        """The config path must reject it too.
+
+        A policy with no `sequence_length` field skips the doubled-length check,
+        so without this the corrupted run starts and converges on nonsense.
+        """
+        cfg = TestPairingIsActuallyWired._cfg(policy_seq=2, mixture_seq=1, pair=True, tmp_path=tmp_path)
+        with pytest.raises(ValueError, match="sequence_length=1"):
+            cfg.validate()
+
+
+class TestOnlyTemporalKeysConcatenate:
+    """Fixed-size tensors must not be doubled when their leading dim equals T.
+
+    `img_is_pad` is `(num_cams,)` and a `subgoal` image is `(3, H, W)`, so the
+    old "leading dim == timestep count" test doubled both at `sequence_length`
+    3 with 3 cameras -- silently, since collation still succeeded.
+    """
+
+    class _CollidingBase(_StubBase):
+        """Adds fixed-size keys whose leading dim happens to equal ``T``."""
+
+        def __getitem__(self, row):
+            item = super().__getitem__(row)
+            item["img_is_pad"] = torch.zeros(T, dtype=torch.bool)  # (num_cams,) == T
+            item["subgoal0"] = torch.zeros(T, 8, 8)  # (3, H, W) with T == 3
+            return item
+
+    @classmethod
+    def _base_with_collisions(cls):
+        return cls._CollidingBase(EPISODES)
+
+    def test_colliding_fixed_size_keys_are_not_doubled(self):
+        ds = PairedSequenceDataset(
+            base=self._base_with_collisions(),
+            pairing_keys={"k": list(EPISODES)},
+            prompts={"k": None},
+            samples_per_epoch=4,
+            seed=0,
+        )
+        sample = ds[0]
+        assert sample["state"].shape[0] == 2 * T, "temporal keys must still concatenate"
+        assert sample["img_is_pad"].shape[0] == T, "img_is_pad is per-camera, not per-timestep"
+        assert sample["subgoal0"].shape[0] == T, "a subgoal image has no timestep axis"
+
+    def test_collision_is_reported_once(self, caplog):
+        ds = PairedSequenceDataset(
+            base=self._base_with_collisions(),
+            pairing_keys={"k": list(EPISODES)},
+            prompts={"k": None},
+            samples_per_epoch=4,
+            seed=0,
+        )
+        with caplog.at_level(logging.WARNING):
+            ds[0]
+            ds[1]
+        assert caplog.text.count("temporal allowlist") == 2, "one warning per colliding key, once each"
+        assert "img_is_pad" in caplog.text and "subgoal0" in caplog.text
+
+
 class TestPairingIsActuallyWired:
     """The pairing must reach ``train.py``, not just exist as a class.
 
@@ -313,6 +422,31 @@ class TestPairingIsActuallyWired:
         sample = wrapped[0]
         assert sample["state"].shape[0] == 2 * T, "paired sample is not the concatenation"
         assert sample["prompt"] == "Open the drawer."
+
+    def test_empty_ambiguous_prompt_is_treated_as_absent(self, tmp_path, monkeypatch):
+        """`ambiguous_prompt: ""` must mean "no override", consistently in both layers.
+
+        The factory's falsy check already read it as absent and warned, but it
+        passed the empty string down to a loader gating on `is not None` -- which
+        blanked the prompt instead of leaving the rollout's in place, erasing the
+        task identity in exactly the cross-task case the warning describes.
+        """
+        from opentau.datasets import factory
+
+        cfg = self._cfg(policy_seq=2 * T, mixture_seq=T, pair=True, tmp_path=tmp_path, prompt="")
+        handed = {}
+        monkeypatch.setattr(factory, "make_dataset", lambda dcfg, c, **kw: _StubBase(EPISODES))
+        monkeypatch.setattr(factory, "_validate_metadata_requirements", lambda *a, **k: None)
+        monkeypatch.setattr(
+            factory,
+            "WeightedDatasetMixture",
+            lambda cfg_, datasets, weights, freq: handed.setdefault("datasets", datasets),
+        )
+
+        factory.make_dataset_mixture(cfg)
+        prompt = handed["datasets"][0][0]["prompt"]
+        assert prompt, "an empty ambiguous_prompt blanked the sample's instruction"
+        assert "drawer" in prompt
 
     def test_missing_ambiguous_prompt_warns_but_is_allowed(self, caplog):
         """No prompt is legitimate for cross-task transfer, so warn rather than refuse.

--- a/tests/datasets/test_paired_sequence.py
+++ b/tests/datasets/test_paired_sequence.py
@@ -32,6 +32,7 @@ import torch
 from opentau.datasets.paired_sequence import PairedSequenceDataset
 
 T = 4  # timesteps per half
+EPISODES = (10, 11, 12)  # default stub episodes for one pairing key
 
 
 class _StubBase:
@@ -73,8 +74,11 @@ class _StubBase:
             "dataset_index": torch.tensor(0),
         }
 
+    def __len__(self):
+        return len(self._episodes)
 
-def _make(episodes=(10, 11, 12), scenes=None, ragged=None, **kw):
+
+def _make(episodes=EPISODES, scenes=None, ragged=None, **kw):
     base = _StubBase(episodes, scenes, ragged)
     return PairedSequenceDataset(
         base=base,
@@ -212,35 +216,103 @@ class TestPairingIsActuallyWired:
     pin the two places that connect the loader to the training path.
     """
 
-    def test_validate_accepts_doubled_policy_length_when_pairing(self):
-        from opentau.configs.default import DatasetMixtureConfig
+    @staticmethod
+    def _cfg(policy_seq, mixture_seq, pair, val_freq=0, tmp_path=None, prompt="Open the drawer."):
+        """Builds a real ``TrainPipelineConfig`` so ``validate()`` runs for real."""
+        from opentau.configs.default import DatasetConfig, DatasetMixtureConfig
+        from opentau.configs.train import TrainPipelineConfig
+        from opentau.policies.pi05_ttt.configuration_pi05_ttt import PI05TTTConfig
 
-        cfg = DatasetMixtureConfig(sequence_length=98, pair_episodes=True)
-        assert cfg.pair_episodes and cfg.sequence_length == 98
-
-    def test_validate_rejects_undoubled_policy_length(self):
-        """The breaking case: pairing on, policy still expecting one half."""
-        import re
-
-        from opentau.configs import train as train_cfg
-
-        src = __import__("inspect").getsource(train_cfg.TrainPipelineConfig.validate)
-        assert "pair_episodes" in src, (
-            "validate() no longer accounts for pairing; a correct paired config "
-            "would be rejected and an unpaired one silently accepted"
+        return TrainPipelineConfig(
+            dataset_mixture=DatasetMixtureConfig(
+                datasets=[
+                    DatasetConfig(
+                        repo_id="mock",
+                        root="/tmp/mock",
+                        episodes=list(EPISODES),
+                        ambiguous_prompt=prompt,
+                    )
+                ],
+                weights=[1.0],
+                action_freq=30.0,
+                sequence_length=mixture_seq,
+                pair_episodes=pair,
+            ),
+            policy=PI05TTTConfig(sequence_length=policy_seq, tbptt_segment_length=policy_seq),
+            output_dir=str(tmp_path),
+            job_name="test_run",
+            seed=42,
+            batch_size=8,
+            val_freq=val_freq,
+            use_policy_training_preset=True,
         )
-        assert re.search(r"emitted \*= 2", src), "the doubling rule is gone"
 
-    def test_factory_wraps_subsets_when_pairing(self):
-        import inspect
+    def test_validate_accepts_doubled_policy_length_when_pairing(self, tmp_path):
+        """Pairing on, policy sized for the concatenation: must pass."""
+        self._cfg(policy_seq=2 * T, mixture_seq=T, pair=True, tmp_path=tmp_path).validate()
 
+    def test_validate_rejects_undoubled_policy_length(self, tmp_path):
+        """The breaking case: pairing on, policy still expecting one half."""
+        cfg = self._cfg(policy_seq=T, mixture_seq=T, pair=True, tmp_path=tmp_path)
+        with pytest.raises(ValueError, match="pair_episodes doubles"):
+            cfg.validate()
+
+    def test_validate_leaves_unpaired_configs_alone(self, tmp_path):
+        """The doubling must not leak into configs that do not pair."""
+        self._cfg(policy_seq=T, mixture_seq=T, pair=False, tmp_path=tmp_path).validate()
+        cfg = self._cfg(policy_seq=2 * T, mixture_seq=T, pair=False, tmp_path=tmp_path)
+        with pytest.raises(ValueError, match="!= emitted timesteps"):
+            cfg.validate()
+
+    def test_validate_rejects_val_freq_with_pairing(self, tmp_path):
+        """`val_freq` and pairing are incompatible, and silently so without this.
+
+        `random_split` partitions frames, not episodes, so both halves keep every
+        episode: a paired val subset would draw its pairs from episodes whose
+        frames are in the training half. It also cannot be constructed, since the
+        `Subset` exposes none of the episode-level attributes the loader indexes
+        with. Rejecting at config time beats an AttributeError after the model has
+        loaded -- or, worse, a val curve that means nothing.
+        """
+        cfg = self._cfg(policy_seq=2 * T, mixture_seq=T, pair=True, val_freq=100, tmp_path=tmp_path)
+        with pytest.raises(ValueError, match="pair_episodes is on with val_freq"):
+            cfg.validate()
+
+        # ...and stays out of the way when pairing is off.
+        self._cfg(policy_seq=T, mixture_seq=T, pair=False, val_freq=100, tmp_path=tmp_path).validate()
+
+    def test_factory_emits_paired_samples(self, tmp_path, monkeypatch):
+        """`make_dataset_mixture` must hand the mixture a *paired* dataset.
+
+        Runs the real factory path with only the base-dataset build and the
+        metadata-heavy mixture constructor stubbed, then inspects what the
+        mixture was actually handed: a `PairedSequenceDataset` emitting
+        `2 * sequence_length` timesteps with the ambiguous prompt applied. A
+        source-level check that `_maybe_pair` is *called* would still pass if it
+        returned the dataset unwrapped.
+        """
         from opentau.datasets import factory
 
-        src = inspect.getsource(factory.make_dataset_mixture)
-        assert "_maybe_pair(" in src, (
-            "make_dataset_mixture no longer wraps subsets; train.py would build "
-            "an unpaired dataloader from a paired config"
+        cfg = self._cfg(policy_seq=2 * T, mixture_seq=T, pair=True, tmp_path=tmp_path)
+        handed = {}
+
+        monkeypatch.setattr(factory, "make_dataset", lambda dcfg, c, **kw: _StubBase(EPISODES))
+        monkeypatch.setattr(factory, "_validate_metadata_requirements", lambda *a, **k: None)
+        monkeypatch.setattr(
+            factory,
+            "WeightedDatasetMixture",
+            lambda cfg_, datasets, weights, freq: handed.setdefault("datasets", datasets),
         )
+
+        factory.make_dataset_mixture(cfg)
+        wrapped = handed["datasets"][0]
+        assert isinstance(wrapped, PairedSequenceDataset), (
+            f"factory handed the mixture a {type(wrapped).__name__}; training would "
+            "run on single unpaired windows from a paired config"
+        )
+        sample = wrapped[0]
+        assert sample["state"].shape[0] == 2 * T, "paired sample is not the concatenation"
+        assert sample["prompt"] == "Open the drawer."
 
     def test_missing_ambiguous_prompt_warns_but_is_allowed(self, caplog):
         """No prompt is legitimate for cross-task transfer, so warn rather than refuse.

--- a/tests/datasets/test_paired_sequence.py
+++ b/tests/datasets/test_paired_sequence.py
@@ -23,9 +23,8 @@ constructed the breaking case first.
 CPU-only: the base dataset is stubbed, so none of this touches the Hub.
 """
 
-from types import SimpleNamespace
-
 import logging
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -257,11 +256,10 @@ class TestPairingIsActuallyWired:
 
         ds_cfg = SimpleNamespace(repo_id="r", episodes=[1, 2], ambiguous_prompt=None)
         cfg = SimpleNamespace(dataset_mixture=SimpleNamespace(pair_episodes=True), seed=0)
-        with caplog.at_level(logging.WARNING):
-            with pytest.raises(TypeError):
-                # Proceeds past the prompt check and fails later on the stub
-                # dataset, which is the point: the prompt no longer blocks it.
-                _maybe_pair(SimpleNamespace(episodes=[1, 2]), ds_cfg, cfg)
+        # Proceeds past the prompt check and fails later on the stub dataset,
+        # which is the point: the prompt no longer blocks it.
+        with caplog.at_level(logging.WARNING), pytest.raises(TypeError):
+            _maybe_pair(SimpleNamespace(episodes=[1, 2]), ds_cfg, cfg)
         assert "ambiguous_prompt" in caplog.text
         assert "cross-task transfer" in caplog.text
 

--- a/tests/datasets/test_paired_sequence.py
+++ b/tests/datasets/test_paired_sequence.py
@@ -1,0 +1,275 @@
+# Copyright 2026 Tensor Auto Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pairing contract for one-shot in-context imitation.
+
+Every property here is one the training run cannot check for itself. A pair with
+the wrong mask boundary, or with the target named in the prompt, produces a run
+that converges and reports a good number while proving nothing — which is the
+same failure mode the alpha=0 ablation had, caught only because something
+constructed the breaking case first.
+
+CPU-only: the base dataset is stubbed, so none of this touches the Hub.
+"""
+
+from types import SimpleNamespace
+
+import logging
+
+import pytest
+import torch
+
+from opentau.datasets.paired_sequence import PairedSequenceDataset
+
+T = 4  # timesteps per half
+
+
+class _StubBase:
+    """Minimal stand-in for ``LeRobotDataset``.
+
+    Emits one distinguishable ``T``-timestep window per episode so a
+    concatenation can be checked against its inputs.
+
+    Args:
+        episodes: Episode indices to serve.
+        scenes: Optional ``{episode: scene_id}``.
+        ragged: Episode whose window is one timestep short, to exercise the
+            mismatch guard.
+    """
+
+    def __init__(self, episodes, scenes=None, ragged=None):
+        self._episodes = list(episodes)
+        self._ragged = ragged
+        rows = {e: i for i, e in enumerate(self._episodes)}
+        self.epi2idx = rows
+        self.episode_data_index = {
+            "from": torch.tensor([rows[e] for e in self._episodes]),
+            "to": torch.tensor([rows[e] + 1 for e in self._episodes]),
+        }
+        self.meta = SimpleNamespace(
+            episodes={e: ({"scene_id": scenes[e]} if scenes else {}) for e in self._episodes}
+        )
+        self._by_row = {rows[e]: e for e in self._episodes}
+
+    def __getitem__(self, row):
+        e = self._by_row[row]
+        n = T - 1 if e == self._ragged else T
+        return {
+            "state": torch.full((n, 3), float(e)),
+            "camera0": torch.full((n, 3, 2, 2), float(e)),
+            "loss_mask": torch.ones(n, dtype=torch.bool),
+            "prompt": f"open the {'left' if e % 2 else 'right'} drawer",
+            "episode_index": torch.tensor(e),
+            "dataset_index": torch.tensor(0),
+        }
+
+
+def _make(episodes=(10, 11, 12), scenes=None, ragged=None, **kw):
+    base = _StubBase(episodes, scenes, ragged)
+    return PairedSequenceDataset(
+        base=base,
+        pairing_keys={"OpenDrawer__left": list(episodes)},
+        prompts={"OpenDrawer__left": "Open the drawer."},
+        samples_per_epoch=64,
+        **kw,
+    )
+
+
+class TestConcatenation:
+    def test_sequence_is_both_halves(self):
+        s = _make()[0]
+        assert s["state"].shape[0] == 2 * T
+        assert s["camera0"].shape[0] == 2 * T
+
+    def test_halves_come_from_different_episodes(self):
+        """The whole method collapses if a pair is one episode twice."""
+        s = _make()[0]
+        first, second = s["state"][0, 0].item(), s["state"][T, 0].item()
+        assert first != second
+
+    def test_a_precedes_b(self):
+        """Order matters: the demonstration must be the part that is masked."""
+        ds = _make()
+        key, a, b = ds._draw(0)
+        s = ds[0]
+        assert s["state"][0, 0].item() == float(a)
+        assert s["state"][T, 0].item() == float(b)
+
+
+class TestLossMask:
+    def test_boundary_is_exact(self):
+        """Off by one here silently supervises a demo frame, or drops a real one."""
+        m = _make()[0]["loss_mask"]
+        assert m.shape == (2 * T,)
+        assert not m[:T].any(), "demonstration half must carry no target"
+        assert m[T:].all(), "rollout half must be fully supervised"
+
+    def test_mask_overrides_whatever_the_base_emitted(self):
+        """The stub returns all-True; the pair mask must win."""
+        assert not _make()[0]["loss_mask"][0]
+
+
+class TestPromptIsStripped:
+    def test_prompt_is_the_ambiguous_one_on_both_halves(self):
+        """The breaking case: leave the base prompt and the demo is redundant.
+
+        The stub's episodes say "open the left drawer" / "open the right
+        drawer". If either survives into the sample, the instruction names the
+        target and the model never needs the demonstration.
+        """
+        s = _make()[0]
+        assert s["prompt"] == "Open the drawer."
+        assert "left" not in s["prompt"] and "right" not in s["prompt"]
+
+
+class TestSameKey:
+    def test_pair_never_crosses_keys(self):
+        """A cross-key pair teaches the demo to predict the wrong thing."""
+        base = _StubBase([1, 2, 3, 4])
+        ds = PairedSequenceDataset(
+            base=base,
+            pairing_keys={"left": [1, 2], "right": [3, 4]},
+            prompts={"left": "Open the drawer.", "right": "Open the drawer."},
+            samples_per_epoch=64,
+        )
+        for i in range(40):
+            key, a, b = ds._draw(i)
+            assert {a, b} <= set(ds.pairing_keys[key])
+
+
+class TestDeterminism:
+    def test_same_index_same_pair(self):
+        """Ranks must agree, and a resume must reproduce the run."""
+        assert _make()._draw(7) == _make()._draw(7)
+
+    def test_different_indices_differ(self):
+        draws = {_make()._draw(i)[1:] for i in range(40)}
+        assert len(draws) > 1, "sampler is returning one pair for every index"
+
+
+class TestSceneConstraint:
+    def test_same_scene_pairs_are_avoided(self):
+        """Two episodes of one scene can be solved by copying A's motion."""
+        ds = _make(episodes=(1, 2, 3, 4), scenes={1: "k1", 2: "k1", 3: "k2", 4: "k3"})
+        same = sum(1 for i in range(60) if ds._scene_of(ds._draw(i)[1]) == ds._scene_of(ds._draw(i)[2]))
+        assert same == 0
+
+    def test_missing_scene_metadata_does_not_reject_everything(self):
+        """Absent scene ids must degrade to a no-op, not an empty epoch."""
+        ds = _make(episodes=(1, 2, 3))
+        assert ds[0]["state"].shape[0] == 2 * T
+
+
+class TestGuards:
+    def test_thin_key_is_refused(self):
+        with pytest.raises(ValueError, match="too thin"):
+            PairedSequenceDataset(base=_StubBase([1]), pairing_keys={"k": [1]}, prompts={"k": "x"})
+
+    def test_missing_prompt_is_refused(self):
+        """Without this the base prompt leaks the answer silently."""
+        with pytest.raises(ValueError, match="no ambiguous prompt"):
+            PairedSequenceDataset(base=_StubBase([1, 2]), pairing_keys={"k": [1, 2]}, prompts={})
+
+    def test_ragged_halves_raise(self):
+        """A short half would slide the mask against the sequence."""
+        ds = _make(episodes=(10, 11, 12), ragged=12)
+        with pytest.raises(ValueError, match="disagree on timestep count"):
+            for i in range(40):
+                ds[i]
+
+    def test_episode_absent_from_base_is_named(self):
+        with pytest.raises(KeyError, match="diverged"):
+            PairedSequenceDataset(base=_StubBase([1, 2]), pairing_keys={"k": [1, 2, 99]}, prompts={"k": "x"})
+
+    def test_non_sequence_base_is_named(self):
+        with pytest.raises(ValueError, match="sequence_length"):
+            PairedSequenceDataset._timesteps({"prompt": "x"})
+
+
+class TestScalarPassthrough:
+    def test_scalars_are_not_concatenated(self):
+        """``dataset_index`` routes normalization; a doubled one would misroute."""
+        s = _make()[0]
+        assert s["dataset_index"].ndim == 0
+
+
+class TestPairingIsActuallyWired:
+    """The pairing must reach ``train.py``, not just exist as a class.
+
+    The first smoke run failed on a config guard, and satisfying that guard
+    naively would have started a run that trained on single windows with no
+    pairing at all — converging, looking healthy, and proving nothing. These
+    pin the two places that connect the loader to the training path.
+    """
+
+    def test_validate_accepts_doubled_policy_length_when_pairing(self):
+        from opentau.configs.default import DatasetMixtureConfig
+
+        cfg = DatasetMixtureConfig(sequence_length=98, pair_episodes=True)
+        assert cfg.pair_episodes and cfg.sequence_length == 98
+
+    def test_validate_rejects_undoubled_policy_length(self):
+        """The breaking case: pairing on, policy still expecting one half."""
+        import re
+
+        from opentau.configs import train as train_cfg
+
+        src = __import__("inspect").getsource(train_cfg.TrainPipelineConfig.validate)
+        assert "pair_episodes" in src, (
+            "validate() no longer accounts for pairing; a correct paired config "
+            "would be rejected and an unpaired one silently accepted"
+        )
+        assert re.search(r"emitted \*= 2", src), "the doubling rule is gone"
+
+    def test_factory_wraps_subsets_when_pairing(self):
+        import inspect
+
+        from opentau.datasets import factory
+
+        src = inspect.getsource(factory.make_dataset_mixture)
+        assert "_maybe_pair(" in src, (
+            "make_dataset_mixture no longer wraps subsets; train.py would build "
+            "an unpaired dataloader from a paired config"
+        )
+
+    def test_missing_ambiguous_prompt_warns_but_is_allowed(self, caplog):
+        """No prompt is legitimate for cross-task transfer, so warn rather than refuse.
+
+        Within-task ambiguity needs the prompt overwritten or the demonstration is
+        redundant. Cross-task transfer needs it left alone or the task identity is
+        erased. The loader cannot tell those apart, so it says so loudly and lets
+        the caller own the choice.
+        """
+        from types import SimpleNamespace
+
+        from opentau.datasets.factory import _maybe_pair
+
+        ds_cfg = SimpleNamespace(repo_id="r", episodes=[1, 2], ambiguous_prompt=None)
+        cfg = SimpleNamespace(dataset_mixture=SimpleNamespace(pair_episodes=True), seed=0)
+        with caplog.at_level(logging.WARNING):
+            with pytest.raises(TypeError):
+                # Proceeds past the prompt check and fails later on the stub
+                # dataset, which is the point: the prompt no longer blocks it.
+                _maybe_pair(SimpleNamespace(episodes=[1, 2]), ds_cfg, cfg)
+        assert "ambiguous_prompt" in caplog.text
+        assert "cross-task transfer" in caplog.text
+
+    def test_pairing_off_is_a_passthrough(self):
+        from types import SimpleNamespace
+
+        from opentau.datasets.factory import _maybe_pair
+
+        sentinel = SimpleNamespace(episodes=[1, 2])
+        cfg = SimpleNamespace(dataset_mixture=SimpleNamespace(pair_episodes=False), seed=0)
+        assert _maybe_pair(sentinel, SimpleNamespace(), cfg) is sentinel


### PR DESCRIPTION
## What this does

Adds one-shot in-context imitation on the data side: a demonstration episode and a rollout episode emitted as **one sequence**, with `loss_mask` zero across the demonstration and one across the rollout.

The demonstration's timesteps still update the policy's recurrent state; only the rollout carries an imitation target. So the gradient on the rollout can only fall by having absorbed something from the demonstration — which is the pressure that makes the state encode *what the task is* rather than generic visual features.

**Nothing is materialized.** A pair exists as a tensor for one training step. Writing out ~146k pairs at 196 timesteps and 3 cameras would be on the order of 100 TB, and would freeze one arbitrary draw of a pair space the sampler otherwise re-draws every epoch.

**Why this can't be a flag on the existing loader.** `LeRobotDataset` builds a window from `delta_timestamps`, which clamps at episode boundaries by design. A pair spans two *different* episodes, so it cannot be expressed as one window however the offsets are written. `PairedSequenceDataset` calls the base dataset twice instead, which preserves image standardization, action padding and the sequence reshape rather than re-deriving them.

**`ambiguous_prompt` is optional, and the distinction is the interesting part.**

- *Within-task ambiguity* — the episodes of one key differ only in their target ("open the **left** drawer" vs "open the **right** drawer"). The prompt must be overwritten with the varying slot removed, or the episode's own instruction names the target and the demonstration is redundant.
- *Cross-task transfer* — the prompt names the task and the demonstration supplies the handling of an unfamiliar object. Overwriting it would erase the task identity the policy needs.

The loader cannot tell those apart, so it **warns** and lets the caller own the choice rather than refusing one of two legitimate designs.

Surface:

| field | where | meaning |
|---|---|---|
| `pair_episodes` | `DatasetMixtureConfig` | emit pairs instead of single windows |
| `ambiguous_prompt` | `DatasetConfig` | optional prompt override; one entry = one pairing key |

`TrainPipelineConfig.validate()` now accounts for pairing doubling the emitted timesteps, so a correct paired config is no longer rejected.

**One detail worth a reviewer's eye.** The same-scene filter degrades to a *random* distinct pair, not a fixed one. An earlier version fell back to `(eps[0], eps[1])`, and when every episode of a key shares a `source_prefix` the filter can never be satisfied — so every sample collapsed onto a single pair while the logged "N ordered pairs available" stayed reassuringly large. The constructor now measures what `_draw` actually produces and logs an error if diversity has collapsed, so the degenerate case is loud rather than silent.

## How it was tested

- Added `tests/datasets/test_paired_sequence.py` — 22 CPU tests covering the concatenation, the loss mask, the prompt-override and prompt-preserving paths, scalar passthrough, distinctness of the two halves, the diversity probe, and that pairing is actually wired into `make_dataset_mixture` rather than only unit-testable.
- `pytest -m "not gpu" tests/datasets/ tests/configs/` → **1041 passed**. The 10 `test_loc_tokens_*` failures are pre-existing on `main` (verified with these changes stashed) and unrelated — they need tokenizer downloads.
- `pre-commit run --files <changed>` → clean.
- Exercised end-to-end on a real multi-GPU training run: the diversity probe reports ~198 distinct `(key, demo, rollout)` triples per 200 draws, all 17 pairing keys covered, no self-pairs.

Not a policy change — no `modeling_*`/`configuration_*`, optimizer, sampler, or training-script edits — so the GPU boxes are left unchecked.

## How to checkout & try? (for the reviewer)

```bash
pytest -sx tests/datasets/test_paired_sequence.py
```

Enable it on any dataset entry whose episodes share a task:

```json
{
  "dataset_mixture": {
    "sequence_length": 6,
    "pair_episodes": true,
    "datasets": [{"repo_id": "...", "ambiguous_prompt": "Open the drawer."}]
  },
  "policy": {"sequence_length": 12}
}
```

`policy.sequence_length` is twice the mixture's, because each half contributes `sequence_length` timesteps.

## Checklist

- [x] I have added Google-style docstrings to important functions and ensured function parameters are typed.
- [ ] My PR includes policy-related changes.
  - [ ] If the above is checked: I have run the GPU pytests (pytest -m "gpu") and regression tests.
